### PR TITLE
Expandable: Improve widget documentation readability

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Expandable.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Expandable.htm
@@ -53,10 +53,9 @@
 <p>To manually create a expandable component, use the component constructor from the <code>tau</code> namespace:</p>
 <p>The constructor requires an <code>HTMLElement</code> parameter to create the component, and you can get it with the <code>document.getElementById()</code> method. The constructor can also take a second parameter, which is an object defining the configuration options for the component.</p>
 
-<pre class="prettyprint">&lt;script&gt;
-   var expandableEl = document.getElementById(&quot;expandable&quot;),
-       expandableWidget = tau.widget.Expandable(expandableEl, {collapsed: false});
-&lt;/script&gt;
+<pre class="prettyprint">
+var expandableEl = document.getElementById(&quot;expandable&quot;),
+    expandableWidget = tau.widget.Expandable(expandableEl, {collapsed: false});
 </pre>
 
 <h2><a id="html-examples0.4407083713449538"></a>HTML Examples</h2>
@@ -152,7 +151,7 @@ expandableWidget.methodName(methodArgument1, methodArgument2, ...);
 
                 <tr>
                     <td>
-                        <pre class="intable prettyprint"><a href="#method-disable">disable</a>() </pre>
+                        <pre class="intable prettyprint">Expandable <a href="#method-disable">disable</a>() </pre>
                     </td>
                     <td><p>Disables the expandable component.</p></td>
                 </tr>
@@ -161,7 +160,7 @@ expandableWidget.methodName(methodArgument1, methodArgument2, ...);
 
                 <tr>
                     <td>
-                        <pre class="intable prettyprint"><a href="#method-enable">enable</a>() </pre>
+                        <pre class="intable prettyprint">Expandable <a href="#method-enable">enable</a>() </pre>
                     </td>
                     <td><p>Enables the expandable component.</p></td>
                 </tr>
@@ -179,7 +178,7 @@ expandableWidget.methodName(methodArgument1, methodArgument2, ...);
                         <p>Disables the expandable component.</p>
                     </div>
                     <div class="synopsis">
-                        <pre class="signature prettyprint">disable() </pre>
+                        <pre class="signature prettyprint">Expandable disable() </pre>
                     </div>
 
                     <div class="description">
@@ -221,10 +220,12 @@ expandableWidget.methodName(methodArgument1, methodArgument2, ...);
    &lt;h6&gt;Expandable head&lt;/h6&gt;
    &lt;div&gt;Content&lt;/div&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var expandableWidget = tau.widget.Expandable(document.getElementById(&quot;expandable&quot;));
-   expandableWidget.disable();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre name="code" class="examplecode prettyprint">
+var expandableWidget = tau.widget.Expandable(document.getElementById(&quot;expandable&quot;));
+
+expandableWidget.disable();
 </pre>
                         </div>
 
@@ -240,7 +241,7 @@ expandableWidget.methodName(methodArgument1, methodArgument2, ...);
                         <p>Enables the expandable component.</p>
                     </div>
                     <div class="synopsis">
-                        <pre class="signature prettyprint">enable() </pre>
+                        <pre class="signature prettyprint">Expandable enable() </pre>
                     </div>
 
                     <div class="description">
@@ -281,10 +282,12 @@ expandableWidget.methodName(methodArgument1, methodArgument2, ...);
    &lt;h6&gt;Expandable head&lt;/h6&gt;
    &lt;div&gt;Content&lt;/div&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var expandableWidget = tau.widget.Expandable(document.getElementById(&quot;expandable&quot;));
-   expandableWidget.enable();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre name="code" class="examplecode prettyprint">
+var expandableWidget = tau.widget.Expandable(document.getElementById(&quot;expandable&quot;));
+
+expandableWidget.enable();
 </pre>
                     </div>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Expandable.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Expandable.htm
@@ -214,6 +214,7 @@ expandableWidget.methodName(methodArgument1, methodArgument2, ...);
                         <div class="example">
                             <span class="example"><p>Code
                                 example:</p><p></p></span>
+                            <p>HTML code:</p>
                             <pre name="code" class="examplecode
                             prettyprint">
 &lt;div id=&quot;expandable&quot; class=&quot;ui-expandable&quot;&gt;
@@ -276,6 +277,7 @@ expandableWidget.disable();
                     <div class="example">
                             <span class="example"><p>Code
                                 example:</p><p></p></span>
+                            <p>HTML code:</p>
                             <pre name="code" class="examplecode
                             prettyprint">
 &lt;div id=&quot;expandable&quot; class=&quot;ui-expandable&quot;&gt;


### PR DESCRIPTION
[Issue] Documentation contained mixed HTML and JS code in examples,
        Method return types in signatures were missing
[Solution] Code examples were separated and missing return types were added

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>