### PR TITLE
Mobile, Drawer: Improve widget documentation readability

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Drawer.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Drawer.htm
@@ -212,7 +212,8 @@
 					<div class="example">
 						<span class="example"><p>Code
 								example:</p><p></p></span>
-						<pre name="code" class="examplecode
+							<p>HTML code:</p>
+							<pre name="code" class="examplecode
 							prettyprint">
 &lt;div class=&quot;ui-drawer&quot; data-position=&quot;left&quot; id=&quot;leftdrawer&quot;&gt;
    &lt;ul class=&quot;ui-listview&quot;&gt;
@@ -263,6 +264,7 @@ drawer.close();
 					<div class="example">
 						<span class="example"><p>Code
 								example:</p><p></p></span>
+						<p>HTML code:</p>
 						<pre name="code" class="examplecode
 							prettyprint">
 &lt;div class=&quot;ui-drawer&quot; data-position=&quot;left&quot; id=&quot;leftdrawer&quot;&gt;
@@ -320,9 +322,9 @@ isOpen = drawer.isOpen();
 
 					</div>
 					<div class="example">
-						<span class="example"><p>Code
-								example:</p><p></p></span>
-						<pre name="code" class="examplecode
+						<span class="example"><p>Code example:</p><p></p></span>
+							<p>HTML code:</p>
+							<pre name="code" class="examplecode
 							prettyprint">
 &lt;div class=&quot;ui-drawer&quot; data-position=&quot;left&quot; id=&quot;leftdrawer&quot;&gt;
    &lt;ul class=&quot;ui-listview&quot;&gt;

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Drawer.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Drawer.htm
@@ -152,7 +152,7 @@
 
 				<tr>
 					<td>
-						<pre class="intable prettyprint"><a href="#method-isOpen">isOpen</a>() </pre>
+						<pre class="intable prettyprint">boolean <a href="#method-isOpen">isOpen</a>() </pre>
 					</td>
 					<td><p>Checks the drawer status.</p></td>
 				</tr>
@@ -221,11 +221,13 @@
       &lt;li class=&quot;ui-drawer-sub-list&quot;&gt;&lt;a href=&quot;#&quot;&gt;Sub item 1&lt;/a&gt;&lt;/li&gt;
    &lt;/ul&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var drawerElement = document.getElementById(&quot;leftdrawer&quot;),
-       drawer = tau.widget.Drawer(drawerElement);
-   drawer.close();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre name="code" class="examplecode prettyprint">
+var drawerElement = document.getElementById(&quot;leftdrawer&quot;),
+    drawer = tau.widget.Drawer(drawerElement);
+
+drawer.close();
 </pre>
 						</div>
 
@@ -240,7 +242,7 @@
 						<p>Checks the drawer status.</p>
 					</div>
 					<div class="synopsis">
-						<pre class="signature prettyprint">isOpen() </pre>
+						<pre class="signature prettyprint">boolean isOpen() </pre>
 					</div>
 
 					<div class="description">
@@ -270,11 +272,13 @@
       &lt;li class=&quot;ui-drawer-sub-list&quot;&gt;&lt;a href=&quot;#&quot;&gt;Sub item 1&lt;/a&gt;&lt;/li&gt;
    &lt;/ul&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var drawerElement = document.getElementById(&quot;leftdrawer&quot;),
-       drawer = tau.widget.Drawer(drawerElement),
-       isOpen = drawer.isOpen();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre name="code" class="examplecode prettyprint">
+var drawerElement = document.getElementById(&quot;leftdrawer&quot;),
+    drawer = tau.widget.Drawer(drawerElement),
+
+isOpen = drawer.isOpen();
 </pre>
 						</div>
 
@@ -327,11 +331,13 @@
       &lt;li class=&quot;ui-drawer-sub-list&quot;&gt;&lt;a href=&quot;#&quot;&gt;Sub item 1&lt;/a&gt;&lt;/li&gt;
    &lt;/ul&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var drawerElement = document.getElementById(&quot;leftdrawer&quot;),
-       drawer = tau.widget.Drawer(drawerElement);
-   drawer.open();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre name="code" class="examplecode prettyprint">
+var drawerElement = document.getElementById(&quot;leftdrawer&quot;),
+    drawer = tau.widget.Drawer(drawerElement);
+
+drawer.open();
 </pre>
 						</div>
 


### PR DESCRIPTION
[Problem]  Documentation contained mixed HTML and JS code in examples,
           Method return types in signatures were missing
[Solution] Code examples were separated and missing return types were added

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>
