### PR TITLE
IndexScrollbar: Mixed HTML & JS

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_indexscrollbar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_indexscrollbar.htm
@@ -46,11 +46,17 @@
 <h2><a id='manual-constructor0.6990520032122731'></a>How to create index scroll bar</h2>
 
 <p>For manual creation of Index Scroll Bar, you can use constructor from <strong>tau</strong> namespace:</p>
+
+<p>JS code:<p>
+
 <pre class="prettyprint">
 var indexElement = document.getElementById('indexscrollbar'),
     indexscrollbar = tau.widget.IndexScrollbar(indexElement);
 </pre>
 <p>To add an index scroll bar component to the application, use the following code:</p>
+
+<p>HTML code:<p>
+
 <pre class="prettyprint">
 &lt;div id=&quot;foo&quot; class=&quot;ui-indexscrollbar&quot;
      data-index=&quot;A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z&quot;&gt;&lt;/div&gt;
@@ -74,6 +80,9 @@ var indexElement = document.getElementById('indexscrollbar'),
 <p>You can retrieve the index value using the <span style="font-family: Courier New,Courier,monospace">event.detail.index</span> property.</p>
 
 <p>In the following example, the list scrolls to the position of the list item defined using the <span style="font-family: Courier New,Courier,monospace">li-divider</span> class, selected by the index scroll bar:</p>
+
+<p>HTML code:<p>
+
 <pre class="prettyprint">
 &lt;div id=&quot;pageIndexScrollbar&quot; class=&quot;ui-page&quot;&gt;
    &lt;header class=&quot;ui-header&quot;&gt;
@@ -102,6 +111,7 @@ var indexElement = document.getElementById('indexscrollbar'),
          &lt;/ul&gt;
       &lt;/div&gt;
    &lt;/section&gt;
+&lt;/div&gt;
 </pre>
 
 <p>JS code:</p>
@@ -162,11 +172,11 @@ var indexElement = document.getElementById('indexscrollbar'),
             isb.destroy();
          });
       }());
-   &lt;/script&gt;
-&lt;/div&gt;
 </pre>
 
 <p>The following example uses the <span style="font-family: Courier New,Courier,monospace">supplementScroll</span> argument, which shows a level 2 index scroll bar. The application code must contain a level 2 index array for each level 1 index character. The example shows a way to analyze list items and create a dictionary (<span style="font-family: Courier New,Courier,monospace">secondIndex</span>) for level 1 indices for the index scroll bar, and a dictionary (<span style="font-family: Courier New,Courier,monospace">keyItem</span>) for moving list items at runtime:</p>
+
+<p>HTML code:<p>
 
 <pre class="prettyprint">
 &lt;div id=&quot;indexscrollbar2&quot; class=&quot;ui-indexscrollbar&quot;

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_indexscrollbar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_indexscrollbar.htm
@@ -54,8 +54,11 @@ var indexElement = document.getElementById('indexscrollbar'),
 <pre class="prettyprint">
 &lt;div id=&quot;foo&quot; class=&quot;ui-indexscrollbar&quot;
      data-index=&quot;A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z&quot;&gt;&lt;/div&gt;
+</pre>
 
-&lt;script&gt;
+<p>JS code:</p>
+
+<pre class="prettyprint">
    (function()
    {
       var elem = document.getElementById(&quot;foo&quot;);
@@ -66,7 +69,6 @@ var indexElement = document.getElementById('indexscrollbar'),
          console.log(index);
       });
    }());
-&lt;/script&gt;
 </pre>
 
 <p>You can retrieve the index value using the <span style="font-family: Courier New,Courier,monospace">event.detail.index</span> property.</p>
@@ -100,7 +102,11 @@ var indexElement = document.getElementById('indexscrollbar'),
          &lt;/ul&gt;
       &lt;/div&gt;
    &lt;/section&gt;
-   &lt;script&gt;
+</pre>
+
+<p>JS code:</p>
+
+<pre class="prettyprint">
       (function()
       {
          var page = document.getElementById(&quot;pageIndexScrollbar&quot;),
@@ -172,8 +178,11 @@ var indexElement = document.getElementById('indexscrollbar'),
    &lt;li&gt;Carry&lt;/li&gt;&lt;li&gt;Cibi&lt;/li&gt;
    &lt;li&gt;Daisy&lt;/li&gt;&lt;li&gt;Derek&lt;/li&gt;&lt;li&gt;Desmond&lt;/li&gt;
 &lt;/ul&gt;
+</pre>
 
-&lt;script&gt;
+<p>JS code:</p>
+
+<pre class="prettyprint">
    (function()
    {
       var page = document.getElementById(&quot;pageIndexScrollbar2&quot;);
@@ -280,7 +289,6 @@ var indexElement = document.getElementById('indexscrollbar'),
          elIndex = {};
       });
    }());
-&lt;/script&gt;
 </pre>
 
 <h2><a id="options-list"></a>Options</h2>
@@ -341,12 +349,6 @@ var indexElement = document.getElementById('indexscrollbar'),
 
 		</tbody>
 	</table>
-
-
-
-
-
-
 
  <div id="footer">
    <hr size="1" />


### PR DESCRIPTION
[Problem] Code snippets with examples have mixed HTML markups and JS code,
 it makes that the examples are unreadable for users.

[Solution] Separation into two blocks improves readability.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>
