### PR TITLE
[5.0] [Common] Added missing information about remove listener behaviour

### DIFF
--- a/docs/application/web/api/5.0/device_api/mobile/tizen/account.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/account.html
@@ -1142,6 +1142,11 @@ If you want to get all the providers, omit the capability argument.
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/application.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/application.html
@@ -1531,8 +1531,7 @@ var watchId = tizen.application.addAppInfoEventListener(appEventCallback);
 </dt>
 <dd class="deprecated">
 <div class="brief">
- Removes the listener to stop receiving notifications for changes on the list of installed
-applications on a device.
+ Removes the listener to stop receiving notifications for changes on the list of installed applications on a device.
             </div>
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 2.4. Instead, use <a href="./package.html#PackageManager::unsetPackageInfoEventListener">tizen.package.unsetPackageInfoEventListener()</a>.
@@ -1655,6 +1654,11 @@ var watchId = tizen.application.addAppStatusChangeListener(appStatusEventCallbac
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -2011,6 +2015,11 @@ tizen.application.getAppsInfo(onListInstalledApps);
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/badge.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/badge.html
@@ -314,6 +314,11 @@ tizen.application.getAppsInfo(onListInstalledApps);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Nothing will be done for app ids which do not have any registered listeners.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/bluetooth.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/bluetooth.html
@@ -1590,6 +1590,11 @@ adapter.setChangeListener(changeListener);
 <p><span class="version">Since: </span>
  2.2
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
@@ -3373,6 +3378,11 @@ adapter.startScan(function onsuccess(device)
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="remark">Remark: </span>
  Example of using can be find at <a href="bluetooth.html#BluetoothGATTCharacteristic::addValueChangeListener">addValueChangeListener</a> code example.
             </p>
@@ -4802,12 +4812,17 @@ adapter.startScan(onDeviceFound, onerror);
 </dt>
 <dd>
 <div class="brief">
- Unregisters a Bluetooth device connection listener
+ Unregisters a Bluetooth device connection listener.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void removeConnectStateChangeListener(long watchID);</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -6673,13 +6688,17 @@ healthProfileHandler.registerSinkApplication(
 </dt>
 <dd>
 <div class="brief">
- Unsets the listener.
-This stops receiving notifications.
+ Unsets the listener. This stops receiving notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void unsetListener();</pre></div>
 <p><span class="version">Since: </span>
  2.2
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/calendar.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/calendar.html
@@ -2084,7 +2084,8 @@ watcherId = calendar.addChangeListener(watcher);
             </p>
 <div class="description">
             <p>
-If the <em>watchId </em>argument is valid and corresponds to a subscription already in place, the watch process must immediately stop and no further callbacks must be invoked. If the <em>watchId </em>argument is not valid or does not correspond to a valid subscription, the method should return without any further action.
+If the <em>watchId </em>argument is valid and corresponds to a subscription already in place, the watch process must immediately stop and no further callbacks must be invoked.
+If the <em>watchId </em>argument is not valid or does not correspond to a valid subscription, the method should return without any further action.
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/content.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/content.html
@@ -1077,6 +1077,11 @@ console.log("Listener ID: " + listenerId);
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1228,6 +1233,11 @@ tizen.content.setChangeListener(listener);
 <p><span class="version">Since: </span>
  2.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/fmradio.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/fmradio.html
@@ -776,6 +776,11 @@ tizen.fmradio.setFMRadioInterruptedListener(interruptCallback);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
@@ -841,6 +846,11 @@ tizen.fmradio.setAntennaChangeListener(antennaCallback);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/humanactivitymonitor.html
@@ -933,6 +933,11 @@ Accumulative total step count: 100
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1057,6 +1062,9 @@ accuracy: MEDIUM
  3.0
             </p>
 <div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
             <p>
 The <em>ErrorCallback</em> method is launched with this error type:
             </p>
@@ -1514,6 +1522,11 @@ Received GESTURE_SHAKE_DETECTED event on Thu Sep 01 2016 14:33:56 GMT+0200 (CEST
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1773,6 +1786,11 @@ Stress level: Normal
 <p><span class="version">Since: </span>
  5.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/iotcon.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/iotcon.html
@@ -849,14 +849,14 @@ watchId = tizen.iotcon.addGeneratedPinListener(RandomPinSuccess);
 <ul>
           <li class="param">
 <span class="name">watchId</span>:
- The watchID identifier returned by the addGeneratedPinListener() method.
+ The watchId identifier returned by the addGeneratedPinListener() method.
                 </li>
         </ul>
 </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
- with error type AbortError, If the operation has been stopped.
+ with error type AbortError, if the operation has been stopped or there is no listener with given watchId.
                 </p></li></ul>
 </li></ul>
         </div>
@@ -1154,7 +1154,7 @@ Resource type: oic.wk.ad
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type AbortError, if the operation has been stopped.
+ with error type AbortError, if the operation has been stopped or listener for given watchId was not found.
                 </p></li>
 </ul>
 </li></ul>
@@ -2726,6 +2726,11 @@ catch (err)
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -3552,6 +3557,11 @@ catch (err)
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener was not set.
+            </p>
+           </div>
 <p><span class="remark">Remark: </span>
  Example of using can be find at <a href="iotcon.html#Resource::setRequestListener">setRequestListener</a> code example.
             </p>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/mediacontroller.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/mediacontroller.html
@@ -695,6 +695,11 @@ watcherId = mcServer.addChangeRequestPlaybackInfoListener(playbackRequestListene
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -814,6 +819,11 @@ watcherId = mcServer.addCommandListener(commandReceiveListener);
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1404,6 +1414,11 @@ watcherId = mcServerInfo.addServerStatusChangeListener(function(status)
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1518,6 +1533,11 @@ watcherId = mcServerInfo.addPlaybackInfoChangeListener(playbackListener);
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/mediakey.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/mediakey.html
@@ -209,6 +209,11 @@ There is a tizen.mediakey object that allows accessing the functionality of the 
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/messaging.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/messaging.html
@@ -2969,6 +2969,9 @@ messageStorage.addFoldersChangeListener(folderChangeCB);
             </p>
 <div class="description">
             <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+            <p>
 The errorCallback is launched with these error types:
             </p>
             <ul>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/nfc.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/nfc.html
@@ -1090,6 +1090,11 @@ adapter.setPeerListener(onSuccessCB);
 <p><span class="version">Since: </span>
  1.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1152,6 +1157,11 @@ adapter.setTagListener(onSuccessCB);
 <p><span class="version">Since: </span>
  1.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1282,6 +1292,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1407,6 +1422,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1528,6 +1548,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1777,6 +1802,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -2909,6 +2939,11 @@ adapter.setPeerListener(onSuccessCB);
 <p><span class="version">Since: </span>
  1.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/package.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/package.html
@@ -571,6 +571,11 @@ tizen.package.setPackageInfoEventListener(packageEventCallback);
 <p><span class="version">Since: </span>
  2.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/power.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/power.html
@@ -395,6 +395,11 @@ tizen.power.setScreenStateChangeListener(onScreenStateChanged);
 <p><span class="version">Since: </span>
  2.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/se.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/se.html
@@ -343,6 +343,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/sensor.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/sensor.html
@@ -761,6 +761,11 @@ lightSensor.start(onsuccessCB);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/sound.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/sound.html
@@ -442,6 +442,11 @@ There is a tizen.sound object that allows accessing the functionality of the Sou
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
@@ -494,6 +499,11 @@ There is a tizen.sound object that allows accessing the functionality of the Sou
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/systeminfo.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/systeminfo.html
@@ -1112,8 +1112,7 @@ any identifier of these properties, but the listener added for them will not be 
             <p>
 If a valid listenerId argument is passed that corresponds to an existing subscription,
 then the watch process must immediately terminate and no further
-callback is invoked. If the listenerId argument does not correspond to a valid subscription,
-the method should return without any further action.
+callback is invoked.
             </p>
            </div>
 <div class="parameters">

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/time.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/time.html
@@ -625,6 +625,11 @@ tizen.time.setDateTimeChangeListener(changedCallback);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
@@ -719,6 +724,11 @@ tizen.time.setTimezoneChangeListener(changedCallback);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/voicecontrol.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/voicecontrol.html
@@ -511,6 +511,11 @@ Result callback - event: SUCCESS, result: alpha
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -629,6 +634,11 @@ Language change callback en_US-&gt;ko_KR
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/5.0/device_api/tv/tizen/account.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/account.html
@@ -1142,6 +1142,11 @@ If you want to get all the providers, omit the capability argument.
 <p><span class="version">Since: </span>
  5.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/tv/tizen/application.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/application.html
@@ -1302,8 +1302,7 @@ var watchId = tizen.application.addAppInfoEventListener(appEventCallback);
 </dt>
 <dd class="deprecated">
 <div class="brief">
- Removes the listener to stop receiving notifications for changes on the list of installed
-applications on a device.
+ Removes the listener to stop receiving notifications for changes on the list of installed applications on a device.
             </div>
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 2.4. Instead, use <a href="./package.html#PackageManager::unsetPackageInfoEventListener">tizen.package.unsetPackageInfoEventListener()</a>.
@@ -1426,6 +1425,11 @@ var watchId = tizen.application.addAppStatusChangeListener(appStatusEventCallbac
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1782,6 +1786,11 @@ tizen.application.getAppsInfo(onListInstalledApps);
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/5.0/device_api/tv/tizen/content.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/content.html
@@ -1075,6 +1075,11 @@ console.log("Listener ID: " + listenerId);
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1226,6 +1231,11 @@ tizen.content.setChangeListener(listener);
 <p><span class="version">Since: </span>
  2.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/tv/tizen/iotcon.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/iotcon.html
@@ -847,14 +847,14 @@ watchId = tizen.iotcon.addGeneratedPinListener(RandomPinSuccess);
 <ul>
           <li class="param">
 <span class="name">watchId</span>:
- The watchID identifier returned by the addGeneratedPinListener() method.
+ The watchId identifier returned by the addGeneratedPinListener() method.
                 </li>
         </ul>
 </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
- with error type AbortError, If the operation has been stopped.
+ with error type AbortError, if the operation has been stopped or there is no listener with given watchId.
                 </p></li></ul>
 </li></ul>
         </div>
@@ -1152,7 +1152,7 @@ Resource type: oic.wk.ad
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type AbortError, if the operation has been stopped.
+ with error type AbortError, if the operation has been stopped or listener for given watchId was not found.
                 </p></li>
 </ul>
 </li></ul>
@@ -2724,6 +2724,11 @@ catch (err)
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -3550,6 +3555,11 @@ catch (err)
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener was not set.
+            </p>
+           </div>
 <p><span class="remark">Remark: </span>
  Example of using can be find at <a href="iotcon.html#Resource::setRequestListener">setRequestListener</a> code example.
             </p>

--- a/docs/application/web/api/5.0/device_api/tv/tizen/mediacontroller.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/mediacontroller.html
@@ -695,6 +695,11 @@ watcherId = mcServer.addChangeRequestPlaybackInfoListener(playbackRequestListene
 <p><span class="version">Since: </span>
  5.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -814,6 +819,11 @@ watcherId = mcServer.addCommandListener(commandReceiveListener);
 <p><span class="version">Since: </span>
  5.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1404,6 +1414,11 @@ watcherId = mcServerInfo.addServerStatusChangeListener(function(status)
 <p><span class="version">Since: </span>
  5.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1518,6 +1533,11 @@ watcherId = mcServerInfo.addPlaybackInfoChangeListener(playbackListener);
 <p><span class="version">Since: </span>
  5.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/5.0/device_api/tv/tizen/package.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/package.html
@@ -569,6 +569,11 @@ tizen.package.setPackageInfoEventListener(packageEventCallback);
 <p><span class="version">Since: </span>
  2.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/tv/tizen/systeminfo.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/systeminfo.html
@@ -1245,8 +1245,7 @@ any identifier of these properties, but the listener added for them will not be 
             <p>
 If a valid listenerId argument is passed that corresponds to an existing subscription,
 then the watch process must immediately terminate and no further
-callback is invoked. If the listenerId argument does not correspond to a valid subscription,
-the method should return without any further action.
+callback is invoked.
             </p>
            </div>
 <div class="parameters">

--- a/docs/application/web/api/5.0/device_api/tv/tizen/time.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/time.html
@@ -625,6 +625,11 @@ tizen.time.setDateTimeChangeListener(changedCallback);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
@@ -719,6 +724,11 @@ tizen.time.setTimezoneChangeListener(changedCallback);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/5.0/device_api/tv/tizen/tvaudiocontrol.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/tvaudiocontrol.html
@@ -218,6 +218,9 @@ are used, then mute is disabled.
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/tv.audio
             </p>
+<p class="warning"><b>Warning:</b>
+  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -232,9 +235,10 @@ are used, then mute is disabled.
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
+This type of error is deprecated since Tizen 5.0. 
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -267,6 +271,9 @@ tizen.tvaudiocontrol.setMute(false);
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/tv.audio
             </p>
+<p class="warning"><b>Warning:</b>
+  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+            </p>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
@@ -280,9 +287,10 @@ tizen.tvaudiocontrol.setMute(false);
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
+This type of error is deprecated since Tizen 5.0. 
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -345,6 +353,9 @@ The value of <em>volume</em> is allowed from 0 to 100. If an invalid value is pa
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/tv.audio
             </p>
+<p class="warning"><b>Warning:</b>
+  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -362,9 +373,10 @@ The value of <em>volume</em> is allowed from 0 to 100. If an invalid value is pa
                 </p></li>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
+This type of error is deprecated since Tizen 5.0. 
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -411,14 +423,18 @@ then execution of this functions will disable it.
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/tv.audio
             </p>
+<p class="warning"><b>Warning:</b>
+  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+            </p>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
+This type of error is deprecated since Tizen 5.0. 
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -469,14 +485,18 @@ then execution of this functions will disable it.
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/tv.audio
             </p>
+<p class="warning"><b>Warning:</b>
+  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+            </p>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
+This type of error is deprecated since Tizen 5.0. 
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -520,6 +540,9 @@ if (tizen.tvaudiocontrol.getVolume() === 0)
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/tv.audio
             </p>
+<p class="warning"><b>Warning:</b>
+  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+            </p>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
@@ -533,9 +556,10 @@ if (tizen.tvaudiocontrol.getVolume() === 0)
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
+This type of error is deprecated since Tizen 5.0. 
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -563,6 +587,9 @@ Note that this method overwrites the previously registered listener.
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/tv.audio
             </p>
+<p class="warning"><b>Warning:</b>
+  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -580,9 +607,10 @@ Note that this method overwrites the previously registered listener.
                 </p></li>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
+This type of error is deprecated since Tizen 5.0. 
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -622,20 +650,29 @@ tizen.tvaudiocontrol.setVolume(expectedVolumeLevel);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/tv.audio
             </p>
+<p class="warning"><b>Warning:</b>
+  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+            </p>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
+This type of error is deprecated since Tizen 5.0. 
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -674,6 +711,9 @@ tizen.tvaudiocontrol.setVolume(expectedVolumeLevel);
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/tv.audio
             </p>
+<p class="warning"><b>Warning:</b>
+  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+            </p>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
@@ -687,9 +727,10 @@ tizen.tvaudiocontrol.setVolume(expectedVolumeLevel);
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
+This type of error is deprecated since Tizen 5.0. 
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -712,6 +753,9 @@ tizen.tvaudiocontrol.setVolume(expectedVolumeLevel);
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/tv.audio
             </p>
+<p class="warning"><b>Warning:</b>
+  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -729,9 +773,10 @@ tizen.tvaudiocontrol.setVolume(expectedVolumeLevel);
                 </p></li>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
+This type of error is deprecated since Tizen 5.0. 
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>

--- a/docs/application/web/api/5.0/device_api/tv/tizen/tvchannel.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/tvchannel.html
@@ -1168,6 +1168,11 @@ catch (error)
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1280,6 +1285,11 @@ catch (error)
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/tv/tizen/tvdisplaycontrol.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/tvdisplaycontrol.html
@@ -232,6 +232,9 @@ For example, Display Control API provides whether your device supports 3D.
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/tv.display
             </p>
+<p><span class="remark">Remark: </span>
+  http://tizen.org/privilege/tv.display (public level) has been deprecated since 5.0. 
+            </p>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
@@ -245,12 +248,13 @@ For example, Display Control API provides whether your device supports 3D.
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
+This type of error is deprecated since Tizen 5.0. 
                 </p></li>
 <li class="list"><p>
  with error type NotSupportedError, if this feature is not supported.
                 </p></li>
 <li class="list"><p>
- with error type UnknownError, in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -285,6 +289,9 @@ catch (error)
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/tv.display
             </p>
+<p><span class="remark">Remark: </span>
+  http://tizen.org/privilege/tv.display (public level) has been deprecated since 5.0. 
+            </p>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
@@ -298,12 +305,13 @@ catch (error)
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
+This type of error is deprecated since Tizen 5.0. 
                 </p></li>
 <li class="list"><p>
  with error type NotSupportedError, if this feature is not supported.
                 </p></li>
 <li class="list"><p>
- with error type UnknownError, in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -351,6 +359,9 @@ catch (error)
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/tv.display
             </p>
+<p><span class="remark">Remark: </span>
+  http://tizen.org/privilege/tv.display (public level) has been deprecated since 5.0. 
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -372,6 +383,7 @@ catch (error)
                 </p></li>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
+This type of error is deprecated since Tizen 5.0. 
                 </p></li>
 <li class="list"><p>
  with error type NotSupportedError, if this feature is not supported.

--- a/docs/application/web/api/5.0/device_api/tv/tizen/tvinfo.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/tvinfo.html
@@ -473,6 +473,11 @@ There is a tizen.tvinfo object that allows accessing the functionality of the TV
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/5.0/device_api/tv/tizen/tvwindow.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/tvwindow.html
@@ -932,6 +932,11 @@ catch (error)
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/tv/tizen/voicecontrol.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/voicecontrol.html
@@ -511,6 +511,11 @@ Result callback - event: SUCCESS, result: alpha
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -629,6 +634,11 @@ Language change callback en_US-&gt;ko_KR
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/account.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/account.html
@@ -1142,6 +1142,11 @@ If you want to get all the providers, omit the capability argument.
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/application.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/application.html
@@ -1531,8 +1531,7 @@ var watchId = tizen.application.addAppInfoEventListener(appEventCallback);
 </dt>
 <dd class="deprecated">
 <div class="brief">
- Removes the listener to stop receiving notifications for changes on the list of installed
-applications on a device.
+ Removes the listener to stop receiving notifications for changes on the list of installed applications on a device.
             </div>
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 2.4. Instead, use <a href="./package.html#PackageManager::unsetPackageInfoEventListener">tizen.package.unsetPackageInfoEventListener()</a>.
@@ -1655,6 +1654,11 @@ var watchId = tizen.application.addAppStatusChangeListener(appStatusEventCallbac
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -2011,6 +2015,11 @@ tizen.application.getAppsInfo(onListInstalledApps);
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/badge.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/badge.html
@@ -314,6 +314,11 @@ tizen.application.getAppsInfo(onListInstalledApps);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Nothing will be done for app ids which do not have any registered listeners.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/bluetooth.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/bluetooth.html
@@ -1331,6 +1331,11 @@ adapter.setChangeListener(changeListener);
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
@@ -3114,6 +3119,11 @@ adapter.startScan(function onsuccess(device)
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="remark">Remark: </span>
  Example of using can be find at <a href="bluetooth.html#BluetoothGATTCharacteristic::addValueChangeListener">addValueChangeListener</a> code example.
             </p>
@@ -4543,12 +4553,17 @@ adapter.startScan(onDeviceFound, onerror);
 </dt>
 <dd>
 <div class="brief">
- Unregisters a Bluetooth device connection listener
+ Unregisters a Bluetooth device connection listener.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void removeConnectStateChangeListener(long watchID);</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -6414,13 +6429,17 @@ healthProfileHandler.registerSinkApplication(
 </dt>
 <dd>
 <div class="brief">
- Unsets the listener.
-This stops receiving notifications.
+ Unsets the listener. This stops receiving notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void unsetListener();</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/calendar.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/calendar.html
@@ -2084,7 +2084,8 @@ watcherId = calendar.addChangeListener(watcher);
             </p>
 <div class="description">
             <p>
-If the <em>watchId </em>argument is valid and corresponds to a subscription already in place, the watch process must immediately stop and no further callbacks must be invoked. If the <em>watchId </em>argument is not valid or does not correspond to a valid subscription, the method should return without any further action.
+If the <em>watchId </em>argument is valid and corresponds to a subscription already in place, the watch process must immediately stop and no further callbacks must be invoked.
+If the <em>watchId </em>argument is not valid or does not correspond to a valid subscription, the method should return without any further action.
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/content.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/content.html
@@ -1077,6 +1077,11 @@ console.log("Listener ID: " + listenerId);
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1228,6 +1233,11 @@ tizen.content.setChangeListener(listener);
 <p><span class="version">Since: </span>
  2.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/humanactivitymonitor.html
@@ -933,6 +933,11 @@ Accumulative total step count: 100
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1057,6 +1062,9 @@ accuracy: MEDIUM
  2.3.2
             </p>
 <div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
             <p>
 The <em>ErrorCallback</em> method is launched with this error type:
             </p>
@@ -1514,6 +1522,11 @@ Received GESTURE_SHAKE_DETECTED event on Thu Sep 01 2016 14:33:56 GMT+0200 (CEST
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1773,6 +1786,11 @@ Stress level: Normal
 <p><span class="version">Since: </span>
  5.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/iotcon.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/iotcon.html
@@ -849,14 +849,14 @@ watchId = tizen.iotcon.addGeneratedPinListener(RandomPinSuccess);
 <ul>
           <li class="param">
 <span class="name">watchId</span>:
- The watchID identifier returned by the addGeneratedPinListener() method.
+ The watchId identifier returned by the addGeneratedPinListener() method.
                 </li>
         </ul>
 </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
- with error type AbortError, If the operation has been stopped.
+ with error type AbortError, if the operation has been stopped or there is no listener with given watchId.
                 </p></li></ul>
 </li></ul>
         </div>
@@ -1154,7 +1154,7 @@ Resource type: oic.wk.ad
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type AbortError, if the operation has been stopped.
+ with error type AbortError, if the operation has been stopped or listener for given watchId was not found.
                 </p></li>
 </ul>
 </li></ul>
@@ -2726,6 +2726,11 @@ catch (err)
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -3552,6 +3557,11 @@ catch (err)
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener was not set.
+            </p>
+           </div>
 <p><span class="remark">Remark: </span>
  Example of using can be find at <a href="iotcon.html#Resource::setRequestListener">setRequestListener</a> code example.
             </p>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/mediacontroller.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/mediacontroller.html
@@ -695,6 +695,11 @@ watcherId = mcServer.addChangeRequestPlaybackInfoListener(playbackRequestListene
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -814,6 +819,11 @@ watcherId = mcServer.addCommandListener(commandReceiveListener);
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1404,6 +1414,11 @@ watcherId = mcServerInfo.addServerStatusChangeListener(function(status)
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1518,6 +1533,11 @@ watcherId = mcServerInfo.addPlaybackInfoChangeListener(playbackListener);
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/mediakey.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/mediakey.html
@@ -209,6 +209,11 @@ There is a tizen.mediakey object that allows accessing the functionality of the 
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/nfc.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/nfc.html
@@ -980,6 +980,11 @@ adapter.setPeerListener(onSuccessCB);
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1042,6 +1047,11 @@ adapter.setTagListener(onSuccessCB);
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1172,6 +1182,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1297,6 +1312,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1418,6 +1438,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1667,6 +1692,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -2799,6 +2829,11 @@ adapter.setPeerListener(onSuccessCB);
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/package.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/package.html
@@ -571,6 +571,11 @@ tizen.package.setPackageInfoEventListener(packageEventCallback);
 <p><span class="version">Since: </span>
  2.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/power.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/power.html
@@ -395,6 +395,11 @@ tizen.power.setScreenStateChangeListener(onScreenStateChanged);
 <p><span class="version">Since: </span>
  2.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/se.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/se.html
@@ -343,6 +343,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/sensor.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/sensor.html
@@ -761,6 +761,11 @@ lightSensor.start(onsuccessCB);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/sound.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/sound.html
@@ -442,6 +442,11 @@ There is a tizen.sound object that allows accessing the functionality of the Sou
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
@@ -494,6 +499,11 @@ There is a tizen.sound object that allows accessing the functionality of the Sou
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/systeminfo.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/systeminfo.html
@@ -1112,8 +1112,7 @@ any identifier of these properties, but the listener added for them will not be 
             <p>
 If a valid listenerId argument is passed that corresponds to an existing subscription,
 then the watch process must immediately terminate and no further
-callback is invoked. If the listenerId argument does not correspond to a valid subscription,
-the method should return without any further action.
+callback is invoked.
             </p>
            </div>
 <div class="parameters">

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/time.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/time.html
@@ -625,6 +625,11 @@ tizen.time.setDateTimeChangeListener(changedCallback);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
@@ -719,6 +724,11 @@ tizen.time.setTimezoneChangeListener(changedCallback);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/voicecontrol.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/voicecontrol.html
@@ -511,6 +511,11 @@ Result callback - event: SUCCESS, result: alpha
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -629,6 +634,11 @@ Language change callback en_US-&gt;ko_KR
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>


### PR DESCRIPTION
Some listener related API (remove*Listener) has missing description about the behaviour when the listener was not registered yet. This commits adds such information to every function.

This change affects only 5.0 directory, so should be added also on previous branches with different pull request.