### PR TITLE
Enable syntax coloring in all examples

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Autodividers.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Autodividers.htm
@@ -7,7 +7,7 @@
     <link href="../../snippet.css" rel="StyleSheet" type="text/css">
     <title>Autodividers</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 <h1>Autodividers</h1>
 
@@ -83,5 +83,10 @@ To support Backward compatibility, please import tau.support-2.3.js.</td>
             href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
         <a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Checkboxradio.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Checkboxradio.htm
@@ -5,7 +5,7 @@
 	<link href="../../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Checkbox Radio</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 <h1>Checkbox Radio</h1>
 
@@ -295,5 +295,10 @@ To support Backward compatibility, please import tau.support-2.3.js.</td>
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Collapsible.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Collapsible.htm
@@ -7,7 +7,7 @@
     <link href="../../snippet.css" rel="StyleSheet" type="text/css">
     <title>Collapsible</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Collapsible</h1>
@@ -540,5 +540,10 @@ collapsible.methodName(methodArgument1, methodArgument2, ...);
             href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
         <a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Controlgroup.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Controlgroup.htm
@@ -7,7 +7,7 @@
 	<link href="../../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Control Group</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Control Group</h1>
@@ -92,5 +92,10 @@ To support Backward compatibility, please import tau.support-2.3.js.</td>
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Datetimepicker.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Datetimepicker.htm
@@ -7,7 +7,7 @@
 	<link href="../../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Date-time Picker</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Date-time Picker</h1>
@@ -76,5 +76,10 @@
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_FastScroll.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_FastScroll.htm
@@ -7,7 +7,7 @@
 	<link href="../../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Fast Scroll</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 <h1>Fast Scroll</h1>
 
@@ -501,5 +501,10 @@ To support Backward compatibility, please import tau.support-2.3.js.</td>
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Gallery.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Gallery.htm
@@ -7,7 +7,7 @@
 	<link href="../../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Gallery</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Gallery</h1>
@@ -687,5 +687,10 @@ $(&quot;#gallery&quot;).gallery(&quot;value&quot;, 0); /* First image is display
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_ListDivider.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_ListDivider.htm
@@ -7,7 +7,7 @@
 	<link href="../../snippet.css" rel="StyleSheet" type="text/css">
 	<title>List Divider</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>List Divider</h1>
@@ -201,5 +201,10 @@ To support Backward compatibility, please import tau.support-2.3.js.</td>
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_MultimediaView.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_MultimediaView.htm
@@ -6,7 +6,7 @@
 	<link href="../../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Multimedia View</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Multimedia View</h1>
@@ -69,5 +69,10 @@
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Notification.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Notification.htm
@@ -7,7 +7,7 @@
 	<link href="../../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Notification</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Notification</h1>
@@ -966,5 +966,10 @@ To support Backward compatibility, please import tau.support-2.3.js.</td>
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_ProgressBar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_ProgressBar.htm
@@ -7,7 +7,7 @@
 	<link href="../../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Progress Bar</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Progress Bar</h1>
@@ -404,5 +404,10 @@ To support Backward compatibility, please import tau.support-2.3.js.</td>
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_ScrollHandler.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_ScrollHandler.htm
@@ -7,7 +7,7 @@
 	<link href="../../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Scroll Handler</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Scroll Handler</h1>
@@ -469,5 +469,10 @@ To support Backward compatibility, please import tau.support-2.3.js.</td>
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_SearchBar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_SearchBar.htm
@@ -7,7 +7,7 @@
 	<link href="../../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Search Bar</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 <h1>Search Bar</h1>
 
@@ -578,5 +578,10 @@ $(&quot;#searchbar&quot;).searchbar(&quot;value&quot;, &quot;New text&quot;);
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_SelectMenu.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_SelectMenu.htm
@@ -7,7 +7,7 @@
 	<link href="../../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Select Menu</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>Select Menu</h1>
 
 <p>The select menu component allows you to create the component in the form of a drop-down list and manage its operation.</p>
@@ -319,5 +319,10 @@ widget.methodName(methodArgument1, methodArgument2, ...);
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Swipe.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Swipe.htm
@@ -8,7 +8,7 @@
 	<link href="../../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Swipe</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 <h1>Swipe</h1>
 
@@ -423,5 +423,10 @@ $(&quot;.selector&quot;).swipe(&quot;methodName&quot;, methodArgument1, methodAr
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_TabBar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_TabBar.htm
@@ -7,7 +7,7 @@
 	<link href="../../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Tab Bar</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Tab Bar</h1>
@@ -259,5 +259,10 @@ To support Backward compatibility, please import tau.support-2.3.js.</td>
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Tokentextarea.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/deprecated/mobile_Tokentextarea.htm
@@ -7,7 +7,7 @@
 	<link href="../../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Token Text Area</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Token Text Area</h1>
@@ -961,5 +961,10 @@ tokentextarea.methodName(methodArgument1, methodArgument2, ...);
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Button.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Button.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Button</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Button</h1>
@@ -511,5 +511,10 @@ In addition, all elements with the <code>class=&quot;ui-btn&quot;</code> and <co
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Checkbox.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Checkbox.htm
@@ -5,7 +5,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Checkbox</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 <h1>Checkbox</h1>
 
@@ -270,5 +270,10 @@
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_ColoredListview.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_ColoredListview.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Colored List View</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>Colored List View</h1>
 
 <p>Colored list view provides the list has gradient background color.</p>
@@ -74,5 +74,10 @@
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Drawer.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Drawer.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Drawer</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Drawer</h1>
@@ -351,5 +351,10 @@
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_DropdownMenu.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_DropdownMenu.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Dropdown Menu</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>Dropdown Menu</h1>
 
 
@@ -426,5 +426,10 @@ widget.methodName(methodArgument1, methodArgument2, ...);
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Expandable.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Expandable.htm
@@ -7,7 +7,7 @@
     <link href="../snippet.css" rel="StyleSheet" type="text/css">
     <title>Expandable</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Expandable</h1>
@@ -302,5 +302,10 @@ expandableWidget.methodName(methodArgument1, methodArgument2, ...);
             href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
         <a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_FloatingActions.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_FloatingActions.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Floating Actions</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>Floating Actions</h1>
 
 <p>Floating actions component creates a floating button at the bottom of the screen.</p>
@@ -93,5 +93,10 @@
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_GridView.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_GridView.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Grid View</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>Grid View</h1>
 
 <p>Grid View components provides a list of grid-type and presents contents that are easily identified as images.</p>
@@ -288,5 +288,10 @@ gridView.methodName(methodArgument1, methodArgument2, ...);
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_IndexScrollBar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_IndexScrollBar.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Index Scrollbar</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 <h1>Index Scrollbar</h1>
 
@@ -60,5 +60,10 @@
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Listview.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Listview.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>List View</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 <h1>List View</h1>
 
@@ -115,5 +115,10 @@
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Navigation.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Navigation.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Navigation</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>Navigation</h1>
 
 
@@ -335,5 +335,10 @@
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_PageIndicator.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_PageIndicator.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>PageIndicator</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>PageIndicator</h1>
 
 <p>PageIndicator component presents as a dot-typed indicator.<br>
@@ -254,5 +254,10 @@ For example, in the situation that the value of numberOfPages is "6", and the va
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_PanelChanger.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_PanelChanger.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Panel Changer</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>Panel Changer</h1>
 
 <p>To implement multi page layout in a page component, you can use panel and panel changer components.</p>
@@ -258,5 +258,10 @@ var elPanelChanger = document.getElementById(&quot;panelchanger&quot;),
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Popup.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Popup.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Popup</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Popup</h1>
@@ -352,5 +352,10 @@ The selector, which causes closing on click, can be changed by setting the <code
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Progress.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Progress.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Progress</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Progress</h1>
@@ -334,5 +334,10 @@
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Radio.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Radio.htm
@@ -5,7 +5,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Radio</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 <h1>Radio</h1>
 
@@ -270,5 +270,10 @@
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_SearchInput.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_SearchInput.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Search Input</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 <h1>Search Input</h1>
 
@@ -212,5 +212,10 @@ var searchEl = document.getElementById(&quot;search-test&quot;),
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_SectionChanger.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_SectionChanger.htm
@@ -7,7 +7,7 @@
 	 <link href="../snippet.css" rel="StyleSheet" type="text/css">
   <title>Section Changer</title>
  </head>
- <body onload="prettyPrint()" id="content">
+ <body id="content">
 
 <h1>Section Changer</h1>
 
@@ -406,5 +406,10 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga
 })();
 </script>
 
- </body>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
+</body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Slider.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Slider.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Slider</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Slider</h1>
@@ -409,5 +409,10 @@
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Tabs.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Tabs.htm
@@ -8,7 +8,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Tabs</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>Tabs</h1>
 The Tabs component is a controller component for operate closely with tabbar and sectionChanger.
 
@@ -198,5 +198,10 @@ When define tabbar in HTML, just add <code>class=&quot;ui-tabbar&quot;</code>. P
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_TextEnveloper.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_TextEnveloper.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Text Enveloper</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>Text Enveloper</h1>
 
 <p>
@@ -369,5 +369,10 @@ textEnveloper.methodName(methodArgument1, methodArgument2, ...);
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_TextInput.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_TextInput.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>TextInput</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>TextInput</h1>
 
 
@@ -240,5 +240,10 @@ TextInput component is decorator for input elements.
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_ToggleSwitch.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_ToggleSwitch.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Toggle Switch</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Toggle Switch</h1>
@@ -330,5 +330,10 @@
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_component_list.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_component_list.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Mobile UI Components</title>
 </head>
-<body onload="prettyPrint()" marginwidth="0" marginheight="0" id="content">
+<body id="content">
 
 <h1>Mobile UI Components</h1>
 
@@ -288,5 +288,10 @@
 	</script>
 	<!--end-->
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_button.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_button.htm
@@ -7,7 +7,7 @@
   <link href="../snippet.css" rel="StyleSheet" type="text/css" />
   <title>Button</title>
  </head>
- <body onload="prettyPrint()" id="content">
+ <body id="content">
 
 <h1>Button</h1>
 
@@ -165,5 +165,10 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga
 })();
 </script>
 
- </body>
+ <script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
+</body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_checkbox.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_checkbox.htm
@@ -7,7 +7,7 @@
   <link href="../snippet.css" rel="StyleSheet" type="text/css" />
   <title>Checkbox and Radio Button</title>
  </head>
- <body onload="prettyPrint()" id="content">
+ <body id="content">
 
 <h1>Checkbox and Radio Button</h1>
 
@@ -119,5 +119,10 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga
 })();
 </script>
 
- </body>
+ <script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
+</body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circleprogressbar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circleprogressbar.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css" />
 	<title>CircleProgressBar</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>CircleProgressBar</h1>
 
 
@@ -288,5 +288,10 @@ progressBar.addEventListener("progresschange", function()
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Circular Index Scroll Bar</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>Circular Index Scroll Bar</h1>
 
 <p>Circular index scroll bar component shows on the screen a circular indicator with an index and support to scroll.</p>
@@ -331,5 +331,10 @@
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_component_list.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_component_list.htm
@@ -7,7 +7,7 @@
 	 <link href="../snippet.css" rel="StyleSheet" type="text/css" />
 	 <title>Wearable UI Components</title>
  </head>
- <body onload="prettyPrint()" id="content">
+ <body id="content">
 
 <h1>Wearable UI Components</h1>
 
@@ -127,5 +127,10 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga
 })();
 </script>
 
- </body>
+ <script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
+</body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_drawer.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_drawer.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css" />
 	<title>Drawer</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>Drawer</h1>
 
 <P>
@@ -647,5 +647,10 @@ You can declare to 'enable' option as below method.
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_indexscrollbar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_indexscrollbar.htm
@@ -7,7 +7,7 @@
   <title>Index Scroll Bar</title>
 </head>
 
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 
 <h1>Index Scroll Bar</h1>
@@ -353,5 +353,10 @@ var indexElement = document.getElementById('indexscrollbar'),
    <font size="1">Except as noted, this content - excluding the Code Examples - is licensed under <a href="http://creativecommons.org/licenses/by/3.0/legalcode" target="_blank">Creative Commons Attribution 3.0</a> and all of the Code Examples contained herein are licensed under <a href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the <a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
   </div>
 
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_list.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_list.htm
@@ -7,7 +7,7 @@
   <link href="../snippet.css" rel="StyleSheet" type="text/css" />
   <title>List</title>
  </head>
- <body onload="prettyPrint()" id="content">
+ <body id="content">
 
 <h1>List</h1>
 
@@ -81,5 +81,10 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga
 })();
 </script>
 
- </body>
+ <script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
+</body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_marquee.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_marquee.htm
@@ -6,7 +6,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css" />
 	<title>Marquee</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>Marquee</h1>
 
 <p>The Marquee component shows moving HTML element.<br>
@@ -350,5 +350,10 @@ It makes &lt;div&gt; element (has some child nodes such as text and img) move ho
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_pageindicator.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_pageindicator.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Page Indicator</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>Page Indicator</h1>
 
 <p>Page indicator component presents as a dot-typed indicator.</p>
@@ -303,5 +303,10 @@ For example, in the situation that the value of numberOfPages is "6", and the va
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_popup.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_popup.htm
@@ -7,7 +7,7 @@
 	 <link href="../snippet.css" rel="StyleSheet" type="text/css" />
 	 <title>Popup</title>
  </head>
- <body onload="prettyPrint()" id="content">
+ <body id="content">
 
 <h1>Popup</h1>
 
@@ -326,5 +326,10 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga
 })();
 </script>
 
- </body>
+ <script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
+</body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_processing.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_processing.htm
@@ -7,7 +7,7 @@
 	 <link href="../snippet.css" rel="StyleSheet" type="text/css" />
 	 <title>Processing</title>
  </head>
- <body onload="prettyPrint()" id="content">
+ <body id="content">
 
 <h1>Processing</h1>
 
@@ -82,5 +82,10 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga
 })();
 </script>
 
- </body>
+ <script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
+</body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_progress.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_progress.htm
@@ -7,7 +7,7 @@
 	 <link href="../snippet.css" rel="StyleSheet" type="text/css" />
 	 <title>Progress</title>
  </head>
- <body onload="prettyPrint()" id="content">
+ <body id="content">
 
 <h1>Progress</h1>
 
@@ -86,5 +86,10 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga
 })();
 </script>
 
- </body>
+ <script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
+</body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_sectionchanger.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_sectionchanger.htm
@@ -7,7 +7,7 @@
 	 <link href="../snippet.css" rel="StyleSheet" type="text/css" />
 	 <title>Section Changer</title>
  </head>
- <body onload="prettyPrint()" id="content">
+ <body id="content">
 
 <h1>Section Changer</h1>
 
@@ -362,5 +362,10 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga
 })();
 </script>
 
- </body>
+ <script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
+</body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_selector.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_selector.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css">
 	<title>Selector</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>Selector</h1>
 
 <p>Selector is component for select specific item to use various methods that drag, click and rotary.<br>
@@ -397,5 +397,10 @@ Indicator arrow is special indicator style that has the arrow. It is used for pr
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_slider.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_slider.htm
@@ -7,7 +7,7 @@
      <link href="../snippet.css" rel="StyleSheet" type="text/css" />
      <title>Slider</title>
  </head>
- <body onload="prettyPrint()" id="content">
+ <body id="content">
 
 <h1>Slider</h1>
 
@@ -45,5 +45,10 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga
 })();
 </script>
 
- </body>
+ <script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
+</body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_snaplistview.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_snaplistview.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css" />
 	<title>SnapListview</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>SnapListview</h1>
 
 
@@ -117,5 +117,10 @@ TAU supported helper script named SnapListMarqueeStyle. You can use tau.helper.S
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_swipelist.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_swipelist.htm
@@ -7,7 +7,7 @@
 	 <link href="../snippet.css" rel="StyleSheet" type="text/css" />
 	 <title>Swipe List</title>
  </head>
- <body onload="prettyPrint()" id="content">
+ <body id="content">
 
 <h1>Swipe List</h1>
 
@@ -239,5 +239,10 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga
 })();
 </script>
 
- </body>
+ <script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
+</body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_toggleswitch.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_toggleswitch.htm
@@ -7,7 +7,7 @@
      <link href="../snippet.css" rel="StyleSheet" type="text/css" />
      <title>Toggle Switch</title>
  </head>
- <body onload="prettyPrint()" id="content">
+ <body id="content">
 
 <h1>Toggle Switch</h1>
 
@@ -75,5 +75,10 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga
 })();
 </script>
 
- </body>
+ <script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
+</body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_viewSwitcher.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_viewSwitcher.htm
@@ -7,7 +7,7 @@
 	<link href="../snippet.css" rel="StyleSheet" type="text/css" />
 	<title>ViewSwitcher</title>
 </head>
-<body onload="prettyPrint()" id="content">
+<body id="content">
 <h1>ViewSwitcher</h1>
 
 
@@ -249,5 +249,10 @@ ViewSwitcher component controls each view elements which are changing position.T
 			href="https://www.tizen.org/bsd-3-clause-license" target="_blank">BSD-3-Clause</a>.<br>For details, see the
 		<a href="https://www.tizen.org/content-license" target="_blank">Content License</a>.</font>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_virtuallist.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_virtuallist.htm
@@ -8,7 +8,7 @@
 	<title>Virtual List</title>
 </head>
 
-<body onload="prettyPrint()" id="content">
+<body id="content">
 
 <h1>Virtual List</h1>
 
@@ -194,5 +194,10 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga
 
 
 
+<script>
+	document.addEventListener("DOMContentLoaded", function () {
+		prettyPrint();
+	});
+</script>
 </body>
 </html>


### PR DESCRIPTION
[Problem] prettyPrint function is not called on developer.tizen.org
          because only part between 'body' tags is copied

[Solution] Apply changes from commit 4cb5dce14589f3ee5ac9df5c21e481884c5ded6c to all files.
