### PR TITLE
Fix wrong privilege level information

### DIFF
--- a/docs/application/dotnet/guides/connectivity/nfc.md
+++ b/docs/application/dotnet/guides/connectivity/nfc.md
@@ -103,7 +103,7 @@ To activate and deactivate NFC:
     ```
 
     > **Note**   
-	> To be able to use this privilege, your application must be signed with a partner-level certificate.
+	> To be able to use this privilege, your application must be signed with a platform-level certificate.
 
 2.  To activate NFC, use the `SetActivationAsync()` method of the [Tizen.Network.Nfc.NfcManager](https://developer.tizen.org/dev-guide/csapi/api/Tizen.Network.Nfc.NfcManager.html) class with the `true` parameter:
 


### PR DESCRIPTION
### Change Description ###
 Fix wrong privilege level information in NFC guide

http://tizen.org/privilege/nfc.admin
this privilege level is platform level on Native and .Net Application

### Bugs Fixed ###
https://github.com/Samsung/TizenFX/issues/462

### API Changes ###
None