### PR TITLE
Filling gaps in the "return value" section.

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Drawer.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Drawer.htm
@@ -254,8 +254,19 @@
 					<div class="returntype">
 						<p><span class="return">Return value:</span></p>
 
+							<table>
+								<tbody>
+								<tr>
+									<th>Type</th>
+									<th>Description</th>
+								</tr>
+								<tr>
+									<td>Boolean</td>
+									<td>Drawer status</td>
+								</tr>
+								</tbody>
+							</table>
 
-							boolean value
 
 					</div>
 					<div class="example">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Navigation.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Navigation.htm
@@ -260,6 +260,14 @@
                 </table>
             </div>
 
+            <div class="returntype">
+                <p><span class="return">Return value:</span></p>
+
+
+                No Return Value
+
+            </div>
+
             <div class="example">
                             <span class="example"><p>Code
                                 example:</p><p></p></span>
@@ -302,6 +310,13 @@
                 <pre class="signature prettyprint">pop() </pre>
             </div>
 
+            <div class="returntype">
+                <p><span class="return">Return value:</span></p>
+
+
+                No Return Value
+
+            </div>
 
             <div class="example">
                                 <span class="example"><p>Code

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Navigation.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Navigation.htm
@@ -264,7 +264,7 @@
                 <p><span class="return">Return value:</span></p>
 
 
-                No Return Value
+                No return value
 
             </div>
 
@@ -314,7 +314,7 @@
                 <p><span class="return">Return value:</span></p>
 
 
-                No Return Value
+                No return value
 
             </div>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Progress.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Progress.htm
@@ -326,7 +326,7 @@
 				<p><span class="return">Return value:</span></p>
 
 
-				No Return Value
+				No return value
 
 			</div>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Progress.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Progress.htm
@@ -228,7 +228,7 @@
 						<th>Description</th>
 					</tr>
 					<tr>
-						<td>Number</td>
+						<td>String | Number</td>
 						<td>Returns value of Progress.</td>
 					</tr>
 					</tbody>
@@ -270,6 +270,23 @@
 				</p>
 			</div>
 
+			<div class="returntype">
+				<p><span class="return">Return value:</span></p>
+
+				<table>
+					<tbody>
+					<tr>
+						<th>Type</th>
+						<th>Description</th>
+					</tr>
+					<tr>
+						<td>Number</td>
+						<td>Returns value of option specified in the argument.</td>
+					</tr>
+					</tbody>
+				</table>
+			</div>
+
 			<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
@@ -304,6 +321,13 @@
 			<div class="description">
 				<p>
 				</p>
+			</div>
+			<div class="returntype">
+				<p><span class="return">Return value:</span></p>
+
+
+				No Return Value
+
 			</div>
 
 			<div class="example">


### PR DESCRIPTION
[Problem] Some methods did not have a "return section" in their description.
[Solution] Add missing sections.
