### PR TITLE
Fix menu tree for dotnet API reference

### DIFF
--- a/docs/application/toc_all.md
+++ b/docs/application/toc_all.md
@@ -183,21 +183,7 @@
 ### [Natural Language Processing](/application/dotnet/guides/nlp/nlp.md)
 
 
-## API Reference
-
-### [Overview](/application/native/api/overview.md)
-
-### Mobile
-#### [5.0](/application/native/api/mobile/5.0/index.html){:target="_blank"}
-#### [4.0](/application/native/api/mobile/4.0/index.html){:target="_blank"}
-#### [3.0](/application/native/api/mobile/3.0/index.html){:target="_blank"}
-#### [2.4](/application/native/api/mobile/2.4/index.html){:target="_blank"}
-
-### Wearable
-#### [5.0](/application/native/api/wearable/5.0/index.html){:target="_blank"}
-#### [4.0](/application/native/api/wearable/4.0/index.html){:target="_blank"}
-#### [3.0](/application/native/api/wearable/3.0/index.html){:target="_blank"}
-#### [2.3.2](/application/native/api/wearable/2.3.2/index.html){:target="_blank"}
+## [API Reference](/application/dotnet/api/overview.md)
 
 
 ## Samples
@@ -693,7 +679,21 @@
 ### [Migration Guide](/application/native/guides/migration-guide.md)
 
 
-## [API Reference](/application/native/api/overview.md)
+## API Reference
+
+### [Overview](/application/native/api/overview.md)
+
+### Mobile
+#### [5.0](/application/native/api/mobile/5.0/index.html){:target="_blank"}
+#### [4.0](/application/native/api/mobile/4.0/index.html){:target="_blank"}
+#### [3.0](/application/native/api/mobile/3.0/index.html){:target="_blank"}
+#### [2.4](/application/native/api/mobile/2.4/index.html){:target="_blank"}
+
+### Wearable
+#### [5.0](/application/native/api/wearable/5.0/index.html){:target="_blank"}
+#### [4.0](/application/native/api/wearable/4.0/index.html){:target="_blank"}
+#### [3.0](/application/native/api/wearable/3.0/index.html){:target="_blank"}
+#### [2.3.2](/application/native/api/wearable/2.3.2/index.html){:target="_blank"}
 
 
 ## [Samples](/development/sample/native)


### PR DESCRIPTION
### Bugs Fixed ###
I should change the menu tree of native API reference, but I changed dotnet's menu tree.
I moved  dotnet's submenus to native.
