### PR TITLE
[sound-manager] remove deprecated enum value in code snippet

### DIFF
--- a/docs/application/native/guides/multimedia/sound.md
+++ b/docs/application/native/guides/multimedia/sound.md
@@ -119,8 +119,7 @@ To query sound device information:
       int ret;
       int _ret;
       sound_device_mask_e mask = SOUND_DEVICE_IO_DIRECTION_OUT_MASK |
-                                 SOUND_DEVICE_IO_DIRECTION_BOTH_MASK |
-                                 SOUND_DEVICE_STATE_ACTIVATED_MASK;
+                                 SOUND_DEVICE_IO_DIRECTION_BOTH_MASK;
       ```
 
    2. Retrieve the sound device list handle and sound device handles.


### PR DESCRIPTION
Signed-off-by: Sangchul Lee <sc11.lee@samsung.com>

### Change Description ###
Remove deprecated enum value in code snippet.


### API Changes ###
It is related to ACR-1228

