### PR TITLE
Fix typo in documents for capi-media-camera API.(repeatly -> repeatedly)

### DIFF
--- a/docs/application/native/api/mobile/2.3.1/group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html
+++ b/docs/application/native/api/mobile/2.3.1/group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html
@@ -858,7 +858,7 @@ Related Features</h2>
   </table>
   </dd>
 </dl>
-<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga6aaa266ddfd155a84fc24d54a27d259f" title="Called to get each supported FPS mode.">camera_attr_supported_fps_cb()</a> repeatly to get each supported FPS mode. </dd></dl>
+<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga6aaa266ddfd155a84fc24d54a27d259f" title="Called to get each supported FPS mode.">camera_attr_supported_fps_cb()</a> repeatedly to get each supported FPS mode. </dd></dl>
 <dl class="see"><dt><b>See also:</b></dt><dd><a class="el" href="group__CAPI__MEDIA__CAMERA__ATTRIBUTES__MODULE.html#ga8277f30d12e68349ded34612d590db04" title="Sets the preview frame rate.">camera_attr_set_preview_fps()</a> </dd>
 <dd>
 <a class="el" href="group__CAPI__MEDIA__CAMERA__ATTRIBUTES__MODULE.html#ga5a1eb34f1725f6532cecf2a34cf2b794" title="Gets the frames per second of a preview video stream.">camera_attr_get_preview_fps()</a> </dd>
@@ -1562,7 +1562,7 @@ Related Features</h2>
   </table>
   </dd>
 </dl>
-<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga2b5ee4451e624aa2802a19e148b89e99" title="Called once for the pixel format of each supported preview format.">camera_supported_preview_format_cb()</a> repeatly to retrieve each supported preview format. </dd></dl>
+<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga2b5ee4451e624aa2802a19e148b89e99" title="Called once for the pixel format of each supported preview format.">camera_supported_preview_format_cb()</a> repeatedly to retrieve each supported preview format. </dd></dl>
 <dl class="see"><dt><b>See also:</b></dt><dd><a class="el" href="group__CAPI__MEDIA__CAMERA__MODULE.html#ga147eda55f03fef20599b49ee0962482c" title="Sets the preview data format.">camera_set_preview_format()</a> </dd>
 <dd>
 <a class="el" href="group__CAPI__MEDIA__CAMERA__MODULE.html#ga9c3c61f60e5ff0f9cf9e73f1a14bc8d4" title="Gets the format of the preview stream.">camera_get_preview_format()</a> </dd>

--- a/docs/application/native/api/mobile/2.4/group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html
+++ b/docs/application/native/api/mobile/2.4/group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html
@@ -912,7 +912,7 @@ Related Features</h2>
   </table>
   </dd>
 </dl>
-<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga6aaa266ddfd155a84fc24d54a27d259f" title="Called to get each supported FPS mode.">camera_attr_supported_fps_cb()</a> repeatly to get each supported FPS mode. </dd></dl>
+<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga6aaa266ddfd155a84fc24d54a27d259f" title="Called to get each supported FPS mode.">camera_attr_supported_fps_cb()</a> repeatedly to get each supported FPS mode. </dd></dl>
 <dl class="see"><dt><b>See also:</b></dt><dd><a class="el" href="group__CAPI__MEDIA__CAMERA__ATTRIBUTES__MODULE.html#ga8277f30d12e68349ded34612d590db04" title="Sets the preview frame rate.">camera_attr_set_preview_fps()</a> </dd>
 <dd>
 <a class="el" href="group__CAPI__MEDIA__CAMERA__ATTRIBUTES__MODULE.html#ga5a1eb34f1725f6532cecf2a34cf2b794" title="Gets the frames per second of a preview video stream.">camera_attr_get_preview_fps()</a> </dd>
@@ -993,7 +993,7 @@ Related Features</h2>
   </table>
   </dd>
 </dl>
-<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga6aaa266ddfd155a84fc24d54a27d259f" title="Called to get each supported FPS mode.">camera_attr_supported_fps_cb()</a> repeatly to get each supported FPS mode. </dd></dl>
+<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga6aaa266ddfd155a84fc24d54a27d259f" title="Called to get each supported FPS mode.">camera_attr_supported_fps_cb()</a> repeatedly to get each supported FPS mode. </dd></dl>
 <dl class="see"><dt><b>See also:</b></dt><dd><a class="el" href="group__CAPI__MEDIA__CAMERA__ATTRIBUTES__MODULE.html#ga8277f30d12e68349ded34612d590db04" title="Sets the preview frame rate.">camera_attr_set_preview_fps()</a> </dd>
 <dd>
 <a class="el" href="group__CAPI__MEDIA__CAMERA__ATTRIBUTES__MODULE.html#ga5a1eb34f1725f6532cecf2a34cf2b794" title="Gets the frames per second of a preview video stream.">camera_attr_get_preview_fps()</a> </dd>
@@ -1697,7 +1697,7 @@ Related Features</h2>
   </table>
   </dd>
 </dl>
-<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga2b5ee4451e624aa2802a19e148b89e99" title="Called once for the pixel format of each supported preview format.">camera_supported_preview_format_cb()</a> repeatly to retrieve each supported preview format. </dd></dl>
+<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga2b5ee4451e624aa2802a19e148b89e99" title="Called once for the pixel format of each supported preview format.">camera_supported_preview_format_cb()</a> repeatedly to retrieve each supported preview format. </dd></dl>
 <dl class="see"><dt><b>See also:</b></dt><dd><a class="el" href="group__CAPI__MEDIA__CAMERA__MODULE.html#ga147eda55f03fef20599b49ee0962482c" title="Sets the preview data format.">camera_set_preview_format()</a> </dd>
 <dd>
 <a class="el" href="group__CAPI__MEDIA__CAMERA__MODULE.html#ga9c3c61f60e5ff0f9cf9e73f1a14bc8d4" title="Gets the format of the preview stream.">camera_get_preview_format()</a> </dd>

--- a/docs/application/native/api/wearable/2.3.1/group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html
+++ b/docs/application/native/api/wearable/2.3.1/group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html
@@ -858,7 +858,7 @@ Related Features</h2>
   </table>
   </dd>
 </dl>
-<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga6aaa266ddfd155a84fc24d54a27d259f" title="Called to get each supported FPS mode.">camera_attr_supported_fps_cb()</a> repeatly to get each supported FPS mode. </dd></dl>
+<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga6aaa266ddfd155a84fc24d54a27d259f" title="Called to get each supported FPS mode.">camera_attr_supported_fps_cb()</a> repeatedly to get each supported FPS mode. </dd></dl>
 <dl class="see"><dt><b>See also:</b></dt><dd><a class="el" href="group__CAPI__MEDIA__CAMERA__ATTRIBUTES__MODULE.html#ga8277f30d12e68349ded34612d590db04" title="Sets the preview frame rate.">camera_attr_set_preview_fps()</a> </dd>
 <dd>
 <a class="el" href="group__CAPI__MEDIA__CAMERA__ATTRIBUTES__MODULE.html#ga5a1eb34f1725f6532cecf2a34cf2b794" title="Gets the frames per second of a preview video stream.">camera_attr_get_preview_fps()</a> </dd>
@@ -1562,7 +1562,7 @@ Related Features</h2>
   </table>
   </dd>
 </dl>
-<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga2b5ee4451e624aa2802a19e148b89e99" title="Called once for the pixel format of each supported preview format.">camera_supported_preview_format_cb()</a> repeatly to retrieve each supported preview format. </dd></dl>
+<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga2b5ee4451e624aa2802a19e148b89e99" title="Called once for the pixel format of each supported preview format.">camera_supported_preview_format_cb()</a> repeatedly to retrieve each supported preview format. </dd></dl>
 <dl class="see"><dt><b>See also:</b></dt><dd><a class="el" href="group__CAPI__MEDIA__CAMERA__MODULE.html#ga147eda55f03fef20599b49ee0962482c" title="Sets the preview data format.">camera_set_preview_format()</a> </dd>
 <dd>
 <a class="el" href="group__CAPI__MEDIA__CAMERA__MODULE.html#ga9c3c61f60e5ff0f9cf9e73f1a14bc8d4" title="Gets the format of the preview stream.">camera_get_preview_format()</a> </dd>

--- a/docs/application/native/api/wearable/2.3.2/group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html
+++ b/docs/application/native/api/wearable/2.3.2/group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html
@@ -899,7 +899,7 @@ Typedefs</h2></td></tr>
   </table>
   </dd>
 </dl>
-<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga6aaa266ddfd155a84fc24d54a27d259f" title="Called to get each supported FPS mode.">camera_attr_supported_fps_cb()</a> repeatly to get each supported FPS mode. </dd></dl>
+<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga6aaa266ddfd155a84fc24d54a27d259f" title="Called to get each supported FPS mode.">camera_attr_supported_fps_cb()</a> repeatedly to get each supported FPS mode. </dd></dl>
 <dl class="see"><dt><b>See also:</b></dt><dd><a class="el" href="group__CAPI__MEDIA__CAMERA__ATTRIBUTES__MODULE.html#ga8277f30d12e68349ded34612d590db04" title="Sets the preview frame rate.">camera_attr_set_preview_fps()</a> </dd>
 <dd>
 <a class="el" href="group__CAPI__MEDIA__CAMERA__ATTRIBUTES__MODULE.html#ga5a1eb34f1725f6532cecf2a34cf2b794" title="Gets the frames per second of a preview video stream.">camera_attr_get_preview_fps()</a> </dd>
@@ -1603,7 +1603,7 @@ Typedefs</h2></td></tr>
   </table>
   </dd>
 </dl>
-<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga2b5ee4451e624aa2802a19e148b89e99" title="Called once for the pixel format of each supported preview format.">camera_supported_preview_format_cb()</a> repeatly to retrieve each supported preview format. </dd></dl>
+<dl class="post"><dt><b>Postcondition:</b></dt><dd>This function invokes <a class="el" href="group__CAPI__MEDIA__CAMERA__CAPABILITY__MODULE.html#ga2b5ee4451e624aa2802a19e148b89e99" title="Called once for the pixel format of each supported preview format.">camera_supported_preview_format_cb()</a> repeatedly to retrieve each supported preview format. </dd></dl>
 <dl class="see"><dt><b>See also:</b></dt><dd><a class="el" href="group__CAPI__MEDIA__CAMERA__MODULE.html#ga147eda55f03fef20599b49ee0962482c" title="Sets the preview data format.">camera_set_preview_format()</a> </dd>
 <dd>
 <a class="el" href="group__CAPI__MEDIA__CAMERA__MODULE.html#ga9c3c61f60e5ff0f9cf9e73f1a14bc8d4" title="Gets the format of the preview stream.">camera_get_preview_format()</a> </dd>


### PR DESCRIPTION
Signed-off-by: Jeongmo Yang <jm80.yang@samsung.com>

### Change Description ###

Fix typo in documents for capi-media-camera API.
: repeatly -> repeatedly