### PR TITLE
[base-utils][ACR-1079] Add guides for plural format module

### DIFF
--- a/docs/application/native/guides/internationalization/i18n.md
+++ b/docs/application/native/guides/internationalization/i18n.md
@@ -219,7 +219,7 @@ The following table describes the details of script codes that you can get using
 
 Since Tizen 4.0, you can also check for specific Unicode character properties, retrieve alternate representations of the same character, such as uppercase and lowercase, and get the name for a specific character.
 
-To check whether a character is in a specific character class, use the `i18n_uchar_is_xxx()` function corresponding to the binary property in the following table.
+To verify whether a character is in a specific character class, use the `i18n_uchar_is_xxx()` function corresponding to the binary property in the following table:
 
 **Table: Binary properties**
 
@@ -793,7 +793,7 @@ Many languages have different approach to create plural nouns. The locale-depend
 enables to manage plural forms of all language correctly. For example, in Polish, there is different plural case for nouns
 counted as few (numbers as 2, 3 or 4) and in case with many objects (more than 5).
 
-PluralFormat deals with this by diving the problem into two parts:
+PluralFormat deals with this by dividing the problem into two parts:
 - It uses Plural Rules that can define more complex conditions for a plural case than just a single interval.
   These plural rules define both what plural cases exist in a language,
   and to which numbers these cases apply.
@@ -804,7 +804,7 @@ PluralFormat deals with this by diving the problem into two parts:
   using localized patterns from resource bundles. For predefined plural rules, see
   [Language Plural Rules](http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html).
 
-### Usage of Plural Format
+### Usage of PluralFormat
 
 The following lists the usage of PluralFormat:
 - You will need to use Plural module to properly use PluralFormat module.
@@ -869,7 +869,7 @@ using a Number format for the PluralFormat locale.
 
 ### Define Custom Plural Rules
 
-To add custom plural rules to the PluralFormat, create a Plural Rules object and add it in Plural Format constructor.
+To add custom plural rules to the PluralFormat, create a Plural Rules object and add it in PluralFormat constructor.
 If you also pass a locale object to constructor, this locale will affect formatted number in the returned message texts.
 
 ## Prerequisites
@@ -3287,7 +3287,7 @@ From Tizen 5.0, you can use the PluralFormat API (in [mobile](../../api/mobile/l
 
 To manage plural formatting:
 
-1. Create a plural format object:
+1. Create a PluralFormat object:
     - Without any additional parameters:
 
       ```
@@ -3306,7 +3306,7 @@ To manage plural formatting:
       i18n_plural_format_create_from_locale_rules_pattern("en_US", rules, pattern, &plural_format);
       ```
 
-2. To clone a plural format object:
+2. To clone a PluralFormat object:
 
     ```
     i18n_plural_format_h clone;

--- a/docs/application/native/guides/internationalization/i18n.md
+++ b/docs/application/native/guides/internationalization/i18n.md
@@ -71,8 +71,12 @@ The main features of the i18n API include:
 
   You can [iterate through strings](#uchar_iter), in a safe way, with UCharIter.
 
+- Formating plural messages
+
+  You can [format plural messages](#plural_format), with PluralFormat.
+
 > **Note**  
-> The Alphabetic Index, FieldPosition, Format, Formattable, Measure, MeasureFormat, MeasureUnit, ParsePosition, Ubidi, Ushape, and Utmscale APIs are supported since Tizen 3.0. The PluralRules, Uversion, and UCharIter APIs are supported since Tizen 4.0. The Immutable Index is supported from Tizen 5.0.
+> The Alphabetic Index, FieldPosition, Format, Formattable, Measure, MeasureFormat, MeasureUnit, ParsePosition, Ubidi, Ushape, and Utmscale APIs are supported since Tizen 3.0. The PluralRules, Uversion, and UCharIter APIs are supported since Tizen 4.0. Immutable Index and PluralFormat is supported since Tizen 5.0.
 
 <a name="ubrk"></a>
 ## Location Boundaries with Ubrk
@@ -772,6 +776,104 @@ The UCharIter API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS_
 The `current()` and `next()` functions only check the current index against the limit, and the `previous()` function only checks the current index against the start, to see if the iterator has already reached the beginning of the iteration range. The assumption - in all iterators - is that the index is moved though the API, which means that it cannot go out of bounds, or that the index is modified though the application code by a developer who knows enough about the iterator implementation to set valid index values.
 
 The UCharIter functions return code unit values in the range of 0 - 0xffff. Before any functions operating on strings are called, the string must be set with the `i18n_uchar_iter_set_string()`, `i18n_uchar_iter_set_UTF16BE()`, or `i18n_uchar_iter_set_UTF8()`function.
+
+
+<a name="plural_format"></a>
+## Formating plural messages with PluralFormat
+
+The PluralFormat API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html) applications) allows you to [format defined plural words](#plural_format_examples). Alongside with PluralRules module, you can define rules to which format would apply.
+
+Plural Format supports the creation of internationalized messages with plural inflection.
+It is based on plural selection, i.e. the caller specifies messages for each plural case
+that can appear in the user's language and the Plural Format selects the appropriate message
+based on the number.
+
+### The Problem of Plural Forms in Internationalized Messages:
+
+Different languages have different ways to inflect plurals. Creating internationalized messages
+that include plural forms is only feasible when the framework is able to handle plural forms
+of all languages correctly. In some languages, like Polish, one plural case applies to infinitely many intervals
+(e.g., the plural case applies to numbers ending with 2, 3, or 4 except those ending with 12, 13, or 14).
+
+Plural Format deals with this by breaking the problem into two parts:
+- It uses Plural Rules that can define more complex conditions for a plural case than just a single interval.
+  These plural rules define both what plural cases exist in a language,
+  and to which numbers these cases apply.
+
+- It provides predefined plural rules for many languages. Thus, the programmer need not worry
+  about the plural cases of a language and does not have to define the plural cases;
+  they can simply use the predefined keywords. The whole plural formatting of messages can be done
+  using localized patterns from resource bundles. For predefined plural rules,
+  see the CLDR Language Plural Rules page at
+  http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html
+
+### Usage of Plural Format:
+
+This discussion assumes that you use Plural Format with a predefined set of plural rules.
+You can create one using one of the constructors that takes a locale object.
+To specify the message pattern, you can either pass it to the constructor or set it explicitly
+using the `i18n_plural_format_apply_pattern()` function.
+The `i18n_plural_format_format_*` functions takes a number object and selects the message
+of the matching plural case. This message will be returned.
+
+### Patterns and Their Interpretation:
+
+The pattern text defines the message output for each plural case of the specified locale.  
+**Syntax:**
+
+```
+pluralStyle = [offsetValue] (selector '{' message '}')+
+offsetValue = "offset:" number
+selector = explicitValue | keyword
+explicitValue = '=' number  // adjacent, no white space in between
+keyword = [^[[:Pattern_Syntax:][:Pattern_White_Space:]]]+
+message: message = messageText (argument messageText)*
+argument = noneArg | simpleArg | complexArg
+complexArg = pluralArg | selectordinalArg
+noneArg = '{' argNameOrNumber '}'
+simpleArg = '{' argNameOrNumber ',' argType [',' argStyle] '}'
+pluralArg = '{' argNameOrNumber ',' "plural" ',' pluralStyle '}'
+selectordinalArg = '{' argNameOrNumber ',' "selectordinal" ',' pluralStyle '}'
+argNameOrNumber = argName | argNumber
+argName = [^[[:Pattern_Syntax:][:Pattern_White_Space:]]]+
+argNumber = '0' | ('1'..'9' ('0'..'9')*)
+argType = "number" | "date" | "time" | "spellout" | "ordinal" | "duration"
+argStyle = "short" | "medium" | "long" | "full" | "integer" | "currency" | "percent" | argStyleText
+```
+
+**Examples:**
+
+```
+one{dog} other{dogs}                        // English plural format for dog
+one{pes} two{psa} few{psi} other{psov}      //Slovenian translation of dog in plural format
+```
+
+Pattern_White_Space between syntax elements is ignored, except between the {curly braces}
+and their sub-message, and between the '=' and the number of an explicitValue.
+
+There are 6 predefined casekeyword in CLDR/ICU - 'zero', 'one', 'two', 'few', 'many' and 'other'.
+You always have to define a message text for the default plural case other
+which is contained in every rule set. If you do not specify a message text for a particular plural case,
+the message text of the plural case other gets assigned to this plural case.
+
+When formatting, the input number is first matched against the explicitValue clauses.
+If there is no exact-number match, then a keyword is selected by calling the Plural Rules
+with the input number minus the offset. (The offset defaults to 0 if it is omitted from the pattern string.)
+If there is no clause with that keyword, then the "other" clauses is returned.
+
+An unquoted pound sign (#) in the selected sub-message itself
+(i.e., outside of arguments nested in the sub-message) is replaced by the input number minus the offset.
+The number-minus-offset value is formatted using a Number Format for the Plural Format's locale.
+
+> **Note:**
+> That argument is formatting without subtracting the offset!
+> If you need a custom format and have a non-zero offset, then you need to pass the number-minus-offset value as a separate parameter.
+
+### Defining Custom Plural Rules:
+
+If you need to use Plural Format with custom rules, you can create a Plural Rules object
+and pass it to Plural Format's constructor. If you also specify a locale in this constructor,
+this locale will be used to format the number in the message texts.
 
 ## Prerequisites
 
@@ -3186,6 +3288,111 @@ Since Tizen 4.0, you can use UcharIter API (in [mobile](../../api/mobile/latest/
    ```
    i18n_uchar_iter_destroy(uchar_iter);
    ```
+
+## Managing Pluralization formatting
+
+Since Tizen 5.0, you can use the PluralFormat API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html applications) to format words for its number-dependent representations.
+
+To manage plural formatting:
+
+1. Create a plural format object:
+    - Without any additional parameters:
+
+      ```
+      i18n_plural_format_h plural_format;
+      i18n_plural_format_create(&plural_format);
+      ```
+
+    - With locale, PluralRules and pattern:
+
+      ```
+      i18n_plural_rules_h rules;
+      ... //create PluralRules object with specified properties
+
+      i18n_plural_format_h plural_format;
+      const char *pattern = "one{dog} other{dogs}";
+      i18n_plural_format_create_from_locale_rules_pattern("en_US", rules, pattern, &plural_format);
+      ```
+
+2. To clone a plural format object:
+
+    ```
+    i18n_plural_format_h clone;
+    i18n_plural_format_clone(plural_format, &clone);
+    ```
+
+3. To set new pattern used by formatter:
+
+    ```
+    const char *new_pattern = "one{cat} other{cats}";
+    i18n_plural_format_apply_pattern(plural_rules, new_pattern);
+    ```
+
+4. To format a plural messsage:
+
+    - For a given int32 number:
+
+      ```
+      i18n_uchar output[BUFSIZE] = { 0 };
+      i18n_field_position_h field_position;
+      i18n_field_position_create_for_field(I18N_FIELD_POSITION_DONT_CARE, &field_position);
+      int32_t number = 4;
+      int output_length = -1;
+
+      i18n_plural_format_format_int32(format, number, field_position,
+                                      BUFSIZE, output, &output_length);
+      ```
+
+    - For a given double number:
+
+      ```
+      i18n_uchar output[BUFSIZE] = { 0 };
+      i18n_field_position_h field_position;
+      i18n_field_position_create_for_field(I18N_FIELD_POSITION_DONT_CARE, &field_position);
+      double number = 4;
+      int output_length = -1;
+
+      i18n_plural_format_format_double(format, number, field_position,
+                                        BUFSIZE, output, &output_length);
+      ```
+
+    - For a given formattable object:
+
+      ```
+      i18n_uchar output[BUFSIZE] = { 0 };
+      i18n_field_position_h field_position;
+      int output_length = -1;
+      i18n_formattable_h formattable;
+
+      i18n_field_position_create_for_field(I18N_FIELD_POSITION_DONT_CARE, &field_position);
+      i18n_formattable_create_with_double(4, &formattable);
+
+      i18n_plural_format_format_formattable(plural_format, formattable, field_position,
+                                            BUFSIZE, output, &output_length);
+      ```
+
+5. To set the number format which will be used during formatting:
+
+    ```
+    i18n_unumber_format_h number_format;
+    i18n_uparse_error_s parse_err;
+    i18n_unumber_create(I18N_UNUMBER_NUMBERING_SYSTEM, NULL, -1,
+                          locale, &parse_err, &number_format);
+
+    i18n_plural_format_set_number_format(plural_format, number_format);
+    ```
+
+6. To get a pattern string which is used in formatting:
+
+    ```
+    i18n_uchar output[BUFSIZE] = { 0 };
+    i18n_field_position_h field_position;
+    i18n_field_position_create_for_field(I18N_FIELD_POSITION_DONT_CARE, &field_position);
+
+    int32_t output_length = -1;
+    i18n_plural_format_to_pattern(plural_format, field_position,
+                                    BUFSIZE, output, &output_length);
+    ```
 
 ## Related Information
 - Dependencies

--- a/docs/application/native/guides/internationalization/i18n.md
+++ b/docs/application/native/guides/internationalization/i18n.md
@@ -805,7 +805,7 @@ Plural Format deals with this by breaking the problem into two parts:
   they can simply use the predefined keywords. The whole plural formatting of messages can be done
   using localized patterns from resource bundles. For predefined plural rules,
   see the CLDR Language Plural Rules page at
-  http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html
+  http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html.
 
 ### Usage of Plural Format:
 
@@ -865,7 +865,7 @@ An unquoted pound sign (#) in the selected sub-message itself
 (i.e., outside of arguments nested in the sub-message) is replaced by the input number minus the offset.
 The number-minus-offset value is formatted using a Number Format for the Plural Format's locale.
 
-> **Note:**
+> **Note:**  
 > That argument is formatting without subtracting the offset!
 > If you need a custom format and have a non-zero offset, then you need to pass the number-minus-offset value as a separate parameter.
 
@@ -3289,6 +3289,7 @@ Since Tizen 4.0, you can use UcharIter API (in [mobile](../../api/mobile/latest/
    i18n_uchar_iter_destroy(uchar_iter);
    ```
 
+<a name="plural_format_examples"></a>
 ## Managing Pluralization formatting
 
 Since Tizen 5.0, you can use the PluralFormat API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html applications) to format words for its number-dependent representations.
@@ -3328,7 +3329,7 @@ To manage plural formatting:
     i18n_plural_format_apply_pattern(plural_rules, new_pattern);
     ```
 
-4. To format a plural messsage:
+4. To format a plural message:
 
     - For a given int32 number:
 

--- a/docs/application/native/guides/internationalization/i18n.md
+++ b/docs/application/native/guides/internationalization/i18n.md
@@ -857,7 +857,7 @@ the `other` keyword message will be returned to this plural case.
 When formatting, the input number is first matched against the explicitValue clauses.
 If there is no exact-number match, then a keyword is selected by calling the Plural Rules
 with the input number minus the offset. (The offset defaults to 0 if it is omitted from the pattern string.)
-If there is no clause with that keyword, then the "other" clauses is returned.
+If there is no clause with that keyword, then the `other` clauses is returned.
 
 An unquoted pound signal (#) is a selected sub message (that is, outside of argument nested in the sub message)
 is replaced by the input number-minus-offset value. The `number-minus-offset` value is formatted

--- a/docs/application/native/guides/internationalization/i18n.md
+++ b/docs/application/native/guides/internationalization/i18n.md
@@ -76,7 +76,7 @@ The main features of the i18n API include:
   You can [format plural messages](#plural_format), with PluralFormat.
 
 > **Note**  
-> The Alphabetic Index, FieldPosition, Format, Formattable, Measure, MeasureFormat, MeasureUnit, ParsePosition, Ubidi, Ushape, and Utmscale APIs are supported from Tizen 3.0. The PluralRules, Uversion, and UCharIter APIs are supported from Tizen 4.0. The Immutable Index and the PluralFormat is supported from Tizen 5.0.
+> The Alphabetic Index, FieldPosition, Format, Formattable, Measure, MeasureFormat, MeasureUnit, ParsePosition, Ubidi, Ushape, and Utmscale APIs are supported since Tizen 3.0. The PluralRules, Uversion, and UCharIter APIs are supported since Tizen 4.0. The Immutable Index and the PluralFormat is supported from Tizen 5.0.
 
 <a name="ubrk"></a>
 ## Location Boundaries with Ubrk

--- a/docs/application/native/guides/internationalization/i18n.md
+++ b/docs/application/native/guides/internationalization/i18n.md
@@ -286,7 +286,7 @@ The enumeration object enables navigation through the enumeration values, with t
 You can get the number of values stored in the enumeration object with the `i18n_uenumeration_count()` function.
 
 <a name="ulocale"></a>
-## Locale-sensitive Operations with Ulocale
+## Locale-Sensitive Operations with Ulocale
 
 The Ulocale API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__ULOCALE__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__ULOCALE__MODULE.html) applications) represents a specific geographical, political, or cultural region. Locale-sensitive operations [use the Ulocale functions to tailor information](#locales) for the user. For example, displaying a number is a locale-sensitive operation. The number must be formatted according to the customs and conventions of the user's native country, region, or culture.
 
@@ -787,7 +787,7 @@ PluralFormat supports creation of locale-dependent messages with plural inflecti
 you have to specify each message for every plural case that will be used, based on the desired language.
 Then, the PluralFormat module will select appropriate text based on the provided number.
 
-### Issues of plural forms in internationalized messages:
+### Issues of plural forms in internationalized messages
 
 Many languages have different approach to create plural nouns. The locale-dependent message is workable when the framework
 enables to manage plural forms of all language correctly. For example, in Polish, there is different plural case for nouns
@@ -814,7 +814,7 @@ The following lists the usage of PluralFormat:
 a number object and returns corresponding message based on the defined rules.
 
 
-### Pattern interpretation:
+### Pattern interpretation
 
 The following pattern text defines the message output for each plural case of the specified locale:  
 **Syntax:**
@@ -867,7 +867,7 @@ using a Number format for the PluralFormat locale.
 > That argument is formatting without subtracting the offset.
 > If you need a custom format and have a non-zero-offset, then you need to pass the `number-minus-offset` value as a separate parameter.
 
-### Define Custom Plural Rules:
+### Define Custom Plural Rules
 
 To add custom plural rules to the PluralFormat, create a Plural Rules object and add it in Plural Format constructor.
 If you also pass a locale object to constructor, this locale will affect formatted number in the returned message texts.
@@ -880,7 +880,7 @@ To use the functions and data types of the i18n API (in [mobile](../../api/mobil
 #include <utils_i18n.h>
 ```
 <a name="characters"></a>
-## Managing Characters and Strings
+## Manage Characters and Strings
 
 Character and string management tasks include:
 
@@ -904,9 +904,9 @@ Character and string management tasks include:
 > All source and destination buffers must be different.
 
 <a name="compare"></a>
-### Comparing Ustrings
+### Compare Ustrings
 
-To compare 2 Ustrings for bitwise equality, use the `i18n_ustring_compare()` function.
+To compare two Ustrings for bitwise equality, use the `i18n_ustring_compare()` function.
 
 The obtained result is equal to 0 if the compared Ustrings are equal. The result is a negative value if the first Ustring is smaller bitwise than the second one, and a positive value if the first Ustring is greater than the second one.
 
@@ -1084,7 +1084,7 @@ Since Tizen 4.0, you can also:
     i18n_ucollator_get_bound(sort_key, result_length, I18N_UCOLLATOR_BOUND_UPPER, 1, bound, 128, &bound_length);
     ```
 
-  - Merge 2 sort keys with the `i18n_ucollator_merge_sort_keys()` function:
+  - Merge two sort keys with the `i18n_ucollator_merge_sort_keys()` function:
 
     ```
     i18n_uchar src1[64];
@@ -1105,7 +1105,7 @@ Since Tizen 4.0, you can also:
     ```
 
 <a name="strings"></a>
-### Converting Strings to Ustrings
+### Convert Strings to Ustrings
 
 To convert strings to Ustrings:
 
@@ -1138,7 +1138,7 @@ To convert strings to Ustrings:
   ```
 
 <a name="ustrings"></a>
-### Converting Ustrings to Strings
+### Convert Ustrings to Strings
 
 To convert Ustrings to strings:
 
@@ -1175,7 +1175,7 @@ To convert Ustrings to strings:
   i18n_ustring_to_UTF8(dest, BUF_SIZE, &dest_len, src, i18n_ustring_get_length(src), &error_code);
   ```
 <a name="unicode"></a>
-### Getting the Unicode Block of a Character
+### Get the Unicode Block of a Character
 
 To get information about the location of a specified character, use the `i18n_uchar_get_ublock_code()` function.
 
@@ -1188,7 +1188,7 @@ i18n_uchar_get_ublock_code(character, &ublock);
 ```
 
 <a name="property"></a>
-### Getting the Property Value of a Character
+### Get the Property Value of a Character
 
 To get the property value of a specified character, use the `i18n_uchar_get_int_property_value()` function.
 
@@ -1203,7 +1203,7 @@ i18n_uchar_get_int_property_value(character, I18N_UCHAR_EAST_ASIAN_WIDTH, &prope
 ```
 
 <a name="uchar_name"></a>
-### Getting the Name of a Character
+### Get the Name of a Character
 
 You can retrieve the name of a Unicode character or retrieve the character from its name:
 
@@ -1229,7 +1229,7 @@ You can retrieve the name of a Unicode character or retrieve the character from 
   ```
 
 <a name="uchar_value"></a>
-### Getting the Decimal Digit Value of a Character
+### Get the Decimal Digit Value of a Character
 
 To retrieve the decimal digit value of a character, use the `i18n_uchar_digit_value()` function:
 
@@ -1241,7 +1241,7 @@ i18n_uchar_char_digit_value(c, &char_digit_value); /* char_digit_value has value
 ```
 
 <a name="uchar_binary_property"></a>
-### Checking for a Character Binary Property
+### Check for a Character Binary Property
 
 You can check whether a Unicode character has a specific binary property in 2 ways:
 
@@ -1266,7 +1266,7 @@ You can check whether a Unicode character has a specific binary property in 2 wa
   i18n_uchar_has_binary_property(c, which, &has_binary_property);
   ```
 <a name="uchar_representation"></a>
-### Getting an Alternate Representation of a Character
+### Get an Alternate Representation of a Character
 
 To get an alternate representation of a character, use the `i18n_uchar_to_xxx()` functions.
 
@@ -1279,7 +1279,7 @@ i18n_uchar_to_upper(c, &to_upper);
 ```
 
 <a name="uchar_age"></a>
-### Getting the Character Age and Unicode Version
+### Get the Character Age and Unicode Version
 
 The character age is the Unicode version in which the character was first designated (as a non-character or for private use) or assigned:
 
@@ -1299,7 +1299,7 @@ The character age is the Unicode version in which the character was first design
   ```
 
 <a name="normalize"></a>
-### Normalizing Ustrings
+### Normalize Ustrings
 
 To normalize a Ustring:
 
@@ -1320,7 +1320,7 @@ To normalize a Ustring:
     ```
 
 <a name="search"></a>
-### Searching Text in a Ustring
+### Search Text in a Ustring
 
 To search for a substring in a Ustring:
 
@@ -1348,7 +1348,7 @@ To search for a substring in a Ustring:
     i18n_usearch_destroy(usearch);
     ```
 <a name="uppercase"></a>
-### Changing the Case in a Ustring
+### Change the Case in a Ustring
 
 To change the case in a Ustring:
 
@@ -1371,7 +1371,7 @@ To change the case in a Ustring:
     i18n_ustring_to_title_new(dest, BUF_SIZE, src, BUF_SIZE, NULL, NULL);
     ```
 <a name="concatenate"></a>
-### Concatenating Ustrings
+### Concatenate Ustrings
 
 To concatenate 2 Ustrings, use the `18n_ustring_cat()` or `18n_ustring_cat_n()` function.
 
@@ -1390,7 +1390,7 @@ i18n_ustring_cat(dest, src);
 ```
 
 <a name="substring"></a>
-### Finding a Substring
+### Find a Substring
 
 To find a substring in a Ustring, use the `i18n_ustring_string()` function.
 
@@ -1408,7 +1408,7 @@ else
     dlog_print(DLOG_DEBUG, LOG_TAG, "Substring index: %d", result - s);
 ```
 <a name="dates"></a>
-## Managing Dates and Calendar
+## Manage Dates and Calendar
 
 To create and use a calendar:
 
@@ -1429,7 +1429,12 @@ To create and use a calendar:
     i18n_ucalendar_create(timezone, -1, I18N_ULOCALE_US, I18N_UCALENDAR_DEFAULT, &ucalendar);
     ```
 
-3. To set a date in the Ucalendar, use the `i18n_ucalendar_set_date_time()` function.In the following example, the date is set as 1 July 2014, 9:00:00.To define the month, you can use numbers (month reduced by 1, such as 0 for January and 1 for February), or to avoid mistakes, the values of the `i18n_ucalendar_months_e` enumeration (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__UCALENDAR__MODULE.html#ga094cacb2ef9ee4805e42e276fec5ae2f) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__UCALENDAR__MODULE.html#ga094cacb2ef9ee4805e42e276fec5ae2f) applications).`i18n_ucalendar_set_date_time(ucalendar, 2014, I18N_UCALENDAR_JULY, 1, 9, 0, 0);`To set a date using milliseconds from the epoch, use the `i18n_ucalendar_set_milliseconds()` function:`i18n_udate udate;/* udate must be set */i18n_ucalendar_set_milliseconds(ucalendar, udate);`To add a specified period to the Ucalendar, use the `i18n_ucalendar_add()` function.Specify the date field to modify (such as year, week, or day) using the `i18n_ucalendar_date_fields_e` enumeration (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__UCALENDAR__MODULE.html#gaee345f9992035a07732d16d69c41c192) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__UCALENDAR__MODULE.html#gaee345f9992035a07732d16d69c41c192) applications) as the second parameter, and the amount to modify as the third parameter (use a negative value to subtract from the existing value).
+3. To set a date in the Ucalendar, use the `i18n_ucalendar_set_date_time()` function. In the following example, the date is set as 1 July 2014, 9:00:00. To define the month, you can use numbers (month reduced by 1, such as 0 for January and 1 for February), or to avoid mistakes, the values of the `i18n_ucalendar_months_e` enumeration (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__UCALENDAR__MODULE.html#ga094cacb2ef9ee4805e42e276fec5ae2f) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__UCALENDAR__MODULE.html#ga094cacb2ef9ee4805e42e276fec5ae2f) applications). `i18n_ucalendar_set_date_time(ucalendar, 2014, I18N_UCALENDAR_JULY, 1, 9, 0, 0);` To set a date using milliseconds from the epoch, use the `i18n_ucalendar_set_milliseconds()` function:
+   ```
+   i18n_udate udate; /* udate must be set */
+   i18n_ucalendar_set_milliseconds(ucalendar, udate);
+   ```
+To add a specified period to the Ucalendar, use the `i18n_ucalendar_add()` function. Specify the date field to modify (such as year, week, or day) using the `i18n_ucalendar_date_fields_e` enumeration (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__UCALENDAR__MODULE.html#gaee345f9992035a07732d16d69c41c192) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__UCALENDAR__MODULE.html#gaee345f9992035a07732d16d69c41c192) applications) as the second parameter, and the amount to modify as the third parameter (use a negative value to subtract from the existing value).
 
     ```
     i18n_ucalendar_add(ucalendar, I18N_UCALENDAR_HOUR, 3);
@@ -1512,7 +1517,7 @@ To create and use a calendar:
         ```
 
 <a name="locales"></a>
-## Managing Locales
+## Manage Locales
 
 To manage the features of a specific geographical, political, or cultural region:
 
@@ -1583,7 +1588,7 @@ To manage the features of a specific geographical, political, or cultural region
     ```
 
 <a name="numbers"></a>
-## Managing Numbers
+## Manage Numbers
 
 To format and parse numbers for a locale:
 
@@ -1626,7 +1631,7 @@ To format and parse numbers for a locale:
     ```
 
 <a name="manage_ubrk"></a>
-## Managing Iteration Using Ubrk
+## Manage Iteration Using Ubrk
 
 To manipulate or iterate through strings, you can use the Ubrk library. It helps you to treat strings as a set of characters, words, or sentences:
 
@@ -1645,7 +1650,7 @@ To manipulate or iterate through strings, you can use the Ubrk library. It helps
  i18n_ubrk_create(I18N_UBRK_WORD, I18N_ULOCALE_US, stringToExamine, -1, &boundary);
  ```
 
-2. To change the position of the iterator, you can use several functions, such as `i18n_ubrk_first()`, `i18n_ubrk_last()`, `i18n_ubrk_next()`, and `i18n_ubrk_previous()`.The following example retrieves the boundaries of the first word in the `stringToExamine` string. The `start` and `end` variables represent the boundaries of the first word, in this example 0 and 7.
+2. To change the position of the iterator, you can use several functions, such as `i18n_ubrk_first()`, `i18n_ubrk_last()`, `i18n_ubrk_next()`, and `i18n_ubrk_previous()`.The following example retrieves the boundaries of the first word in the `stringToExamine` string. The `start` and `end` variables represent the boundaries of the first word, in this example `0` and `7`.
 
     ```
     int32_t start = i18n_ubrk_first(boundary);
@@ -1664,12 +1669,12 @@ To manipulate or iterate through strings, you can use the Ubrk library. It helps
     i18n_ubrk_destroy(boundary);
     ```
 <a name="uenum"></a>
-## Managing Enumerations
+## Manage Enumerations
 
 To create collections of strings and iterate through them, [create an enumeration](#create_enum). You can also [obtain enumerations from specific functions](#get_enum).
 
 <a name="create_enum"></a>
-### Creating an Enumeration
+### Create an Enumeration
 
 To create an enumeration based on existing strings:
 
@@ -1722,7 +1727,7 @@ To create an enumeration based on existing strings:
     18n_uenumeration_destroy(strings_enum);
     ```
 <a name="get_enum"></a>
-### Obtaining an Enumeration
+### Obtain an Enumeration
 
 Certain functions in the i18n module provide enumerations of values related to them. After the enumeration is obtained, you can iterate through its values.
 
@@ -1799,7 +1804,7 @@ Certain functions in the i18n module provide enumerations of values related to t
     ```
 
 <a name="tmz"></a>
-## Managing Time Zones
+## Manage Time Zones
 
 To manage time zone details, such as the time zone offset and daylight savings:
 
@@ -1868,7 +1873,7 @@ To manage time zone details, such as the time zone offset and daylight savings:
    ```
 
 <a name="manage_uset"></a>
-## Managing Sets
+## Manage Sets
 
 You can create sets, which contain characters and strings. You can iterate through the set elements and carry out various operations on the set.
 
@@ -1969,7 +1974,7 @@ To manage sets:
     ```
 
 <a name="alpha_idx_example"></a>
-## Managing Alphabetic Indexes
+## Manage Alphabetic Indexes
 
 Since Tizen 3.0, you can generate an alphabetical list of clickable labels by using the Alphabetic Index API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__ALPHA__IDX__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__ALPHA__IDX__MODULE.html) applications).
 
@@ -2098,16 +2103,7 @@ To generate and manage an alphabetic index:
        i18n_alpha_idx_reset_bucket_iter(alpha_idx);
        ```
 
-       The iterator is set before the first bucket. To move the iterator to the first bucket, use the
-
-
-       ```
-       i18n_alpha_idx_next_bucket()
-       ```
-
-​        
-
-       function.
+       The iterator is set before the first bucket. To move the iterator to the first bucket, use the `i18n_alpha_idx_next_bucket()` function.
 
      - To reset the record iterator:
 
@@ -2115,17 +2111,7 @@ To generate and manage an alphabetic index:
        i18n_alpha_idx_reset_record_iter(alpha_idx);
        ```
 
-       The iterator is set before the first record in the current bucket. To move the iterator to the first record, use the
-
-​        
-
-       ```
-       i18n_alpha_idx_next_record()
-       ```
-
-​        
-
-       function.
+       The iterator is set before the first record in the current bucket. To move the iterator to the first record, use the `i18n_alpha_idx_next_record()` function.
 
 4. To retrieve information:
 
@@ -2263,7 +2249,7 @@ From Tizen 5.0, you can use immutable index API (in [mobile](../../api/mobile/la
    ```
 
 <a name="field_pos_example"></a>
-## Managing the Field Position
+## Manage the Field Position
 
 Since Tizen 3.0, you can use the FieldPosition API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__FIELD__POSITION__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__FIELD__POSITION__MODULE.html) applications) to manage the field position for formatted output.
 
@@ -2345,7 +2331,7 @@ To manage the field position:
    i18n_field_position_destroy(field_pos);
    ```
 <a name="format_examples"></a>
-## Managing String Formatting
+## Manage String Formatting
 
 Since Tizen 3.0, you can use the Format API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__FORMAT__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__FORMAT__MODULE.html) applications) to manage format objects, which derive from this module, and their string representations:
 
@@ -2434,17 +2420,9 @@ Since Tizen 3.0, you can use the Format API (in [mobile](../../api/mobile/latest
    ```
 
 <a name="formattable_examples"></a>
-### Converting Between Types
+### Convert Between Types
 
-You can use the Formattable API (in
-
-mobile
-
- and
-
-wearable
-
- applications) to convert between data types.
+You can use the Formattable API (in mobile and wearable applications) to convert between data types.
 
 To manage formattable objects:
 
@@ -2514,7 +2492,7 @@ To manage formattable objects:
    ```
 
 <a name="measure_examples"></a>
-## Managing Measure Objects
+## Manage Measure Objects
 
 Since Tizen 3.0, you can use the Measure API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__MEASURE__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__MEASURE__MODULE.html) applications) to create measure objects, containing a numerical value and a measurement unit.
 
@@ -2568,7 +2546,7 @@ To manage measure objects:
    ```
 
 <a name="measure_unit_examples"></a>
-### Managing Measurement Units
+### Manage Measurement Units
 
 You can use the MeasureUnit API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__MEASURE__UNIT__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__MEASURE__UNIT__MODULE.html) applications) to create measure unit objects, which can be passed to the Measure or MeasureFormat (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__MEASURE__FORMAT__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__MEASURE__FORMAT__MODULE.html) applications) APIs.
 
@@ -2655,7 +2633,7 @@ You can use the MeasureUnit API (in [mobile](../../api/mobile/latest/group__CAPI
    i18n_measure_unit_destroy(unit);
    ```
 <a name="measure_format_examples"></a>
-### Formatting Measure Objects
+### Format Measure Objects
 
 You can format measure objects using the MeasureFormat API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__MEASURE__FORMAT__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__MEASURE__FORMAT__MODULE.html) applications).
 
@@ -2795,8 +2773,6 @@ To format measure objects:
 
      i18n_measure_h measure = NULL;
      i18n_measure_create(formattable, measure_unit_2, &measure);
-     ```
-
 
      i18n_uchar append_to[BUFSIZE] = {0};
      i18n_field_position_h field_position;
@@ -2814,7 +2790,7 @@ To format measure objects:
    i18n_measure_format_destroy(measure_format);
    ```
 <a name="parse_position_examples"></a>
-## Managing the Parse Position
+## Manage the Parse Position
 
 Since Tizen 3.0, you can use the ParsePosition API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__PARSE__POSITION__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__PARSE__POSITION__MODULE.html) applications) to track the current position while parsing.
 
@@ -2887,7 +2863,7 @@ To manage the parse position:
    ```
 
 <a name="ubidi_examples"></a>
-## Managing Bidirectional Text
+## Manage Bidirectional Text
 
 Since Tizen 3.0, you can use the Ubidi API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__UBIDI__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__UBIDI__MODULE.html) applications) to implement the Unicode Bidirectional Algorithm.
 
@@ -2976,7 +2952,7 @@ To manage bidirectional text:
    ```
 
 <a name="ushape_examples"></a>
-## Shaping Arabic Characters
+## Shape Arabic Characters
 
 Since Tizen 3.0, you can use the Ushape API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__USHAPE__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__USHAPE__MODULE.html) applications) to manage Arabic character shapes.
 
@@ -3007,15 +2983,26 @@ Since Tizen 3.0, you can use the Ushape API (in [mobile](../../api/mobile/latest
   i18n_ustring_copy_au(buf, dest);
   ```
 <a name="utmscale_examples"></a>
-## Converting Time Scales
+## Convert Time Scales
 
 Since Tizen 3.0, you can use the Utmscale API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__UTMSCALE__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__UTMSCALE__MODULE.html) applications) to convert binary datetimes between various platform-dependent time scales.
 
 To convert a datetime value:
 
-1. To retrieve conversion constants for a specific time scale, use the `i18n_utmscale_get_time_scale_value()` function with the values of the `i18n_utmscale_value_e` enumeration (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__UTMSCALE__MODULE.html#ga34893d20b446359e32767b57e6cdde29) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__UTMSCALE__MODULE.html#ga34893d20b446359e32767b57e6cdde29) applications):`int64_t value = NULL;i18n_utmscale_get_time_scale_value(I18N_UTMSCALE_JAVA_TIME, I18N_UTMSCALE_VALUE_UNITS, &value);/* Returns 10000, the number of universal time units (ticks) in each Java time unit (milliseconds) */`
+1. To retrieve conversion constants for a specific time scale, use the `i18n_utmscale_get_time_scale_value()` function with the values of the `i18n_utmscale_value_e` enumeration (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__UTMSCALE__MODULE.html#ga34893d20b446359e32767b57e6cdde29) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__UTMSCALE__MODULE.html#ga34893d20b446359e32767b57e6cdde29) applications):
 
-2. To convert the retrieved `int64_t` Java time to universal time scale:`int64_t universal_time = NULL;i18n_utmscale_from_int64(value, I18N_UTMSCALE_ICU4C_TIME, &universal_time);`
+   ```
+   int64_t value = NULL;
+   i18n_utmscale_get_time_scale_value(I18N_UTMSCALE_JAVA_TIME, I18N_UTMSCALE_VALUE_UNITS, &value);
+   /* Returns 10000, the number of universal time units (ticks) in each Java time unit (milliseconds) */
+   ```
+
+2. To convert the retrieved `int64_t` Java time to universal time scale:
+
+   ```
+   int64_t universal_time = NULL;
+   i18n_utmscale_from_int64(value, I18N_UTMSCALE_ICU4C_TIME, &universal_time);
+   ```
 
 3. To convert the universal time value back to Java time:
 
@@ -3024,17 +3011,10 @@ To convert a datetime value:
    ```
 
 <a name="plural_rules_examples"></a>
-## Managing Pluralization Rules
+## Manage Pluralization Rules
 
-Since Tizen 4.0, you can use the PluralRules API (in
-
-mobile
-
- and
-
-wearable
-
- applications) to create rules for number-dependent word representations.
+Since Tizen 4.0, you can use the PluralRules API (in mobile and wearable
+applications) to create rules for number-dependent word representations.
 
 To manage plural rules:
 
@@ -3120,19 +3100,34 @@ To manage plural rules:
    i18n_plural_rules_destroy(rules);
    ```
 <a name="manage_version"></a>
-## Retrieving the ICU Version
+## Retrieve the ICU Version
 
 Since Tizen 4.0, you can retrieve the current ICU library version by using the Uversion API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__UVERSION__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__UVERSION__MODULE.html) applications).
 
 To retrieve the current version:
 
-1. To get the current ICU version, use the `i18n_uversion_get_version()` function, which returns the version number in a `uversion` array, in hexadecimal format:`i18n_uversion_info array;i18n_uversion_get_version(array);`
+1. To get the current ICU version, use the `i18n_uversion_get_version()` function, which returns the version number in a `uversion` array, in hexadecimal format:
+
+   ```
+   i18n_uversion_info array;
+   i18n_uversion_get_version(array);
+   ```
+
 2. To convert the version number between hexadecimal and dotted decimal format:
-   - To convert the version number from hexadecimal format into a string in dotted decimal format, use the `i18n_uversion_to_string()` function:`char *decimal_version;i18n_uversion_to_string(array, decimal_version);`
-   - To convert the version number from a string in dotted decimal format to hexadecimal format, use the `i18n_uversion_from_string()` function:`char *decimal_version = "57.1";i18n_uversion_from_string(decimal_version, version);`If your source string is of the `i18n_uchar` type, use the `i18n_uversion_from_ustring()` function instead.
+   - To convert the version number from hexadecimal format into a string in dotted decimal format, use the `i18n_uversion_to_string()` function:
+   ```
+   char *decimal_version;
+   i18n_uversion_to_string(array, decimal_version);
+   ```
+   - To convert the version number from a string in dotted decimal format to hexadecimal format, use the `i18n_uversion_from_string()` function:
+   ```
+   char *decimal_version = "57.1";
+   i18n_uversion_from_string(decimal_version, version);
+   ```
+   If your source string is of the `i18n_uchar` type, use the `i18n_uversion_from_ustring()` function instead.
 
 <a name="uchar_iter_examples"></a>
-## Iterating through Strings
+## Iterate through Strings
 
 Since Tizen 4.0, you can use UcharIter API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__UCHAR__ITER__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__UCHAR__ITER__MODULE.html) applications) to safely iterate through strings:
 

--- a/docs/application/native/guides/internationalization/i18n.md
+++ b/docs/application/native/guides/internationalization/i18n.md
@@ -76,7 +76,7 @@ The main features of the i18n API include:
   You can [format plural messages](#plural_format), with PluralFormat.
 
 > **Note**  
-> The Alphabetic Index, FieldPosition, Format, Formattable, Measure, MeasureFormat, MeasureUnit, ParsePosition, Ubidi, Ushape, and Utmscale APIs are supported since Tizen 3.0. The PluralRules, Uversion, and UCharIter APIs are supported since Tizen 4.0. The Immutable Index and the PluralFormat is supported from Tizen 5.0.
+> The Alphabetic Index, FieldPosition, Format, Formattable, Measure, MeasureFormat, MeasureUnit, ParsePosition, Ubidi, Ushape, and Utmscale APIs are supported since Tizen 3.0. The PluralRules, Uversion, and UCharIter APIs are supported since Tizen 4.0. The Immutable Index and the PluralFormat are supported from Tizen 5.0.
 
 <a name="ubrk"></a>
 ## Location Boundaries with Ubrk
@@ -807,10 +807,10 @@ PluralFormat deals with this by diving the problem into two parts:
 ### Usage of Plural Format
 
 The following lists the usage of PluralFormat:
-1. You will need to use Plural module to properly use PluralFormat module.
-2. To get default set of rules, you can use constructor, which takes local object as parameter.
-3. A message pattern is specified by passing argument to constructor, or set it explicitly by using `18n_plural_format_apply_pattern()`.
-4. To obtain formatted message, you need to use one of `i18n_plural_format_format_*`, which also takes
+- You will need to use Plural module to properly use PluralFormat module.
+- To get default set of rules, you can use constructor, which takes local object as parameter.
+- A message pattern is specified by passing argument to constructor, or set it explicitly by using `i18n_plural_format_apply_pattern()`.
+- To obtain formatted message, you need to use one of `i18n_plural_format_format_*`, which also takes
 a number object and returns corresponding message based on the defined rules.
 
 
@@ -3289,7 +3289,7 @@ Since Tizen 4.0, you can use UcharIter API (in [mobile](../../api/mobile/latest/
 <a name="plural_format_examples"></a>
 ## Manage Pluralization formatting
 
-From Tizen 5.0, you can use the PluralFormat API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html applications) to format words for its number-dependent representations.
+From Tizen 5.0, you can use the PluralFormat API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html) applications) to format words for its number-dependent representations.
 
 To manage plural formatting:
 

--- a/docs/application/native/guides/internationalization/i18n.md
+++ b/docs/application/native/guides/internationalization/i18n.md
@@ -814,7 +814,7 @@ The following lists the usage of PluralFormat:
 a number object and returns corresponding message based on the defined rules.
 
 
-### Pattern interpretation
+### Pattern Interpretation
 
 The following pattern text defines the message output for each plural case of the specified locale:  
 **Syntax:**
@@ -942,9 +942,9 @@ For a more complex, locale-sensitive comparison, use the Ucollator API (in [mobi
     i18n_ucollator_get_strength(coll, &strength);\
     ```
 
-3. Compare 2 Ustrings.
+3. Compare two Ustrings.
 
-   To compare 2 Ustrings, you have 2 options:
+   To compare two Ustrings, you have two options:
 
    - `i18n_ucollator_equal()`: Shows whether the compared Ustrings are equal.
    - `i18n_ucollator_str_collator()`: Shows whether the first Ustring is equal to, smaller, or greater than the second Ustring (`I18N_UCOLLATOR_EQUAL`, `I18N_UCOLLATOR_LESS`, or `I18N_UCOLLATOR_GREATER`).

--- a/docs/application/native/guides/internationalization/i18n.md
+++ b/docs/application/native/guides/internationalization/i18n.md
@@ -76,7 +76,7 @@ The main features of the i18n API include:
   You can [format plural messages](#plural_format), with PluralFormat.
 
 > **Note**  
-> The Alphabetic Index, FieldPosition, Format, Formattable, Measure, MeasureFormat, MeasureUnit, ParsePosition, Ubidi, Ushape, and Utmscale APIs are supported since Tizen 3.0. The PluralRules, Uversion, and UCharIter APIs are supported since Tizen 4.0. Immutable Index and PluralFormat is supported since Tizen 5.0.
+> The Alphabetic Index, FieldPosition, Format, Formattable, Measure, MeasureFormat, MeasureUnit, ParsePosition, Ubidi, Ushape, and Utmscale APIs are supported since Tizen 3.0. The PluralRules, Uversion, and UCharIter APIs are supported since Tizen 4.0. The Immutable Index and the PluralFormat is supported since Tizen 5.0.
 
 <a name="ubrk"></a>
 ## Location Boundaries with Ubrk
@@ -783,19 +783,17 @@ The UCharIter functions return code unit values in the range of 0 - 0xffff. Befo
 
 The PluralFormat API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html) applications) allows you to [format defined plural words](#plural_format_examples). Alongside with PluralRules module, you can define rules to which format would apply.
 
-Plural Format supports creating locale-dependent messages with plural inflection.
-To enable plural formatting, user have to specify each message for every plural case
-that will be used, based on the desired language. Then the Plural Format module will be
-selecting appropriate text based on provided number.
+PluralFormat supports creation of locale-dependent messages with plural inflection. To enable plural formatting,
+you have to specify each message for every plural case that will be used, based on the desired language.
+Then, the PluralFormat module will select appropriate text based on the provided number.
 
-### The Problem of Plural Forms in Internationalized Messages:
+### Issues of plural forms in internationalized messages:
 
-Many languages have different approach to create plural nouns. To create locale dependent messages is only
-workable when framework enables to manage plural forms of all languages correctly. For example in Polish,
-one plural case applies to infinitely many intervals (e.g., the plural case applies to numbers ending with
-2, 3, or 4 except those ending with 12, 13, or 14).
+Many languages have different approach to create plural nouns. The locale-dependent message is workable when the framework
+enables to manage plural forms of all language correctly. For example, in Polish, there is different plural case for nouns
+counted as few (numbers as 2, 3 or 4) and in case with many objects (more than 5).
 
-Plural Format deals with this by breaking the problem into two parts:
+PluralFormat deals with this by diving the problem into two parts:
 - It uses Plural Rules that can define more complex conditions for a plural case than just a single interval.
   These plural rules define both what plural cases exist in a language,
   and to which numbers these cases apply.
@@ -805,18 +803,19 @@ Plural Format deals with this by breaking the problem into two parts:
   they can simply use the predefined keywords. The whole plural formatting of messages can be done
   using localized patterns from resource bundles. For predefined plural rules,
   see the CLDR Language Plural Rules page at
-  http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html.
+  http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html.
 
 ### Usage of Plural Format:
 
-To properly use Plural Format module, you will need to use Plural Rules module, to obtain
-predefined sets of rules. To get default set of rules, use constructor which takes locale object
-as parameter. Specifying message pattern is done by passing argument to constructor or to set it
-explicitly by using the `i18n_plural_format_apply_pattern()` function.
-To obtain formatted message, you need to use one of the `i18n_plural_format_format_*` functions,
-which takes also a number object and returns corresponding message based on the defined rules.
+The following lists the usage of PluralFormat:
+1. You will need to use Plural module to properly use PluralFormat module.
+2. To get default set of rules, you can use constructor, which takes local object as parameter.
+3. A message pattern is specified by passing argument to constructor, or set it explicitly by using 18n_plural_format_apply_pattern().
+4. To obtain formatted message, you need to use one of i18n_plural_format_format_*, which also takes
+a number object and returns corresponding message based on the defined rules.
 
-### Patterns and Their Interpretation:
+
+### Pattern interpretation:
 
 The pattern text defines the message output for each plural case of the specified locale.  
 **Syntax:**
@@ -851,29 +850,28 @@ one{pies} few{psy} other{psów}       //Polish translation of dog in plural form
 Pattern_White_Space between syntax elements is ignored, except between the {curly braces}
 and their sub-message, and between the '=' and the number of an explicitValue.
 
-In ICU there are 6 predefined keywords: 'zero', 'one', 'two', 'few', 'many' and 'other'.
-It is obligatory to define message text for the 'other' keyword which is contained in
-every rule set. In case that you do not define specified message for a particular number object,
-the 'other' keyword message will be returned to this plural case.
+In International Components for Unicode (ICU) there are six predefined keywords:
+`zero`, `one`, `two`, `few`, `many` and `other`. It is obligatory to define message text for the `other` keyword,
+which is included in every rule set. In case if you do not define the specified message for a particular number object,
+the `other` keyword message will be returned to this plural case.
 
 When formatting, the input number is first matched against the explicitValue clauses.
 If there is no exact-number match, then a keyword is selected by calling the Plural Rules
 with the input number minus the offset. (The offset defaults to 0 if it is omitted from the pattern string.)
 If there is no clause with that keyword, then the "other" clauses is returned.
 
-An unquoted pound sign (#) in the selected sub-message itself
-(i.e., outside of arguments nested in the sub-message) is replaced by the input number minus the offset.
-The number-minus-offset value is formatted using a Number Format for the Plural Format's locale.
+An unquoted pound signal (#) is a selected sub message (that is, outside of argument nested in the sub message)
+is replaced by the input number-minus-offset value. The `number-minus-offset` value is formatted
+using a Number format for the PluralFormat locale.
 
 > **Note:**  
-> That argument is formatting without subtracting the offset!
-> If you need a custom format and have a non-zero offset, then you need to pass the number-minus-offset value as a separate parameter.
+> That argument is formatting without subtracting the offset.
+> If you need a custom format and have a non-zero-offset, then you need to pass the `number-minus-offset` value as a separate parameter.
 
 ### Defining Custom Plural Rules:
 
-To add custom plural rules to Plural Format, create a Plural Rules object and put it in
-Plural Format's constructor. If you also pass a locale object to constructor, this locale
-will affect formatted number in the returned message texts.
+To add custom plural rules to the PluralFormat, create a Plural Rules object and add it in Plural Format constructor.
+If you also pass a locale object to constructor, this locale will affect formatted number in the returned message texts.
 
 ## Prerequisites
 

--- a/docs/application/native/guides/internationalization/i18n.md
+++ b/docs/application/native/guides/internationalization/i18n.md
@@ -783,17 +783,17 @@ The UCharIter functions return code unit values in the range of 0 - 0xffff. Befo
 
 The PluralFormat API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html) applications) allows you to [format defined plural words](#plural_format_examples). Alongside with PluralRules module, you can define rules to which format would apply.
 
-Plural Format supports the creation of internationalized messages with plural inflection.
-It is based on plural selection, i.e. the caller specifies messages for each plural case
-that can appear in the user's language and the Plural Format selects the appropriate message
-based on the number.
+Plural Format supports creating locale-dependent messages with plural inflection.
+To enable plural formatting, user have to specify each message for every plural case
+that will be used, based on the desired language. Then the Plural Format module will be
+selecting appropriate text based on provided number.
 
 ### The Problem of Plural Forms in Internationalized Messages:
 
-Different languages have different ways to inflect plurals. Creating internationalized messages
-that include plural forms is only feasible when the framework is able to handle plural forms
-of all languages correctly. In some languages, like Polish, one plural case applies to infinitely many intervals
-(e.g., the plural case applies to numbers ending with 2, 3, or 4 except those ending with 12, 13, or 14).
+Many languages have different approach to create plural nouns. To create locale dependent messages is only
+workable when framework enables to manage plural forms of all languages correctly. For example in Polish,
+one plural case applies to infinitely many intervals (e.g., the plural case applies to numbers ending with
+2, 3, or 4 except those ending with 12, 13, or 14).
 
 Plural Format deals with this by breaking the problem into two parts:
 - It uses Plural Rules that can define more complex conditions for a plural case than just a single interval.
@@ -809,12 +809,12 @@ Plural Format deals with this by breaking the problem into two parts:
 
 ### Usage of Plural Format:
 
-This discussion assumes that you use Plural Format with a predefined set of plural rules.
-You can create one using one of the constructors that takes a locale object.
-To specify the message pattern, you can either pass it to the constructor or set it explicitly
-using the `i18n_plural_format_apply_pattern()` function.
-The `i18n_plural_format_format_*` functions takes a number object and selects the message
-of the matching plural case. This message will be returned.
+To properly use Plural Format module, you will need to use Plural Rules module, to obtain
+predefined sets of rules. To get default set of rules, use constructor which takes locale object
+as parameter. Specifying message pattern is done by passing argument to constructor or to set it
+explicitly by using the `i18n_plural_format_apply_pattern()` function.
+To obtain formatted message, you need to use one of the `i18n_plural_format_format_*` functions,
+which takes also a number object and returns corresponding message based on the defined rules.
 
 ### Patterns and Their Interpretation:
 
@@ -844,17 +844,17 @@ argStyle = "short" | "medium" | "long" | "full" | "integer" | "currency" | "perc
 **Examples:**
 
 ```
-one{dog} other{dogs}                        // English plural format for dog
-one{pes} two{psa} few{psi} other{psov}      //Slovenian translation of dog in plural format
+one{dog} other{dogs}                 // English plural format for dog
+one{pies} few{psy} other{psów}       //Polish translation of dog in plural format
 ```
 
 Pattern_White_Space between syntax elements is ignored, except between the {curly braces}
 and their sub-message, and between the '=' and the number of an explicitValue.
 
-There are 6 predefined casekeyword in CLDR/ICU - 'zero', 'one', 'two', 'few', 'many' and 'other'.
-You always have to define a message text for the default plural case other
-which is contained in every rule set. If you do not specify a message text for a particular plural case,
-the message text of the plural case other gets assigned to this plural case.
+In ICU there are 6 predefined keywords: 'zero', 'one', 'two', 'few', 'many' and 'other'.
+It is obligatory to define message text for the 'other' keyword which is contained in
+every rule set. In case that you do not define specified message for a particular number object,
+the 'other' keyword message will be returned to this plural case.
 
 When formatting, the input number is first matched against the explicitValue clauses.
 If there is no exact-number match, then a keyword is selected by calling the Plural Rules
@@ -871,9 +871,9 @@ The number-minus-offset value is formatted using a Number Format for the Plural 
 
 ### Defining Custom Plural Rules:
 
-If you need to use Plural Format with custom rules, you can create a Plural Rules object
-and pass it to Plural Format's constructor. If you also specify a locale in this constructor,
-this locale will be used to format the number in the message texts.
+To add custom plural rules to Plural Format, create a Plural Rules object and put it in
+Plural Format's constructor. If you also pass a locale object to constructor, this locale
+will affect formatted number in the returned message texts.
 
 ## Prerequisites
 

--- a/docs/application/native/guides/internationalization/i18n.md
+++ b/docs/application/native/guides/internationalization/i18n.md
@@ -76,7 +76,7 @@ The main features of the i18n API include:
   You can [format plural messages](#plural_format), with PluralFormat.
 
 > **Note**  
-> The Alphabetic Index, FieldPosition, Format, Formattable, Measure, MeasureFormat, MeasureUnit, ParsePosition, Ubidi, Ushape, and Utmscale APIs are supported since Tizen 3.0. The PluralRules, Uversion, and UCharIter APIs are supported since Tizen 4.0. The Immutable Index and the PluralFormat is supported since Tizen 5.0.
+> The Alphabetic Index, FieldPosition, Format, Formattable, Measure, MeasureFormat, MeasureUnit, ParsePosition, Ubidi, Ushape, and Utmscale APIs are supported from Tizen 3.0. The PluralRules, Uversion, and UCharIter APIs are supported from Tizen 4.0. The Immutable Index and the PluralFormat is supported from Tizen 5.0.
 
 <a name="ubrk"></a>
 ## Location Boundaries with Ubrk
@@ -779,7 +779,7 @@ The UCharIter functions return code unit values in the range of 0 - 0xffff. Befo
 
 
 <a name="plural_format"></a>
-## Formating plural messages with PluralFormat
+## Format plural messages with PluralFormat
 
 The PluralFormat API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html) applications) allows you to [format defined plural words](#plural_format_examples). Alongside with PluralRules module, you can define rules to which format would apply.
 
@@ -868,7 +868,7 @@ using a Number format for the PluralFormat locale.
 > That argument is formatting without subtracting the offset.
 > If you need a custom format and have a non-zero-offset, then you need to pass the `number-minus-offset` value as a separate parameter.
 
-### Defining Custom Plural Rules:
+### Define Custom Plural Rules:
 
 To add custom plural rules to the PluralFormat, create a Plural Rules object and add it in Plural Format constructor.
 If you also pass a locale object to constructor, this locale will affect formatted number in the returned message texts.
@@ -3288,9 +3288,9 @@ Since Tizen 4.0, you can use UcharIter API (in [mobile](../../api/mobile/latest/
    ```
 
 <a name="plural_format_examples"></a>
-## Managing Pluralization formatting
+## Manage Pluralization formatting
 
-Since Tizen 5.0, you can use the PluralFormat API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html applications) to format words for its number-dependent representations.
+From Tizen 5.0, you can use the PluralFormat API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html applications) to format words for its number-dependent representations.
 
 To manage plural formatting:
 

--- a/docs/application/native/guides/internationalization/i18n.md
+++ b/docs/application/native/guides/internationalization/i18n.md
@@ -801,23 +801,22 @@ PluralFormat deals with this by diving the problem into two parts:
 - It provides predefined plural rules for many languages. Thus, the programmer need not worry
   about the plural cases of a language and does not have to define the plural cases;
   they can simply use the predefined keywords. The whole plural formatting of messages can be done
-  using localized patterns from resource bundles. For predefined plural rules,
-  see the CLDR Language Plural Rules page at
-  http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html.
+  using localized patterns from resource bundles. For predefined plural rules, see
+  [Language Plural Rules](http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html).
 
-### Usage of Plural Format:
+### Usage of Plural Format
 
 The following lists the usage of PluralFormat:
 1. You will need to use Plural module to properly use PluralFormat module.
 2. To get default set of rules, you can use constructor, which takes local object as parameter.
-3. A message pattern is specified by passing argument to constructor, or set it explicitly by using 18n_plural_format_apply_pattern().
-4. To obtain formatted message, you need to use one of i18n_plural_format_format_*, which also takes
+3. A message pattern is specified by passing argument to constructor, or set it explicitly by using `18n_plural_format_apply_pattern()`.
+4. To obtain formatted message, you need to use one of `i18n_plural_format_format_*`, which also takes
 a number object and returns corresponding message based on the defined rules.
 
 
 ### Pattern interpretation:
 
-The pattern text defines the message output for each plural case of the specified locale.  
+The following pattern text defines the message output for each plural case of the specified locale:  
 **Syntax:**
 
 ```

--- a/docs/application/native/guides/internationalization/i18n.md
+++ b/docs/application/native/guides/internationalization/i18n.md
@@ -118,8 +118,8 @@ A Ucalendar object can produce all the time field values needed to implement the
 
 When computing a Udate from the time fields, 2 special circumstances can arise. The information can be insufficient to compute the Udate (you have only the year and the month, but not the day of the month), or the information can be inconsistent (such as "Tuesday, July 15, 1996" even though July 15, 1996 is actually a Monday).
 
-- **Insufficient information**The calendar uses the default information to specify the missing fields. This can vary by calendar: for the Gregorian calendar, the default for a field is the same as that of the start of the epoch, such as `I18N_UCALENDAR_YEAR = 1970`, `I18N_UCALENDAR_MONTH = JANUARY`, `I18N_UCALENDAR_DATE = 1`.
-- **Inconsistent information**If the fields conflict, the calendar prefers the most recently set fields. For example, when determining the day, the calendar looks for one of the following field combinations listed in the following table. The most recent combination, as determined by the most recently set single field, is used.
+- **Insufficient information**: The calendar uses the default information to specify the missing fields. This can vary by calendar. For example, the Gregorian calendar, the default for a field is the same as that of the start of the epoch, such as `I18N_UCALENDAR_YEAR = 1970`, `I18N_UCALENDAR_MONTH = JANUARY`, `I18N_UCALENDAR_DATE = 1`.
+- **Inconsistent information**: If there is field’s conflict, the calendar prefers the most recently set fields. For example, when determining the day, the calendar looks for one of the following field combinations listed in the following table. The most recent combination, as determined by the most recently set single field, is used.
 
 <a name="uchar"></a>
 ## Unicode Character Management with Uchar
@@ -292,9 +292,9 @@ The Ulocale API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I
 
 You create a locale with one of the following options. Each component is separated by an underscore in the locale string.
 
-- `newLanguage`A valid [ISO language code](http://www.loc.gov/standards/iso639-2/php/code_list.php) (lower-case 2-letter code as defined by the ISO-639 standard).
-- `newLanguage + newCountry`A valid ISO language code and an additional [ISO country code](http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html).
-- `newLanguage + newCountry + newVariant`A valid ISO language code, ISO country code, and additional information on the variant. The variant codes are vendor and browser-specific. For example, use `WIN` for Windows, `MAC` for Macintosh, and `POSIX` for POSIX. Where there are 2 variants, separate them with an underscore, and put the most important one first. For example, a Traditional Spanish collation might be referenced, with `ES`, `ES`, `Traditional_WIN`.
+- `newLanguage`: A valid [ISO language code](http://www.loc.gov/standards/iso639-2/php/code_list.php) (lower-case 2-letter code as defined by the ISO-639 standard).
+- `newLanguage + newCountry`: A valid ISO language code and an additional [ISO country code](http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html).
+- `newLanguage + newCountry + newVariant`: A valid ISO language code, ISO country code, and additional information on the variant. The variant codes are vendor and browser-specific. For example, use `WIN` for Windows, `MAC` for Macintosh, and `POSIX` for POSIX. Where there are two variants, separate them with an underscore, and put the most important one first. For example, a Traditional Spanish collation might be referenced, with `ES`, `ES`, `Traditional_WIN`.
 
 Because a locale is simply an identifier for a region, no validity check is performed when you specify a locale. If you want to see whether particular resources are available for the locale you asked for, you must query those resources.
 
@@ -320,7 +320,7 @@ The Usearch API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I
 
 Uset is a mutable [set of Unicode characters and multicharacter strings that you can manage](#manage_uset). The sets represent character classes used in regular expressions. A character specifies a subset of the Unicode code points. The legal code points are U+0000 to U+10FFFF, inclusive.
 
-The set supports 2 functions:
+The set supports two functions:
 
 - The operand function allows the caller to modify the value of the set. The operand function works similarly to the boolean logic: a boolean OR is implemented by add, a boolean AND is implemented by retain, a boolean XOR is implemented by a complement taking an argument, and a boolean NOT is implemented by a complement with no argument. In terms of traditional set theory function names, add is a union, retain is an intersection, remove is an asymmetric difference, and complement with no argument is a set complement with respect to the superset range `MIN_VALUE-MAX_VALUE`.
 - The `i18n_uset_apply_pattern()` or `i18n_uset_to_pattern()` function. Unlike the functions that add characters or categories, and control the logic of the set, the `i18n_uset_apply_pattern()` function sets all attributes of a set at once, based on a string pattern.
@@ -347,7 +347,7 @@ Property patterns specify a set of characters having a certain property as defin
 
 Patterns specify individual characters, ranges of characters, and Unicode property sets. When the elements are concatenated, they specify their union. To complement a set, place a '^' immediately after the opening '['. Property patterns are inverted by modifying their delimiters, `[:^foo]` and `\\P{foo}`. In any other location, '^' has no special meaning.
 
-Ranges are indicated by placing a '-' between 2 characters, as in "a-z". This specifies the range of all characters from the left to the right, in Unicode order. If the left character is greater than or equal to the right character, it is a syntax error. If a '-' occurs as the first character after the opening '[' or '[^', or if it occurs as the last character before the closing ']', it is taken as a literal. This means that `[a\-b]`, `[-ab]`, and `[ab-]` all indicate the same set of 3 characters, 'a', 'b', and '-'.
+Ranges are indicated by placing a '-' between two characters, as in "a-z". This specifies the range of all characters from the left to the right, in Unicode order. If the left character is greater than or equal to the right character, it is a syntax error. If a '-' occurs as the first character after the opening '[' or '[^', or if it occurs as the last character before the closing ']', it is taken as a literal. This means that `[a\-b]`, `[-ab]`, and `[ab-]` all indicate the same set of 3 characters, 'a', 'b', and '-'.
 
 Sets can be intersected using the '&' operator or the asymmetric set difference can be taken using the '-' operator. For example, `[[:L:]&[\\u0000-\\u0FFF]]` indicates the set of all Unicode letters with values less than 4096. Operators ('&' and '|') have equal precedence and bind left-to-right. This means that `[[:L:]-[a-z]-[\\u0100-\\u01FF]]` is equivalent to `[[[:L:]-[a-z]]-[\\u0100-\\u01FF]]`. This only really matters for difference; intersection is commutative.
 
@@ -369,7 +369,7 @@ Sets can be intersected using the '&' operator or the asymmetric set difference 
 
 ### Formal Syntax
 
-The following table provide examples of formal syntax patterns.
+The following table provide examples of formal syntax patterns:
 
 **Table: Formal syntax patterns**
 
@@ -418,7 +418,7 @@ The Alphabetic Index API (in [mobile](../../api/mobile/latest/group__CAPI__BASE_
 
 You can use the index directly, or with a client that does not support localized collation. The following example shows an alphabetical index.
 
-The Alphabetic Index API also supports creating buckets for strings that are sorted before the first label (underflow), after the last label (overflow), and between scripts (inflow). For example, if an index is constructed with labels for Russian and for English characters, Greek characters can be placed in an inflow bucket between the other 2 scripts.
+The Alphabetic Index API also supports creating buckets for strings that are sorted before the first label (underflow), after the last label (overflow), and between scripts (inflow). For example, if an index is constructed with labels for Russian and for English characters, Greek characters can be placed in an inflow bucket between the other two scripts.
 
 <a name="immutable_idx"></a>
 ## Using Immutable Index
@@ -432,7 +432,7 @@ The FieldPosition API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UT
 
 Fields are identified by constants defined in the `xxx_format_field_e` enumerations.
 
-The field position within formatted output is tracked with 2 indices: the indices of the first and the last characters of the field. Some formatting functions require a field position object as a parameter. These formatting functions can be used to perform partial formatting or retrieve information about formatted output, such as field positions.
+The field position within formatted output is tracked with two indices, which includes the indices of the first and the last characters of the field. Some formatting functions require a field position object as a parameter. These formatting functions can be used to perform partial formatting or retrieve information about formatted output, such as field positions.
 
 <a name="format"></a>
 ## String Format Management
@@ -456,7 +456,7 @@ The Measure API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I
 
 The MeasureUnit API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__MEASURE__UNIT__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__MEASURE__UNIT__MODULE.html) applications) allows you to [create measure unit objects](#measure_unit_examples) and combine them with numerical values to create measure objects. The [measure objects can also be formatted](#measure_format_examples) using the MeasureFormat API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__MEASURE__FORMAT__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__MEASURE__FORMAT__MODULE.html)applications).
 
-The following table lists the supported measures and units.
+The following table lists the supported measures and units:
 
 **Table: Measures and units**
 
@@ -779,7 +779,7 @@ The UCharIter functions return code unit values in the range of 0 - 0xffff. Befo
 
 
 <a name="plural_format"></a>
-## Format plural messages with PluralFormat
+## Format Plural Messages with PluralFormat
 
 The PluralFormat API (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__PLURAL__FORMAT__MODULE.html) applications) allows you to [format defined plural words](#plural_format_examples). Alongside with PluralRules module, you can define rules to which format would apply.
 
@@ -787,7 +787,7 @@ PluralFormat supports creation of locale-dependent messages with plural inflecti
 you have to specify each message for every plural case that will be used, based on the desired language.
 Then, the PluralFormat module will select appropriate text based on the provided number.
 
-### Issues of plural forms in internationalized messages
+### Issues of Plural Forms in Internationalized Messages
 
 Many languages have different approach to create plural nouns. The locale-dependent message is workable when the framework
 enables to manage plural forms of all language correctly. For example, in Polish, there is different plural case for nouns
@@ -1243,7 +1243,7 @@ i18n_uchar_char_digit_value(c, &char_digit_value); /* char_digit_value has value
 <a name="uchar_binary_property"></a>
 ### Check for a Character Binary Property
 
-You can check whether a Unicode character has a specific binary property in 2 ways:
+You can verify whether a Unicode character has a specific binary property in two ways:
 
 - Use the corresponding `i18n_uchar_is_xxx()` function.
 
@@ -1373,7 +1373,7 @@ To change the case in a Ustring:
 <a name="concatenate"></a>
 ### Concatenate Ustrings
 
-To concatenate 2 Ustrings, use the `18n_ustring_cat()` or `18n_ustring_cat_n()` function.
+To concatenate two Ustrings, use the `18n_ustring_cat()` or `18n_ustring_cat_n()` function.
 
 The functions differ in that the latter takes a third parameter to define a maximum number of characters to append to the destination string.
 
@@ -1435,7 +1435,6 @@ To create and use a calendar:
    i18n_ucalendar_set_milliseconds(ucalendar, udate);
    ```
 To add a specified period to the Ucalendar, use the `i18n_ucalendar_add()` function. Specify the date field to modify (such as year, week, or day) using the `i18n_ucalendar_date_fields_e` enumeration (in [mobile](../../api/mobile/latest/group__CAPI__BASE__UTILS__I18N__UCALENDAR__MODULE.html#gaee345f9992035a07732d16d69c41c192) and [wearable](../../api/wearable/latest/group__CAPI__BASE__UTILS__I18N__UCALENDAR__MODULE.html#gaee345f9992035a07732d16d69c41c192) applications) as the second parameter, and the amount to modify as the third parameter (use a negative value to subtract from the existing value).
-
     ```
     i18n_ucalendar_add(ucalendar, I18N_UCALENDAR_HOUR, 3);
     ```
@@ -1462,7 +1461,7 @@ To add a specified period to the Ucalendar, use the `i18n_ucalendar_add()` funct
     i18n_ucalendar_get_now(&now);
     ```
 
-   To check whether the Ucalendar date is in daylight saving time, use the `i18n_ucalendar_is_in_daylight_time()` function:
+   To verify whether the Ucalendar date is in daylight saving time, use the `i18n_ucalendar_is_in_daylight_time()` function:
 
    ```
    bool dst;
@@ -1510,11 +1509,11 @@ To add a specified period to the Ucalendar, use the `i18n_ucalendar_add()` funct
 
 6. When no longer needed, destroy the Ucalendar, Udatepg, and Udate instances using the `i18n_ucalendar_destroy()`, `i18n_udatepg_destroy()`, and `i18n_udate_destroy()` functions:
 
-        ```
-        i18n_ucalendar_destroy(ucalendar);
-        i18n_udatepg_destroy(udatepg);
-        i18n_udate_destroy(date_format);
-        ```
+    ```
+    i18n_ucalendar_destroy(ucalendar);
+    i18n_udatepg_destroy(udatepg);
+    i18n_udate_destroy(date_format);
+    ```
 
 <a name="locales"></a>
 ## Manage Locales
@@ -1911,19 +1910,19 @@ To manage sets:
         i18n_uchar32 uchar = i18n_uset_char_at(set, i);
     ```
 
-   - Check whether the set contains a specific character using the `i18n_uset_contains()` function:
+   - Verify whether the set contains a specific character using the `i18n_uset_contains()` function:
 
     ```
     i18n_ubool contains_character = i18n_uset_contains(set, 'a');
     ```
 
-   - Check whether the set contains characters from a specific range using the `i18n_uset_contains_range()` function.The following example uses the range "a-c".
+   - Verify whether the set contains characters from a specific range using the `i18n_uset_contains_range()` function.The following example uses the range "a-c".
 
     ```
     i18n_ubool contains_character = i18n_uset_contains_range(set, 'a', 'c');
     ```
 
-   - Check whether the set contains characters from another set using the `i18n_uset_contains_all()` function:
+   - Verify whether the set contains characters from another set using the `i18n_uset_contains_all()` function:
 
     ```
     i18n_uset_h compare_set = NULL;
@@ -1962,7 +1961,7 @@ To manage sets:
     }
     ```
 
-   - Check whether the set contains a string using the `i18n_uset_contains_string()` function:
+   - Verify whether the set contains a string using the `i18n_uset_contains_string()` function:
 
     ```
     const char *input_string = "Input string";


### PR DESCRIPTION
Signed-off-by: Lukasz Pik <lu.pik@samsung.com>

### Change Description ###
- Add guides for plural format module in base-utils



### API Changes ###
 - ACR: ACR-1079 http://suprem.sec.samsung.net/jira/browse/ACR-1079

