### PR TITLE
Fix broken links in Web API Reference

### DIFF
--- a/docs/application/web/api/2.4/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
+++ b/docs/application/web/api/2.4/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
@@ -27,7 +27,7 @@
 		<td class="note">This component is optimized for circular UI. The component may not be shown properly in rectangular UI.</td>
 	</tr>
 	<tr>
-		<td class="note">If you want information for support to both circular and rectangular UI, see <a href="../../../../org.tizen.ui.practices/html/web/tau/indexscrollbar_ww.htm">here</a>.</td>
+		<td class="note">If you want information for support to both circular and rectangular UI, see <a href="https://developer.tizen.org/development/guides/web-application/user-interface/tizen-advanced-ui/applications-circular-ui/creating-index-scroll-bars">here</a>.</td>
 	</tr>
 	</tbody>
 </table>

--- a/docs/application/web/api/2.4/ui_fw_api/ui_fw_api_cover.htm
+++ b/docs/application/web/api/2.4/ui_fw_api/ui_fw_api_cover.htm
@@ -5,7 +5,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=9" />
 	<link rel="stylesheet" type="text/css" href="../css/styles.css" />
 	<link rel="stylesheet" type="text/css" href="../css/snippet.css" />
-	<script type="text/javascript" src="../scripts/snippet.js"></script>	
+	<script type="text/javascript" src="../scripts/snippet.js"></script>
 	<script type="text/javascript" src="../scripts/jquery.util.js" charset="utf-8"></script>
 	<script type="text/javascript" src="../scripts/common.js" charset="utf-8"></script>
 	<script type="text/javascript" src="../scripts/core.js" charset="utf-8"></script>
@@ -22,7 +22,7 @@
 	 <div id="toc_border"><div id="toc">
 		 <p class="toc-title">Related Info</p>
 		 <ul class="toc">
-			 <li><a href="../../../org.tizen.ui.practices/html/web/tau/guides_tau_w.htm">Tizen Advanced UI framework (TAU): Guides</a></li>
+			 <li><a href="https://developer.tizen.org/development/guides/web-application/user-interface/tizen-advanced-ui">Tizen Advanced UI framework (TAU): Guides</a></li>
 		 </ul>
 	 </div></div>
  </div>

--- a/docs/application/web/api/3.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
+++ b/docs/application/web/api/3.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
@@ -27,7 +27,7 @@
 		<td class="note">This component is optimized for circular UI. The component may not be shown properly in rectangular UI.</td>
 	</tr>
 	<tr>
-		<td class="note">If you want information for support to both circular and rectangular UI, see <a href="../../../../org.tizen.ui.practices/html/web/tau/indexscrollbar_ww.htm">here</a></td>
+		<td class="note">If you want information for support to both circular and rectangular UI, see <a href="https://developer.tizen.org/development/guides/web-application/user-interface/tizen-advanced-ui/applications-circular-ui/creating-index-scroll-bars">here</a></td>
 	</tr>
 	</tbody>
 </table>
@@ -300,7 +300,7 @@
 
 
 					</div>
-					
+
 						<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>

--- a/docs/application/web/api/3.0/ui_fw_api/ui_fw_api_cover.htm
+++ b/docs/application/web/api/3.0/ui_fw_api/ui_fw_api_cover.htm
@@ -5,7 +5,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=9" />
 	<link rel="stylesheet" type="text/css" href="../css/styles.css" />
 	<link rel="stylesheet" type="text/css" href="../css/snippet.css" />
-	<script type="text/javascript" src="../scripts/snippet.js"></script>	
+	<script type="text/javascript" src="../scripts/snippet.js"></script>
 	<script type="text/javascript" src="../scripts/jquery.util.js" charset="utf-8"></script>
 	<script type="text/javascript" src="../scripts/common.js" charset="utf-8"></script>
 	<script type="text/javascript" src="../scripts/core.js" charset="utf-8"></script>
@@ -22,7 +22,7 @@
 	 <div id="toc_border"><div id="toc">
 		 <p class="toc-title">Related Info</p>
 		 <ul class="toc">
-			 <li><a href="../../../org.tizen.ui.practices/html/web/tau/guides_tau_w.htm">Tizen Advanced UI framework (TAU): Guides</a></li>
+			 <li><a href="https://developer.tizen.org/development/guides/web-application/user-interface/tizen-advanced-ui">Tizen Advanced UI framework (TAU): Guides</a></li>
 		 </ul>
 	 </div></div>
  </div>

--- a/docs/application/web/api/4.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
+++ b/docs/application/web/api/4.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
@@ -27,7 +27,7 @@
 		<td class="note">This component is optimized for circular UI. The component may not be shown properly in rectangular UI.</td>
 	</tr>
 	<tr>
-		<td class="note">If you want information for support to both circular and rectangular UI, see <a href="../../../../org.tizen.ui.practices/html/web/tau/indexscrollbar_ww.htm">here</a></td>
+		<td class="note">If you want information for support to both circular and rectangular UI, see <a href="https://developer.tizen.org/development/guides/web-application/user-interface/tizen-advanced-ui/applications-circular-ui/creating-index-scroll-bars">here</a></td>
 	</tr>
 	</tbody>
 </table>

--- a/docs/application/web/api/4.0/ui_fw_api/ui_fw_api_cover.htm
+++ b/docs/application/web/api/4.0/ui_fw_api/ui_fw_api_cover.htm
@@ -22,7 +22,7 @@
 	 <div id="toc_border"><div id="toc">
 		 <p class="toc-title">Related Info</p>
 		 <ul class="toc">
-			 <li><a href="../../../org.tizen.ui.practices/html/web/tau/guides_tau_w.htm">Tizen Advanced UI framework (TAU): Guides</a></li>
+			 <li><a href="https://developer.tizen.org/development/guides/web-application/user-interface/tizen-advanced-ui">Tizen Advanced UI framework (TAU): Guides</a></li>
 		 </ul>
 	 </div></div>
  </div>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
@@ -27,7 +27,7 @@
 		<td class="note">This component is optimized for circular UI. The component may not be shown properly in rectangular UI.</td>
 	</tr>
 	<tr>
-		<td class="note">If you want information for support to both circular and rectangular UI, see <a href="../../../../org.tizen.ui.practices/html/web/tau/indexscrollbar_ww.htm">here</a></td>
+		<td class="note">If you want information for support to both circular and rectangular UI, see <a href="https://developer.tizen.org/development/guides/web-application/user-interface/tizen-advanced-ui/applications-circular-ui/creating-index-scroll-bars">here</a></td>
 	</tr>
 	</tbody>
 </table>

--- a/docs/application/web/api/5.0/ui_fw_api/ui_fw_api_cover.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/ui_fw_api_cover.htm
@@ -22,7 +22,7 @@
 	 <div id="toc_border"><div id="toc">
 		 <p class="toc-title">Related Info</p>
 		 <ul class="toc">
-			 <li><a href="../../../org.tizen.ui.practices/html/web/tau/guides_tau_w.htm">Tizen Advanced UI framework (TAU): Guides</a></li>
+			 <li><a href="https://developer.tizen.org/development/guides/web-application/user-interface/tizen-advanced-ui">Tizen Advanced UI framework (TAU): Guides</a></li>
 		 </ul>
 	 </div></div>
  </div>


### PR DESCRIPTION
Signed-off-by: Mijin, Cho <mijin85.cho@samsung.com>

### Change Description ###

There are some broken links from web api reference files to web guide.
So I fixed the broken links.

- From API Reference files, the links to guide/training should should go to TD, not to md file.