### PR TITLE
Mobile, FloatingActions: Separate JS and HTML code in examples

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_FloatingActions.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_FloatingActions.htm
@@ -32,6 +32,7 @@
 <h2><a id="manual-constructor"></a>Manual Constructor</h2>
 <p>To manually create a floating actions component, use the component constructor from the <code>tau</code> namespace:</p>
 <p>The constructor requires an <code>HTMLElement</code> parameter to create the component, and you can get it with the <code>document.getElementById()</code> method. The constructor can also take a second parameter, which is an object defining the configuration options for the component.</p>
+<p>HTML code:</p>
 <pre class="prettyprint">
 &lt;div class=&quot;ui-floatingactions&quot; id=&quot;floating&quot;&gt;
    &lt;button class=&quot;ui-floatingactions-item&quot; data-icon=&quot;floating-add&quot;/&gt;

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_FloatingActions.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_FloatingActions.htm
@@ -37,10 +37,11 @@
    &lt;button class=&quot;ui-floatingactions-item&quot; data-icon=&quot;floating-add&quot;/&gt;
    &lt;button class=&quot;ui-floatingactions-item&quot; data-icon=&quot;floating-search&quot;/&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var elFloatingActions = document.getElementById(&quot;floating&quot;),
-       flaotingActions = tau.widget.FloatingActions(elFloatingActions);
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var elFloatingActions = document.getElementById(&quot;floating&quot;),
+    floatingActions = tau.widget.FloatingActions(elFloatingActions);
 </pre>
 
 <h2><a id="options-list"></a>Options</h2>


### PR DESCRIPTION
[Problem] Documentation contained mixed HTML and JS code in examples
[Solution] Code examples were separated

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>
