### PR TITLE
[base-utils] Add guides for immutable index module

### DIFF
--- a/docs/application/native/guides/internationalization/i18n.md
+++ b/docs/application/native/guides/internationalization/i18n.md
@@ -2103,59 +2103,59 @@ From Tizen 5.0, you can use immutable index API (in [mobile](../../api/mobile/la
 
    - Create an alphabetic index:
 
-   ```
-   i18n_alpha_idx_h alpha_idx;
-   i18n_alpha_idx_create("en", "US", &alpha_idx);
-   ```
+      ```
+      i18n_alpha_idx_h alpha_idx;
+      i18n_alpha_idx_create("en", "US", &alpha_idx);
+      ```
 
    - Fill the index with data. See the [alphabetic index example](#alpha_idx_example).
 
    - Create an immutable index:
 
-   ```
-   i18n_immutable_idx_h im_index;
-   i18n_immutable_idx_create(alpha_idx, &im_index);
-   ```
+      ```
+      i18n_immutable_idx_h im_index;
+      i18n_immutable_idx_create(alpha_idx, &im_index);
+      ```
 
 2. To use the immutable index:
 
    - Get the number of buckets:
 
-   ```
-   int bucket_count = 0;
-   i18n_immutable_idx_get_bucket_count(im_index, &bucket_count);
-   ```
+      ```
+      int bucket_count = 0;
+      i18n_immutable_idx_get_bucket_count(im_index, &bucket_count);
+      ```
 
    - Get the bucket index using the bucket name:
 
-   ```
-   char *bucket_name = ...
-   int32_t bucket_index;
+      ```
+      char *bucket_name = ...
+      int32_t bucket_index;
 
-   i18n_immutable_idx_get_bucket_index(im_index, bucket_name, &bucket_index);
-   ```
+      i18n_immutable_idx_get_bucket_index(im_index, bucket_name, &bucket_index);
+      ```
 
    - Get the label of a given bucket using the bucket index:
 
-   ```
-   char *label = NULL;
-   int32_t bucket_index = ...
+      ```
+      char *label = NULL;
+      int32_t bucket_index = ...
 
-   i18n_immutable_idx_get_bucket_label(im_index, bucket_index, &label);
+      i18n_immutable_idx_get_bucket_label(im_index, bucket_index, &label);
 
-   /* Use the label ... */
+      /* Use the label ... */
 
-   free(label);
-   ```
+      free(label);
+      ```
 
    - Get the label type of a given bucket:
 
-   ```
-   int32_t bucket_index = ...
-   i18n_alpha_idx_label_type_e label_type;
+      ```
+      int32_t bucket_index = ...
+      i18n_alpha_idx_label_type_e label_type;
 
-   i18n_immutable_idx_get_bucket_label_type(im_index, bucket_index, &label_type);
-   ```
+      i18n_immutable_idx_get_bucket_label_type(im_index, bucket_index, &label_type);
+      ```
 
 3. Destroy the index when it is no longer needed:
 

--- a/docs/application/native/guides/internationalization/i18n.md
+++ b/docs/application/native/guides/internationalization/i18n.md
@@ -29,7 +29,7 @@ The main features of the i18n API include:
 
 - Managing alphabetic indexes
 
-  You can use the Alphabetic Index functions to [generate a list of labels](#alpha_idx) that can be used as an index. For immutable, thread-safe index you can use an [Immutable Index](#immutable_idx).
+  You can use the alphabetic index functions to [generate a list of labels](#alpha_idx) that can be used as an index. For immutable thread-safe index, you can use an [immutable index](#immutable_idx).
 
 - Managing the field position in formatted output
 
@@ -72,7 +72,7 @@ The main features of the i18n API include:
   You can [iterate through strings](#uchar_iter), in a safe way, with UCharIter.
 
 > **Note**  
-> The Alphabetic Index, FieldPosition, Format, Formattable, Measure, MeasureFormat, MeasureUnit, ParsePosition, Ubidi, Ushape, and Utmscale APIs are supported since Tizen 3.0. The PluralRules, Uversion, and UCharIter APIs are supported since Tizen 4.0. Immutable Index is supported since Tizen 5.0.
+> The Alphabetic Index, FieldPosition, Format, Formattable, Measure, MeasureFormat, MeasureUnit, ParsePosition, Ubidi, Ushape, and Utmscale APIs are supported since Tizen 3.0. The PluralRules, Uversion, and UCharIter APIs are supported since Tizen 4.0. The Immutable Index is supported from Tizen 5.0.
 
 <a name="ubrk"></a>
 ## Location Boundaries with Ubrk
@@ -419,7 +419,7 @@ The Alphabetic Index API also supports creating buckets for strings that are sor
 <a name="immutable_idx"></a>
 ## Using Immutable Index
 
-The Immutable Index API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__IMMUTABLE__IDX__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__ALPHA__IDX__MODULE.html) applications) provides an immutable, thread-safe version of an [Alphabetic Index](#alpha_idx). Immutable indices also allow random access to buckets. An immutable index is constructed using a regular alphabetic index. The immutable index will contain the same data as the alphabetic index on which it was based, except the data records. The [example](#immutable_idx_example) shows creation and basic usage.
+The immutable index API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__IMMUTABLE__IDX__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__ALPHA__IDX__MODULE.html) applications) provides an immutable, thread-safe version of an [alphabetic index](#alpha_idx). Immutable indices also allow random access to buckets. An immutable index is constructed using a regular alphabetic index. The immutable index contains similar data as the alphabetic index on which it is based, except for the data records. For more information on the creation and the basic usage of an immutable index, see [example](#immutable_idx_example).
 
 <a name="field_pos"></a>
 ## Field Identification in Formatted Output
@@ -2097,22 +2097,20 @@ To generate and manage an alphabetic index:
    ```
 
 <a name="immutable_idx_example"></a>
-Since Tizen 5.0, you can use Immutable Index API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__IMMUTABLE__IDX__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__ALPHA__IDX__MODULE.html) applications) to create an immutable index - a thread-safe version of an [Alphabetic Index](#alpha_idx) without data records.
+From Tizen 5.0, you can use immutable index API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__IMMUTABLE__IDX__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__ALPHA__IDX__MODULE.html) applications) to create an immutable index, a thread-safe version of an [alphabetic index](#alpha_idx) without data records.
 
 1. To create an immutable index:
 
-   - Create an alphabetic index
+   - Create an alphabetic index:
 
    ```
    i18n_alpha_idx_h alpha_idx;
    i18n_alpha_idx_create("en", "US", &alpha_idx);
    ```
 
-   - Fill the index with data
+   - Fill the index with data. See the [alphabetic index example](#alpha_idx_example).
 
-   See the [Alphabetic Index example](#alpha_idx_example).
-
-   - Create an immutable index
+   - Create an immutable index:
 
    ```
    i18n_immutable_idx_h im_index;
@@ -2128,7 +2126,7 @@ Since Tizen 5.0, you can use Immutable Index API (in [mobile](../../api/mobile/l
    i18n_immutable_idx_get_bucket_count(im_index, &bucket_count);
    ```
 
-  - Get the bucket's index by the bucket's name:
+   - Get the bucket index using the bucket name:
 
    ```
    char *bucket_name = ...
@@ -2137,7 +2135,7 @@ Since Tizen 5.0, you can use Immutable Index API (in [mobile](../../api/mobile/l
    i18n_immutable_idx_get_bucket_index(im_index, bucket_name, &bucket_index);
    ```
 
-   - Get the label of a given bucket, knowing the bucket's index:
+   - Get the label of a given bucket using the bucket index:
 
    ```
    char *label = NULL;
@@ -2159,7 +2157,7 @@ Since Tizen 5.0, you can use Immutable Index API (in [mobile](../../api/mobile/l
    i18n_immutable_idx_get_bucket_label_type(im_index, bucket_index, &label_type);
    ```
 
-3. Destroy the index when it's no longer needed:
+3. Destroy the index when it is no longer needed:
 
    ```
    i18n_immutable_idx_destroy(im_index);

--- a/docs/application/native/guides/internationalization/i18n.md
+++ b/docs/application/native/guides/internationalization/i18n.md
@@ -29,7 +29,7 @@ The main features of the i18n API include:
 
 - Managing alphabetic indexes
 
-  You can use the Alphabetic Index functions to [generate a list of labels](#alpha_idx) that can be used as an index.
+  You can use the Alphabetic Index functions to [generate a list of labels](#alpha_idx) that can be used as an index. For immutable, thread-safe index you can use an [Immutable Index](#immutable_idx).
 
 - Managing the field position in formatted output
 
@@ -72,7 +72,7 @@ The main features of the i18n API include:
   You can [iterate through strings](#uchar_iter), in a safe way, with UCharIter.
 
 > **Note**  
-> The Alphabetic Index, FieldPosition, Format, Formattable, Measure, MeasureFormat, MeasureUnit, ParsePosition, Ubidi, Ushape, and Utmscale APIs are supported since Tizen 3.0. The PluralRules, Uversion, and UCharIter APIs are supported since Tizen 4.0.
+> The Alphabetic Index, FieldPosition, Format, Formattable, Measure, MeasureFormat, MeasureUnit, ParsePosition, Ubidi, Ushape, and Utmscale APIs are supported since Tizen 3.0. The PluralRules, Uversion, and UCharIter APIs are supported since Tizen 4.0. Immutable Index is supported since Tizen 5.0.
 
 <a name="ubrk"></a>
 ## Location Boundaries with Ubrk
@@ -415,6 +415,11 @@ The Alphabetic Index API (in [mobile](../../api/mobile/latest/group__CAPI__BASE_
 You can use the index directly, or with a client that does not support localized collation. The following example shows an alphabetical index.
 
 The Alphabetic Index API also supports creating buckets for strings that are sorted before the first label (underflow), after the last label (overflow), and between scripts (inflow). For example, if an index is constructed with labels for Russian and for English characters, Greek characters can be placed in an inflow bucket between the other 2 scripts.
+
+<a name="immutable_idx"></a>
+## Using Immutable Index
+
+The Immutable Index API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__IMMUTABLE__IDX__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__ALPHA__IDX__MODULE.html) applications) provides an immutable, thread-safe version of an [Alphabetic Index](#alpha_idx). Immutable indices also allow random access to buckets. An immutable index is constructed using a regular alphabetic index. The immutable index will contain the same data as the alphabetic index on which it was based, except the data records. The [example](#immutable_idx_example) shows creation and basic usage.
 
 <a name="field_pos"></a>
 ## Field Identification in Formatted Output
@@ -2089,6 +2094,75 @@ To generate and manage an alphabetic index:
 
    ```
    i18n_alpha_idx_destroy(alpha_idx);
+   ```
+
+<a name="immutable_idx_example"></a>
+Since Tizen 5.0, you can use Immutable Index API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__IMMUTABLE__IDX__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__ALPHA__IDX__MODULE.html) applications) to create an immutable index - a thread-safe version of an [Alphabetic Index](#alpha_idx) without data records.
+
+1. To create an immutable index:
+
+   - Create an alphabetic index
+
+   ```
+   i18n_alpha_idx_h alpha_idx;
+   i18n_alpha_idx_create("en", "US", &alpha_idx);
+   ```
+
+   - Fill the index with data
+
+   See the [Alphabetic Index example](#alpha_idx_example).
+
+   - Create an immutable index
+
+   ```
+   i18n_immutable_idx_h im_index;
+   i18n_immutable_idx_create(alpha_idx, &im_index);
+   ```
+
+2. To use the immutable index:
+
+   - Get the number of buckets:
+
+   ```
+   int bucket_count = 0;
+   i18n_immutable_idx_get_bucket_count(im_index, &bucket_count);
+   ```
+
+  - Get the bucket's index by the bucket's name:
+
+   ```
+   char *bucket_name = ...
+   int32_t bucket_index;
+
+   i18n_immutable_idx_get_bucket_index(im_index, bucket_name, &bucket_index);
+   ```
+
+   - Get the label of a given bucket, knowing the bucket's index:
+
+   ```
+   char *label = NULL;
+   int32_t bucket_index = ...
+
+   i18n_immutable_idx_get_bucket_label(im_index, bucket_index, &label);
+
+   /* Use the label ... */
+
+   free(label);
+   ```
+
+   - Get the label type of a given bucket:
+
+   ```
+   int32_t bucket_index = ...
+   i18n_alpha_idx_label_type_e label_type;
+
+   i18n_immutable_idx_get_bucket_label_type(im_index, bucket_index, &label_type);
+   ```
+
+3. Destroy the index when it's no longer needed:
+
+   ```
+   i18n_immutable_idx_destroy(im_index);
    ```
 
 <a name="field_pos_example"></a>


### PR DESCRIPTION
Added guide for immutable index module from base-utils library.

[ACR] http://suprem.sec.samsung.net/jira/browse/ACR-1118

Signed-off-by: Lukasz Pik <lu.pik@samsung.com>
