### PR TITLE
Add privilege tables with API version

### DIFF
--- a/docs/application/dotnet/getting-started/sec-privileges.md
+++ b/docs/application/dotnet/getting-started/sec-privileges.md
@@ -169,7 +169,7 @@ Tizen application privileges are loosely bound to APIs, so most of the
 privileges can be identified by the APIs that the application calls.
 However, there are some privileges that are not coupled with the Tizen
 APIs. To allow easy identification, those privileges are mapped to
-corresponding system resources that are similar as other privileges.
+corresponding system resources that are similar to other privileges.
 
 The following table lists the non-API bound privileges:
 

--- a/docs/application/dotnet/getting-started/sec-privileges.md
+++ b/docs/application/dotnet/getting-started/sec-privileges.md
@@ -110,8 +110,8 @@ when using security-sensitive API modules in .net applications:
 | `http://tizen.org/privilege/imemanager` | public |  | The application can manage installed input methods. |
 | `http://tizen.org/privilege/inputgenerator` | platform |  | The application can simulate keys being pressed and touch interactions with the screen. |
 | `http://tizen.org/privilege/keygrab` | platform |  | The application can read actions involving special keys, such as the volume keys on this or other devices (for example, TV remote controls), even when it is running in the background. |
-| `http://tizen.org/privilege/keymanager` | public |  | The application can save keys, certificates, and data to, and retrieve and delete them from, password-protected storage. Checking the statuses of certificates while connected to a mobile network may result in additional charges depending on user's payment plan. |
-| `http://tizen.org/privilege/keymanager.admin` | platform |  | The application can lock and unlock password-protected storage, and manage password changes for it. |
+| `http://tizen.org/privilege/keymanager` | public |  | The application can save keys, certificates, and data to, and retrieve and delete them from, password-protected storage. Checking the statuses of certificates while connected to a mobile network may result in additional charges depending on user's payment plan. Deprecated since 3.0. |
+| `http://tizen.org/privilege/keymanager.admin` | platform |  | The application can lock and unlock password-protected storage, and manage password changes for it. Deprecated since 3.0. |
 | `http://tizen.org/privilege/led` | public |  | The application can turn LEDs on or off. For example, the LED on the front of the device and the camera flash can be turned on or off. |
 | `http://tizen.org/privilege/location` | public | Location | The application can use user's location data. |
 | `http://tizen.org/privilege/location.coarse` | public | Location | The application can determine user's approximate location including user's device's Cell ID, LAC (Location Area Code), and TAC (Tracking Area Code). |
@@ -122,7 +122,7 @@ when using security-sensitive API modules in .net applications:
 | `http://tizen.org/privilege/mediahistory.read` | public | User history | The application can read the statistics concerning the music and videos played on the device, such as the peak times for playing music or videos. |
 | `http://tizen.org/privilege/message.read` | public | Message | The application can read text and multimedia messages, and any information related to them. |
 | `http://tizen.org/privilege/message.write` | public | Message | The application can write, send, delete, move text and multimedia messages, download multimedia messages, and change the settings and statuses of messages, such as read or unread. This may result in additional charges depending on user's payment plan. |
-| `http://tizen.org/privilege/minicontrol.provider` | public |  | The application can show a small toolbar on the notification panel or lock screen while it is open. |
+| `http://tizen.org/privilege/minicontrol.provider` | public |  | The application can show a small toolbar on the notification panel or lock screen while it is open. Deprecated since 3.0. |
 | `http://tizen.org/privilege/network.get` | public |  | The application can retrieve network information such as the status of each network, its type, and detailed network profile information. |
 | `http://tizen.org/privilege/network.profile` | public |  | The application can add, remove, and edit network profiles. |
 | `http://tizen.org/privilege/network.set` | public |  | The application can turn Wi-Fi on and off, and connect to and disconnect from Wi-Fi and mobile networks. This may result in additional charges depending on user's payment plan. |
@@ -144,7 +144,7 @@ when using security-sensitive API modules in .net applications:
 | `http://tizen.org/privilege/softap` | public |  | The application can manage SoftAP configuration settings, such as the Service Set Identifier (SSID) and password. |
 | `http://tizen.org/privilege/softap.admin` | platform |  | The application can turn SoftAP on or off, and change its settings. |
 | `http://tizen.org/privilege/systemmonitor` | public |  | The application can read system information, including information from the CPU and RAM. |
-| `http://tizen.org/privilege/systemsettings` | public |  | The application can read and write unrestricted system settings. |
+| `http://tizen.org/privilege/systemsettings` | public |  | The application can read and write unrestricted system settings. Deprecated since 2.3.1. |
 | `http://tizen.org/privilege/systemsettings.admin` | platform |  | The application can read and write all system settings. |
 | `http://tizen.org/privilege/tee.client` | partner |  | The application can call security related functions running inside a Trusted Execution Environment (TEE), which ensures that sensitive data is stored, processed, and protected in an isolated, trusted environment. |
 | `http://tizen.org/privilege/telephony` | public |  | The application can retrieve telephony information, such as the network and SIM card used, the IMEI, and the statuses of calls. |

--- a/docs/application/dotnet/index.md
+++ b/docs/application/dotnet/index.md
@@ -34,6 +34,10 @@ The introduction to .Net applications documentation provides the overall informa
 
   Introduces several third party libraries that  are used to develop .NET applications. It is classified according to the use and according to the purpose of use.
 
+- [Security and API Privileges](getting-started/sec-privileges.md)
+
+  Intorduces various privileges that you can declare for security-sensitive operations.
+
 ### Visual Studio Tools for Tizen [![Download](media/ic_docs_download.png)](https://marketplace.visualstudio.com/items?itemName=tizen.VisualStudioToolsforTizen)
 
 For more information, see [Learn more &gt;](../vstools/index.md)

--- a/docs/application/native/tutorials/details/details.md
+++ b/docs/application/native/tutorials/details/details.md
@@ -4,6 +4,7 @@ When designing Tizen native applications, you need to take into account the foll
 
 - [Application Filtering](app-filtering.md)
 - [Security and API Privileges](sec-privileges.md)
+- [Security and API Privileges for Apps with API Version 4.0 or Earlier](old-versioned-sec-privileges.md)
 - [Event Handling](event-handling.md)
 - [Error Handling](error-handling.md)
 - [File System Directory Hierarchy](io-overview.md)

--- a/docs/application/native/tutorials/details/old-versioned-sec-privileges.md
+++ b/docs/application/native/tutorials/details/old-versioned-sec-privileges.md
@@ -1,0 +1,246 @@
+
+# Security and API Privileges for Apps with API Version 4.0 or Earlier
+
+The API version restriction of privileges are deprecated since 5.0. This page provides privilege information with its supported version for developing apps with API version 4.0 or less.
+
+<a name="mobile"></a>
+## Mobile Native API Privileges
+
+The following table lists the API privileges, which you must declare
+when using security-sensitive API modules in mobile native applications:
+
+**Table: Mobile native API privileges**
+
+| Privilege                                | Level    | Privacy      | Since | Description                              |
+|----------------------------------------|-------|------------|-----|----------------------------------------|
+| `http://tizen.org/privilege/account.read` | public   | Account      | 2.3   | The application can read accounts.       |
+| `http://tizen.org/privilege/account.write` | public   | Account      | 2.3   | The application can create, edit, and delete accounts. |
+| `http://tizen.org/privilege/alarm.get`   | public   | -            | 2.3   | The application can read information about the saved alarms. |
+| `http://tizen.org/privilege/alarm.set`   | public   | -            | 2.3   | The application can set alarms and wake the device up at scheduled times. |
+| `http://tizen.org/privilege/antivirus.admin` | platform | -            | 3.0   | The application can enable or disable antivirus programs and manage detected malware. |
+| `http://tizen.org/privilege/antivirus.scan` | partner  | -            | 3.0   | The application can request to scan files in other applications or on the device to detect harmful content. |
+| `http://tizen.org/privilege/antivirus.webprotect` | partner  | -            | 3.0   | The application can check the reputation of a Web address and determine whether accessing it can put the user's device at risk. |
+| `http://tizen.org/privilege/apphistory.read` | public   | User history | 2.4   | The application can read the statistics of application usage, such as which applications have been used frequently or recently. |
+| `http://tizen.org/privilege/appmanager.kill` | platform | -            | 2.3   | The application can close other applications. |
+| `http://tizen.org/privilege/appmanager.kill.bgapp` | public   | -            | 2.4   | The application can request to close applications running in the background. |
+| `http://tizen.org/privilege/appmanager.launch` | public   | -            | 2.3   | The application can open other applications. |
+| `http://tizen.org/privilege/blocknumber.read` | partner  | -            | 4.0   | The application can read rules for blocking calls and messages. |
+| `http://tizen.org/privilege/blocknumber.write` | partner  | -            | 4.0   | The application can write rules for blocking calls and messages. |
+| `http://tizen.org/privilege/bluetooth`   | public   | -            | 2.3   | The application can perform unrestricted actions using Bluetooth, such as scanning for and connecting to other devices. |
+| `http://tizen.org/privilege/bluetooth.admin` | platform | -            | 2.3   | The application can change Bluetooth settings, such as switching Bluetooth on or off, setting the device name, and enabling or disabling the AV remote control. |
+| `http://tizen.org/privilege/bookmark.admin` | platform | Bookmark     | 2.3   | The application can retrieve, create, edit, and delete Internet bookmarks. |
+| `http://tizen.org/privilege/calendar.read` | public   | Calendar     | 2.3   | The application can read events and tasks. |
+| `http://tizen.org/privilege/calendar.write` | public   | Calendar     | 2.3   | The application can create, update, and delete events and tasks. |
+| `http://tizen.org/privilege/call`        | public   | Call         | 2.3   | The application can make phone calls to numbers when they are tapped without further confirmation. This can result in additional charges depending on the user's payment plan. |
+| `http://tizen.org/privilege/callhistory.read` | public   | User history | 2.3   | The application can read call log items. |
+| `http://tizen.org/privilege/callhistory.write` | public   | User history | 2.3   | The application can create, update, and delete call log items. |
+| `http://tizen.org/privilege/camera`      | public   | Camera       | 2.3   | The application can take pictures and switch the camera flash on and off while using the camera. |
+| `http://tizen.org/privilege/contact.read` | public   | Contacts     | 2.3   | The application can read the user profile, contacts, and contact history. Contact history can include social network activity. |
+| `http://tizen.org/privilege/contact.write` | public   | Contacts     | 2.3   | The application can create, update, and delete the user profile, contacts, and any contact history that is related to this application. Contact history can include social network activity. |
+| `http://tizen.org/privilege/content.write` | public   | -            | 2.3   | The application can change media information. This information can be used by other applications. |
+| `http://tizen.org/privilege/datasharing` | public   | -            | 2.3   | The application can share data with other applications. |
+| `http://tizen.org/privilege/display`     | public   | -            | 2.3   | The application can manage display settings, such as the brightness. This can increase battery consumption. |
+| `http://tizen.org/privilege/download`    | public   | -            | 2.3   | The application can manage HTTP downloads. This can result in additional charges depending on the user's payment plan. |
+| `http://tizen.org/privilege/dpm.bluetooth` | partner  | -            | 3.0   | The application can restrict Bluetooth connections. This can prevent applications that use Bluetooth from working properly. |
+| `http://tizen.org/privilege/dpm.browser` | partner  | -            | 3.0   | The application can prevent the use of browser applications. This can prevent applications that use browser applications from working properly. |
+| `http://tizen.org/privilege/dpm.camera`  | partner  | -            | 3.0   | The application can restrict the use of the camera. This can prevent applications that use the camera from working properly. |
+| `http://tizen.org/privilege/dpm.clipboard` | partner  | -            | 3.0   | The application can restrict the use of the clipboard. This can prevent applications that use the clipboard from working properly. |
+| `http://tizen.org/privilege/dpm.debugging` | partner  | -            | 3.0   | The application can restrict the use of debugging. This can prevent applications that use debugging from working properly. |
+| `http://tizen.org/privilege/dpm.email`   | partner  | -            | 3.0   | The application can restrict POP and IMAP email access. This can prevent applications that use email services from working properly. |
+| `http://tizen.org/privilege/dpm.location` | partner  | -            | 3.0   | The application can restrict the use of location functions. This can prevent applications that use location functions from working properly. |
+| `http://tizen.org/privilege/dpm.lock`    | partner  | -            | 3.0   | The application can lock the device. |
+| `http://tizen.org/privilege/dpm.message` | partner  | -            | 3.0   | The application can restrict the use of text, multimedia, and chat messaging services. This can prevent applications that use messaging services from working properly. |
+| `http://tizen.org/privilege/dpm.microphone` | partner  | -            | 3.0   | The application can restrict the use of the microphone. This can prevent applications that use the microphone from working properly. |
+| `http://tizen.org/privilege/dpm.password` | partner  | -            | 3.0   | The application can manage password policies and reset the passwords used to unlock the device and recover data. |
+| `http://tizen.org/privilege/dpm.security` | partner  | -            | 3.0   | The application can change security settings, such as those for certificate installation, data encryption, and factory data resets. |
+| `http://tizen.org/privilege/dpm.storage` | partner  | -            | 3.0   | The application can prevent the use of external storages, such as SD cards and USB storage devices. This can prevent applications that use external storage from working properly. |
+| `http://tizen.org/privilege/dpm.usb`     | partner  | -            | 3.0   | The application can prevent USB connections, including the use of USB tethering. This can prevent applications that use USB connections from working properly. |
+| `http://tizen.org/privilege/dpm.wifi`    | partner  | -            | 3.0   | The application can restrict the use of Wi-Fi networks and mobile hotspots. If the device cannot connect to a Wi-Fi network, it can connect to a mobile network. This can result in additional charges depending on the user's payment plan. |
+| `http://tizen.org/privilege/dpm.wipe`    | partner  | -            | 3.0   | The application can erase all data from the user's device and reset the user's device to its factory default settings. |
+| `http://tizen.org/privilege/dpm.zone`    | partner  | -            | 3.0   | The application can create and remove containers. Containers are private workspaces which provide separate application runtime environments and data storage. |
+| `http://tizen.org/privilege/email`       | public   | -            | 2.3   | The application can manage the user's email accounts, including the user's folders and emails, POP3 and IMAP downloads, and SMTP uploads. This can result in additional charges depending on the user's payment plan. |
+| `http://tizen.org/privilege/email.admin` | platform | -            | 2.3   | The application can manage the email application settings. |
+| `http://tizen.org/privilege/fido.client` | public   | -            | 3.0   | The application can trigger authenticators on the user's device and it can request to use the user's PIN or biometrics (fingerprints or irises) for authentication. |
+| `http://tizen.org/privilege/gestureactivation` | platform | -            | 4.0   | The application can allow and block special touch gestures. |
+| `http://tizen.org/privilege/gesturegrab` | platform | -            | 4.0   | The application can read special touch gestures, even while it is running in the background. |
+| `http://tizen.org/privilege/haptic`      | public   | -            | 2.3   | The application can control vibration feedback. |
+| `http://tizen.org/privilege/healthinfo`  | public   | Sensor       | 2.3.1 | The application can read health information gathered by the device sensors, such as the pedometer and heart rate monitor. |
+| `http://tizen.org/privilege/ime`         | public   | -            | 2.4   | The application can provide users with a way to enter characters and symbols into an associated text field. |
+| `http://tizen.org/privilege/imemanager`  | public   | -            | 2.4   | The application can manage installed input methods. |
+| `http://tizen.org/privilege/inputgenerator` | platform | -            | 2.4   | The application can simulate keys being pressed and touch interactions with the screen. |
+| `http://tizen.org/privilege/keygrab`     | platform | -            | 2.4   | The application can read actions involving special keys, such as the volume keys on this or other devices (such as TV remote controls), even when it is running in the background. |
+| `http://tizen.org/privilege/keymanager`  | public   | -            | 2.3   | The application can save keys, certificates, and data to, and retrieve and delete them from, a password-protected storage. Checking the status of certificates while connected to a mobile network can result in additional charges depending on the user's payment plan. Deprecated since 3.0. |
+| `http://tizen.org/privilege/keymanager.admin` | platform | -            | 2.3   | The application can lock and unlock a password-protected storage, and manage password changes for it. Deprecated since 2.4. |
+| `http://tizen.org/privilege/led`         | public   | -            | 2.3   | The application can switch LEDs on or off, such as the LED on the front of the device and the camera flash. |
+| `http://tizen.org/privilege/location`    | public   | Location     | 2.3   | The application can read the user's location information. |
+| `http://tizen.org/privilege/location.coarse` | public   | Location     | 3.0   | The application can determine the user's approximate location including the user device's Cell ID, LAC (Location Area Code), and TAC (Tracking Area Code). |
+| `http://tizen.org/privilege/location.enable` | platform | Location     | 2.3   | The application can control the user's location service settings. |
+| `http://tizen.org/privilege/mapservice`  | public   | -            | 2.4   | The application can use map services, such as geocoding, places, and routing (directions). |
+| `http://tizen.org/privilege/mediacontroller.client` | public   | -            | 2.4   | The application can receive information about currently playing media from applications that are allowed to send it, and can control those applications remotely. |
+| `http://tizen.org/privilege/mediacontroller.server` | public   | -            | 2.4   | The application can send information about currently playing media to applications that are allowed to receive it, and can be controlled remotely by those applications. |
+| `http://tizen.org/privilege/mediahistory.read` | public   | User history | 2.4   | The application can read the statistics concerning the music and videos played on the device, such as the peak times for playing music or videos. |
+| `http://tizen.org/privilege/message.read` | public   | Message      | 2.3   | The application can read text and multimedia messages, and any information related to them. |
+| `http://tizen.org/privilege/message.write` | public   | Message      | 2.3   | The application can write, send, delete, and move text and multimedia messages, and change the settings and status of the messages, such as read or unread. |
+| `http://tizen.org/privilege/minicontrol.provider` | public   | -            | 2.4   | The application can show a small toolbar on the notification panel or lock screen while it is open. Deprecated since 3.0. |
+| `http://tizen.org/privilege/network.get` | public   | -            | 2.3   | The application can retrieve network information, such as the status of each network, its type, and detailed network profile information. |
+| `http://tizen.org/privilege/network.profile` | public   | -            | 2.3   | The application can add, remove, and edit network profiles. |
+| `http://tizen.org/privilege/network.set` | public   | -            | 2.3   | The application can switch Wi-Fi on and off, and connect to and disconnect from Wi-Fi and mobile networks. This can result in additional charges depending on the user's payment plan. |
+| `http://tizen.org/privilege/nfc`         | public   | -            | 2.3   | The application can read and write NFC tag information, and send NFC messages to other devices. |
+| `http://tizen.org/privilege/nfc.admin`   | platform | -            | 2.3   | The application can change NFC settings, such as switching NFC on or off. |
+| `http://tizen.org/privilege/nfc.cardemulation` | public   | -            | 2.3   | The application can access smart card details, such as credit card details, and allow users to make payments using NFC. |
+| `http://tizen.org/privilege/notification` | public   | -            | 2.3   | The application can show and hide its own notifications and badges. |
+| `http://tizen.org/privilege/packagemanager.admin` | platform | -            | 2.3   | The application can install and uninstall application packages. |
+| `http://tizen.org/privilege/packagemanager.clearcache` | public   | -            | 2.4   | The application can clear other applications' caches. |
+| `http://tizen.org/privilege/packagemanager.info` | public   | -            | 2.3   | The application can retrieve detailed application package information. |
+| `http://tizen.org/privilege/peripheralio` | platform   | -            | 4.0   | The application can communicate with peripherals using industry standard protocols and interfaces, such as GPIO, I2C, PWM, UART, and SPI. |
+| `http://tizen.org/privilege/power`       | public   | -            | 2.3   | The application can control power-related settings, such as dimming the screen. |
+| `http://tizen.org/privilege/push`        | public   | -            | 2.3   | The application can receive notifications from the Internet. This can result in additional charges depending on the user's payment plan. |
+| `http://tizen.org/privilege/reboot`      | platform | -            | 2.3.1 | The application can restart the device.  |
+| `http://tizen.org/privilege/recorder`    | public   | Microphone   | 2.3   | The application can record video and audio. |
+| `http://tizen.org/privilege/screenshot`  | platform | -            | 2.3   | The application can capture screenshots. |
+| `http://tizen.org/privilege/secureelement` | public   | -            | 2.3.1 | The application can access secure smart card chips, such as UICC/SIM, embedded secure elements, and secure SD cards. |
+| `http://tizen.org/privilege/shortcut`    | public   | -            | 2.3   | The application can create and delete shortcuts. |
+| `http://tizen.org/privilege/systemmonitor` | public   | -            | 2.4   | The application can read system information, including information from the CPU and RAM. |
+| `http://tizen.org/privilege/systemsettings` | public   | -            | 2.3   | The application can read and write unrestricted system settings. Deprecated since 2.3.1. |
+| `http://tizen.org/privilege/systemsettings.admin` | platform | -            | 2.3   | The application can read and write all system settings. |
+| `http://tizen.org/privilege/tee.client` | partner | -            | 4.0   | The application can call security related functions running inside a Trusted Execution Environment (TEE), which ensures that sensitive data is stored, processed, and protected in an isolated, trusted environment. |
+| `http://tizen.org/privilege/telephony`   | public   | -            | 2.3   | The application can retrieve telephony information, such as the network and SIM card used, the IMEI, and the status of calls. |
+| `http://tizen.org/privilege/telephony.admin` | platform | -            | 2.3   | The application can manage telephony settings, such as those for incoming and outgoing calls, forwarding and holding calls, networks, and SIM cards. |
+| `http://tizen.org/privilege/tethering.admin` | platform | -            | 2.3   | The application can enable and disable tethering services. This can result in additional charges depending on the user's payment plan. |
+| `http://tizen.org/privilege/use_ir`      | public   | -            | 3.0   | The application can use the infrared transmitter. |
+| `http://tizen.org/privilege/volume.set`  | public   | -            | 2.3   | The application can adjust the volume for different features, such as notification alerts, ringtones, and media. |
+| `http://tizen.org/privilege/vpnservice`  | public   | -            | 3.0   | The application can manage the VPN (virtual private network) and change its settings. |
+| `http://tizen.org/privilege/web-history.admin` | platform | User history | 2.3   | The application can manage the user's Internet history. |
+| `http://tizen.org/privilege/widget.viewer` | public   | -            | 2.3.1 | The application can show widgets, and information from their associated applications, on the home screen. |
+| `http://tizen.org/privilege/wifidirect`  | public   | -            | 2.3   | The application can enable and disable Wi-Fi Direct&reg;, manage Wi-Fi Direct connections, and change Wi-Fi Direct settings. |
+| `http://tizen.org/privilege/window.priority.set` | public   | -            | 2.3   | The application can appear on top of other windows and screens, including the lock screen, according to the order of priority of the windows. This can prevent the user from interacting with other applications or screens until the window for the application is closed. |
+| `http://tizen.org/privilege/zigbee` | public   | -            | 4.0   | The application can connect a ZigBee coordinator to end devices and control connected end devices. |
+| `http://tizen.org/privilege/zigbee.admin` | platform   | -            | 4.0   | The application can control a connected ZigBee coordinator, e.g. turning it on or off. |
+
+<a name="wearable"></a>
+## Wearable Native API Privileges
+
+The following table lists the API privileges, which you must declare
+when using security-sensitive API modules in wearable native
+applications:
+
+**Table: Wearable native API privileges**
+
+| Privilege                                | Level    | Privacy      | Since | Description                              |
+|----------------------------------------|--------|------------|-----|----------------------------------------|
+| `http://tizen.org/privilege/account.read` | public   | Account      | 3.0   | The application can read accounts.       |
+| `http://tizen.org/privilege/account.write` | public   | Account      | 3.0   | The application can create, edit, and delete accounts. |
+| `http://tizen.org/privilege/alarm.get`   | public   | -            | 2.3.1 | The application can read information about the saved alarms. |
+| `http://tizen.org/privilege/alarm.set`   | public   | -            | 2.3.1 | The application can set alarms and wake the device up at scheduled times. |
+| `http://tizen.org/privilege/antivirus.admin` | platform | -            | 3.0   | The application can enable or disable antivirus programs and manage detected malware. |
+| `http://tizen.org/privilege/antivirus.scan` | partner  | -            | 3.0   | The application can request to scan files in other applications or on the device to detect harmful content. |
+| `http://tizen.org/privilege/antivirus.webprotect` | partner  | -            | 3.0   | The application can check the reputation of a Web address and determine whether accessing it can put the user's device at risk. |
+| `http://tizen.org/privilege/apphistory.read` | public | User history         | 4.0 | The application can read the statistics of application usage, such as which applications have been used frequently or recently. |
+| `http://tizen.org/privilege/appmanager.kill` | platform | -            | 2.3.1 | The application can close other applications. |
+| `http://tizen.org/privilege/appmanager.kill.bgapp` | public   | -            | 3.0   | The application can request to close applications running in the background. |
+| `http://tizen.org/privilege/appmanager.launch` | public   | -            | 2.3.1 | The application can open other applications. |
+| `http://tizen.org/privilege/blocknumber.read` | partner  | -            | 4.0   | The application can read rules for blocking calls and messages. |
+| `http://tizen.org/privilege/blocknumber.write`   | partner    | -      | 4.0 | The application can write rules for blocking calls and messages. |
+| `http://tizen.org/privilege/bluetooth`   | public   | -            | 2.3.1 | The application can perform unrestricted actions using  Bluetooth, such as scanning for and connecting to other devices. |
+| `http://tizen.org/privilege/bluetooth.admin` | platform | -            | 2.3.1 | The application can change Bluetooth settings, such as switching Bluetooth on or off, setting the device name, and enabling or disabling the AV remote control. |
+| `http://tizen.org/privilege/calendar.read` | public   | Calendar | 3.0 | The application can read events and tasks. |
+| `http://tizen.org/privilege/calendar.write` | public   | Calendar | 3.0 | The application can create, update, and delete events and tasks. |
+| `http://tizen.org/privilege/call`        | public   | Call         | 2.3.1 | The application can make phone calls to numbers when they are tapped without further confirmation. This can result in additional charges depending on the user's payment plan. |
+| `http://tizen.org/privilege/callhistory.read` | public   | User history | 2.3.1 | The application can read call log items. |
+| `http://tizen.org/privilege/callhistory.write` | public   | User history | 2.3.1 | The application can create, update, and delete call log items. |
+| `http://tizen.org/privilege/camera`      | public   | Camera       | 2.3.1 | The application can take pictures and switch the camera flash on and off while using the camera. |
+| `http://tizen.org/privilege/contact.read` | public   | Contacts     | 3.0   | The application can read the user profile, contacts, and contact history. Contact history can include social network activity. |
+| `http://tizen.org/privilege/contact.write` | public   | Contacts     | 3.0   | The application can create, update, and delete the user profile, contacts, and any contact history that is related to this application. Contact history can include social network activity. |
+| `http://tizen.org/privilege/content.write` | public   | -            | 2.3.1 | The application can change media information. This information can be used by other applications. |
+| `http://tizen.org/privilege/datasharing` | public   | -            | 2.3.1 | The application can share data with other applications. |
+| `http://tizen.org/privilege/display`     | public   | -            | 2.3.1 | The application can manage display settings, such as the brightness. This can increase battery consumption. |
+| `http://tizen.org/privilege/download`    | public   | -            | 2.3.1 | The application can manage HTTP downloads. This can result in additional charges depending on the user's payment plan. |
+| `http://tizen.org/privilege/dpm.bluetooth` | partner  | -            | 3.0   | The application can restrict Bluetooth connections. This can prevent applications that use Bluetooth from working properly. |
+| `http://tizen.org/privilege/dpm.browser` | partner  | -            | 3.0   | The application can prevent the use of browser applications. This can prevent applications that use browser applications from working properly. |
+| `http://tizen.org/privilege/dpm.camera`  | partner  | -            | 3.0   | The application can restrict the use of the camera. This can prevent applications that use the camera from working properly. |
+| `http://tizen.org/privilege/dpm.clipboard` | partner  | -            | 3.0   | The application can restrict the use of the clipboard. This can prevent applications that use the clipboard from working properly. |
+| `http://tizen.org/privilege/dpm.debugging` | partner  | -            | 3.0   | The application can restrict the use of debugging. This can prevent applications that use debugging from working properly. |
+| `http://tizen.org/privilege/dpm.email`   | partner  | -            | 3.0   | The application can restrict POP and IMAP email access. This can prevent applications that use email services from working properly. |
+| `http://tizen.org/privilege/dpm.location` | partner  | -            | 3.0   | The application can restrict the use of location functions. This can prevent applications that use location functions from working properly. |
+| `http://tizen.org/privilege/dpm.lock`    | partner  | -            | 3.0   | The application can lock the device. |
+| `http://tizen.org/privilege/dpm.message` | partner  | -            | 3.0   | The application can restrict the use of text, multimedia, and chat messaging services. This can prevent applications that use messaging services from working properly. |
+| `http://tizen.org/privilege/dpm.microphone` | partner  | -            | 3.0   | The application can restrict the use of the microphone. This can prevent applications that use the microphone from working properly. |
+| `http://tizen.org/privilege/dpm.password` | partner  | -            | 3.0   | The application can manage password policies and reset the passwords used to unlock the device and recover data. |
+| `http://tizen.org/privilege/dpm.security` | partner  | -            | 3.0   | The application can change security settings, such as those for certificate installation, data encryption, and factory data resets. |
+| `http://tizen.org/privilege/dpm.storage` | partner  | -            | 3.0   | The application can prevent the use of external storages, such as SD cards and USB storage devices. This can prevent applications that use external storage from working properly. |
+| `http://tizen.org/privilege/dpm.usb`     | partner  | -            | 3.0   | The application can prevent USB connections, including the use of USB tethering. This can prevent applications that use USB connections from working properly. |
+| `http://tizen.org/privilege/dpm.wifi`    | partner  | -            | 3.0   | The application can restrict the use of Wi-Fi networks and mobile hotspots. If the device cannot connect to a Wi-Fi network, it can connect to a mobile network. This can result in additional charges depending on the user's payment plan. |
+| `http://tizen.org/privilege/dpm.wipe`    | partner  | -            | 3.0   | The application can erase all data from the user's device and reset the user's device to its factory default settings. |
+| `http://tizen.org/privilege/dpm.zone`    | partner  | -            | 3.0   | The application can create and remove containers. Containers are private workspaces which provide separate application runtime environments and data storage. |
+| `http://tizen.org/privilege/email`       | public   | -            | 3.0   | The application can manage the user's email accounts, including the user's folders and emails, POP3 and IMAP downloads, and SMTP uploads. This can result in additional charges depending on the user's payment plan. |
+| `http://tizen.org/privilege/fido.client` | public   | -            | 3.0   | The application can trigger authenticators on the user's device and it can request to use the user's PIN or biometrics (fingerprints or irises) for authentication. |
+| `http://tizen.org/privilege/gestureactivation`      | platform   | -            | 4.0 | The application can allow and block special touch gestures. |
+| `http://tizen.org/privilege/gesturegrab`      | platform   | -            | 4.0 | The application can read special touch gestures, even while it is running in the background. |
+| `http://tizen.org/privilege/haptic`      | public   | -            | 2.3.1 | The application can control vibration feedback. |
+| `http://tizen.org/privilege/healthinfo`  | public   | Sensor       | 2.3.1 | The application can read health information gathered by the device sensors, such as the pedometer and heart rate monitor. |
+| `http://tizen.org/privilege/ime`         | public   | -            | 3.0   | The application can provide users with a way to enter characters and symbols into an associated text field. |
+| `http://tizen.org/privilege/imemanager`  | public   | -            | 3.0   | The application can manage installed input methods. |
+| `http://tizen.org/privilege/inputgenerator` | platform | -            | 3.0   | The application can simulate keys being pressed and touch interactions with the screen. |
+| `http://tizen.org/privilege/keygrab`     | platform | -            | 3.0   | The application can read actions involving special keys, such as the volume keys on this or other devices (such as TV remote controls), even when it is running in the background. |
+| `http://tizen.org/privilege/keymanager`  | public   | -            | 2.3.1 | The application can save keys, certificates, and data to, and retrieve and delete them from, a password-protected storage. |
+| `http://tizen.org/privilege/keymanager.admin` | platform | -            | 2.3.1 | The application can lock and unlock a password-protected storage, and manage password changes for it. Deprecated since 3.0. |
+| `http://tizen.org/privilege/led`         | public   | -            | 2.3.1 | The application can switch LEDs on or off, such as the LED on the front of the device and the camera flash. |
+| `http://tizen.org/privilege/location`    | public   | Location     | 2.3.1 | The application can read the user's location information. |
+| `http://tizen.org/privilege/location.coarse` | public   | Location     | 3.0   | The application can determine the user's approximate location including the user device's Cell ID, LAC (Location Area Code), and TAC (Tracking Area Code). |
+| `http://tizen.org/privilege/location.enable` | platform | Location     | 2.3.1 | The application can control the user's location service settings. |
+| `http://tizen.org/privilege/mapservice`  | public   | -            | 2.3.2 | The application can use map services, such as geocoding, places, and routing (directions). |
+| `http://tizen.org/privilege/mediacontroller.client` | public   | -            | 3.0   | The application can receive information about currently playing media from applications that are allowed to send it, and can control those applications remotely. |
+| `http://tizen.org/privilege/mediacontroller.server` | public   | -            | 3.0   | The application can send information about currently playing media to applications that are allowed to receive it, and can be controlled remotely by those applications. |
+| `http://tizen.org/privilege/message.read` | public   | Message      | 2.3.1 | The application can read text and multimedia messages, and any information related to them. |
+| `http://tizen.org/privilege/message.write` | public   | Message      | 2.3.1 | The application can write, send, delete, and move text and multimedia messages, download multimedia messages, and change the settings and status of the messages, such as read or unread. This can result in additional charges depending on the user's payment plan. |
+| `http://tizen.org/privilege/network.get` | public   | -            | 2.3.1 | The application can retrieve network information, such as the status of each network, its type, and detailed network profile information. |
+| `http://tizen.org/privilege/network.profile` | public   | -            | 2.3.1 | The application can add, remove, and edit network profiles. |
+| `http://tizen.org/privilege/network.set` | public   | -            | 2.3.1 | The application can switch Wi-Fi on and off, and connect to and disconnect from Wi-Fi and mobile networks. This can result in additional charges depending on the user's payment plan. |
+| `http://tizen.org/privilege/nfc`         | public   | -            | 2.3.1 | The application can read and write NFC tag information, and send NFC messages to other devices. |
+| `http://tizen.org/privilege/nfc.admin`   | platform | -            | 2.3.1 | The application can change NFC settings, such as switching NFC on or off. |
+| `http://tizen.org/privilege/nfc.cardemulation` | public   | -            | 2.3.1 | The application can access smart card details, such as credit card details, and allow users to make payments using NFC. |
+| `http://tizen.org/privilege/notification` | public   | -            | 2.3.1 | The application can show and hide its own notifications and badges. |
+| `http://tizen.org/privilege/packagemanager.admin` | platform | -            | 2.3.1 | The application can install and uninstall application packages. |
+| `http://tizen.org/privilege/packagemanager.clearcache` | public   | -            | 3.0   | The application can clear other applications' caches. |
+| `http://tizen.org/privilege/packagemanager.info` | public   | -            | 2.3.1 | The application can retrieve detailed application package information. |
+| `http://tizen.org/privilege/peripheralio` | platform   | -            | 4.0 | The application can communicate with peripherals using industry standard protocols and interfaces, such as GPIO, I2C, PWM, UART, and SPI. |
+| `http://tizen.org/privilege/power`       | public   | -            | 2.3.1 | The application can control power-related settings, such as dimming the screen. |
+| `http://tizen.org/privilege/push`        | public   | -            | 2.3.1 | The application can receive notifications from the Internet. This can result in additional charges depending on the user's payment plan. |
+| `http://tizen.org/privilege/reboot`      | platform | -            | 2.3.1 | The application can restart the device.  |
+| `http://tizen.org/privilege/recorder`    | public   | Microphone   | 2.3.1   | The application can record video and audio. |
+| `http://tizen.org/privilege/screenshot`  | platform | -            | 2.3.1   | The application can capture screenshots. |
+| `http://tizen.org/privilege/secureelement` | public   | -            | 2.3.1 | The application can access secure smart card chips, such as UICC/SIM, embedded secure elements, and secure SD cards. |
+| `http://tizen.org/privilege/systemmonitor` | public   | -            | 3.0   | The application can read system information, including information from the CPU and RAM. |
+| `http://tizen.org/privilege/systemsettings.admin` | platform | -            | 2.3.1   | The application can read and write all system settings. |
+| `http://tizen.org/privilege/tee.client` | partner | -            | 4.0   | The application can call security related functions running inside a Trusted Execution Environment (TEE), which ensures that sensitive data is stored, processed, and protected in an isolated, trusted environment. |
+| `http://tizen.org/privilege/telephony`   | public   | -            | 2.3.1   | The application can retrieve telephony information, such as the network and SIM card used, the IMEI, and the status of calls. |
+| `http://tizen.org/privilege/telephony.admin` | platform | -            | 2.3.1   | The application can manage telephony settings, such as those for incoming and outgoing calls, forwarding and holding calls, networks, and SIM cards. |
+| `http://tizen.org/privilege/use_ir`      | public   | -            | 3.0   | The application can use the infrared transmitter. |
+| `http://tizen.org/privilege/volume.set`  | public   | -            | 2.3.1   | The application can adjust the volume for different features, such as notification alerts, ringtones, and media. |
+| `http://tizen.org/privilege/widget.viewer` | public   | -            | 2.3.1 | The application can show widgets, and information from their associated applications, on the home screen. |
+| `http://tizen.org/privilege/window.priority.set` | public   | -            | 2.3.1   | The application can appear on top of other windows and screens, including the lock screen, according to the order of priority of the windows. This can prevent the user from interacting with other applications or screens until the window for the application is closed. |
+| `http://tizen.org/privilege/zigbee`      | public   | -            | 4.0   | The application can connect a ZigBee coordinator to end devices and control connected end devices. |
+| `http://tizen.org/privilege/zigbee.admin`      | platform   | -            | 4.0   | The application can control a connected ZigBee coordinator, e.g. turning it on or off. |
+
+
+<a name="nonAPI"></a>
+## Non-API Bound Privileges
+
+
+Tizen application privileges are loosely bound to APIs, so most of the
+privileges can be identified by the APIs that the application calls.
+However, there are some privileges that are not coupled with the Tizen
+APIs. To allow easy identification, those privileges are mapped to
+corresponding system resources that are similar as other privileges.
+
+The following table lists the non-API bound privileges:
+
+**Table: Non-API bound privileges**
+
+| Privilege                                | Level  | Privacy  | Since(mobile/wearable) | Description                              |
+|----------------------------------------|------|------|----------------------|----------------------------------------|
+| `http://tizen.org/privilege/internet`    | public | - | 2.3 / 2.3.1            | Most of the mobile and wearable devices use a cellular network for IP communication. However, the cellular network can cause data costs and an application that sends data through the Internet can be crucial for user privacy. Due to the importance of the functionality, a privilege for controlling application Internet access has been added.<br><br>The new privilege is coupled with IP addresses of the destination and source of the IP packets. If your socket is connecting or listening to any IP address except 127.0.0.1, this privilege is required to communicate properly. If your application does not have this privilege, the connection is blocked in the kernel layer and returns an error in the `connect()` function as the permission is denied. If you are listening to a socket, you never receive any packets from the outside without errors on the socket functions.<br><br>If you are using the `listen()` and `connect()` functions between the local loopback interface (127.0.0.1), you cannot connect to a random application (due to sandboxing) no matter how you add this privilege. However, you can connect between multiple processes of the same application binary. |
+| `http://tizen.org/privilege/mediastorage` | public | Storage | 2.3 / 2.3.1            | When you connect the device to a computer (Windows&reg; or macOS) through USB, you can access a dedicated media storage area shown as massive media storage. This region of the storage is called media storage and is usually used for multimedia files, such as photos, videos, and music files. Since this storage area is used for user private data, access to it must be protected with a privilege.<br>If your application does not have this privilege, no file operations into the media storage area succeed and you receive a permission denied error. If you have this privilege, you can read and write directories and files, create new files, and delete files in the storage area.<br><br>This privilege is treated as privacy privilege since platform version 4.0. |
+| `http://tizen.org/privilege/externalstorage` | public | Storage | 2.3 / 2.3.1            | Similar to the media storage, many devices support external storages, such as MicroSD card or USB memory. As with the media storage, the access to an external storage must be protected with a privilege. You can find the absolute path of the external storage with the [Storage](../../api/mobile/latest/group__CAPI__SYSTEM__STORAGE__MODULE.html) API functions, such as `storage_get_root_directory()` function.<br>If your application does not have this privilege, all file operations fail with a permission denied error. If you have this privilege, you have full access to the external storage.<br><br>This privilege is treated as privacy privilege since platform version 4.0. |
+| `http://tizen.org/privilege/externalstorage.appdata` | public | - | 2.3 / 2.3.1            | Many devices support external storages, such as MicroSD card or USB memory. As with the media storage, the access to an external storage must be protected with a privilege.<br><br>If your application does not have this privilege, no file operations with the application data stored in the external storage area succeed and you receive a permission denied error. If you have this privilege, you can store data in the application-specific directory of the external storage. You can find the path for storing data in the external storage with, for example, the `app_get_external_data_path()`, `app_get_external_cache_path()`, and `app_get_external_shared_data_path()` functions. |
+| `http://tizen.org/privilege/appdir.shareddata` | public | - | 3.0 / 3.0              | Since Tizen 3.0, the application must have this privilege to support the `shared/data` directory.<br><br>The `app_get_shared_data_path()` and `app_manager_get_shared_data_path()` functions return an error when the application does not have this privilege. Note that the `shared/data` directory is writable for the application itself and readable for all other applications. You must be careful when you use this privilege and share data through the `shared/data` directory. For a more secure way of sharing files with another application, try to pass the file path through an application control. |

--- a/docs/application/native/tutorials/details/old-versioned-sec-privileges.md
+++ b/docs/application/native/tutorials/details/old-versioned-sec-privileges.md
@@ -231,7 +231,7 @@ Tizen application privileges are loosely bound to APIs, so most of the
 privileges can be identified by the APIs that the application calls.
 However, there are some privileges that are not coupled with the Tizen
 APIs. To allow easy identification, those privileges are mapped to
-corresponding system resources that are similar as other privileges.
+corresponding system resources that are similar to other privileges.
 
 The following table lists the non-API bound privileges:
 

--- a/docs/application/native/tutorials/details/old-versioned-sec-privileges.md
+++ b/docs/application/native/tutorials/details/old-versioned-sec-privileges.md
@@ -182,7 +182,7 @@ applications:
 | `http://tizen.org/privilege/imemanager`  | public   | -            | 3.0   | The application can manage installed input methods. |
 | `http://tizen.org/privilege/inputgenerator` | platform | -            | 3.0   | The application can simulate keys being pressed and touch interactions with the screen. |
 | `http://tizen.org/privilege/keygrab`     | platform | -            | 3.0   | The application can read actions involving special keys, such as the volume keys on this or other devices (such as TV remote controls), even when it is running in the background. |
-| `http://tizen.org/privilege/keymanager`  | public   | -            | 2.3.1 | The application can save keys, certificates, and data to, and retrieve and delete them from, a password-protected storage. |
+| `http://tizen.org/privilege/keymanager`  | public   | -            | 2.3.1 | The application can save keys, certificates, and data to, and retrieve and delete them from, a password-protected storage. Deprecated since 3.0. |
 | `http://tizen.org/privilege/keymanager.admin` | platform | -            | 2.3.1 | The application can lock and unlock a password-protected storage, and manage password changes for it. Deprecated since 3.0. |
 | `http://tizen.org/privilege/led`         | public   | -            | 2.3.1 | The application can switch LEDs on or off, such as the LED on the front of the device and the camera flash. |
 | `http://tizen.org/privilege/location`    | public   | Location     | 2.3.1 | The application can read the user's location information. |

--- a/docs/application/native/tutorials/details/sec-privileges.md
+++ b/docs/application/native/tutorials/details/sec-privileges.md
@@ -46,6 +46,8 @@ applications).
 The Tizen Studio also provides privilege checker tools to check whether the Tizen application source code contains any privilege violations. For more information, see [Verifying APIs and
 Privileges](../../../tizen-studio/native-tools/api-checker.md).
 
+The API version restriction of privileges are deprecated since platform version 5.0. So, if you are develeoping an app with an earlier API version and need information about supported version, see [this page](./old-versioned-sec-privileges.md). The page does not include privileges issued after 4.0.
+
 <a name="API"></a>
 ## Native API Privileges
 
@@ -113,8 +115,8 @@ when using security-sensitive API modules in native applications:
 | `http://tizen.org/privilege/imemanager` | public |  | The application can manage installed input methods. |
 | `http://tizen.org/privilege/inputgenerator` | platform |  | The application can simulate keys being pressed and touch interactions with the screen. |
 | `http://tizen.org/privilege/keygrab` | platform |  | The application can read actions involving special keys, such as the volume keys on this or other devices (for example, TV remote controls), even when it is running in the background. |
-| `http://tizen.org/privilege/keymanager` | public |  | The application can save keys, certificates, and data to, and retrieve and delete them from, password-protected storage. Checking the statuses of certificates while connected to a mobile network may result in additional charges depending on user's payment plan. |
-| `http://tizen.org/privilege/keymanager.admin` | platform |  | The application can lock and unlock password-protected storage, and manage password changes for it. |
+| `http://tizen.org/privilege/keymanager` | public |  | The application can save keys, certificates, and data to, and retrieve and delete them from, password-protected storage. Checking the statuses of certificates while connected to a mobile network may result in additional charges depending on user's payment plan. Deprecated since 3.0. |
+| `http://tizen.org/privilege/keymanager.admin` | platform |  | The application can lock and unlock password-protected storage, and manage password changes for it. Deprecated since 3.0. |
 | `http://tizen.org/privilege/led` | public |  | The application can turn LEDs on or off. For example, the LED on the front of the device and the camera flash can be turned on or off. |
 | `http://tizen.org/privilege/location` | public | Location | The application can use user's location data. |
 | `http://tizen.org/privilege/location.coarse` | public | Location | The application can determine user's approximate location including user's device's Cell ID, Location Area Code (LAC), and Tracking Area Code (TAC). |
@@ -125,7 +127,7 @@ when using security-sensitive API modules in native applications:
 | `http://tizen.org/privilege/mediahistory.read` | public | User history | The application can read the statistics concerning the music and videos played on the device, such as the peak times for playing music or videos. |
 | `http://tizen.org/privilege/message.read` | public | Message | The application can read text and multimedia messages, and any information related to them. |
 | `http://tizen.org/privilege/message.write` | public | Message | The application can write, send, delete, move text and multimedia messages, download multimedia messages, and change the settings and statuses of messages, such as read or unread. This may result in additional charges depending on user's payment plan. |
-| `http://tizen.org/privilege/minicontrol.provider` | public |  | The application can show a small toolbar on the notification panel or lock screen while it is open. |
+| `http://tizen.org/privilege/minicontrol.provider` | public |  | The application can show a small toolbar on the notification panel or lock screen while it is open. Deprecated since 3.0. |
 | `http://tizen.org/privilege/network.get` | public |  | The application can retrieve network information such as the status of each network, its type, and detailed network profile information. |
 | `http://tizen.org/privilege/network.profile` | public |  | The application can add, remove, and edit network profiles. |
 | `http://tizen.org/privilege/network.set` | public |  | The application can turn Wi-Fi on and off, and connect to and disconnect from Wi-Fi and mobile networks. This may result in additional charges depending on user's payment plan. |
@@ -147,7 +149,7 @@ when using security-sensitive API modules in native applications:
 | `http://tizen.org/privilege/softap` | public |  | The application can manage SoftAP configuration settings, such as the Service Set Identifier (SSID) and password. |
 | `http://tizen.org/privilege/softap.admin` | platform |  | The application can turn SoftAP on or off, and change its settings. |
 | `http://tizen.org/privilege/systemmonitor` | public |  | The application can read system information, including information from the CPU and RAM. |
-| `http://tizen.org/privilege/systemsettings` | public |  | The application can read and write unrestricted system settings. |
+| `http://tizen.org/privilege/systemsettings` | public |  | The application can read and write unrestricted system settings. Deprecated since 2.3.1. |
 | `http://tizen.org/privilege/systemsettings.admin` | platform |  | The application can read and write all system settings. |
 | `http://tizen.org/privilege/tee.client` | partner |  | The application can call security related functions running inside a Trusted Execution Environment (TEE), which ensures that sensitive data is stored, processed, and protected in an isolated, trusted environment. |
 | `http://tizen.org/privilege/telephony` | public |  | The application can retrieve telephony information, such as the network and SIM card used, the IMEI, and the statuses of calls. |

--- a/docs/application/native/tutorials/details/sec-privileges.md
+++ b/docs/application/native/tutorials/details/sec-privileges.md
@@ -192,7 +192,7 @@ Tizen application privileges are loosely bound to APIs, so most of the
 privileges can be identified by the APIs that the application calls.
 However, there are some privileges that are not coupled with the Tizen
 APIs. To allow easy identification, those privileges are mapped to
-corresponding system resources that are similar as other privileges.
+corresponding system resources that are similar to other privileges.
 
 The following table lists the non-API bound privileges:
 

--- a/docs/application/toc_all.md
+++ b/docs/application/toc_all.md
@@ -26,6 +26,7 @@
 ### [Test Tizen .NET Application on a Gear device](/application/dotnet/tutorials/test/testing-your-app-on-gear.md)
 ### [Packaging a .NET and Web Hybrid Application](/application/dotnet/tutorials/hybrid/create-dotnet-hybrid-package.md)
 ### [Third Party Libraries for Tizen .NET Application](/application/dotnet/tutorials/library/library-list.md)
+### [Security and API Privileges](/application/dotnet/getting-started/sec-privileges.md)
 
 
 ## Guides
@@ -237,6 +238,7 @@
 #### [Overview](/application/native/tutorials/details/details.md)
 #### [Application Filtering](/application/native/tutorials/details/app-filtering.md)
 #### [Security and API Privileges](/application/native/tutorials/details/sec-privileges.md)
+#### [Security and API Privileges for Apps with API Version 4.0 or Earlier](/application/native/tutorials/details/old-versioned-sec-privileges.md)
 #### [Event Handling](/application/native/tutorials/details/event-handling.md)
 #### [Error Handling](/application/native/tutorials/details/error-handling.md)
 #### [File System Directory Hierarchy](/application/native/tutorials/details/io-overview.md)
@@ -709,6 +711,7 @@
 #### [Running and Debugging Applications](/application/web/tutorials/process/run-debug-app.md)
 ### [Application Filtering](/application/web/tutorials/app-filtering.md)
 ### [Security and API Privileges](/application/web/tutorials/sec-privileges.md)
+### [Security and API Privileges for Apps with API Version 4.0 or Earlier](/application/web/tutorials/old-versioned-sec-privileges.md)
 ### [Web Runtime](/application/web/tutorials/web-runtime.md)
 ### [Event Handling](/application/web/tutorials/event-handling.md)
 ### [Application Signing and Certificates](/application/web/tutorials/sign-certificate.md)

--- a/docs/application/web/tutorials/old-versioned-sec-privileges.md
+++ b/docs/application/web/tutorials/old-versioned-sec-privileges.md
@@ -1,0 +1,240 @@
+# Security and API Privileges for Apps with API Version 4.0 or Earlier
+
+The API version restriction of privileges are deprecated since 5.0. This page provides privilege information with its supported version for developing apps with API version 4.0 or less.
+
+
+<a name="mobile"></a>
+## Mobile Web API Privileges
+
+The following tables list the API privileges, which you must declare when using security-sensitive API modules in mobile Web applications:
+
+**Table: Mobile Web Device API privileges**
+
+| Privilege                                | Level    | Privacy                   | Since | Description                              |
+| ---------------------------------------- | -------- | ------------------------- | ----- | ---------------------------------------- |
+| `http://tizen.org/privilege/account.read` | public   | Account                   | 2.3   | The application can read accounts.       |
+| `http://tizen.org/privilege/account.write` | public   | Account                   | 2.3   | The application can create, edit, and delete accounts. |
+| `http://tizen.org/privilege/alarm`       | public   | -                         | 2.2.1 | The application can manage alarms by retrieving saved alarms and waking the device up at scheduled times. |
+| `http://tizen.org/privilege/apphistory.read` | public   | -                         | 4.0   | The application can read the statistics of application usage, such as which applications have been used frequently or recently. |
+| `http://tizen.org/privilege/application.info` | public   | -                         | 2.2.1 | The application can retrieve information related to other applications. |
+| `http://tizen.org/privilege/application.launch` | public   | -                         | 2.2.1 | The application can open other applications using the application ID or application control. |
+| `http://tizen.org/privilege/appmanager.certificate` | partner  | -                         | 2.2.1 | The application can retrieve specified application certificates. |
+| `http://tizen.org/privilege/appmanager.kill` | partner  | -                         | 2.2.1 | The application can close other applications. |
+| `http://tizen.org/privilege/appmanager.launch` | public   | -                         | 4.0   | The application can open other applications. |
+| `http://tizen.org/privilege/bluetooth`   | public   | -                         | 2.4   | The application can perform unrestricted actions using Bluetooth, such as scanning for and connecting to other devices. |
+| `http://tizen.org/privilege/bluetooth.admin` | public | - | 2.2.1  | The application can change Bluetooth settings, such as turning Bluetooth on or off, setting the device name, and enabling or disabling AV remote control. Deprecated since 2.4. |
+| `http://tizen.org/privilege/bluetooth.gap` | public | - | 2.2.1 | The application can use the Bluetooth Generic Access Profile (GAP). As an example, it can scan and pair with devices. Deprecated since 2.4. |
+| `http://tizen.org/privilege/bluetooth.health` | public | - | 2.2.1 | The application can use the Bluetooth Health Device Profile (HDP). As an example, it can send health information. Deprecated since 2.4. |
+| `http://tizen.org/privilege/bluetooth.spp` | public | - | 2.2.1 | The application can use the Bluetooth Serial Port Profile (SPP). As an example, it can send serial data. Deprecated since 2.4. |
+| `http://tizen.org/privilege/bluetoothmanager` | platform | -                         | 2.2.1 | The application can change Bluetooth system settings related to privacy and security, such as the visibility mode. |
+| `http://tizen.org/privilege/bookmark.read` | platform | Bookmark                  | 2.2.1 | The application can read bookmarks.      |
+| `http://tizen.org/privilege/bookmark.write` | platform | Bookmark                  | 2.2.1 | The application can create, edit, and delete bookmarks. |
+| `http://tizen.org/privilege/calendar.read` | public   | Calendar                  | 2.2.1 | The application can read events and tasks. |
+| `http://tizen.org/privilege/calendar.write` | public   | Calendar                  | 2.2.1 | The application can create, update, and delete events and tasks. |
+| `http://tizen.org/privilege/call`        | public   | Call                      | 2.3   | The application can make phone calls to numbers when they are tapped without further confirmation. This can result in additional charges depending on the user's payment plan. |
+| `http://tizen.org/privilege/callhistory.read` | public   | Contacts and User history | 2.2.1 | The application can read call log items. |
+| `http://tizen.org/privilege/callhistory.write` | public   | Contacts and User history | 2.2.1 | The application can create, update, and delete call log items. |
+| `http://tizen.org/privilege/contact.read` | public   | Contacts                  | 2.2.1 | The application can read the user profile, contacts, and contact history.<br> Contact history can include social network activity. |
+| `http://tizen.org/privilege/contact.write` | public   | Contacts                  | 2.2.1 | The application can create, update, and delete the user profile, contacts, and any contact history that is related to this application.<br> Contact history can include social network activity. |
+| `http://tizen.org/privilege/content.read` | public   | -                         | 2.2.1 | The application can read media content information. |
+| `http://tizen.org/privilege/content.write` | public   | -                         | 2.2.1 | The application can create, update, and delete media content information. |
+| `http://tizen.org/privilege/datacontrol.consumer` | public   | -                         | 2.2.1 | The application can read data exported by data control providers. |
+| `http://tizen.org/privilege/datasharing` | public   | -                         | 4.0   | The application can share data with other applications. |
+| `http://tizen.org/privilege/datasync`    | public   | -                         | 2.2.1 | The application can synchronize device data, such as contacts and calendar events, using the OMA DS 1.2 protocol. |
+| `http://tizen.org/privilege/download`    | public   | -                         | 2.2.1 | The application can manage HTTP downloads. |
+| `http://tizen.org/privilege/filesystem.read` | public   | -                         | 2.2.1 | The application can read file systems.   |
+| `http://tizen.org/privilege/filesystem.write` | public   | -                         | 2.2.1 | The application can write to file systems. |
+| `http://tizen.org/privilege/healthinfo`  | public   | Sensor                    | 2.3   | The application can read the user's health information gathered by device sensors, such as pedometer or heart rate monitor. |
+| `http://tizen.org/privilege/ime`         | public   | -                         | 2.4   | The application can provide users with a way to enter characters and symbols into an associated text field. |
+| `http://tizen.org/privilege/led`         | public   | -                         | 2.4   | The application can switch LEDs on or off, such as the LED on the front of the device and the camera flash. |
+| `http://tizen.org/privilege/location`    | public   | Location                  | 2.2.1 | The application can read the user's location information. |
+| `http://tizen.org/privilege/mediacontroller.client` | public   | -                         | 2.4   | The application can receive information about currently playing media from applications that are allowed to send it, and can control those applications remotely. |
+| `http://tizen.org/privilege/mediacontroller.server` | public   | -                         | 2.4   | The application can send information about currently playing media to applications that are allowed to receive it, and can be controlled remotely by those applications. |
+| `http://tizen.org/privilege/messaging.read` | public   | Message                   | 2.2.1 | The application can retrieve messages from message boxes or receive messages. |
+| `http://tizen.org/privilege/messaging.write` | public   | Message                   | 2.2.1 | The application can write, send, sync, and remove text messages, multimedia messages, and emails. |
+| `http://tizen.org/privilege/networkbearerselection` | partner  | -                         | 2.2.1 | The application can request and release a specific network connection. |
+| `http://tizen.org/privilege/nfc.admin`   | public   | -                         | 2.2.1 | The application can change NFC settings, such as switching NFC on or off. Deprecated since 2.3. |
+| `http://tizen.org/privilege/nfc.cardemulation` | public   | -                         | 2.3   | The application can access smart card details, such as credit card details, and allow users to make payments through NFC. |
+| `http://tizen.org/privilege/nfc.common`  | public   | -                         | 2.2.1 | The application can use common NFC features. |
+| `http://tizen.org/privilege/nfc.p2p`     | public   | -                         | 2.2.1 | The application can push NFC messages to other devices. |
+| `http://tizen.org/privilege/nfc.tag`     | public   | -                         | 2.2.1 | The application can read and write NFC tag information. |
+| `http://tizen.org/privilege/notification` | public   | -                         | 2.2.1 | The application can show and hide its own notifications and badges. |
+| `http://tizen.org/privilege/package.info` | public   | -                         | 2.2.1 | The application can retrieve information about installed packages. |
+| `http://tizen.org/privilege/packagemanager.install` | platform | -                         | 2.2.1 | The application can install or uninstall application packages. |
+| `http://tizen.org/privilege/power`       | public   | -                         | 2.2.1 | The application can control power-related settings, such as dimming the screen. |
+| `http://tizen.org/privilege/push`        | public   | -                         | 2.2.1 | The application can receive notifications from the Internet. |
+| `http://tizen.org/privilege/recorder`    | public   | -                         | 4.0   | The application can record video and audio. |
+| `http://tizen.org/privilege/secureelement` | public   | -                         | 2.2.1 | The application can access secure smart card chips, such as UICC/SIM, embedded secure elements, and secure SD cards. |
+| `http://tizen.org/privilege/setting`     | public   | -                         | 2.2.1 | The application can change and read user settings. |
+| `http://tizen.org/privilege/system`      | public   | -                         | 2.2.1 | The application can read system information. |
+| `http://tizen.org/privilege/systemmanager` | partner | - | 2.2.1 | The application can read secure system information. Deprecated since 2.3.1. |
+| `http://tizen.org/privilege/tee.client`  | partner  | -                         | 4.0   | The application can communicate with a Trusted Application. |
+| `http://tizen.org/privilege/telephony`   | public   | -                         | 2.3.1 | The application can retrieve telephony information, such as the network and SIM card used, the IMEI, and the status of calls. |
+| `http://tizen.org/privilege/volume.set`  | public   | -                         | 2.3   | The application can adjust the volume for different features, such as notification alerts, ringtones, and media. |
+| `http://tizen.org/privilege/websetting`  | public   | -                         | 2.2.1 | The application can change its Web application settings, including deleting cookies. Deprecated since 2.4. |
+| `http://tizen.org/privilege/widget.viewer` | public   | -                         | 3.0   | The application can show widgets, and information from their associated applications, on the home screen. |
+
+**Table: Mobile Web W3C/HTML5 API privileges**
+
+| Privilege                                | Level  | Privacy               | Since | Description                              |
+| ---------------------------------------- | ------ | --------------------- | ----- | ---------------------------------------- |
+| `http://tizen.org/privilege/internet`    | public | -                     | 2.3   | The application can access the Internet using the [WebSocket](../api/latest/w3c_api/w3c_api_m.html#websocket), [XMLHttpRequest](../api/latest/w3c_api/w3c_api_m.html#httpreq), [Server-Sent Events](../api/latest/w3c_api/w3c_api_m.html#serversent), [HTML5 Application caches](../api/latest/w3c_api/w3c_api_m.html#cache), and [Cross-Origin Resource Sharing](../api/latest/w3c_api/w3c_api_m.html#cross) APIs. |
+| `http://tizen.org/privilege/mediacapture` | public | Camera and Microphone | 2.2.1 | The application can manipulate streams from cameras and microphones using the [getUserMedia](../api/latest/w3c_api/w3c_api_m.html#getusermedia) API.<br> **Privilege behavior:**<br> In the local domain, if this privilege is defined, permission is granted. Otherwise, execution is blocked. In the remote domain, if this privilege is defined, pop-up user prompt is used. Otherwise, execution is blocked. |
+| `http://tizen.org/privilege/unlimitedstorage` | public | -                     | 2.2.1 | The application can use the storage with unlimited size with the [File API: Directories and System](../api/latest/w3c_api/w3c_api_m.html#directory), [File API: Writer](../api/latest/w3c_api/w3c_api_m.html#writer), [Indexed Database](../api/latest/w3c_api/w3c_api_m.html#database), and [Web SQL Database](../api/latest/w3c_api/w3c_api_m.html#sql) APIs.<br>**Privilege behavior:**<br>In the local domain, if this privilege is defined, permission is granted. Otherwise, pop-up user prompt is used. In the remote domain, pop-up user prompt is used. |
+| `http://tizen.org/privilege/notification` | public | -                     | 2.2.1 | The application can display simple notifications using the [Web Notifications](../api/latest/w3c_api/w3c_api_m.html#webnoti) API.<br>**Privilege behavior:**<br>In the local domain, if this privilege is defined, permission is granted. Otherwise, pop-up user prompt is used. In the remote domain, pop-up user prompt is used. |
+| `http://tizen.org/privilege/location`    | public | Location              | 2.2.1 | The application can access geographic locations using the [Geolocation](../api/latest/w3c_api/w3c_api_m.html#geo) API.<br>**Privilege behavior:**<br>In the local domain, if this privilege is defined, permission is granted. Otherwise, execution is blocked. In the remote domain, if this privilege is defined, pop-up user prompt is used. Otherwise, execution is blocked. |
+
+**Table: Mobile Web Supplementary API privileges**
+
+| Privilege                               | Level  | Since | Description                              |
+| --------------------------------------- | ------ | ----- | ---------------------------------------- |
+| `http://tizen.org/privilege/fullscreen` | public | 2.2.1 | The application can display in the full-screen mode using the [FullScreen API - Mozilla](../api/latest/w3c_api/w3c_api_m.html#fullscreen) API.<br>**Privilege behavior:**<br>If this privilege is defined, permission is granted without user interaction. Otherwise, permission is granted by user interaction. |
+
+
+<a name="wearable"></a>
+## Wearable Web API Privileges
+
+The following tables list the API privileges, which you must declare when using security-sensitive API modules in wearable Web applications:
+
+**Table: Wearable Web Device API privileges**
+
+| Privilege                                | Level    | Privacy      | Since | Description                              |
+| ---------------------------------------- | -------- | ------------ | ----- | ---------------------------------------- |
+| `http://tizen.org/privilege/account.read` | public   | Account      | 4.0   | The application can read accounts.       |
+| `http://tizen.org/privilege/account.write` | public   | Account      | 4.0   | The application can create, edit, and delete accounts. |
+| `http://tizen.org/privilege/alarm`       | public   | -            | 2.2.1 | The application can set alarms and wake up the device at scheduled times. |
+| `http://tizen.org/privilege/apphistory.read` | public   | User history | 4.0   | The application can read the statistics of application usage, such as which applications have been used frequently or recently. |
+| `http://tizen.org/privilege/application.info` | public   | -            | 2.2.1 | The application can retrieve information related to other applications. |
+| `http://tizen.org/privilege/application.launch` | public   | -            | 2.2.1 | The application can open other applications using the application ID or application control. |
+| `http://tizen.org/privilege/appmanager.certificate` | partner  | -            | 2.2.1 | The application can retrieve specified application certificates. |
+| `http://tizen.org/privilege/appmanager.kill` | partner  | -            | 2.2.1 | The application can close other applications. |
+| `http://tizen.org/privilege/appmanager.launch` | public   | -            | 4.0   | The application can open other applications. |
+| `http://tizen.org/privilege/bluetooth`   | public   | -            | 3.0   | The application can perform unrestricted actions using Bluetooth, such as scanning for and connecting to other devices. |
+| `http://tizen.org/privilege/bluetooth.admin` | public | - | 2.3.1  | The application can change Bluetooth settings, such as turning Bluetooth on or off, setting the device name, and enabling or disabling AV remote control. Deprecated since 3.0. |
+| `http://tizen.org/privilege/bluetooth.gap` | public | - | 2.3.1 | The application can use the Bluetooth Generic Access Profile (GAP). As an example, it can scan and pair with devices. Deprecated since 3.0. |
+| `http://tizen.org/privilege/bluetooth.health` | public | - | 2.3.1 | The application can use the Bluetooth Health Device Profile (HDP). As an example, it can send health information. Deprecated since 3.0. |
+| `http://tizen.org/privilege/bluetooth.spp` | public | - | 2.3.1 | The application can use the Bluetooth Serial Port Profile (SPP). As an example, it can send serial data. Deprecated since 3.0. |
+| `http://tizen.org/privilege/bluetoothmanager` | platform | -            | 2.3.1 | The application can change Bluetooth system settings related to privacy and security, such as the visibility mode. |
+| `http://tizen.org/privilege/calendar.read` | public   | Calendar     | 4.0   | The application can read events and tasks. |
+| `http://tizen.org/privilege/calendar.write` | public   | Calendar     | 4.0   | The application can create, update, and delete events and tasks. |
+| `http://tizen.org/privilege/call`        | public   | Call         | 2.2.1 | The application can make phone calls to numbers when they are tapped without further confirmation. |
+| `http://tizen.org/privilege/contact.read` | public   | Contacts     | 4.0   | The application can read your profile, contacts, and contact history.<br> Contact history can include social network activity. |
+| `http://tizen.org/privilege/contact.write` | public   | Contacts     | 4.0   | The application can create, update, and delete your profile, contacts, and any contact history that is related to this application.<br> Contact history can include social network activity. |
+| `http://tizen.org/privilege/content.read` | public   | -            | 2.2.1 | The application can read media content information. |
+| `http://tizen.org/privilege/content.write` | public   | -            | 2.2.1 | The application can create, update, and delete media content information. |
+| `http://tizen.org/privilege/datacontrol.consumer` | public   | -            | 2.3.2 | The application can read data exported by data control providers. |
+| `http://tizen.org/privilege/datasharing` | public   | -            | 4.0   | The application can share data with other applications. |
+| `http://tizen.org/privilege/download`    | public   | -            | 2.2.1 | The application can manage HTTP downloads. |
+| `http://tizen.org/privilege/filesystem.read` | public   | -            | 2.2.1 | The application can read file systems.   |
+| `http://tizen.org/privilege/filesystem.write` | public   | -            | 2.2.1 | The application can write to file systems. |
+| `http://tizen.org/privilege/healthinfo`  | public   | Sensor       | 2.2.1 | The application can read the user's health information gathered by device sensors, such as pedometer or heart rate monitor. |
+| `http://tizen.org/privilege/ime`         | public   | -            | 3.0   | The application can provide users with a way to enter characters and symbols into an associated text field. |
+| `http://tizen.org/privilege/led`         | public   | -            | 3.0   | The application can switch LEDs on or off, such as the LED on the front of the device and the camera flash. |
+| `http://tizen.org/privilege/location`    | public   | Location     | 2.2.1 | The application can read the user's location information. |
+| `http://tizen.org/privilege/mediacontroller.client` | public   | -            | 3.0   | The application can receive information about currently playing media from applications that are allowed to send it, and can control those applications remotely. |
+| `http://tizen.org/privilege/mediacontroller.server` | public   | -            | 3.0   | The application can send information about currently playing media to applications that are allowed to receive it, and can be controlled remotely by those applications. |
+| `http://tizen.org/privilege/nfc.admin`   | public   | -            | 2.3.1 | The application can change NFC settings, such as switching NFC on or off. Deprecated since 2.3. |
+| `http://tizen.org/privilege/nfc.cardemulation` | public   | -            | 2.3.1 | The application can access smart card details, such as credit card details, and allow users to make payments through NFC. |
+| `http://tizen.org/privilege/nfc.common`  | public   | -            | 2.3.1 | The application can use common NFC features. |
+| `http://tizen.org/privilege/nfc.p2p`     | public   | -            | 2.3.1 | The application can push NFC messages to other devices. |
+| `http://tizen.org/privilege/nfc.tag`     | public   | -            | 2.3.1 | The application can read and write NFC tag information. |
+| `http://tizen.org/privilege/notification` | public   | -            | 2.2.1 | The application can show and hide its own notifications and badges. |
+| `http://tizen.org/privilege/package.info` | public   | -            | 2.2.1 | The application can retrieve information about installed packages. |
+| `http://tizen.org/privilege/packagemanager.install` | platform | -            | 2.2.1 | The application can install or uninstall application packages. |
+| `http://tizen.org/privilege/power`       | public   | -            | 2.2.1 | The application can control power-related settings, such as dimming the screen. |
+| `http://tizen.org/privilege/push`        | public   | -            | 2.2.1 | The application can receive notifications from the Internet. |
+| `http://tizen.org/privilege/recorder`    | public   | Microphone   | 4.0   | The application can record video and audio. |
+| `http://tizen.org/privilege/secureelement` | public   | -            | 2.3.1 | The application can access secure smart card chips, such as UICC/SIM, embedded secure elements, and secure SD cards. |
+| `http://tizen.org/privilege/setting`     | public   | -            | 2.2.1 | The application can change and read user settings. |
+| `http://tizen.org/privilege/system`      | public   | -            | 2.2.1 | The application can read system information. |
+| `http://tizen.org/privilege/systemmanager` | partner | - | 2.2.1 | The application can read secure system information. Deprecated since 2.3.1. |
+| `http://tizen.org/privilege/tee.client`  | partner  | -            | 4.0   | The application can communicate with a Trusted Application. |
+| `http://tizen.org/privilege/telephony`   | public   | -            | 2.3.1 | The application can retrieve telephony information, such as the network and SIM card used, the IMEI, and the status of calls. |
+| `http://tizen.org/privilege/volume.set`  | public   | -            | 2.2.1 | The application can adjust the volume for different features, such as notification alerts, ringtones, and media. |
+| `http://tizen.org/privilege/widget.viewer` | public   | -            | 2.3.2 | The application can show widgets, and information from their associated applications, on the home screen. |
+
+**Table: Wearable Web W3C/HTML5 API privileges**
+
+| Privilege                                | Level  | Privacy               | Since | Description                              |
+| ---------------------------------------- | ------ | --------------------- | ----- | ---------------------------------------- |
+| `http://tizen.org/privilege/internet`    | public | -                     | 2.2.1 | The application can access the Internet using the [WebSocket](../api/latest/w3c_api/w3c_api_w.html#websocket), [XMLHttpRequest](../api/latest/w3c_api/w3c_api_w.html#httpreq), and [Cross-Origin Resource Sharing](../api/latest/w3c_api/w3c_api_w.html#cross) APIs. |
+| `http://tizen.org/privilege/mediacapture` | public | Camera and Microphone | 2.2.1 | The application can manipulate streams from cameras and microphones using the [getUserMedia](../api/latest/w3c_api/w3c_api_w.html#getusermedia) API.<br>**Privilege behavior:**<br>In the local domain, if this privilege is defined, permission is granted. Otherwise, execution is blocked. In the remote domain, if this privilege is defined, pop-up user prompt is used. Otherwise, execution is blocked. |
+| `http://tizen.org/privilege/unlimitedstorage` | public | -                     | 2.2.1 | The application can use the storage with unlimited size with the [Indexed Database](../api/latest/w3c_api/w3c_api_w.html#database) API.<br>**Privilege behavior:**<br>In the local domain, if this privilege is defined, permission is granted. Otherwise, pop-up user prompt is used. In the remote domain, pop-up user prompt is used. |
+| `http://tizen.org/privilege/location`    | public | Location              | 2.2.1 | The application can access geographic locations using the [Geolocation](../api/latest/w3c_api/w3c_api_w.html#geo) API.<br>**Privilege behavior:**<br>In the local domain, if this privilege is defined, permission is granted. Otherwise, execution is blocked. In the remote domain, if this privilege is defined, pop-up user prompt is used. Otherwise, execution is blocked. |
+
+**Table: Wearable Web Supplementary API privileges**
+
+| Privilege                                | Level  | Privacy               | Since | Description                              |
+| ---------------------------------------- | ------ | --------------------- | ----- | ---------------------------------------- |
+| `http://tizen.org/privilege/camera`      | public | Camera and Microphone | 2.2.1 | The application can capture video and image on a target device using the [Camera API (Tizen Extension)](../api/latest/w3c_api/w3c_api_w.html#camera) (Video Recording and Image Capture) API.<br>**Privilege behavior:**<br>In the local domain, if this privilege is defined, permission is granted. Otherwise, execution is blocked. In the remote domain, execution is blocked. |
+| `http://tizen.org/privilege/audiorecorder` | public | Microphone            | 2.2.1 | The application can record an audio stream on a target device using the [Camera API (Tizen Extension)](../api/latest/w3c_api/w3c_api_w.html#camera) (Audio Recording) API.<br>**Privilege behavior:**<br>In the local domain, if this privilege is defined, permission is granted. Otherwise, execution is blocked. In the remote domain, execution is blocked. |
+
+
+<a name="tv"></a>
+## TV Web API Privileges
+
+The following tables list the API privileges, which you must declare when using security-sensitive API modules in TV Web applications.
+
+**Table: TV Web Device API privileges**
+
+| Privilege                                | Level    | Since | Description                              |
+| ---------------------------------------- | -------- | ----- | ---------------------------------------- |
+| `http://tizen.org/privilege/alarm`       | public   | 3.0   | The application can retrieve saved alarms and wake up the device at scheduled times. |
+| `http://tizen.org/privilege/apphistory.read` | public   | 4.0   | The application can read the statistics of application usage, such as which applications have been used frequently or recently. |
+| `http://tizen.org/privilege/application.info` | public   | 3.0   | The application can retrieve information related to other applications. |
+| `http://tizen.org/privilege/application.launch` | public   | 3.0   | The application can open other applications using the application ID or application control. |
+| `http://tizen.org/privilege/appmanager.certificate` | partner  | 3.0   | The application can retrieve specified application certificates. |
+| `http://tizen.org/privilege/appmanager.kill` | partner  | 3.0   | The application can close other applications. |
+| `http://tizen.org/privilege/appmanager.launch` | public   | 4.0   | The application can open other applications. |
+| `http://tizen.org/privilege/content.read` | public   | 3.0   | The application can read media content information. |
+| `http://tizen.org/privilege/content.write` | public   | 3.0   | The application can change media information. This information can be used by other applications. |
+| `http://tizen.org/privilege/datacontrol.consumer` | public   | 3.0   | The application can read data exported by data control providers. |
+| `http://tizen.org/privilege/datasharing` | public   | 4.0   | The application can share data with other applications. |
+| `http://tizen.org/privilege/download`    | public   | 3.0   | The application can manage HTTP downloads. This can result in additional charges depending on the user's payment plan. |
+| `http://tizen.org/privilege/filesystem.read` | public   | 3.0   | The application can read file systems.   |
+| `http://tizen.org/privilege/filesystem.write` | public   | 3.0   | The application can write to file systems. |
+| `http://tizen.org/privilege/internet`    | public   | 3.0   | The application can access the Internet. This may result in additional charges depending on your payment plan. |
+| `http://tizen.org/privilege/keymanager` | public | 2.4 | The application can save keys, certificates, and data to, and retrieve and delete them from, password-protected storage. Checking the statuses of certificates while connected to a mobile network may result in additional charges depending on user's payment plan. Deprecated since 3.0. |
+| `http://tizen.org/privilege/led`         | public   | 3.0   | The application can switch LEDs on or off, such as the LED on the front of the device and the camera flash. |
+| `http://tizen.org/privilege/mediacapture` | public   | 3.0   | The application can capture video and audio data. |
+| `http://tizen.org/privilege/package.info` | public   | 3.0   | The application can retrieve information about installed packages. |
+| `http://tizen.org/privilege/packagemanager.install` | platform | 3.0   | The application can install or uninstall application packages. |
+| `http://tizen.org/privilege/push`        | public   | 3.0   | The application can receive notifications from the Internet. This can result in additional charges depending on the user's payment plan. |
+| `http://tizen.org/privilege/recorder`    | public   | 4.0   | The application can record video and audio. |
+| `http://tizen.org/privilege/system`      | public   | 3.0   | The application can read system information. |
+| `http://tizen.org/privilege/systemmanager` | partner | 2.3 | The application can read secure system information. Deprecated since 2.4. |
+| `http://tizen.org/privilege/tee.client`  | partner  | 4.0   | The application can communicate with a Trusted Application. |
+| `http://tizen.org/privilege/telephony`   | public   | 3.0   | The application can retrieve telephony information, such as the network and SIM card used, the IMEI, and the status of calls. |
+| `http://tizen.org/privilege/tv.audio`    | public   | 3.0   | The application can change the volume, enable and disable the silent mode, detect volume changes, and play beeps. |
+| `http://tizen.org/privilege/tv.channel`  | public   | 3.0   | The application can change the TV channel, read information about TV channels and programs, and receive notifications when the TV channel has been changed. |
+| `http://tizen.org/privilege/tv.display`  | public   | 3.0   | The application can check whether a device supports 3D and read information about the 3D mode. |
+| `http://tizen.org/privilege/tv.inputdevice` | public   | 3.0   | The application can capture the key events of an input device, such as TV remote control, and release key grabbing. |
+| `http://tizen.org/privilege/tv.window`   | public   | 3.0   | The application can embed the display of a video source, specify the size, and show or hide the embedded display. |
+| `http://tizen.org/privilege/volume.set`  | public   | 3.0   | The application can adjust the volume for different features, such as notification alerts, ringtones, and media. |
+
+**Table: TV Web W3C/HTML5 API privileges**
+
+| Privilege                                | Level  | Since | Description                              |
+| ---------------------------------------- | ------ | ----- | ---------------------------------------- |
+| `http://tizen.org/privilege/unlimitedstorage` | public | 3.0   | The application can use the storage with unlimited size with the [Indexed Database](../api/latest/w3c_api/w3c_api_tv.html#database) API.<br> **Privilege behavior:**<br> - In the local domain, if this privilege is defined, permission is granted. Otherwise, pop-up user prompt is used.<br> - In the remote domain, pop-up user prompt is used. |
+
+**Table: TV Web Supplementary API privileges**
+
+| Privilege                                | Level  | Since | Description                              |
+| ---------------------------------------- | ------ | ----- | ---------------------------------------- |
+| `http://tizen.org/privilege/fullscreen`  | public   | 3.0   | The application can use the full screen view. |
+
+
+<a name="nonAPI"></a>
+## Non-API Bound Privileges
+
+Tizen application privileges are loosely bound to APIs, so most of the privileges can be identified by the APIs that the application calls. However, there are some privileges that are not coupled with the Tizen APIs. To allow easy identification, those privileges are mapped to corresponding system resources that are similar as other privileges.
+
+The following table lists the non-API bound privileges:
+
+**Table: Non-API bound privileges**
+
+| Privilege      | Level          | Privacy        | Since          | Description    |
+|---------------|---------------|-----------------|----------------|-----------------|
+| `http://tizen.org/privilege/mediastorage` | public | Storage | 4.0 | When you connect the device to a computer (Windows&reg; or macOS) through USB, you can access a dedicated media storage area shown as massive media storage. This region of the storage is called media storage and is usually used for multimedia files, such as photos, videos, and music files. Since this storage area is used for user private data, access to it must be protected with a privilege.<br> If your application does not have this privilege, no file operations into the media storage area succeed and you receive a permission denied error. If you have this privilege, you can read and write directories and files, create new files, and delete files in the storage area.      |
+| `http://tizen.org/privilege/externalstorage` | public | Storage | 4.0 | Similar to the media storage, many devices support external storages, such as MicroSD card or USB memory. As with the media storage, the access to an external storage must be protected with a privilege.<br> If your application does not have this privilege, all file operations fail with a permission denied error. If you have this privilege, you have full access to the external storage. |

--- a/docs/application/web/tutorials/old-versioned-sec-privileges.md
+++ b/docs/application/web/tutorials/old-versioned-sec-privileges.md
@@ -228,7 +228,7 @@ The following tables list the API privileges, which you must declare when using 
 <a name="nonAPI"></a>
 ## Non-API Bound Privileges
 
-Tizen application privileges are loosely bound to APIs, so most of the privileges can be identified by the APIs that the application calls. However, there are some privileges that are not coupled with the Tizen APIs. To allow easy identification, those privileges are mapped to corresponding system resources that are similar as other privileges.
+Tizen application privileges are loosely bound to APIs, so most of the privileges can be identified by the APIs that the application calls. However, there are some privileges that are not coupled with the Tizen APIs. To allow easy identification, those privileges are mapped to corresponding system resources that are similar to other privileges.
 
 The following table lists the non-API bound privileges:
 

--- a/docs/application/web/tutorials/overview.md
+++ b/docs/application/web/tutorials/overview.md
@@ -10,6 +10,8 @@ The introduction to Web applications documentation provides overall information 
 
 - [Security and API Privileges](sec-privileges.md)
 
+- [Security and API Privileges for Apps with API Version 4.0 or Earlier](old-versioned-sec-privileges.md)
+
 - [Web Runtime](web-runtime.md)
 
 - [Event Handling](event-handling.md) (in **wearable applications only**)

--- a/docs/application/web/tutorials/sec-privileges.md
+++ b/docs/application/web/tutorials/sec-privileges.md
@@ -20,6 +20,8 @@ Since Tizen platform 3.0, some privileges are categorized as privacy-related and
 
 The Tizen Studio also provides privilege checker tools to check whether the Tizen application source code contains any privilege violations. For more information, see [Verifying Privilege Usage](../../tizen-studio/web-tools/privilege-checker.md).
 
+The API version restriction of privileges are deprecated since platform version 5.0. So, if you are develeoping an app with an earlier API version and need information about supported version, see [this page](./old-versioned-sec-privileges.md). The page does not include privileges issued after 4.0.
+
 <a name="API"></a>
 ## Web API Privileges
 
@@ -39,10 +41,10 @@ The following tables list the API privileges, which you must declare when using 
 | `http://tizen.org/privilege/appmanager.kill` | partner |  | The application can close other applications. |
 | `http://tizen.org/privilege/appmanager.launch` | public |  | The application can open other applications. |
 | `http://tizen.org/privilege/bluetooth` | public |  | The application can perform unrestricted actions using Bluetooth, such as scanning for and connecting to other devices. |
-| `http://tizen.org/privilege/bluetooth.admin` | public |  | The application can change Bluetooth settings, such as turning Bluetooth on or off, setting the device name, and enabling or disabling AV remote control. |
-| `http://tizen.org/privilege/bluetooth.gap` | public |  | The application can use the Bluetooth Generic Access Profile (GAP). As an example, it can scan and pair with devices. |
-| `http://tizen.org/privilege/bluetooth.health` | public |  | The application can use the Bluetooth Health Device Profile (HDP). As an example, it can send health information. |
-| `http://tizen.org/privilege/bluetooth.spp` | public |  | The application can use the Bluetooth Serial Port Profile (SPP). As an example, it can send serial data. |
+| `http://tizen.org/privilege/bluetooth.admin` | public |  | The application can change Bluetooth settings, such as turning Bluetooth on or off, setting the device name, and enabling or disabling AV remote control. Deprecated since 3.0. |
+| `http://tizen.org/privilege/bluetooth.gap` | public |  | The application can use the Bluetooth Generic Access Profile (GAP). As an example, it can scan and pair with devices. Deprecated since 3.0. |
+| `http://tizen.org/privilege/bluetooth.health` | public |  | The application can use the Bluetooth Health Device Profile (HDP). As an example, it can send health information. Deprecated since 3.0. |
+| `http://tizen.org/privilege/bluetooth.spp` | public |  | The application can use the Bluetooth Serial Port Profile (SPP). As an example, it can send serial data. Deprecated since 3.0. |
 | `http://tizen.org/privilege/bluetoothmanager` | platform |  | The application can change Bluetooth system settings related to privacy and security, such as the visibility mode. |
 | `http://tizen.org/privilege/bookmark.read` | platform | Bookmark | The application can read bookmarks. |
 | `http://tizen.org/privilege/bookmark.write` | platform | Bookmark | The application can create, edit, and delete bookmarks. |
@@ -64,7 +66,7 @@ The following tables list the API privileges, which you must declare when using 
 | `http://tizen.org/privilege/healthinfo` | public | Sensor | The application can read health information gathered by the device sensors, such as the pedometer and the heart rate monitor. |
 | `http://tizen.org/privilege/ime` | public |  | The application can provide users with a way to enter characters and symbols into an associated text field. |
 | `http://tizen.org/privilege/internet` | public | | The application can access the Internet. This may result in additional charges depending on user's payment plan. |
-| `http://tizen.org/privilege/keymanager` | public |  | The application can save keys, certificates, and data to, and retrieve and delete them from, password-protected storage. Checking the statuses of certificates while connected to a mobile network may result in additional charges depending on user's payment plan. |
+| `http://tizen.org/privilege/keymanager` | public |  | The application can save keys, certificates, and data to, and retrieve and delete them from, password-protected storage. Checking the statuses of certificates while connected to a mobile network may result in additional charges depending on user's payment plan. Deprecated since 3.0. |
 | `http://tizen.org/privilege/led` | public |  | The application can turn LEDs on or off, such as the LED on the front of the device and the camera flash. |
 | `http://tizen.org/privilege/location` | public | | The application can use user's location data. |
 | `http://tizen.org/privilege/mediacapture` | public | Camera & Microphone | The application can capture video and audio data.  |
@@ -73,7 +75,7 @@ The following tables list the API privileges, which you must declare when using 
 | `http://tizen.org/privilege/messaging.read` | public | Message & Storage | The application can retrieve emails, text messages, and multimedia messages from the server or receive them directly. This may result in additional charges depending on user's payment plan. |
 | `http://tizen.org/privilege/messaging.write` | public | Message & Storage | The application can write text messages, multimedia messages, and emails. This may result in additional charges depending on user's payment plan. |
 | `http://tizen.org/privilege/networkbearerselection` | partner |  | The application can restrict the device so some specific domains can only be accessed via mobile networks. This may result in additional charges depending on user's payment plan. |
-| `http://tizen.org/privilege/nfc.admin` | public |  | The application can change NFC settings, such as turning NFC on or off. |
+| `http://tizen.org/privilege/nfc.admin` | public |  | The application can change NFC settings, such as turning NFC on or off. Deprecated since 2.3. |
 | `http://tizen.org/privilege/nfc.cardemulation` | public |  | The application can access smart card details, such as credit card details, and allow users to make payments via NFC. |
 | `http://tizen.org/privilege/nfc.common` | public |  | The application can use NFC common features. |
 | `http://tizen.org/privilege/nfc.p2p` | public |  | The application can push NFC messages to other devices. |
@@ -87,16 +89,16 @@ The following tables list the API privileges, which you must declare when using 
 | `http://tizen.org/privilege/secureelement` | public |  | The application can access secure smart card chips such as UICC/SIM, embedded secure elements, and secure SD cards. |
 | `http://tizen.org/privilege/setting` | public |  | The application can change and read user settings. |
 | `http://tizen.org/privilege/system` | public |  | The application can read system information. |
-| `http://tizen.org/privilege/systemmanager` | partner |  | The application can read secure system information. |
+| `http://tizen.org/privilege/systemmanager` | partner |  | The application can read secure system information. Deprecated since 2.4. |
 | `http://tizen.org/privilege/tee.client` | partner |  | The application can call security related functions running inside a Trusted Execution Environment (TEE), which ensures that sensitive data is stored, processed, and protected in an isolated, trusted environment. |
 | `http://tizen.org/privilege/telephony` | public |  | The application can retrieve telephony information, such as the network and SIM card used, the IMEI, and the statuses of calls. |
-| `http://tizen.org/privilege/tv.audio` | public |  | The application can change the volume, enable and disable silent mode, detect volume changes, and play beeps. |
+| `http://tizen.org/privilege/tv.audio` | public |  | The application can change the volume, enable and disable silent mode, detect volume changes, and play beeps. Deprecated since 5.0. |
 | `http://tizen.org/privilege/tv.channel` | public |  | The application can change the TV channel, read information about TV channels and programmes, and receive notifications when the TV channel has been changed. |
-| `http://tizen.org/privilege/tv.display` | public |  | The application can check whether a device supports 3D and read information about 3D mode. |
+| `http://tizen.org/privilege/tv.display` | public |  | The application can check whether a device supports 3D and read information about 3D mode. Deprecated since 5.0. |
 | `http://tizen.org/privilege/tv.inputdevice` | public |  | The application can capture the key events of an input device, for example, TV remote control, and release key grabbing. |
 | `http://tizen.org/privilege/tv.window` | public |  | The application can embed the display of a video source, specify the size, and show or hide the embedded display. |
 | `http://tizen.org/privilege/volume.set` | public |  | The application can adjust the volume for different features, such as notification alerts, ringtones, and media. |
-| `http://tizen.org/privilege/websetting` | public |  | The application can change its web application settings, including deleting its cookies. |
+| `http://tizen.org/privilege/websetting` | public |  | The application can change its web application settings, including deleting its cookies. Deprecated since 2.4. |
 | `http://tizen.org/privilege/widget.viewer` | public |  | The application can show widgets, and information from their associated applications, on the home screen. |
 
 **Table: Web W3C/HTML5 API privileges**
@@ -121,7 +123,7 @@ The following tables list the API privileges, which you must declare when using 
 <a name="nonAPI"></a>
 ## Non-API Bound Privileges
 
-Tizen application privileges are loosely bound to APIs, so most of the privileges can be identified by the APIs that the application calls. However, there are some privileges that are not coupled with the Tizen APIs. To allow easy identification, those privileges are mapped to corresponding system resources - same as other privileges.
+Tizen application privileges are loosely bound to APIs, so most of the privileges can be identified by the APIs that the application calls. However, there are some privileges that are not coupled with the Tizen APIs. To allow easy identification, those privileges are mapped to corresponding system resources that are similar as other privileges.
 
 The following table lists the non-API bound privileges:
 

--- a/docs/application/web/tutorials/sec-privileges.md
+++ b/docs/application/web/tutorials/sec-privileges.md
@@ -123,7 +123,7 @@ The following tables list the API privileges, which you must declare when using 
 <a name="nonAPI"></a>
 ## Non-API Bound Privileges
 
-Tizen application privileges are loosely bound to APIs, so most of the privileges can be identified by the APIs that the application calls. However, there are some privileges that are not coupled with the Tizen APIs. To allow easy identification, those privileges are mapped to corresponding system resources that are similar as other privileges.
+Tizen application privileges are loosely bound to APIs, so most of the privileges can be identified by the APIs that the application calls. However, there are some privileges that are not coupled with the Tizen APIs. To allow easy identification, those privileges are mapped to corresponding system resources that are similar to other privileges.
 
 The following table lists the non-API bound privileges:
 


### PR DESCRIPTION
### Change Description ###

The API version restriction of privileges are deprecated since Tizen platform 5.0 and 
API versions were removed from privilege document. 
However, there are apps that are being developed in a lower version(< 5.0) somewhere, and 
we need to provide information for them, so I added pages for that.