### PR TITLE
[TV] Removed unneeded privileges from TV modules since 5.0

### DIFF
--- a/docs/application/web/api/5.0/device_api/tv/tizen/tvaudiocontrol.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/tvaudiocontrol.html
@@ -219,7 +219,7 @@ are used, then mute is disabled.
  http://tizen.org/privilege/tv.audio
             </p>
 <p class="warning"><b>Warning:</b>
-  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+ http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -235,7 +235,7 @@ are used, then mute is disabled.
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
-This type of error is deprecated since Tizen 5.0. 
+This type of error is deprecated since Tizen 5.0.
                 </p></li>
 <li class="list"><p>
  with error type UnknownError in an unspecified error case.
@@ -272,7 +272,7 @@ tizen.tvaudiocontrol.setMute(false);
  http://tizen.org/privilege/tv.audio
             </p>
 <p class="warning"><b>Warning:</b>
-  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+ http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0.
             </p>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
@@ -287,7 +287,7 @@ tizen.tvaudiocontrol.setMute(false);
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
-This type of error is deprecated since Tizen 5.0. 
+This type of error is deprecated since Tizen 5.0.
                 </p></li>
 <li class="list"><p>
  with error type UnknownError in an unspecified error case.
@@ -354,7 +354,7 @@ The value of <em>volume</em> is allowed from 0 to 100. If an invalid value is pa
  http://tizen.org/privilege/tv.audio
             </p>
 <p class="warning"><b>Warning:</b>
-  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+ http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -373,7 +373,7 @@ The value of <em>volume</em> is allowed from 0 to 100. If an invalid value is pa
                 </p></li>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
-This type of error is deprecated since Tizen 5.0. 
+This type of error is deprecated since Tizen 5.0.
                 </p></li>
 <li class="list"><p>
  with error type UnknownError in an unspecified error case.
@@ -424,14 +424,14 @@ then execution of this functions will disable it.
  http://tizen.org/privilege/tv.audio
             </p>
 <p class="warning"><b>Warning:</b>
-  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+ http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0.
             </p>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
-This type of error is deprecated since Tizen 5.0. 
+This type of error is deprecated since Tizen 5.0.
                 </p></li>
 <li class="list"><p>
  with error type UnknownError in an unspecified error case.
@@ -486,14 +486,14 @@ then execution of this functions will disable it.
  http://tizen.org/privilege/tv.audio
             </p>
 <p class="warning"><b>Warning:</b>
-  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+ http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0.
             </p>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
-This type of error is deprecated since Tizen 5.0. 
+This type of error is deprecated since Tizen 5.0.
                 </p></li>
 <li class="list"><p>
  with error type UnknownError in an unspecified error case.
@@ -541,7 +541,7 @@ if (tizen.tvaudiocontrol.getVolume() === 0)
  http://tizen.org/privilege/tv.audio
             </p>
 <p class="warning"><b>Warning:</b>
-  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+ http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0.
             </p>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
@@ -556,7 +556,7 @@ if (tizen.tvaudiocontrol.getVolume() === 0)
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
-This type of error is deprecated since Tizen 5.0. 
+This type of error is deprecated since Tizen 5.0.
                 </p></li>
 <li class="list"><p>
  with error type UnknownError in an unspecified error case.
@@ -588,7 +588,7 @@ Note that this method overwrites the previously registered listener.
  http://tizen.org/privilege/tv.audio
             </p>
 <p class="warning"><b>Warning:</b>
-  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+ http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -607,7 +607,7 @@ Note that this method overwrites the previously registered listener.
                 </p></li>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
-This type of error is deprecated since Tizen 5.0. 
+This type of error is deprecated since Tizen 5.0.
                 </p></li>
 <li class="list"><p>
  with error type UnknownError in an unspecified error case.
@@ -662,14 +662,14 @@ Calling this function has no effect if listener is not set.
  http://tizen.org/privilege/tv.audio
             </p>
 <p class="warning"><b>Warning:</b>
-  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+ http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0.
             </p>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
-This type of error is deprecated since Tizen 5.0. 
+This type of error is deprecated since Tizen 5.0.
                 </p></li>
 <li class="list"><p>
  with error type UnknownError in an unspecified error case.
@@ -712,7 +712,7 @@ tizen.tvaudiocontrol.setVolume(expectedVolumeLevel);
  http://tizen.org/privilege/tv.audio
             </p>
 <p class="warning"><b>Warning:</b>
-  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+ http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0.
             </p>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
@@ -727,7 +727,7 @@ tizen.tvaudiocontrol.setVolume(expectedVolumeLevel);
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
-This type of error is deprecated since Tizen 5.0. 
+This type of error is deprecated since Tizen 5.0.
                 </p></li>
 <li class="list"><p>
  with error type UnknownError in an unspecified error case.
@@ -754,7 +754,7 @@ This type of error is deprecated since Tizen 5.0.
  http://tizen.org/privilege/tv.audio
             </p>
 <p class="warning"><b>Warning:</b>
-  http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0. 
+ http://tizen.org/privilege/tv.audio (public level) has been deprecated since 5.0.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -773,7 +773,7 @@ This type of error is deprecated since Tizen 5.0.
                 </p></li>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
-This type of error is deprecated since Tizen 5.0. 
+This type of error is deprecated since Tizen 5.0.
                 </p></li>
 <li class="list"><p>
  with error type UnknownError in an unspecified error case.

--- a/docs/application/web/api/5.0/device_api/tv/tizen/tvdisplaycontrol.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/tvdisplaycontrol.html
@@ -232,8 +232,8 @@ For example, Display Control API provides whether your device supports 3D.
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/tv.display
             </p>
-<p><span class="remark">Remark: </span>
-  http://tizen.org/privilege/tv.display (public level) has been deprecated since 5.0. 
+<p class="warning"><b>Warning:</b>
+ http://tizen.org/privilege/tv.display (public level) has been deprecated since 5.0.
             </p>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
@@ -248,7 +248,7 @@ For example, Display Control API provides whether your device supports 3D.
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
-This type of error is deprecated since Tizen 5.0. 
+This type of error is deprecated since Tizen 5.0.
                 </p></li>
 <li class="list"><p>
  with error type NotSupportedError, if this feature is not supported.
@@ -289,8 +289,8 @@ catch (error)
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/tv.display
             </p>
-<p><span class="remark">Remark: </span>
-  http://tizen.org/privilege/tv.display (public level) has been deprecated since 5.0. 
+<p class="warning"><b>Warning:</b>
+ http://tizen.org/privilege/tv.display (public level) has been deprecated since 5.0.
             </p>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
@@ -305,7 +305,7 @@ catch (error)
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
-This type of error is deprecated since Tizen 5.0. 
+This type of error is deprecated since Tizen 5.0.
                 </p></li>
 <li class="list"><p>
  with error type NotSupportedError, if this feature is not supported.
@@ -359,8 +359,8 @@ catch (error)
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/tv.display
             </p>
-<p><span class="remark">Remark: </span>
-  http://tizen.org/privilege/tv.display (public level) has been deprecated since 5.0. 
+<p class="warning"><b>Warning:</b>
+ http://tizen.org/privilege/tv.display (public level) has been deprecated since 5.0.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -383,7 +383,7 @@ catch (error)
                 </p></li>
 <li class="list"><p>
  with error type SecurityError, if the application does not have the privilege to call this method.
-This type of error is deprecated since Tizen 5.0. 
+This type of error is deprecated since Tizen 5.0.
                 </p></li>
 <li class="list"><p>
  with error type NotSupportedError, if this feature is not supported.


### PR DESCRIPTION
TV API does not need any privilege on native level, thus for consistency,
  privileges are also not needed on web level.

[ACR] http://suprem.sec.samsung.net/jira/browse/TWDAPI-198

#518 - related pull request. Adds deprecation information in file docs/application/web/tutorials/sec-privileges.md. To avoid conflicts I didn't add this information again.