### PR TITLE
Mobile, Button: Try to enable syntax coloring in examples

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Button.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Button.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Button</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Button</h1>
@@ -511,5 +511,10 @@ In addition, all elements with the <code>class=&quot;ui-btn&quot;</code> and <co
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>


### PR DESCRIPTION
[Problem] prettyPrint function is not called on developer.tizen.org
          because only part between 'body' tags is copied
[Solution] Syntax coloring function has been moved to inline script

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>
