### PR TITLE
Updated files with minor changes according to review checklist

### DIFF
--- a/docs/application/tizen-studio/release-notes/2-3-release-notes.md
+++ b/docs/application/tizen-studio/release-notes/2-3-release-notes.md
@@ -62,7 +62,7 @@
 	-   The Component Designer crashes if an alias is selected as the source group of an added item.
 -	Emulator
 	-   To use the Tizen emulator, install an Intel VTx supported by the CPU, and the latest version of the graphic card driver provided by the vendor. To verify the prerequisites for the Tizen emulator, see [Prerequisites for the Tizen Studio](https://developer.tizen.org/development/tizen-studio/download/installing-tizen-studio/prerequisites).
-	    -   If the host machine is using NVIDIA&reg; Optimus&reg; technology on either Ubuntu or Windows&reg;, you must set the Tizen emulator to run with your NVIDIA graphics card. For Ubuntu, verify the [bumblebee project](https://wiki.ubuntu.com/Bumblebee ). For Windows&reg;, select *High Speed NVIDIA Processor* as *Preferred Graphics processor* in the NVIDIA control panel.
+	    -   If the host machine is using NVIDIA&reg; Optimus&reg; technology on either Ubuntu or Windows&reg;, you must set the Tizen emulator to run with your NVIDIA&reg; graphics card. For Ubuntu, verify the [bumblebee project](https://wiki.ubuntu.com/Bumblebee ). For Windows&reg;, select *High Speed NVIDIA&reg; Processor* as *Preferred Graphics processor* in the NVIDIA&reg; control panel.
 	    -   On Ubuntu, if the graphics driver is out-of-date, your Ubuntu desktop session occasionally logs out while launching the Emulator Manager, or the emulator skin is displayed improperly. Verify the prerequisites and upgrade to the latest graphics driver.
 	-   On Ubuntu 14.04, a shortcut menu can sometimes appear transparent.
 	-   On Windows&reg;, depending on your OS theme (such as Non-Aero themes and Windows XP themes), a display surface can be erased for a while if the emulator window is covered with another window. If you click the emulator window, the display surface runs correctly again.
@@ -70,8 +70,8 @@
 	    -   Close some other programs and try to launch the emulator again.
 	    -   If the RAM size is set to 768 or 1024 MB for the VM in the Emulator Manager, change it to 512 MB.
 	    -   Increase the user area of the virtual memory in the system to 3 GB by entering the *bcdedit /setincreaseuserva 3072* command on the console with administrator rights (only in Windows&reg; 7), and reboot.
-	-   If you use a MacBook Pro which has both Intel HD and NVIDIA&reg; GPUs, the emulator can unexpectedly terminate when you execute the emulator with OpenGL ES version set v1.1 & v2.0. Verify the emulator configuration in the Emulator Manager and on the general tab in the emulator configuration window, set OpenGL ES version to v2.0 & v3.0.
-	-   When you launch the Emulator Manager in the Tizen IDE, the Emulator Manager's shortcut image may not be displayed properly.
+	-   If you use a MacBook Pro which has both Intel HD and NVIDIA&reg; GPUs, the emulator can unexpectedly terminate when you execute the emulator with OpenGL ES version 1.1 or 2.0. Verify the emulator configuration in the Emulator Manager and on the general tab in the emulator configuration window, set OpenGL ES version to version 2.0 or to version 3.0.
+	-   When you launch the Emulator Manager in the Tizen IDE, the shortcut image of Emulator Manager may not be displayed properly.
 	-   Basic Web applications does not install on SD cards.
 -	CLI and SDB
 	-   The Tizen Studio does not support the SDB ([Smart Development Bridge](https://developer.tizen.org/development/tizen-studio/web-tools/running-and-testing-your-app/sdb)) bash auto-completion on Windows&reg; (it is available on Ubuntu and macOS).
@@ -79,10 +79,10 @@
 	-   When analyzing applications on commercial devices running Tizen 3.0, newly-released or after a firmware update, the following problems exist:
 	    -   The Core Frequency information is not shown.
 	    -   The screenshots on scene transitions feature will not work.
-	-   When analyzing applications on the Tizen 4.0 emulator or reference device, the start-up profiling information is not shown.
-	-   The UI Hierarchy viewer feature and start-up profiling are not performed simultaneously.
+	-   When analyzing applications on the Tizen 4.0 emulator or reference device, the startup profiling information is not shown.
+	-   The UI Hierarchy viewer feature and startup profiling are not performed simultaneously.
 	-   The Dynamic Analyzer cannot perform Web application profiling with a commercial Tizen device, due to the security policy.
-	-   The Dynamic Analyzer cannot show life-cycle information for Web applications.
+	-   The Dynamic Analyzer cannot show lifecycle information for Web applications.
 	-   Widget applications cannot be profiled with the Dynamic Analyzer. They are hidden in the application list on the toolbar for all Tizen platforms, except Tizen 2.3.2.
 -	Web Inspector
 	-   If your Google Chrome&trade; browser version is higher than 54, the Web Inspector console and some other functions does not work properly due to Web core compatibility issues.

--- a/docs/application/tizen-studio/release-notes/2-4-release-notes.md
+++ b/docs/application/tizen-studio/release-notes/2-4-release-notes.md
@@ -68,7 +68,7 @@
 	    -   Close some other programs and try to launch the emulator again.
 	    -   If the RAM size is set to 768 or 1024 MB for the VM in the Emulator Manager, change it to 512 MB.
 	    -   Increase the user area of the virtual memory in the system to 3 GB by entering the *bcdedit /setincreaseuserva 3072* command on the console with administrator rights (only in Windows&reg; 7), and reboot.
-	-   If you use a MacBook Pro which has both Intel HD and NVIDIA&reg; GPUs, the emulator can unexpectedly terminate when you execute the emulator with OpenGL ES version set v1.1 and OpenGL ES version set v2.0. Verify the emulator configuration in the Emulator Manager and on the general tab in the emulator configuration window, set OpenGL ES version to version v2.0 and version v3.0.
+	-   If you use a MacBook Pro which has both Intel HD and NVIDIA&reg; GPUs, the emulator can unexpectedly terminate when you execute the emulator with OpenGL ES version 1.1 or 2.0. Verify the emulator configuration in the Emulator Manager and on the general tab in the emulator configuration window, set OpenGL ES version to version 2.0 or to version 3.0.
 	-   When you launch the Emulator Manager in the Tizen IDE, the shortcut image of Emulator Manager may not be displayed properly.
 	-   Basic Web applications does not install on SD cards.
 -	CLI and SDB
@@ -77,10 +77,10 @@
 	-   When analyzing applications on commercial devices running Tizen 3.0, newly-released or after a firmware update, the following problems exist:
 	    -   The Core Frequency information is not shown.
 	    -   The screenshots on scene transitions feature will not work.
-	-   When analyzing applications on the Tizen 4.0 emulator or reference device, the start-up profiling information is not shown.
-	-   The UI Hierarchy viewer feature and start-up profiling are not performed simultaneously.
+	-   When analyzing applications on the Tizen 4.0 emulator or reference device, the startup profiling information is not shown.
+	-   The UI Hierarchy viewer feature and startup profiling are not performed simultaneously.
 	-   The Dynamic Analyzer cannot perform Web application profiling with a commercial Tizen device, due to the security policy.
-	-   The Dynamic Analyzer cannot show life-cycle information for Web applications.
+	-   The Dynamic Analyzer cannot show lifecycle information for Web applications.
 	-   Widget applications cannot be profiled with the Dynamic Analyzer. They are hidden in the application list on the toolbar for all Tizen platforms, except Tizen 2.3.2.
 -	Web Inspector
 	-   If your Google Chrome™ browser version is higher than 54, the Web Inspector console and some other functions does not work properly due to Web core compatibility issues.


### PR DESCRIPTION
According to the Tizen Doc Team checklist, made some minor changes in the files.

- Changed v3.0 to version 3.0, v2.0 to version 2.0, and v1.1 to version 1.1.
As we cant set the version to version 2.0 and 3.0 at the same time, the & symbol is replaced by or.
For example, set OpenGL ES version to v2.0 & v3.0, rephrased to 
set OpenGL ES version to version 2.0 or to version 3.0.


- Rephrased a sentence to avoid possessive apostrophe.
"the Emulator Manager's shortcut image" rephrased to 
"the shortcut image of Emulator Manager"

- Changed hyphenated words:
   life-cycle to lifecycle
   start-up to startup

Please verify the changes.