### PR TITLE
Add feature key for wifi-direct tethering

### DIFF
--- a/docs/application/native/guides/device/system.md
+++ b/docs/application/native/guides/device/system.md
@@ -372,6 +372,7 @@ The following table lists the network feature keys.
 | `http://tizen.org/feature/network.tethering.bluetooth` | `bool` | The platform returns `true` for this key and the `http://tizen.org/feature/network.tethering` key, if the device supports tethering over Bluetooth. |
 | `http://tizen.org/feature/network.tethering.usb` | `bool` | The platform returns `true` for this key and the `http://tizen.org/feature/network.tethering` key, if the device supports tethering over USB connection. |
 | `http://tizen.org/feature/network.tethering.wifi` | `bool` | The platform returns `true` for this key and the `http://tizen.org/feature/network.tethering` key, if the device supports tethering over Wi-Fi. |
+| `http://tizen.org/feature/network.tethering.wifi.direct` | `bool` | The platform returns `true` for this key and the `http://tizen.org/feature/network.tethering` key, if the device supports tethering over Wi-Fi Direct. |
 | `http://tizen.org/feature/network.vpn`   | `bool` | The platform returns `true` for this key, if the device supports the Virtual Private Network feature (VPN). |
 | `http://tizen.org/feature/network.wifi`  | `bool` | The platform returns `true` for this key, if the device supports all APIs which require Wi-Fi. |
 | `http://tizen.org/feature/network.wifi.direct` | `bool` | The platform returns `true` for this key and the `http://tizen.org/feature/network.wifi` key, if the device supports Wi-Fi Direct&reg;. |

--- a/docs/application/native/tutorials/details/app-filtering.md
+++ b/docs/application/native/tutorials/details/app-filtering.md
@@ -218,6 +218,7 @@ Reference](../../../../org.tizen.native.mobile.apireference/index.html).
 | `http://tizen.org/feature/network.tethering.bluetooth` | Specify this key, if the application requires the tethering over Bluetooth feature. | 2.3   |
 | `http://tizen.org/feature/network.tethering.usb` | Specify this key, if the application requires the tethering over USB connection feature. | 2.3   |
 | `http://tizen.org/feature/network.tethering.wifi` | Specify this key, if the application requires the tethering over Wi-Fi feature. | 2.3   |
+| `http://tizen.org/feature/network.tethering.wifi.direct` | Specify this key, if the application requires the tethering over Wi-Fi Direct feature. | 4.0   |
 | `http://tizen.org/feature/network.vpn`   | Specify this key, if the application requires the Virtual Private Network feature (VPN). | 3.0   |
 | `http://tizen.org/feature/network.wifi`  | Specify this key, if the application requires the use of any API that, in turn, requires the Wi-Fi feature. | 2.2.1 |
 | `http://tizen.org/feature/network.wifi.direct` | Specify this key, if the application requires the Wi-Fi Direct&reg; feature. | 2.2.1 |


### PR DESCRIPTION
network.tethering.wifi.direct feature has been added since tizen 4.0

[related ACR]
http://suprem.sec.samsung.net/jira/browse/ACR-967
