### PR TITLE
Revise the Event Broadcast and Subscription guide to divide a table

### DIFF
--- a/docs/application/native/guides/app-management/event.md
+++ b/docs/application/native/guides/app-management/event.md
@@ -210,40 +210,137 @@ The application can get the event name and data in the first `app_control_cb()` 
 <a name="platform"></a>
 ## Platform Event Types
 
-The following table lists the platform event types.
+The following list shows the events of modules:
 
-**Table: Platform event types**
+- capi-system-device
 
-| Module | Category | Event name | Event data Key | Event data Value | Condition | Notes |
-|--------|--------|--------|--------|--------|--------|--------|
-| capi-system-device | battery      | `tizen.system.event.battery_charger_status` | `battery_charger_status`  | - `"disconnected"`: Charger is not connected<br>- `"connected"`: Charger is connected<br>- `"charging"`: Charging is enabled<br>- `"discharging"`: Charging is disabled (for example, 100% full  state) | When the  charger has been connected or disconnected, or when the charging state has  changed (charging or not). | If there is an  earlier occurrence regarding this event, you receive the event as soon as you  register an event handler for this event. You can use this earlier event data  as the initial value. |
-| capi-system-device | battery      | `tizen.system.event.battery_level_status`  | `battery_level_status`    | - `"empty"` <br>- `"critical"` <br>- `"low"` <br>- `"high"` <br>- `"full"` | When the  battery level has changed.     | You can get the  current value with the `device_battery_get_level_status()` function. |
-| deviced            | usb          | `tizen.system.event.usb_status`            | `usb_status`              | - `"disconnected"`:  USB cable is not connected<br>- `"connected"`: USB cable is connected, but the service is not  available<br>-  `"available"`: USB service is available (for example, mtp or SDB) | When the USB  cable has been connected or disconnected, or when the USB service state has  changed. | You can get the  current value with the `RUNTIME_INFO_KEY_USB_CONNECTED` key. |
-| deviced            | earjack      | `tizen.system.event.earjack_status`       | `earjack_status`                 | - `"disconnected"`:  Earjack is not connected <br>- `"connected"`: Earjack is connected | When the  earjack connection state has changed. | You can get the  current value with the `RUNTIME_INFO_KEY_AUDIO_JACK_STATUS` key. |
-| deviced            | display      | `tizen.system.event.display_state`         | `display_state`           | - `"normal"`:  Display on, normal brightness<br>- `"dim"`: Display on, dimmed brightness<br>- `"off"`: Display off | When the  display state has changed.     | You can get the  current value with the `device_display_get_state()` function. |
-| systemd            | system       | `tizen.system.event.boot_completed`        | N/A                     | N/A                                      | When the  platform has completed booting. | You can treat  the initial value as `false`  before you receive this event. If the application is already in a  boot-completed state before you register an event handler, you receive the  event as soon as you register the event handler. |
-| systemd            | system       | `tizen.system.event.system_shutdown`       | N/A                     | N/A                                      | When  the system power-off has been started. | You  can treat the initial value as `false` before you receive this event. If the application is already  in a shutting-down state before you register an event handler, you receive  the event as soon as you register the event handler. |
-| resourced          | ram memory   | `tizen.system.event.low_memory`            | `low_memory`              | - `"normal"`:  Available > 200MB <br> - `"soft_warning"`: 100MB < available <= 200MB <br>- `"hard_warning"`: Available <= 100MB    <br> **Note**<br> The above numbers can vary depending on the total RAM size of the  target device. | When  the size of available memory has changed. | If  there is an earlier occurrence regarding this event, you receive the event as  soon as you register an event handler for this event. You can use this  earlier event data as the initial value. |
-| network            | connectivity | `tizen.system.event.wifi_state`            | `wifi_state`              | - `"on"`:  Wi-Fi on <br>-  `"off"`: Wi-Fi off <br>- `"connected"`: Wi-Fi connection established | When the Wi-Fi  state has changed.       | You can get the  current value with the `connection_get_wifi_state()` function. |
-| network            | connectivity | `tizen.system.event.bt_state`              | `bt_state`                | - `"off"`:  Legacy Bluetooth off <br>-  `"on"`: Legacy Bluetooth on | When the  Bluetooth state has changed.   | You can get the  current value with the `bt_adapter_get_state()` function. |
-| network            | connectivity | `tizen.system.event.bt_state`              | `bt_le_state`             | - `"off"`:  LE function off <br>- `"on"`: LE function on | When Bluetooth  LE state has changed.    |   -                                       |
-| network            | connectivity | `tizen.system.event.bt_state`              | `bt_transfering_state`    | - `"non_transfering"`:  Idle state  <br>-  `"transfering"`: File is transferring | When the file  transfer state has changed. | -                                         |
-| libslp-location    | location     | `tizen.system.event.location_enable_state` | `location_enable_state`   | - `"disabled"`:  Location disabled <br>-  `"enabled"`: Location enabled | When the `location-enable_state` has been  changed, for example, by the user toggling the location setting in the  settings menu or quick panel. | You can get the  current value with the `location_manager_is_enabled_method()` function. |
-| libslp-location    | location     | `tizen.system.event.gps_enable_state`      | `gps_enable_state`        | - `"disabled"`:  GPS disabled  <br>- `"enabled"`: GPS enabled | When the `gps-enable_state` has changed.   | You can get the  current value with the `location_manager_is_enabled_method()` function. |
-| libslp-location    | location     | `tizen.system.event.nps_enable_state`      | `nps_enable_state`        | - `"disabled"`:  NPS disabled <br>-  `"enabled"`: NPS enabled | When the NPS  setting has been changed, for example, by the user toggling the location  settings. | You can get the  current value with the `location_manager_is_enabled_method()` function. |
-| msg-service        | message      | `tizen.system.event.incoming_msg`          | `msg_type`                | - `"sms"`:  SMS-type message <br>-  `"push"`: Push-type message <br>-  `"cb"`: Cb-type message | When an SMS,  push, or CB message has been received. |       -                                   |
-| msg-service        | message      | `tizen.system.event.incoming_msg`          | `msg_id`                  | `msg_id`: Message ID of the received message (string of the unsigned `int` type value) | -                                         |           -                               |
-| alarm-manager      | time         | `tizen.system.event.time_changed`          | N/A                     | N/A                                      | When  the system time setting has changed. | You  can get the current value with the `alarm_get_current_time()` function. |
-| setting            | time         | `tizen.system.event.time_zone`             | `time_zone`               | The  value of this key is the time zone value of the time zone database, for  example, "Asia/Seoul", "America/New_York". For more  information, see the IANA Time Zone Database. | When  the time zone has changed.         | You  can get the current value with the `SYSTEM_SETTINGS_KEY_LOCALE_TIMEZONE` key. |
-| setting            | locale       | `tizen.system.event.hour_format`           | `hour_format`             | - `"12"` <br>- `"24"`                             | When  the `hour_format` has changed,  for example, by the user toggling the date and time settings for the 24-hour  clock (where **OFF** stands  for the 12-hour clock). | You  can get the current value with the `SYSTEM_SETTINGS_KEY_LOCALE_TIMEFORMAT_24HOUR` key. |
-| setting            | locale       | `tizen.system.event.language_set`          | `language_set`            | The value of  this key is the full name of the locale, for example, `ko_KR.UTF8` for Korean and `en_US.UTF8` for American English. For more information, see the Linux  locale information. | When the `language_set` has changed.       | You can get the  current value with the `SYSTEM_SETTINGS_KEY_LOCALE_LANGUAGE` key. |
-| setting            | locale       | `tizen.system.event.region_format`         | `region_format`           | The  value of this key is the full name of the locale, for example, `ko_KR.UTF8` for the Korean region  format and `en_US.UTF8`  for the USA region format. For more information, see the Linux locale  information. | When  the `region_format` has changed.     | You  can get the current value with the `SYSTEM_SETTINGS_KEY_LOCALE_COUNTRY` key. |
-| setting            | sound        | `tizen.system.event.silent_mode`           | `silent_mode`             | - `"on"` <br> - `"off"`                            | When  the ringtone has been changed to 0 or another mode. For example, if the call  slider has been changed to 0, `silent_mode` is `"on"`. Otherwise, `silent_mode` is `"off"`. | You  can get the current value with the `SYSTEM_SETTINGS_KEY_SOUND_SILENT_MODE` key. |
-| setting            | vibration    | `tizen.system.event.vibration_state`       | `vibration_state`         | - `"on"` <br> - `"off"`                           | When the  vibration state has changed.   | You can get the  current value with the `RUNTIME_INFO_KEY_VIBRATION_ENABLED` key. |
-| setting            | screen       | `tizen.system.event.screen_autorotate_state` | `screen_autorotate_state` | - `"on"` <br> - `"off"`                       | When the `screen_autorotate_state` has been  changed, for example, by the user toggling the display settings. | You can get the  current value with the `SYSTEM_SETTINGS_KEY_DISPLAY_SCREEN_ROTATION_AUTO` key. |
-| setting            | mobile       | `tizen.system.event.mobile_data_state`     | `mobile_data_state`       | - `"on"` <br> - `"off"`            | When the `mobile_data_state` has been changed,  for example, by the user toggling the network settings. | You can get the  current value with the `SYSTEM_SETTINGS_KEY_3G_DATA_NETWORK_ENABLED` key. |
-| setting            | mobile       | `tizen.system.event.data_roaming_state`    | `data_roaming_state`      | - `"on"` <br> - `"off"`                   | When the `data_roaming_state` has been changed,  for example, by the user toggling the network settings. | You can get the  current value with the `RUNTIME_INFO_KEY_DATA_ROAMING_ENABLED` key. |
-| setting            | font         | `tizen.system.event.font_set`              | `font_set`                | The value of  this key is the font name of the string type by font-config. | When the font  has changed.              | You can get the  current value with the `SYSTEM_SETTINGS_KEY_FONT_TYPE` key. |
+  - battery
+
+    | Event name | Event data Key | Event data Value | Condition | Notes |
+    |-------|-------|--------|--------|--------|
+    | `tizen.system.event.battery_charger_status` | `battery_charger_status`  | - `"disconnected"`: Charger is not connected<br>- `"connected"`: Charger is connected<br>- `"charging"`: Charging is enabled<br>- `"discharging"`: Charging is disabled (for example, 100% full  state) | When the  charger has been connected or disconnected, or when the charging state has  changed (charging or not). | If there is an  earlier occurrence regarding this event, you receive the event as soon as you  register an event handler for this event. You can use this earlier event data  as the initial value. |
+    | `tizen.system.event.battery_level_status`  | `battery_level_status`    | - `"empty"` <br>- `"critical"` <br>- `"low"` <br>- `"high"` <br>- `"full"` | When the  battery level has changed.     | You can get the  current value with the `device_battery_get_level_status()` function. |
+
+- deviced
+
+  - usb
+
+    | Event name | Event data Key | Event data Value | Condition | Notes |
+    |-------|-------|--------|--------|--------|
+    | `tizen.system.event.usb_status`            | `usb_status`              | - `"disconnected"`:  USB cable is not connected<br>- `"connected"`: USB cable is connected, but the service is not  available<br>-  `"available"`: USB service is available (for example, mtp or SDB) | When the USB  cable has been connected or disconnected, or when the USB service state has  changed. | You can get the  current value with the `RUNTIME_INFO_KEY_USB_CONNECTED` key. |
+
+  - earjack
+
+    | Event name | Event data Key | Event data Value | Condition | Notes |
+    |-------|-------|--------|--------|--------|
+    | `tizen.system.event.earjack_status`       | `earjack_status`                 | - `"disconnected"`:  Earjack is not connected <br>- `"connected"`: Earjack is connected | When the  earjack connection state has changed. | You can get the  current value with the `RUNTIME_INFO_KEY_AUDIO_JACK_STATUS` key. |
+
+  - display
+
+    | Event name | Event data Key | Event data Value | Condition | Notes |
+    |-------|-------|--------|--------|--------|
+    | `tizen.system.event.display_state`         | `display_state`           | - `"normal"`:  Display on, normal brightness<br>- `"dim"`: Display on, dimmed brightness<br>- `"off"`: Display off | When the  display state has changed.     | You can get the  current value with the `device_display_get_state()` function. |
+
+- systemd
+
+  - system
+
+    | Event name | Event data Key | Event data Value | Condition | Notes |
+    |-------|-------|--------|--------|--------|
+    | `tizen.system.event.boot_completed`        | N/A                     | N/A                                      | When the  platform has completed booting. | You can treat  the initial value as `false`  before you receive this event. If the application is already in a  boot-completed state before you register an event handler, you receive the  event as soon as you register the event handler. |
+    | `tizen.system.event.system_shutdown`       | N/A                     | N/A                                      | When  the system power-off has been started. | You  can treat the initial value as `false` before you receive this event. If the application is already  in a shutting-down state before you register an event handler, you receive  the event as soon as you register the event handler. |
+
+- resourced
+
+  - ram memory
+
+    | Event name | Event data Key | Event data Value | Condition | Notes |
+    |-------|-------|--------|--------|--------|
+    | `tizen.system.event.low_memory`            | `low_memory`              | - `"normal"`:  Available > 200MB <br> - `"soft_warning"`: 100MB < available <= 200MB <br>- `"hard_warning"`: Available <= 100MB    <br> **Note**<br> The above numbers can vary depending on the total RAM size of the  target device. | When  the size of available memory has changed. | If  there is an earlier occurrence regarding this event, you receive the event as  soon as you register an event handler for this event. You can use this  earlier event data as the initial value. |
+
+- network
+
+  - connectivity
+
+    | Event name | Event data Key | Event data Value | Condition | Notes |
+    |-------|-------|--------|--------|--------|
+    | `tizen.system.event.wifi_state`            | `wifi_state`              | - `"on"`:  Wi-Fi on <br>-  `"off"`: Wi-Fi off <br>- `"connected"`: Wi-Fi connection established | When the Wi-Fi  state has changed.       | You can get the  current value with the `connection_get_wifi_state()` function. |
+    | `tizen.system.event.bt_state`              | `bt_state`                | - `"off"`:  Legacy Bluetooth off <br>-  `"on"`: Legacy Bluetooth on | When the  Bluetooth state has changed.   | You can get the  current value with the `bt_adapter_get_state()` function. |
+    | `tizen.system.event.bt_state`              | `bt_le_state`             | - `"off"`:  LE function off <br>- `"on"`: LE function on | When Bluetooth  LE state has changed.    |   -                                       |
+    | `tizen.system.event.bt_state`              | `bt_transfering_state`    | - `"non_transfering"`:  Idle state  <br>-  `"transfering"`: File is transferring | When the file  transfer state has changed. | -                                         |
+
+- libslp-location
+
+  - location
+
+    | Event name | Event data Key | Event data Value | Condition | Notes |
+    |-------|-------|--------|--------|--------|
+    | `tizen.system.event.location_enable_state` | `location_enable_state`   | - `"disabled"`:  Location disabled <br>-  `"enabled"`: Location enabled | When the `location-enable_state` has been  changed, for example, by the user toggling the location setting in the  settings menu or quick panel. | You can get the  current value with the `location_manager_is_enabled_method()` function. |
+    | `tizen.system.event.gps_enable_state`      | `gps_enable_state`        | - `"disabled"`:  GPS disabled  <br>- `"enabled"`: GPS enabled | When the `gps-enable_state` has changed.   | You can get the  current value with the `location_manager_is_enabled_method()` function. |
+    | `tizen.system.event.nps_enable_state`      | `nps_enable_state`        | - `"disabled"`:  NPS disabled <br>-  `"enabled"`: NPS enabled | When the NPS  setting has been changed, for example, by the user toggling the location  settings. | You can get the  current value with the `location_manager_is_enabled_method()` function. |
+
+- msg-service
+
+  - message
+
+    | Event name | Event data Key | Event data Value | Condition | Notes |
+    |-------|-------|--------|--------|--------|
+    | `tizen.system.event.incoming_msg`          | `msg_type`                | - `"sms"`:  SMS-type message <br>-  `"push"`: Push-type message <br>-  `"cb"`: Cb-type message | When an SMS,  push, or CB message has been received. |       -                                   |
+    | `tizen.system.event.incoming_msg`          | `msg_id`                  | `msg_id`: Message ID of the received message (string of the unsigned `int` type value) | -                                         |           -                               |
+- alarm-manager
+
+  - time
+
+    | Event name | Event data Key | Event data Value | Condition | Notes |
+    |-------|-------|--------|--------|--------|
+    | `tizen.system.event.time_changed`          | N/A                     | N/A                                      | When  the system time setting has changed. | You  can get the current value with the `alarm_get_current_time()` function. |
+
+- setting
+
+  - time
+
+    | Event name | Event data Key | Event data Value | Condition | Notes |
+    |-------|-------|--------|--------|--------|
+    | `tizen.system.event.time_zone`             | `time_zone`               | The  value of this key is the time zone value of the time zone database, for  example, "Asia/Seoul", "America/New_York". For more  information, see the IANA Time Zone Database. | When  the time zone has changed.         | You  can get the current value with the `SYSTEM_SETTINGS_KEY_LOCALE_TIMEZONE` key. |
+
+  - locale
+
+    | Event name | Event data Key | Event data Value | Condition | Notes |
+    |-------|-------|--------|--------|--------|
+    | `tizen.system.event.hour_format`           | `hour_format`             | - `"12"` <br>- `"24"`                             | When  the `hour_format` has changed,  for example, by the user toggling the date and time settings for the 24-hour  clock (where **OFF** stands  for the 12-hour clock). | You  can get the current value with the `SYSTEM_SETTINGS_KEY_LOCALE_TIMEFORMAT_24HOUR` key. |
+    | `tizen.system.event.language_set`          | `language_set`            | The value of  this key is the full name of the locale, for example, `ko_KR.UTF8` for Korean and `en_US.UTF8` for American English. For more information, see the Linux  locale information. | When the `language_set` has changed.       | You can get the  current value with the `SYSTEM_SETTINGS_KEY_LOCALE_LANGUAGE` key. |
+    | `tizen.system.event.region_format`         | `region_format`           | The  value of this key is the full name of the locale, for example, `ko_KR.UTF8` for the Korean region  format and `en_US.UTF8`  for the USA region format. For more information, see the Linux locale  information. | When  the `region_format` has changed.     | You  can get the current value with the `SYSTEM_SETTINGS_KEY_LOCALE_COUNTRY` key. |
+
+  - sound
+
+    | Event name | Event data Key | Event data Value | Condition | Notes |
+    |-------|-------|--------|--------|--------|
+    | `tizen.system.event.silent_mode`           | `silent_mode`             | - `"on"` <br> - `"off"`                            | When  the ringtone has been changed to 0 or another mode. For example, if the call  slider has been changed to 0, `silent_mode` is `"on"`. Otherwise, `silent_mode` is `"off"`. | You  can get the current value with the `SYSTEM_SETTINGS_KEY_SOUND_SILENT_MODE` key. |
+
+  - vibration
+
+    | Event name | Event data Key | Event data Value | Condition | Notes |
+    |-------|-------|--------|--------|--------|
+    | `tizen.system.event.vibration_state`       | `vibration_state`         | - `"on"` <br> - `"off"`                           | When the  vibration state has changed.   | You can get the  current value with the `RUNTIME_INFO_KEY_VIBRATION_ENABLED` key. |
+
+  - screen
+
+    | Event name | Event data Key | Event data Value | Condition | Notes |
+    |-------|-------|--------|--------|--------|
+    | `tizen.system.event.screen_autorotate_state` | `screen_autorotate_state` | - `"on"` <br> - `"off"`                       | When the `screen_autorotate_state` has been  changed, for example, by the user toggling the display settings. | You can get the  current value with the `SYSTEM_SETTINGS_KEY_DISPLAY_SCREEN_ROTATION_AUTO` key. |
+
+  - mobile
+
+    | Event name | Event data Key | Event data Value | Condition | Notes |
+    |-------|-------|--------|--------|--------|
+    | `tizen.system.event.mobile_data_state`     | `mobile_data_state`       | - `"on"` <br> - `"off"`            | When the `mobile_data_state` has been changed,  for example, by the user toggling the network settings. | You can get the  current value with the `SYSTEM_SETTINGS_KEY_3G_DATA_NETWORK_ENABLED` key. |
+    | `tizen.system.event.data_roaming_state`    | `data_roaming_state`      | - `"on"` <br> - `"off"`                   | When the `data_roaming_state` has been changed,  for example, by the user toggling the network settings. | You can get the  current value with the `RUNTIME_INFO_KEY_DATA_ROAMING_ENABLED` key. |
+
+  - font
+
+    | Event name | Event data Key | Event data Value | Condition | Notes |
+    |-------|-------|--------|--------|--------|
+    | `tizen.system.event.font_set`              | `font_set`                | The value of  this key is the font name of the string type by font-config. | When the font  has changed.              | You can get the  current value with the `SYSTEM_SETTINGS_KEY_FONT_TYPE` key. |
 
 ## Related Information
 - Dependencies


### PR DESCRIPTION
### Change Description ###

The Event Broadcast and Subscription guide was revised because it is hard to read that the width of table is wilder than that of contents.
You can see ## Platform Event Types section,  which is composed a big table on https://developer.tizen.org/node/21539/revisions/62839/view.


