### PR TITLE
Checkbox add missing return types and separate HTML and JS code in examples

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Checkbox.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Checkbox.htm
@@ -46,6 +46,7 @@
 
 <pre class="prettyprint">&lt;input type=&quot;checkbox&quot; name=&quot;checkbox-1&quot; id=&quot;checkbox-1&quot;/&gt;
 &lt;label for=&quot;checkbox-1&quot;&gt;Apple&lt;/label&gt;
+
 &lt;input type=&quot;checkbox&quot; name=&quot;checkbox-2&quot; id=&quot;checkbox-2&quot; checked=&quot;checked&quot;/&gt;
 &lt;label for=&quot;checkbox-2&quot;&gt;Banana&lt;/label&gt;
 </pre>
@@ -132,12 +133,13 @@
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;input type=&quot;checkbox&quot; name=&quot;checkbox-1&quot; id=&quot;checkbox-1&quot;/&gt;
-&lt;label for=&quot;checkbox-1&quot;&gt;Normal&lt;/label&gt;
-&lt;script&gt;
-   var element = document.getElementById(&quot;checkbox-1&quot;),
-       checkboxWidget = tau.widget.Checkbox(element);
-   checkboxWidget.disable();
-&lt;/script&gt;
+&lt;label for=&quot;checkbox-1&quot;&gt;Normal&lt;/label&gt;</pre>
+<p>JS code:</p>
+<pre name="code" class="examplecode prettyprint">
+var element = document.getElementById(&quot;checkbox-1&quot;),
+    checkboxWidget = tau.widget.Checkbox(element);
+
+checkboxWidget.disable();
 </pre>
 		</div>
 
@@ -189,11 +191,13 @@
 							prettyprint">
 &lt;input type=&quot;checkbox&quot; name=&quot;checkbox-1&quot; id=&quot;checkbox-1&quot;/&gt;
 &lt;label for=&quot;checkbox-1&quot;&gt;Normal&lt;/label&gt;
-&lt;script&gt;
-   var element = document.getElementById(&quot;checkbox-1&quot;),
-       checkboxWidget = tau.widget.Checkbox(element);
-   checkboxWidget.enable();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre name="code" class="examplecode prettyprint">
+var element = document.getElementById(&quot;checkbox-1&quot;),
+    checkboxWidget = tau.widget.Checkbox(element);
+
+checkboxWidget.enable();
 </pre>
 		</div>
 
@@ -244,15 +248,16 @@
 							prettyprint">
 &lt;input type=&quot;checkbox&quot; name=&quot;checkbox-1&quot; id=&quot;checkbox-1&quot;/&gt;
 &lt;label for=&quot;checkbox-1&quot;&gt;Normal&lt;/label&gt;
-&lt;script&gt;
-   var element = document.getElementById(&quot;checkbox-1&quot;),
-       checkboxWidget = tau.widget.Checkbox(element);
+</pre>
+<p>JS code:</p>
+<pre name="code" class="examplecode prettyprint">
+var element = document.getElementById(&quot;checkbox-1&quot;),
+    checkboxWidget = tau.widget.Checkbox(element);
 
-   /* Set value to checkbox element */
-   checkboxWidget.value("checkbox-value");
-   /* Return checked checkbox element */
-   console.log(checkboxWidget.value());
-&lt;/script&gt;
+/* Set value to checkbox element */
+checkboxWidget.value("checkbox-value");
+/* Return checked checkbox element */
+console.log(checkboxWidget.value());
 </pre>
 		</div>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Checkbox.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Checkbox.htm
@@ -64,7 +64,7 @@
 
 	<tr>
 		<td>
-			<pre class="intable prettyprint"><a href="#method-disable">disable</a>() </pre>
+			<pre class="intable prettyprint">Checkbox <a href="#method-disable">disable</a>() </pre>
 		</td>
 		<td><p>Disables the component.</p></td>
 	</tr>
@@ -73,14 +73,14 @@
 
 	<tr>
 		<td>
-			<pre class="intable prettyprint"><a href="#method-enable">enable</a>() </pre>
+			<pre class="intable prettyprint">Checkbox <a href="#method-enable">enable</a>() </pre>
 		</td>
 		<td><p>Enables the component.</p></td>
 	</tr>
 
 	<tr>
 		<td>
-			<pre class="intable prettyprint"><a href="#method-value">value</a>() </pre>
+			<pre class="intable prettyprint">{string | number} <a href="#method-value">value</a>() </pre>
 		</td>
 		<td><p>Set/Return a value from checkbox element.</p></td>
 	</tr>
@@ -97,7 +97,7 @@
 			<p>Disables the component.</p>
 		</div>
 		<div class="synopsis">
-			<pre class="signature prettyprint">disable() </pre>
+			<pre class="signature prettyprint">Checkbox disable() </pre>
 		</div>
 
 		<div class="description">
@@ -153,7 +153,7 @@
 			<p>Enables the component.</p>
 		</div>
 		<div class="synopsis">
-			<pre class="signature prettyprint">enable() </pre>
+			<pre class="signature prettyprint">Checkbox enable() </pre>
 		</div>
 
 		<div class="description">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Checkbox.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Checkbox.htm
@@ -130,6 +130,7 @@
 		<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;input type=&quot;checkbox&quot; name=&quot;checkbox-1&quot; id=&quot;checkbox-1&quot;/&gt;
@@ -187,6 +188,7 @@ checkboxWidget.disable();
 		<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;input type=&quot;checkbox&quot; name=&quot;checkbox-1&quot; id=&quot;checkbox-1&quot;/&gt;
@@ -244,6 +246,7 @@ checkboxWidget.enable();
 		<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;input type=&quot;checkbox&quot; name=&quot;checkbox-1&quot; id=&quot;checkbox-1&quot;/&gt;


### PR DESCRIPTION
[Problem] There were no return types in method signatures
[Solution] Add missing return types