### PR TITLE
[4.0] [Common] Added missing information about remove listener behaviour

### DIFF
--- a/docs/application/web/api/4.0/device_api/mobile/tizen/account.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/account.html
@@ -1142,6 +1142,11 @@ If you want to get all the providers, omit the capability argument.
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/application.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/application.html
@@ -1531,8 +1531,7 @@ var watchId = tizen.application.addAppInfoEventListener(appEventCallback);
 </dt>
 <dd class="deprecated">
 <div class="brief">
- Removes the listener to stop receiving notifications for changes on the list of installed
-applications on a device.
+ Removes the listener to stop receiving notifications for changes on the list of installed applications on a device.
             </div>
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 2.4. Instead, use <a href="./package.html#PackageManager::unsetPackageInfoEventListener">tizen.package.unsetPackageInfoEventListener()</a>.
@@ -1655,6 +1654,11 @@ var watchId = tizen.application.addAppStatusChangeListener(appStatusEventCallbac
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -2011,6 +2015,11 @@ tizen.application.getAppsInfo(onListInstalledApps);
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/badge.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/badge.html
@@ -314,6 +314,11 @@ tizen.application.getAppsInfo(onListInstalledApps);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Nothing will be done for app ids which do not have any registered listeners.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/bluetooth.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/bluetooth.html
@@ -1590,6 +1590,11 @@ adapter.setChangeListener(changeListener);
 <p><span class="version">Since: </span>
  2.2
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
@@ -3373,6 +3378,11 @@ adapter.startScan(function onsuccess(device)
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="remark">Remark: </span>
  Example of using can be find at <a href="bluetooth.html#BluetoothGATTCharacteristic::addValueChangeListener">addValueChangeListener</a> code example.
             </p>
@@ -4802,12 +4812,17 @@ adapter.startScan(onDeviceFound, onerror);
 </dt>
 <dd>
 <div class="brief">
- Unregisters a Bluetooth device connection listener
+ Unregisters a Bluetooth device connection listener.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void removeConnectStateChangeListener(long watchID);</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -6673,13 +6688,17 @@ healthProfileHandler.registerSinkApplication(
 </dt>
 <dd>
 <div class="brief">
- Unsets the listener.
-This stops receiving notifications.
+ Unsets the listener. This stops receiving notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void unsetListener();</pre></div>
 <p><span class="version">Since: </span>
  2.2
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/calendar.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/calendar.html
@@ -2077,7 +2077,8 @@ watcherId = calendar.addChangeListener(watcher);
             </p>
 <div class="description">
             <p>
-If the <em>watchId </em>argument is valid and corresponds to a subscription already in place, the watch process must immediately stop and no further callbacks must be invoked. If the <em>watchId </em>argument is not valid or does not correspond to a valid subscription, the method should return without any further action.
+If the <em>watchId </em>argument is valid and corresponds to a subscription already in place, the watch process must immediately stop and no further callbacks must be invoked.
+If the <em>watchId </em>argument is not valid or does not correspond to a valid subscription, the method should return without any further action.
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/content.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/content.html
@@ -1064,6 +1064,11 @@ console.log("Listener ID: " + listenerId);
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1215,6 +1220,11 @@ tizen.content.setChangeListener(listener);
 <p><span class="version">Since: </span>
  2.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/fmradio.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/fmradio.html
@@ -729,6 +729,11 @@ tizen.fmradio.setFMRadioInterruptedListener(interruptCallback);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
@@ -794,6 +799,11 @@ tizen.fmradio.setAntennaChangeListener(antennaCallback);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/humanactivitymonitor.html
@@ -898,6 +898,11 @@ Accumulative total step count: 100
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1022,6 +1027,9 @@ accuracy: MEDIUM
  3.0
             </p>
 <div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
             <p>
 The <em>ErrorCallback</em> method is launched with this error type:
             </p>
@@ -1479,6 +1487,11 @@ Received GESTURE_SHAKE_DETECTED event on Thu Sep 01 2016 14:33:56 GMT+0200 (CEST
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/iotcon.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/iotcon.html
@@ -836,14 +836,14 @@ watchId = tizen.iotcon.addGeneratedPinListener(RandomPinSuccess);
 <ul>
           <li class="param">
 <span class="name">watchId</span>:
- The watchID identifier returned by the addGeneratedPinListener() method.
+ The watchId identifier returned by the addGeneratedPinListener() method.
                 </li>
         </ul>
 </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
- with error type AbortError, If the operation has been stopped.
+ with error type AbortError, if the operation has been stopped or there is no listener with given watchId.
                 </p></li></ul>
 </li></ul>
         </div>
@@ -1141,7 +1141,7 @@ Resource type: oic.wk.ad
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type AbortError, if the operation has been stopped.
+ with error type AbortError, if the operation has been stopped or listener for given watchId was not found.
                 </p></li>
 </ul>
 </li></ul>
@@ -2713,6 +2713,11 @@ catch (err)
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -3539,6 +3544,11 @@ catch (err)
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener was not set.
+            </p>
+           </div>
 <p><span class="remark">Remark: </span>
  Example of using can be find at <a href="iotcon.html#Resource::setRequestListener">setRequestListener</a> code example.
             </p>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/mediacontroller.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/mediacontroller.html
@@ -695,6 +695,11 @@ watcherId = mcServer.addChangeRequestPlaybackInfoListener(playbackRequestListene
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -814,6 +819,11 @@ watcherId = mcServer.addCommandListener(commandReceiveListener);
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1404,6 +1414,11 @@ watcherId = mcServerInfo.addServerStatusChangeListener(function(status)
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1518,6 +1533,11 @@ watcherId = mcServerInfo.addPlaybackInfoChangeListener(playbackListener);
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/mediakey.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/mediakey.html
@@ -209,6 +209,11 @@ There is a tizen.mediakey object that allows accessing the functionality of the 
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/messaging.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/messaging.html
@@ -2956,6 +2956,9 @@ messageStorage.addFoldersChangeListener(folderChangeCB);
             </p>
 <div class="description">
             <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+            <p>
 The errorCallback is launched with these error types:
             </p>
             <ul>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/nfc.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/nfc.html
@@ -1090,6 +1090,11 @@ adapter.setPeerListener(onSuccessCB);
 <p><span class="version">Since: </span>
  1.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1152,6 +1157,11 @@ adapter.setTagListener(onSuccessCB);
 <p><span class="version">Since: </span>
  1.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1282,6 +1292,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1407,6 +1422,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1528,6 +1548,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1777,6 +1802,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -2909,6 +2939,11 @@ adapter.setPeerListener(onSuccessCB);
 <p><span class="version">Since: </span>
  1.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/package.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/package.html
@@ -558,6 +558,11 @@ tizen.package.setPackageInfoEventListener(packageEventCallback);
 <p><span class="version">Since: </span>
  2.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/power.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/power.html
@@ -393,6 +393,11 @@ tizen.power.setScreenStateChangeListener(onScreenStateChanged);
 <p><span class="version">Since: </span>
  2.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/se.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/se.html
@@ -343,6 +343,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/sensor.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/sensor.html
@@ -761,6 +761,11 @@ lightSensor.start(onsuccessCB);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/sound.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/sound.html
@@ -442,6 +442,11 @@ There is a tizen.sound object that allows accessing the functionality of the Sou
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
@@ -494,6 +499,11 @@ There is a tizen.sound object that allows accessing the functionality of the Sou
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/systeminfo.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/systeminfo.html
@@ -1112,8 +1112,7 @@ any identifier of these properties, but the listener added for them will not be 
             <p>
 If a valid listenerId argument is passed that corresponds to an existing subscription,
 then the watch process must immediately terminate and no further
-callback is invoked. If the listenerId argument does not correspond to a valid subscription,
-the method should return without any further action.
+callback is invoked.
             </p>
            </div>
 <div class="parameters">

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/time.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/time.html
@@ -625,6 +625,11 @@ tizen.time.setDateTimeChangeListener(changedCallback);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
@@ -719,6 +724,11 @@ tizen.time.setTimezoneChangeListener(changedCallback);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/voicecontrol.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/voicecontrol.html
@@ -511,6 +511,11 @@ Result callback - event: SUCCESS, result: alpha
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -629,6 +634,11 @@ Language change callback en_US-&gt;ko_KR
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/4.0/device_api/tv/tizen/application.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/application.html
@@ -1302,8 +1302,7 @@ var watchId = tizen.application.addAppInfoEventListener(appEventCallback);
 </dt>
 <dd class="deprecated">
 <div class="brief">
- Removes the listener to stop receiving notifications for changes on the list of installed
-applications on a device.
+ Removes the listener to stop receiving notifications for changes on the list of installed applications on a device.
             </div>
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 2.4. Instead, use <a href="./package.html#PackageManager::unsetPackageInfoEventListener">tizen.package.unsetPackageInfoEventListener()</a>.
@@ -1426,6 +1425,11 @@ var watchId = tizen.application.addAppStatusChangeListener(appStatusEventCallbac
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1782,6 +1786,11 @@ tizen.application.getAppsInfo(onListInstalledApps);
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/4.0/device_api/tv/tizen/content.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/content.html
@@ -1064,6 +1064,11 @@ console.log("Listener ID: " + listenerId);
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1215,6 +1220,11 @@ tizen.content.setChangeListener(listener);
 <p><span class="version">Since: </span>
  2.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/tv/tizen/iotcon.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/iotcon.html
@@ -836,14 +836,14 @@ watchId = tizen.iotcon.addGeneratedPinListener(RandomPinSuccess);
 <ul>
           <li class="param">
 <span class="name">watchId</span>:
- The watchID identifier returned by the addGeneratedPinListener() method.
+ The watchId identifier returned by the addGeneratedPinListener() method.
                 </li>
         </ul>
 </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
- with error type AbortError, If the operation has been stopped.
+ with error type AbortError, if the operation has been stopped or there is no listener with given watchId.
                 </p></li></ul>
 </li></ul>
         </div>
@@ -1141,7 +1141,7 @@ Resource type: oic.wk.ad
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type AbortError, if the operation has been stopped.
+ with error type AbortError, if the operation has been stopped or listener for given watchId was not found.
                 </p></li>
 </ul>
 </li></ul>
@@ -2713,6 +2713,11 @@ catch (err)
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -3539,6 +3544,11 @@ catch (err)
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener was not set.
+            </p>
+           </div>
 <p><span class="remark">Remark: </span>
  Example of using can be find at <a href="iotcon.html#Resource::setRequestListener">setRequestListener</a> code example.
             </p>

--- a/docs/application/web/api/4.0/device_api/tv/tizen/package.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/package.html
@@ -558,6 +558,11 @@ tizen.package.setPackageInfoEventListener(packageEventCallback);
 <p><span class="version">Since: </span>
  2.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/tv/tizen/systeminfo.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/systeminfo.html
@@ -1245,8 +1245,7 @@ any identifier of these properties, but the listener added for them will not be 
             <p>
 If a valid listenerId argument is passed that corresponds to an existing subscription,
 then the watch process must immediately terminate and no further
-callback is invoked. If the listenerId argument does not correspond to a valid subscription,
-the method should return without any further action.
+callback is invoked.
             </p>
            </div>
 <div class="parameters">

--- a/docs/application/web/api/4.0/device_api/tv/tizen/time.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/time.html
@@ -625,6 +625,11 @@ tizen.time.setDateTimeChangeListener(changedCallback);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
@@ -719,6 +724,11 @@ tizen.time.setTimezoneChangeListener(changedCallback);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/4.0/device_api/tv/tizen/tvaudiocontrol.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/tvaudiocontrol.html
@@ -234,7 +234,7 @@ are used, then mute is disabled.
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -282,7 +282,7 @@ tizen.tvaudiocontrol.setMute(false);
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -364,7 +364,7 @@ The value of <em>volume</em> is allowed from 0 to 100. If an invalid value is pa
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -418,7 +418,7 @@ then execution of this functions will disable it.
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -476,7 +476,7 @@ then execution of this functions will disable it.
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -535,7 +535,7 @@ if (tizen.tvaudiocontrol.getVolume() === 0)
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -582,7 +582,7 @@ Note that this method overwrites the previously registered listener.
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -622,6 +622,11 @@ tizen.tvaudiocontrol.setVolume(expectedVolumeLevel);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -635,7 +640,7 @@ tizen.tvaudiocontrol.setVolume(expectedVolumeLevel);
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -689,7 +694,7 @@ tizen.tvaudiocontrol.setVolume(expectedVolumeLevel);
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -731,7 +736,7 @@ tizen.tvaudiocontrol.setVolume(expectedVolumeLevel);
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type UnknownError in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>

--- a/docs/application/web/api/4.0/device_api/tv/tizen/tvchannel.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/tvchannel.html
@@ -1168,6 +1168,11 @@ catch (error)
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1280,6 +1285,11 @@ catch (error)
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/tv/tizen/tvdisplaycontrol.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/tvdisplaycontrol.html
@@ -250,7 +250,7 @@ For example, Display Control API provides whether your device supports 3D.
  with error type NotSupportedError, if this feature is not supported.
                 </p></li>
 <li class="list"><p>
- with error type UnknownError, in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>
@@ -303,7 +303,7 @@ catch (error)
  with error type NotSupportedError, if this feature is not supported.
                 </p></li>
 <li class="list"><p>
- with error type UnknownError, in any other error case.
+ with error type UnknownError in an unspecified error case.
                 </p></li>
 </ul>
 </li></ul>

--- a/docs/application/web/api/4.0/device_api/tv/tizen/tvinfo.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/tvinfo.html
@@ -473,6 +473,11 @@ There is a tizen.tvinfo object that allows accessing the functionality of the TV
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/4.0/device_api/tv/tizen/tvwindow.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/tvwindow.html
@@ -932,6 +932,11 @@ catch (error)
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/tv/tizen/voicecontrol.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/voicecontrol.html
@@ -511,6 +511,11 @@ Result callback - event: SUCCESS, result: alpha
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -629,6 +634,11 @@ Language change callback en_US-&gt;ko_KR
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/account.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/account.html
@@ -1142,6 +1142,11 @@ If you want to get all the providers, omit the capability argument.
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/application.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/application.html
@@ -1531,8 +1531,7 @@ var watchId = tizen.application.addAppInfoEventListener(appEventCallback);
 </dt>
 <dd class="deprecated">
 <div class="brief">
- Removes the listener to stop receiving notifications for changes on the list of installed
-applications on a device.
+ Removes the listener to stop receiving notifications for changes on the list of installed applications on a device.
             </div>
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 2.4. Instead, use <a href="./package.html#PackageManager::unsetPackageInfoEventListener">tizen.package.unsetPackageInfoEventListener()</a>.
@@ -1655,6 +1654,11 @@ var watchId = tizen.application.addAppStatusChangeListener(appStatusEventCallbac
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -2011,6 +2015,11 @@ tizen.application.getAppsInfo(onListInstalledApps);
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/badge.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/badge.html
@@ -314,6 +314,11 @@ tizen.application.getAppsInfo(onListInstalledApps);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Nothing will be done for app ids which do not have any registered listeners.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/bluetooth.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/bluetooth.html
@@ -1331,6 +1331,11 @@ adapter.setChangeListener(changeListener);
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
@@ -3114,6 +3119,11 @@ adapter.startScan(function onsuccess(device)
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="remark">Remark: </span>
  Example of using can be find at <a href="bluetooth.html#BluetoothGATTCharacteristic::addValueChangeListener">addValueChangeListener</a> code example.
             </p>
@@ -4543,12 +4553,17 @@ adapter.startScan(onDeviceFound, onerror);
 </dt>
 <dd>
 <div class="brief">
- Unregisters a Bluetooth device connection listener
+ Unregisters a Bluetooth device connection listener.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void removeConnectStateChangeListener(long watchID);</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -6414,13 +6429,17 @@ healthProfileHandler.registerSinkApplication(
 </dt>
 <dd>
 <div class="brief">
- Unsets the listener.
-This stops receiving notifications.
+ Unsets the listener. This stops receiving notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void unsetListener();</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/calendar.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/calendar.html
@@ -2077,7 +2077,8 @@ watcherId = calendar.addChangeListener(watcher);
             </p>
 <div class="description">
             <p>
-If the <em>watchId </em>argument is valid and corresponds to a subscription already in place, the watch process must immediately stop and no further callbacks must be invoked. If the <em>watchId </em>argument is not valid or does not correspond to a valid subscription, the method should return without any further action.
+If the <em>watchId </em>argument is valid and corresponds to a subscription already in place, the watch process must immediately stop and no further callbacks must be invoked.
+If the <em>watchId </em>argument is not valid or does not correspond to a valid subscription, the method should return without any further action.
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/content.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/content.html
@@ -1077,6 +1077,11 @@ console.log("Listener ID: " + listenerId);
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1228,6 +1233,11 @@ tizen.content.setChangeListener(listener);
 <p><span class="version">Since: </span>
  2.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/humanactivitymonitor.html
@@ -898,6 +898,11 @@ Accumulative total step count: 100
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1022,6 +1027,9 @@ accuracy: MEDIUM
  2.3.2
             </p>
 <div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
             <p>
 The <em>ErrorCallback</em> method is launched with this error type:
             </p>
@@ -1479,6 +1487,11 @@ Received GESTURE_SHAKE_DETECTED event on Thu Sep 01 2016 14:33:56 GMT+0200 (CEST
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/iotcon.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/iotcon.html
@@ -849,14 +849,14 @@ watchId = tizen.iotcon.addGeneratedPinListener(RandomPinSuccess);
 <ul>
           <li class="param">
 <span class="name">watchId</span>:
- The watchID identifier returned by the addGeneratedPinListener() method.
+ The watchId identifier returned by the addGeneratedPinListener() method.
                 </li>
         </ul>
 </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
- with error type AbortError, If the operation has been stopped.
+ with error type AbortError, if the operation has been stopped or there is no listener with given watchId.
                 </p></li></ul>
 </li></ul>
         </div>
@@ -1154,7 +1154,7 @@ Resource type: oic.wk.ad
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type AbortError, if the operation has been stopped.
+ with error type AbortError, if the operation has been stopped or listener for given watchId was not found.
                 </p></li>
 </ul>
 </li></ul>
@@ -2726,6 +2726,11 @@ catch (err)
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -3552,6 +3557,11 @@ catch (err)
 <p><span class="version">Since: </span>
  3.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener was not set.
+            </p>
+           </div>
 <p><span class="remark">Remark: </span>
  Example of using can be find at <a href="iotcon.html#Resource::setRequestListener">setRequestListener</a> code example.
             </p>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/mediacontroller.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/mediacontroller.html
@@ -695,6 +695,11 @@ watcherId = mcServer.addChangeRequestPlaybackInfoListener(playbackRequestListene
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -814,6 +819,11 @@ watcherId = mcServer.addCommandListener(commandReceiveListener);
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1404,6 +1414,11 @@ watcherId = mcServerInfo.addServerStatusChangeListener(function(status)
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1518,6 +1533,11 @@ watcherId = mcServerInfo.addPlaybackInfoChangeListener(playbackListener);
 <p><span class="version">Since: </span>
  2.4
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/mediakey.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/mediakey.html
@@ -209,6 +209,11 @@ There is a tizen.mediakey object that allows accessing the functionality of the 
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/nfc.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/nfc.html
@@ -980,6 +980,11 @@ adapter.setPeerListener(onSuccessCB);
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1042,6 +1047,11 @@ adapter.setTagListener(onSuccessCB);
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1172,6 +1182,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1297,6 +1312,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1418,6 +1438,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -1667,6 +1692,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>
@@ -2799,6 +2829,11 @@ adapter.setPeerListener(onSuccessCB);
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/package.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/package.html
@@ -571,6 +571,11 @@ tizen.package.setPackageInfoEventListener(packageEventCallback);
 <p><span class="version">Since: </span>
  2.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/power.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/power.html
@@ -393,6 +393,11 @@ tizen.power.setScreenStateChangeListener(onScreenStateChanged);
 <p><span class="version">Since: </span>
  2.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/se.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/se.html
@@ -343,6 +343,11 @@ catch (err)
 <p><span class="version">Since: </span>
  2.3.1
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
             </p>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/sensor.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/sensor.html
@@ -761,6 +761,11 @@ lightSensor.start(onsuccessCB);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/sound.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/sound.html
@@ -442,6 +442,11 @@ There is a tizen.sound object that allows accessing the functionality of the Sou
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
@@ -494,6 +499,11 @@ There is a tizen.sound object that allows accessing the functionality of the Sou
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/systeminfo.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/systeminfo.html
@@ -1112,8 +1112,7 @@ any identifier of these properties, but the listener added for them will not be 
             <p>
 If a valid listenerId argument is passed that corresponds to an existing subscription,
 then the watch process must immediately terminate and no further
-callback is invoked. If the listenerId argument does not correspond to a valid subscription,
-the method should return without any further action.
+callback is invoked.
             </p>
            </div>
 <div class="parameters">

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/time.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/time.html
@@ -625,6 +625,11 @@ tizen.time.setDateTimeChangeListener(changedCallback);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
@@ -719,6 +724,11 @@ tizen.time.setTimezoneChangeListener(changedCallback);
 <p><span class="version">Since: </span>
  2.3
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if listener is not set.
+            </p>
+           </div>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul><li class="list"><p>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/voicecontrol.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/voicecontrol.html
@@ -511,6 +511,11 @@ Result callback - event: SUCCESS, result: alpha
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -629,6 +634,11 @@ Language change callback en_US-&gt;ko_KR
 <p><span class="version">Since: </span>
  4.0
             </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>


### PR DESCRIPTION
  Some listener related API (remove*Listener) has missing description about the behaviour
  when the listener was not registered yet. This commits adds such information to every function.
