### PR TITLE
[Web][Guide] Add remark about Wi-Fi properties change

### DIFF
--- a/docs/application/web/guides/device/system-information.md
+++ b/docs/application/web/guides/device/system-information.md
@@ -234,6 +234,29 @@ To receive notifications on property value changes:
    var id = tizen.systeminfo.addPropertyValueArrayChangeListener('SIM', successCallback);
    ```
 
+
+> **Note**  
+> In case of `WIFI_NETWORK` property, value change listener is triggered on `ipAddress` and `ip6Address` properties change in the network layer. These changes are not consistent with the `status` or `signalStrength` properties of a physical adapter in physical layer.  
+According to the previous constraints, in a specific situation, the listener could be triggered just before network adapter shutdown. In this case, the value of `status` returned by the listener will be outdated.
+
+To ensure receiving proper values, use the following code example:
+
+```
+function errorCallback(err) {
+    console.log('Error occurred ' + err.code)
+};
+
+function successCallback() {
+    setTimeout(function() {
+        tizen.systeminfo.getPropertyValue('WIFI_NETWORK', function(wifi) {
+            console.log("Wi-Fi status: " + wifi.status);
+        }, errorCallback);
+    }, 500);
+};
+
+tizen.systeminfo.addPropertyValueChangeListener('WIFI_NETWORK', successCallback, errorCallback);
+```
+
 <a name="property"></a>
 ## System Information Properties
 


### PR DESCRIPTION
WIFI_NETWORK properties listener triggers before change of some values.
Example code to get proper values has been added.

Signed-off-by: Rafal Walczyna <r.walczyna@partner.samsung.com>

### Change Description ###

Example code to get proper values from property value change listener in SystemInfo module been added.

### Bugs Fixed ###

[TDAF-765]

### API Changes ###

--
