### PR TITLE
Modify the thumbnail size instead of returning the error

### DIFF
--- a/docs/application/native/guides/multimedia/media-content.md
+++ b/docs/application/native/guides/multimedia/media-content.md
@@ -1047,7 +1047,6 @@ To access media item information:
                char *album = NULL;
                char *album_artist = NULL;
                int duration = 0;
-               time_t time_played = 0;
 
                ret = media_info_get_video(media_handle, &video_handle);
                if (ret != MEDIA_CONTENT_ERROR_NONE) {
@@ -1058,13 +1057,11 @@ To access media item information:
                    video_meta_get_album_artist(video_handle, &album_artist);
                    video_meta_get_duration(video_handle, &duration);
 
-                   media_info_get_played_time(media_handle, &time_played);
-
                    dlog_print(DLOG_DEBUG, LOG_TAG, "This is a video");
                    dlog_print(DLOG_DEBUG, LOG_TAG,
                               "Title: %s, Album: %s, Artist: %s, Album_artist: %s \n
-                               Duration: %d, Played time: %d",
-                              title, album, artist, album_artist, duration, time_played);
+                               Duration: %d",
+                              title, album, artist, album_artist, duration);
                }
 
                free(artist);

--- a/docs/application/native/guides/multimedia/thumbnail-images.md
+++ b/docs/application/native/guides/multimedia/thumbnail-images.md
@@ -119,7 +119,8 @@ To extract a thumbnail from the file:
    You get a BGRA color image.
 
 > **Note**  
-> Since 5.5, if the requested width and height of the thumbnail are bigger than the those of the image, they changes their sizes to those of the image.
+>
+> Since Tizen 5.5, if the requested width and height of the thumbnail are bigger than the image, then the thumbnail size is changed to the image size.
 
 ## Related Information
 - Dependencies

--- a/docs/application/native/guides/multimedia/thumbnail-images.md
+++ b/docs/application/native/guides/multimedia/thumbnail-images.md
@@ -118,6 +118,9 @@ To extract a thumbnail from the file:
 
    You get a BGRA color image.
 
+> **Note**  
+> Since 5.5, if the requested width and height of the thumbnail are bigger than the those of the image, they changes their sizes to those of the image.
+
 ## Related Information
 - Dependencies
   - Tizen 5.0 and Higher for Mobile


### PR DESCRIPTION
### Change Description ###

If the width and height of the thumbnail to be generated exceeds the original resolution,
the value changes to the original resolution instead of returning the error.


### API Changes ###

 - ACR: ACR-1327

