### PR TITLE
Mobile, Listview: Separate JS and HTML code in examples

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Listview.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Listview.htm
@@ -53,9 +53,11 @@
    &lt;li&gt;Barry&lt;/li&gt;
    &lt;li&gt;Bill&lt;/li&gt;
 &lt;/ul&gt;
-&lt;script&gt;
-   tau.widget.Listview(document.getElementById(&quot;list&quot;));
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var listviewEl = document.getElementById("list"),
+    listview = tau.widget.Listview(listviewEl);
 </pre>
 <h2><a id="html-example code0.796579651767388"></a>HTML Examples</h2>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Listview.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Listview.htm
@@ -47,6 +47,7 @@
 
 <p>To manually create a list view component, use the component constructor from the <code>tau</code> namespace:</p>
 
+<p>HTML code:</p>
 <pre class="prettyprint">&lt;ul id=&quot;list&quot;&gt;
    &lt;li&gt;Anton&lt;/li&gt;
    &lt;li&gt;Arabella&lt;/li&gt;


### PR DESCRIPTION
[Problem] Documentation contained mixed HTML and JS code in examples
[Solution] Code examples were separated

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>
