### PR TITLE
[Messaging] Update attributes available for filtering

### DIFF
--- a/docs/application/web/guides/data/data-filter.md
+++ b/docs/application/web/guides/data/data-filter.md
@@ -332,7 +332,7 @@ The following tables list the filter types you can use with specific message att
 
 The following table lists the attributes by which `Message` objects may be filtered.
 
-**Table: Filter attributes for finding Messages**
+**Table: Attributes available for filters used in [findMessages()](../../api/latest/device_api/mobile/tizen/messaging.html#MessageStorage::findMessages) and [addMessagesChangeListener()](../../api/latest/device_api/mobile/tizen/messaging.html#MessageStorage::addMessagesChangeListener)**
 <a name="message-filters-table"></a>
 
 | Attribute        | Attribute filter supported | Attribute range filter supported |
@@ -342,7 +342,7 @@ The following table lists the attributes by which `Message` objects may be filte
 | `conversationId` | Yes                        | No                               |
 | `folderId`       | Yes                        | No                               |
 | `type`           | Yes                        | No                               |
-| `timestamp`      | No                         | Yes                              |
+| `timestamp`      | No<sup><a href="#messages-table-footnote">*</a></sup> | Yes   |
 | `from`           | Yes                        | No                               |
 | `to`             | Yes                        | No                               |
 | `cc`             | Yes                        | No                               |
@@ -354,18 +354,20 @@ The following table lists the attributes by which `Message` objects may be filte
 | `subject`        | Yes                        | No                               |
 | `inResponseTo`   | Yes                        | No                               |
 | `messageStatus`  | Yes                        | No                               |
-| `attachments`    | No                         | No                               |
+| `attachments`    | No<sup><a href="#messages-table-footnote">*</a></sup> | No    |
+
+<sup name="messages-table-footnote">*</sup> This attribute may be used in `AttributeFilter` with `EXISTS` match flag.
 
 The following table lists the attributes by which `MessageConversation` objects may be filtered.
 
-**Table: Filter attributes for finding conversations**
+**Table: Attributes available for filters used in [findConversations()](../../api/latest/device_api/mobile/tizen/messaging.html#MessageStorage::findConversations) and [addConversationsChangeListener()](../../api/latest/device_api/mobile/tizen/messaging.html#MessageStorage::addConversationsChangeListener)**
 <a name="conversation-filters-table"></a>
 
 | Attribute        | Attribute filter supported | Attribute range filter supported |
 | ---------------- | -------------------------- | -------------------------------- |
 | `id`             | Yes                        | No                               |
 | `type`           | Yes                        | No                               |
-| `timestamp`      | No                         | Yes                              |
+| `timestamp`      | No<sup><a href="#conversations-table-footnote">*</a></sup> | Yes|
 | `messageCount`   | Yes                        | Yes                              |
 | `unreadMessages` | Yes                        | Yes                              |
 | `preview`        | Yes                        | No                               |
@@ -377,9 +379,11 @@ The following table lists the attributes by which `MessageConversation` objects 
 | `bcc`            | Yes                        | No                               |
 | `lastMessageId`  | Yes                        | No                               |
 
+<sup name="conversations-table-footnote">*</sup> This attribute may be used in `AttributeFilter` with `EXISTS` match flag
+
 The following table lists the attributes by which `MessageFolder` objects may be filtered.
 
-**Table: Filter attributes for finding folders**
+**Table: Attributes available for filters used in [findFolders()](../../api/latest/device_api/mobile/tizen/messaging.html#MessageStorage::findFolders) and [addFoldersChangeListener()](../../api/latest/device_api/mobile/tizen/messaging.html#MessageStorage::addFoldersChangeListener)**
 <a name="folder-filters-table"></a>
 
 | Attribute        | Attribute filter supported | Attribute range filter supported |

--- a/docs/application/web/guides/data/data-filter.md
+++ b/docs/application/web/guides/data/data-filter.md
@@ -145,6 +145,7 @@ Basically, you search the content of the device for media items where the media 
 
        /* Filter for the image media type */
        var typeImageFilter = new tizen.AttributeFilter('type', 'EXACTLY', 'IMAGE');
+   }
    ```
 
 2. Create a composite filter that finds all content that matches one of the media type filters:

--- a/docs/application/web/guides/data/data-filter.md
+++ b/docs/application/web/guides/data/data-filter.md
@@ -330,15 +330,16 @@ The following table lists the filter types you can use with specific content att
 
 The following tables list the filter types you can use with specific message attributes in the methods of the [MessageStorage](../../api/latest/device_api/mobile/tizen/messaging.html#MessageStorage) interface.
 
-The following table lists the filter attributes related to the `findMessage()` method.
+The following table lists the attributes by which `Message` objects may be filtered.
 
-**Table: Filter attributes for finding messages**
+**Table: Filter attributes for finding Messages**
+<a name="message-filters-table"></a>
 
 | Attribute        | Attribute filter supported | Attribute range filter supported |
 | ---------------- | -------------------------- | -------------------------------- |
 | `id`             | Yes                        | No                               |
 | `serviceId`      | Yes                        | No                               |
-| `conversationId` | No                         | No                               |
+| `conversationId` | Yes                        | No                               |
 | `folderId`       | Yes                        | No                               |
 | `type`           | Yes                        | No                               |
 | `timestamp`      | No                         | Yes                              |
@@ -351,44 +352,46 @@ The following table lists the filter attributes related to the `findMessage()` m
 | `hasAttachment`  | Yes                        | No                               |
 | `isHighPriority` | Yes                        | No                               |
 | `subject`        | Yes                        | No                               |
-| `isResponseTo`   | No                         | No                               |
-| `messageStatus`  | No                         | No                               |
+| `inResponseTo`   | Yes                        | No                               |
+| `messageStatus`  | Yes                        | No                               |
 | `attachments`    | No                         | No                               |
 
-The following table lists the filter attributes related to the `findConversations()` method.
+The following table lists the attributes by which `MessageConversation` objects may be filtered.
 
 **Table: Filter attributes for finding conversations**
+<a name="conversation-filters-table"></a>
 
 | Attribute        | Attribute filter supported | Attribute range filter supported |
 | ---------------- | -------------------------- | -------------------------------- |
 | `id`             | Yes                        | No                               |
 | `type`           | Yes                        | No                               |
 | `timestamp`      | No                         | Yes                              |
-| `messageCount`   | Yes                        | No                               |
-| `unreadMessages` | Yes                        | No                               |
+| `messageCount`   | Yes                        | Yes                              |
+| `unreadMessages` | Yes                        | Yes                              |
 | `preview`        | Yes                        | No                               |
-| `subject`        | No                         | No                               |
-| `isRead`         | No                         | No                               |
+| `subject`        | Yes                        | No                               |
+| `isRead`         | Yes                        | No                               |
 | `from`           | Yes                        | No                               |
 | `to`             | Yes                        | No                               |
-| `cc`             | No                         | No                               |
-| `bcc`            | No                         | No                               |
-| `lastMessageId`  | No                         | No                               |
+| `cc`             | Yes                        | No                               |
+| `bcc`            | Yes                        | No                               |
+| `lastMessageId`  | Yes                        | No                               |
 
-The following table lists the filter attributes related to the `findFolders()` method.
+The following table lists the attributes by which `MessageFolder` objects may be filtered.
 
-**Table: Filter attributes for finding message folders**
+**Table: Filter attributes for finding folders**
+<a name="folder-filters-table"></a>
 
 | Attribute        | Attribute filter supported | Attribute range filter supported |
 | ---------------- | -------------------------- | -------------------------------- |
-| `id`             | No                         | No                               |
-| `parentId`       | No                         | No                               |
+| `id`             | Yes                        | No                               |
+| `parentId`       | Yes                        | No                               |
 | `serviceId`      | Yes                        | No                               |
-| `contentType`    | No                         | No                               |
-| `name`           | No                         | No                               |
-| `path`           | No                         | No                               |
-| `type`           | No                         | No                               |
-| `synchronizable` | No                         | No                               |
+| `contentType`    | Yes                        | No                               |
+| `name`           | Yes                        | No                               |
+| `path`           | Yes                        | No                               |
+| `type`           | Yes                        | No                               |
+| `synchronizable` | Yes                        | No                               |
 
 > **Note**  
 > The `FULLSTRING` value of the `FilterMatchFlag` enumerator (in [mobile](../../api/latest/device_api/mobile/tizen/tizen.html#FilterMatchFlag), [wearable](../../api/latest/device_api/wearable/tizen/tizen.html#FilterMatchFlag), and [TV](../../api/latest/device_api/tv/tizen/tizen.html#FilterMatchFlag) applications) is not supported and returns an error callback.


### PR DESCRIPTION
### Change Description ###

Related ACR - http://suprem.sec.samsung.net/jira/browse/TWDAPI-205 - makes it possible to use more attributes to filter Messages, MessageFolders and MessageConversations.
This commit adds the information about newly supported attributes to
the "Data Filtering and Sorting" guide.

The change adds HTML anchors to the tables with respective message filter attributes, so that it will be possible to link directly to them.

### API Changes ###

 - ACR: http://suprem.sec.samsung.net/jira/browse/TWDAPI-205