### PR TITLE
[Native/guide] Fix Privacy related prermissions dependency in docs

### DIFF
--- a/docs/application/native/guides/security/privacy-related-permissions.md
+++ b/docs/application/native/guides/security/privacy-related-permissions.md
@@ -134,5 +134,5 @@ To check whether an application has permission to use a privilege, and to reques
 
 ## Related Information
 - Dependencies
-  - Tizen 2.3 and Higher for Mobile
-  - Tizen 2.3.1 and Higher for Wearable
+  - Tizen 4.0 and Higher for Mobile
+  - Tizen 4.0 and Higher for Wearable


### PR DESCRIPTION
Signed-off-by: Ernest Borowski <e.borowski@partner.samsung.com>

### Change Description ###

Fixed dependency of Privacy privileges.
PrivacyPrivilegeManager was introduced in tizen 4.0, but inside docs there is tizen 2.3.x.
This patch should be cherry-picked to all branches.