### PR TITLE
CircularIndexScrollbar: Mixed HTML & JS

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
@@ -73,7 +73,7 @@
 <p>Second parameter is <strong>options</strong> and it is a object with options for component.</p>
 
 <p>To add a circular index scroll bar component to the application, use the following code:</p>
-
+<p>HTML code:</p>
 <pre class="prettyprint">
 &lt;div id="indexscrollbar" class="ui-circularindexscrollbar"
      data-index="A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z"&gt;&lt;/div&gt;
@@ -98,7 +98,7 @@
 <p>The index value can be retrieved by accessing event.detail.index property.</p>
 
 <p>In the following example, the list scrolls to the position of the list item defined using the li-divider class which is selected by the circular index scroll bar:</p>
-
+<p>HTML code:</p>
 <pre class="prettyprint">
 &lt;div id="pageIndexScrollbar" class="ui-page"&gt;
    &lt;header class="ui-header"&gt;
@@ -308,6 +308,7 @@
 						<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
+                                                        <p>HTML code:</p>
 							<pre name="code" class="examplecode	prettyprint">
 &lt;div id="circularindexscrollbar"&gt;&lt;/div&gt;
 							</pre>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
@@ -77,19 +77,22 @@
 <pre class="prettyprint">
 &lt;div id="indexscrollbar" class="ui-circularindexscrollbar"
      data-index="A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z"&gt;&lt;/div&gt;
-&lt;script&gt;
-   (function()
-   {
-      var elem = document.getElementById("indexscrollbar");
-      tau.widget.CircularIndexScrollbar(elem);
-      elem.addEventListener("select", function(event)
-      {
-         var index = event.detail.index;
-         /* Print selected index */
-         console.log(index);
-      });
-   }());
-&lt;/script&gt;
+</pre>
+
+<p>JS code:</p>
+
+<pre class="prettyprint">
+	   (function()
+	   {
+		  var elem = document.getElementById("indexscrollbar");
+		  tau.widget.CircularIndexScrollbar(elem);
+		  elem.addEventListener("select", function(event)
+		  {
+			 var index = event.detail.index;
+			 /* Print selected index */
+			 console.log(index);
+		  });
+	   }());
 </pre>
 
 <p>The index value can be retrieved by accessing event.detail.index property.</p>
@@ -120,9 +123,13 @@
       &lt;/ul&gt;
    &lt;/section&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   (function()
-   {
+</pre>
+
+<p>JS code:</p>
+
+<pre class="prettyprint">
+    (function()
+    {
       var page = document.getElementById("pageIndexScrollbar"),
           indexScrollbar;
 
@@ -182,10 +189,7 @@
          indexScrollbar.destroy();
       });
    }());
-&lt;/script&gt;
 </pre>
-
-
 
 	<h2><a id="options-list"></a>Options</h2>
 
@@ -304,17 +308,17 @@
 						<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
-							<pre name="code" class="examplecode
-							prettyprint">
+							<pre name="code" class="examplecode	prettyprint">
 &lt;div id="circularindexscrollbar"&gt;&lt;/div&gt;
-&lt;script&gt;
-   var circularindexElement = document.getElementById("circularindexscrollbar"),
+							</pre>
+<p>JS code:</p>
+<pre name="code" class="examplecode prettyprint">
+var circularindexElement = document.getElementById("circularindexscrollbar"),
        circularIndexScrollbar = tau.widget.CircularIndexScrollbar(circularindexElement),
        /* Return current index value */
        value = circularIndexScrollbar.value();
    /* Set the index value */
    circularIndexScrollbar.value("C");
-&lt;/script&gt;
 </pre>
 						</div>
 


### PR DESCRIPTION
[Problem] Code snippets with examples have mixed HTML markups and JS code,
 it makes that the examples are unreadable for users.

[Solution] Separation into two blocks improves readability.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>
