### PR TITLE
viewSwitcher: Add missing return type

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_viewSwitcher.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_viewSwitcher.htm
@@ -156,7 +156,7 @@ ViewSwitcher component controls each view elements which are changing position.T
 
 				<tr>
 					<td>
-						<pre class="intable prettyprint"><a href="#method-getActiveIndex">getActiveIndex</a>() </pre>
+						<pre class="intable prettyprint">number <a href="#method-getActiveIndex">getActiveIndex</a>() </pre>
 					</td>
 					<td><p>Get the active view index</p></td>
 				</tr>
@@ -206,7 +206,7 @@ ViewSwitcher component controls each view elements which are changing position.T
 						<p>Get the active view index</p>
 					</div>
 					<div class="synopsis">
-						<pre class="signature prettyprint">getActiveIndex() </pre>
+						<pre class="signature prettyprint">number getActiveIndex() </pre>
 					</div>
 
 					<div class="description">


### PR DESCRIPTION
[Problem] getActiveIndex method signature had return value type missing
[Solution] Add missing return value type

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>