### PR TITLE
Seperate HTML and JS code

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_GridView.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_GridView.htm
@@ -35,6 +35,7 @@
 <h2><a id="manual-constructor"></a>Manual Constructor</h2>
 <p>To manually create a grid view component, use the component constructor from the <code>tau</code> namespace:</p>
 <p>The constructor requires an <code>HTMLElement</code> parameter to create the component, and you can get it with the <code>document.getElementById()</code> method. The constructor can also take a second parameter, which is an object defining the configuration options for the component.</p>
+<p>HTML code:</p>
 <pre class="prettyprint">
 &lt;ul id=&quot;gridview&quot; class=&quot;ui-gridview&quot;&gt;
    &lt;li class=&quot;ui-gridview-item&quot;&gt;
@@ -54,10 +55,12 @@
       &lt;div class=&quot;ui-gridview-handler&quot;&gt;&lt;/div&gt;
    &lt;/li&gt;
 &lt;/ul&gt;
-&lt;script&gt;
-   var elGridView = document.getElementById(&quot;gridview&quot;),
-       gridView = tau.widget.GridView(elGridView);
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var elGridView = document.getElementById(&quot;gridview&quot;),
+    gridView = tau.widget.GridView(elGridView);
+
 </pre>
 
 <h2><a id="options-list"></a>Options</h2>
@@ -206,13 +209,11 @@ gridView.methodName(methodArgument1, methodArgument2, ...);
 	                            example:</p><p></p></span>
                             <pre name="code" class="examplecode
                             prettyprint">
-&lt;script&gt;
-   var elGridView = document.getElementById("gridview"),
-       gridView = tau.widget.GridView(elGridView),
-       item;
+var elGridView = document.getElementById("gridview"),
+    gridView = tau.widget.GridView(elGridView),
+    item;
 
-   gridView.addItem(item);
-&lt;/script&gt;
+gridView.addItem(item);
 </pre>
 		</div>
 	</dd>
@@ -265,13 +266,11 @@ gridView.methodName(methodArgument1, methodArgument2, ...);
 	                            example:</p><p></p></span>
                             <pre name="code" class="examplecode
                             prettyprint">
-&lt;script&gt;
-   var elGridView = document.getElementById("gridview"),
-       gridView = tau.widget.GridView(elGridView),
-       item;
+var elGridView = document.getElementById("gridview"),
+    gridView = tau.widget.GridView(elGridView),
+    item;
 
-   gridView.removeItem(item);
-&lt;/script&gt;
+gridView.removeItem(item);
 </pre>
 		</div>
 	</dd>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_IndexScrollBar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_IndexScrollBar.htm
@@ -33,6 +33,7 @@
 <p>To manually create a index scrollbar component, use the component constructor from the <code>tau</code> namespace.</p>
 <p>The index scrollbar component makes index indicator using elements that has "ui-group-index" class.
 
+<p>HTML code:</p>
 <pre class="prettyprint">
 &lt;div data-role=&quot;page&quot; id=&quot;indexscrollbarPage&quot;&gt;
    &lt;div data-role=&quot;indexscrollbar&quot; id=&quot;indexscrollbar&quot;&gt;&lt;/div&gt;
@@ -47,9 +48,10 @@
       &lt;/ul&gt;
    &lt;/div&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var isb = tau.widget.IndexScrollbar(document.getElementById(&quot;indexscrollbar&quot;));
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var isb = tau.widget.IndexScrollbar(document.getElementById(&quot;indexscrollbar&quot;));
 </pre>
 
 <div id="footer">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_PageIndicator.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_PageIndicator.htm
@@ -71,6 +71,7 @@ var elPageIndicator = document.getElementById(&quot;pageIndicator&quot;),
 <br>
 <li>
 <p>To use page indicator with section changer component</p>
+<p>HTML code:</p>
 <pre class="prettyprint">
 &lt;div class=&quot;ui-content&quot;&gt;
    &lt;div class=&quot;ui-page-indicator&quot; id=&quot;pageIndicator&quot; data-number-of-pages=&quot;4&quot; style=&quot;bottom: 0;&quot;&gt;&lt;/div&gt;
@@ -100,16 +101,17 @@ var elPageIndicator = document.getElementById(&quot;pageIndicator&quot;),
       &lt;/div&gt;
    &lt;/div&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var sectionChanger = document.getElementById(&quot;hsectionchanger&quot;),
-       elPageIndicator = document.getElementById(&quot;pageIndicator&quot;),
-       pageIndicator;
-   pageIndicator = tau.widget.PageIndicator(elPageIndicator);
-   sectionChanger.addEventListener(&quot;sectionchange&quot;, function(e)
-   {
-      pageIndicator.setActive(e.detail.active);
-   }, false);
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var sectionChanger = document.getElementById(&quot;hsectionchanger&quot;),
+    elPageIndicator = document.getElementById(&quot;pageIndicator&quot;),
+    pageIndicator;
+pageIndicator = tau.widget.PageIndicator(elPageIndicator);
+sectionChanger.addEventListener(&quot;sectionchange&quot;, function(e)
+{
+   pageIndicator.setActive(e.detail.active);
+}, false);
 </pre>
 </li></ul>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Popup.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Popup.htm
@@ -61,13 +61,15 @@
 
 <p>To manually create a button component, use the component constructor from the <code>tau</code> namespace:</p>
 
+<p>HTML code:</p>
 <pre class="prettyprint">&lt;div id=&quot;popup&quot;&gt;
    &lt;p&gt;This is not a popup yet. But when TAU namespace calls me as widget, I will be popup.&lt;/p&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var popupElement = document.getElementById(&quot;popup&quot;),
-       popup = tau.widget.Popup(popupElement);
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var popupElement = document.getElementById(&quot;popup&quot;),
+    popup = tau.widget.Popup(popupElement);
 </pre>
 
 <h2><a id="html-examples0.8655443852767348"></a>HTML Examples</h2>
@@ -210,18 +212,20 @@ In mobile profile, default value is &quot;origin&quot; and if popup has no optio
 
 <p>To handle popup events, use the following code:</p>
 
+<p>HTML code:</p>
 <pre class="prettyprint">&lt;!--Popup HTML code--&gt;
 &lt;div id=&quot;popup&quot; data-role=&quot;popup&quot;&gt;
    &lt;p&gt;This is a completely basic popup, no options set.&lt;/p&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   /* Use popup events */
-   var popup = document.getElementById(&quot;popup&quot;);
-   popup.addEventListener(&quot;popupafteropen&quot;, function()
-   {
-      /* Implement code for popupafteropen event */
-   });
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+/* Use popup events */
+var popup = document.getElementById(&quot;popup&quot;);
+popup.addEventListener(&quot;popupafteropen&quot;, function()
+{
+   /* Implement code for popupafteropen event */
+});
 </pre>
 
 	<h3>Summary</h3>
@@ -272,24 +276,28 @@ In mobile profile, default value is &quot;origin&quot; and if popup has no optio
 <li>Open manually:
 <p>To open a popup with the &quot;popup&quot; <code>id</code> property, the <code>tau</code> namespace can be used.:</p>
 
+<p>HTML code:</p>
 <pre class="prettyprint">&lt;div id=&quot;popup&quot;&gt;
    &lt;p&gt;This is a completely basic popup, no options set.&lt;/p&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var popupElement = document.getElementById(&quot;popup&quot;),
-       popup = tau.widget.Popup(popupElement);
-   popup.open();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var popupElement = document.getElementById(&quot;popup&quot;),
+    popup = tau.widget.Popup(popupElement);
+popup.open();
 </pre>
 
 <p>With the TAU API, you can open a popup anywhere:</p>
 
+<p>HTML code:</p>
 <pre class="prettyprint">&lt;div id=&quot;popup&quot;&gt;
    &lt;p&gt;This is a completely basic popup, no options set.&lt;/p&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   tau.openPopup(&quot;#popup&quot;);
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+tau.openPopup(&quot;#popup&quot;);
 </pre></li></ul>
 
 <h3>Close Popup</h3>
@@ -317,30 +325,34 @@ The selector, which causes closing on click, can be changed by setting the <code
 <li>Close manually:
 <p>To close a popup with the &quot;popup&quot; <code>id</code> property, the <code>tau</code> namespace can be used:</p>
 
+<p>HTML code:</p>
 <pre class="prettyprint">&lt;a href=&quot;#popup&quot; data-position-to=&quot;window&quot;&gt;Click to open popup&lt;/a&gt;
 &lt;div id=&quot;popup&quot; data-role=&quot;popup&quot;&gt;
    &lt;p&gt;This is a completely basic popup, no options set.&lt;/p&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var popupElement = document.getElementById(&quot;popup&quot;),
-       popup = tau.widget.Popup(popupElement);
-   /* Close popup after opening */
-   popupElement.addEventListener(&quot;popupafteropen&quot;, function()
-   {
-      popup.close();
-   });
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var popupElement = document.getElementById(&quot;popup&quot;),
+    popup = tau.widget.Popup(popupElement);
+/* Close popup after opening */
+popupElement.addEventListener(&quot;popupafteropen&quot;, function()
+{
+   popup.close();
+});
 </pre>
 
 
 <p>With the TAU API, you can close a popup anywhere:</p>
 
+<p>HTML code:</p>
 <pre class="prettyprint">&lt;div id=&quot;popup&quot;&gt;
    &lt;p&gt;This is a completely basic popup, no options set.&lt;/p&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   tau.closePopup();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+tau.closePopup();
 </pre></li></ul>
 
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Radio.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Radio.htm
@@ -129,15 +129,17 @@
 		<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;input type=&quot;radio&quot; name=&quot;radio-1&quot; id=&quot;radio-1&quot;/&gt;
 &lt;label for=&quot;radio-1&quot;&gt;Normal&lt;/label&gt;
-&lt;script&gt;
-   var element = document.getElementById(&quot;radio-1&quot;),
-       radioWidget = tau.widget.Radio(element);
-   radioWidget.disable();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var element = document.getElementById(&quot;radio-1&quot;),
+    radioWidget = tau.widget.Radio(element);
+radioWidget.disable();
 </pre>
 		</div>
 
@@ -185,15 +187,17 @@
 		<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;input type=&quot;radio&quot; name=&quot;radio-1&quot; id=&quot;radio-1&quot;/&gt;
 &lt;label for=&quot;radio-1&quot;&gt;Normal&lt;/label&gt;
-&lt;script&gt;
-   var element = document.getElementById(&quot;radio-1&quot;),
-       radioWidget = tau.widget.Radio(element);
-   radioWidget.enable();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var element = document.getElementById(&quot;radio-1&quot;),
+    radioWidget = tau.widget.Radio(element);
+radioWidget.enable();
 </pre>
 		</div>
 
@@ -240,19 +244,21 @@
 		<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;input type=&quot;radio&quot; name=&quot;radio-1&quot; id=&quot;radio-1&quot;/&gt;
 &lt;label for=&quot;radio-1&quot;&gt;Normal&lt;/label&gt;
-&lt;script&gt;
-   var element = document.getElementById(&quot;radio-1&quot;),
-       radioWidget = tau.widget.Radio(element);
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var element = document.getElementById(&quot;radio-1&quot;),
+    radioWidget = tau.widget.Radio(element);
 
-   /* Set value to radio element */
-   radioWidget.value("radio-value");
-   /* Return checked radio element */
-   console.log(radioWidget.value());
-&lt;/script&gt;
+/* Set value to radio element */
+radioWidget.value("radio-value");
+/* Return checked radio element */
+console.log(radioWidget.value());
 </pre>
 		</div>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_SearchInput.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_SearchInput.htm
@@ -54,24 +54,25 @@
 
 <p>To manually create a SearchInput component, use the component constructor from the <code>tau</code> namespace.</p>
 
+<p>HTML code:</p>
 <pre class="prettyprint">
 &lt;input type=&quot;search&quot; id=&quot;search-test&quot;/&gt;
-&lt;script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
 var searchEl = document.getElementById(&quot;search-test&quot;),
     searchWidget = tau.widget.SearchInput(searchEl);
-&lt;/script&gt;
 </pre>
 
 <h2><a id="methods0.952881425851956"></a>Methods</h2>
 
 <p>To call a method on the component, please refer the following:</p>
 
-<pre class="prettyprint">&lt;script&gt;
-   var searchInputElement = document.getElementById(&#39;search-test&#39;),
-       searchInput = tau.widget.SearcnInput(searchInputElement);
+<pre class="prettyprint">
+var searchInputElement = document.getElementById(&#39;search-test&#39;),
+    searchInput = tau.widget.SearcnInput(searchInputElement);
 
-   searchInput.methodName(methodArgument1, methodArgument2, ...);
-&lt;/script&gt;
+searchInput.methodName(methodArgument1, methodArgument2, ...);
 </pre>
 
 	<h3>Summary</h3>
@@ -141,12 +142,10 @@ var searchEl = document.getElementById(&quot;search-test&quot;),
 								example:</p><p></p></span>
 							<pre name="code" class="examplecode
 							prettyprint">
-&lt;script&gt;
-   var element = document.getElementById(&quot;searchinput&quot;),
-       searchInputWidget = tau.widget.SearchInput(element);
+var element = document.getElementById(&quot;searchinput&quot;),
+    searchInputWidget = tau.widget.SearchInput(element);
 
-   searchInputWidget.disable();
-&lt;/script&gt;
+searchInputWidget.disable();
 </pre>
 						</div>
 				</dd>
@@ -189,12 +188,10 @@ var searchEl = document.getElementById(&quot;search-test&quot;),
 								example:</p><p></p></span>
 							<pre name="code" class="examplecode
 							prettyprint">
-&lt;script&gt;
-   var element = document.getElementById(&quot;searchinput&quot;),
-       searchInputWidget = tau.widget.SearchInput(element);
+var element = document.getElementById(&quot;searchinput&quot;),
+    searchInputWidget = tau.widget.SearchInput(element);
 
-   searchInputWidget.enable();
-&lt;/script&gt;
+searchInputWidget.enable();
 </pre>
 						</div>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_SectionChanger.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_SectionChanger.htm
@@ -270,15 +270,17 @@ var sectionChangerEl = document.getElementById(&quot;sectionchanger&quot;),
 					<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;div id=&quot;sectionChanger&quot;&gt;&lt;/div&gt;
-&lt;script&gt;
-   var element = document.getElementById(&quot;sectionChanger&quot;),
-       sectionChangerWidget = tau.widget.SectionChanger(element);
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var element = document.getElementById(&quot;sectionChanger&quot;),
+    sectionChangerWidget = tau.widget.SectionChanger(element);
 
-   sectionChangerWidget.setActiveSection(2);
-&lt;/script&gt;
+sectionChangerWidget.setActiveSection(2);
 </pre>
 					</div>
 
@@ -325,16 +327,18 @@ var sectionChangerEl = document.getElementById(&quot;sectionchanger&quot;),
 					<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;div id=&quot;sectionChanger&quot;&gt;&lt;/div&gt;
-&lt;script&gt;
-   var element = document.getElementById(&quot;sectionChanger&quot;),
-       sectionChangerWidget = tau.widget.SectionChanger(element),
-       activeSectionIndex;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var element = document.getElementById(&quot;sectionChanger&quot;),
+    sectionChangerWidget = tau.widget.SectionChanger(element),
+    activeSectionIndex;
 
-   activeSectionIndex = sectionChangerWidget.getActiveSectionIndex();
-&lt;/script&gt;
+activeSectionIndex = sectionChangerWidget.getActiveSectionIndex();
 </pre>
 					</div>
 				</dd>
@@ -370,17 +374,19 @@ var sectionChangerEl = document.getElementById(&quot;sectionchanger&quot;),
 					<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;div id=&quot;sectionChanger&quot;&gt;&lt;/div&gt;
-&lt;script&gt;
-   var element = document.getElementById(&quot;sectionChanger&quot;),
-       sectionChangerWidget = tau.widget.SectionChanger(element);
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var element = document.getElementById(&quot;sectionChanger&quot;),
+    sectionChangerWidget = tau.widget.SectionChanger(element);
 
-   /* Do some DOM changes dynamically */
+/* Do some DOM changes dynamically */
 
-   sectionChangerWidget.refresh();
-&lt;/script&gt;
+sectionChangerWidget.refresh();
 </pre>
 					</div>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Slider.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Slider.htm
@@ -48,11 +48,13 @@
 
 <p>To manually create a slider component, use the component constructor from the <code>tau</code> namespace</p>
 
+<p>HTML code:</p>
 <pre class="prettyprint">&lt;input id=&quot;slider&quot;/&gt;
-&lt;script&gt;
-   var sliderElement = document.getElementById(&quot;slider&quot;),
-       slider = tau.widget.Slider(sliderElement);
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var sliderElement = document.getElementById(&quot;slider&quot;),
+    slider = tau.widget.Slider(sliderElement);
 </pre>
 
 <p>The constructor requires an <code>HTMLElement</code> parameter to create the component, and you can get it with the <code>document.getElementById()</code> method. The constructor can also take a second parameter, which is an object defining the configuration options for the component.</p>
@@ -105,17 +107,19 @@
 
 <p>To call a method on the component, use one of the existing APIs:</p>
 
+<p>HTML code:</p>
 <pre class="prettyprint">&lt;input id=&quot;slider&quot; type=&quot;range&quot; name=&quot;slider&quot; value=&quot;60&quot; min=&quot;0&quot; max=&quot;100&quot;/&gt;
-&lt;script&gt;
-   var slider = document.getElementById(&quot;slider&quot;),
-       slider = tau.widget.Slider(slider);
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var slider = document.getElementById(&quot;slider&quot;),
+    slider = tau.widget.Slider(slider);
 
-   /*
-      slider.methodName(methodArgument1, methodArgument2, ...);
-      For example:
-   */
-   var value = slider.value(5);
-&lt;/script&gt;
+/*
+   slider.methodName(methodArgument1, methodArgument2, ...);
+   For example:
+*/
+var value = slider.value(5);
 </pre>
 
 	<h3>Summary</h3>
@@ -206,14 +210,16 @@
 						<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;input id=&quot;mySlider1&quot; name=&quot;mySlider1&quot; data-popup=&#39;false&#39; type=&quot;range&quot; value=&quot;5&quot; min=&quot;0&quot; max=&quot;10&quot;/&gt;
-&lt;script&gt;
-   var slider = document.getElementById(&quot;mySlider1&quot;),
-       sliderWidget = tau.widget.Slider(slider);
-   sliderWidget.disable();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var slider = document.getElementById(&quot;mySlider1&quot;),
+    sliderWidget = tau.widget.Slider(slider);
+sliderWidget.disable();
 </pre>
 						</div>
 
@@ -260,14 +266,16 @@
 						<div class="example">
 							<span class="example"><p>Code
 								example :</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;input id=&quot;mySlider1&quot; name=&quot;mySlider1&quot; data-popup=&#39;false&#39; type=&quot;range&quot; value=&quot;5&quot; min=&quot;0&quot; max=&quot;10&quot;/&gt;
-&lt;script&gt;
-   var slider = document.getElementById(&quot;mySlider1&quot;),
-       sliderWidget = tau.widget.Slider(slider);
-   sliderWidget.enable();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var slider = document.getElementById(&quot;mySlider1&quot;),
+    sliderWidget = tau.widget.Slider(slider);
+sliderWidget.enable();
 </pre>
 						</div>
 
@@ -319,14 +327,16 @@
 						<div class="example">
 							<span class="example"><p>Code
 								example :</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;input id=&quot;mySlider1&quot; name=&quot;mySlider1&quot; data-popup=&#39;false&#39; type=&quot;range&quot; value=&quot;5&quot; min=&quot;0&quot; max=&quot;10&quot;/&gt;
-&lt;script&gt;
-   var slider = document.getElementById(&quot;mySlider1&quot;),
-       sliderWidget = tau.widget.Slider(slider);
-   sliderWidget.refresh();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var slider = document.getElementById(&quot;mySlider1&quot;),
+     sliderWidget = tau.widget.Slider(slider);
+sliderWidget.refresh();
 </pre>
 						</div>
 
@@ -381,17 +391,19 @@
 						<div class="example">
 							<span class="example"><p>Code
 								example :</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;input id=&quot;mySlider1&quot; name=&quot;mySlider1&quot; data-popup=&#39;false&#39; type=&quot;range&quot; value=&quot;5&quot; min=&quot;0&quot; max=&quot;10&quot;/&gt;
-&lt;script&gt;
-   var slider = document.getElementById(&quot;mySlider1&quot;),
-       sliderWidget = tau.widget.Slider(slider);
-   /* Value contains index of select tag */
-   value = sliderWidget.value();
-   /* Sets the index for the slider */
-   sliderWidget.value(&quot;1&quot;);
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var slider = document.getElementById(&quot;mySlider1&quot;),
+    sliderWidget = tau.widget.Slider(slider);
+/* Value contains index of select tag */
+value = sliderWidget.value();
+/* Sets the index for the slider */
+sliderWidget.value(&quot;1&quot;);
 </pre>
 						</div>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Tabs.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Tabs.htm
@@ -90,11 +90,9 @@ When define tabbar in HTML, just add <code>class=&quot;ui-tabbar&quot;</code>. P
 <p>For manual creation of tabs widget you can use constructor of widget</p>
 
 <pre class="prettyprint">
-&lt;script&gt;
-   var tabsElement = document.getElementById("tabs"),
-       tabs;
-   tabs = tau.widget.Tabs(tabsElement);
-&lt;/script&gt;
+var tabsElement = document.getElementById("tabs"),
+    tabs;
+tabs = tau.widget.Tabs(tabsElement);
 </pre>
 
 <h2><a id="methods-list"></a>Methods list</h2>

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_TextEnveloper.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_TextEnveloper.htm
@@ -76,10 +76,8 @@ If you want to delete word block, you should press the backspace key. If you foc
 <p>To manually create a TextEnveloper component, use the component constructor from the tau namespace.</p>
 
 <pre class="prettyprint">
-&lt;script&gt;
-   var textEnveloperElement = document.getElementById("textenveloper"),
-       textEnveloper = tau.component.TextEnveloper(textEnveloperElement);
-&lt;/script&gt;
+var textEnveloperElement = document.getElementById("textenveloper"),
+    textEnveloper = tau.component.TextEnveloper(textEnveloperElement);
 </pre>
 
 
@@ -218,12 +216,10 @@ textEnveloper.methodName(methodArgument1, methodArgument2, ...);
 								example:</p><p></p></span>
 							<pre name="code" class="examplecode
 							prettyprint">
-&lt;script&gt;
-   var textEnveloperElement = document.getElementById(&quot;textenveloper&quot;),
-       textEnveloper = tau.component.TextEnveloper(textEnveloperElement);
+var textEnveloperElement = document.getElementById(&quot;textenveloper&quot;),
+    textEnveloper = tau.component.TextEnveloper(textEnveloperElement);
 
-   textEnveloper.add("hello");
-&lt;/script&gt;
+textEnveloper.add("hello");
 </pre>
 		</div>
 
@@ -285,12 +281,10 @@ textEnveloper.methodName(methodArgument1, methodArgument2, ...);
 								example:</p><p></p></span>
 							<pre name="code" class="examplecode
 							prettyprint">
-&lt;script&gt;
-   var textEnveloperElement = document.getElementById(&quot;textenveloper&quot;),
-       textEnveloper = tau.component.TextEnveloper(textEnveloperElement);
+var textEnveloperElement = document.getElementById(&quot;textenveloper&quot;),
+    textEnveloper = tau.component.TextEnveloper(textEnveloperElement);
 
-   textEnveloper.remove(1);
-&lt;/script&gt;
+textEnveloper.remove(1);
 </pre>
 		</div>
 
@@ -342,16 +336,14 @@ textEnveloper.methodName(methodArgument1, methodArgument2, ...);
 								example:</p><p></p></span>
 							<pre name="code" class="examplecode
 							prettyprint">
-&lt;script&gt;
-   var textEnveloperElement = document.getElementById(&quot;textenveloper&quot;),
-       textEnveloper = tau.component.TextEnveloper(textEnveloperElement),
-       textTokenLength;
+var textEnveloperElement = document.getElementById(&quot;textenveloper&quot;),
+    textEnveloper = tau.component.TextEnveloper(textEnveloperElement),
+    textTokenLength;
 
-   textEnveloper.add("hello1");
-   textEnveloper.add("hello2");
-   /* textTokenLength will be 2 */
-   textTokenLength = textEnveloper.length();
-&lt;/script&gt;
+textEnveloper.add("hello1");
+textEnveloper.add("hello2");
+/* textTokenLength will be 2 */
+textTokenLength = textEnveloper.length();
 </pre>
 		</div>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_TextInput.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_TextInput.htm
@@ -158,14 +158,16 @@ TextInput component is decorator for input elements.
 						<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">&lt;input type=&quot;text&quot; name=&quot;texttype&quot; id=&quot;texttype&quot;/&gt;
-&lt;script&gt;
-   var inputElement = document.getElementById(&quot;texttype&quot;),
-       textInputWidget = tau.widget.TextInput();
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var inputElement = document.getElementById(&quot;texttype&quot;),
+    textInputWidget = tau.widget.TextInput();
 
-   textInputWidget.enable();
-&lt;/script&gt;
+textInputWidget.enable();
 </pre>
 						</div>
 
@@ -215,14 +217,16 @@ TextInput component is decorator for input elements.
 						<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">&lt;input type=&quot;text&quot; name=&quot;texttype&quot; id=&quot;texttype&quot;/&gt;
-&lt;script&gt;
-   var inputElement = document.getElementById(&quot;texttype&quot;),
-       textInputWidget = tau.widget.TextInput();
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var inputElement = document.getElementById(&quot;texttype&quot;),
+    textInputWidget = tau.widget.TextInput();
 
-   textInputWidget.disable();
-&lt;/script&gt;
+textInputWidget.disable();
 </pre>
 						</div>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_ToggleSwitch.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_ToggleSwitch.htm
@@ -79,12 +79,14 @@
 
 <p>To manually create a toggle switch component, use the component constructor from the <strong>tau</strong> namespace:</p>
 
+<p>HTML code:</p>
 <pre class="prettyprint">
 &lt;input type=&quot;checkbox&quot; name=&quot;toggle-1&quot; id=&quot;toggle-1&quot; class=&quot;ui-toggleswitch&quot;/&gt;
 
-&lt;script&gt;
-   var toggleComponent = tau.widget.ToggleSwitch(document.getElementById(&quot;toggle-1&quot;));
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var toggleComponent = tau.widget.ToggleSwitch(document.getElementById(&quot;toggle-1&quot;));
 </pre>
 
 	<h2><a id="methods-list"></a>Methods</h2>
@@ -170,17 +172,19 @@
 						<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;select name=&quot;flip-1&quot; id=&quot;flip-1&quot; class=&quot;ui-toggleswitch&quot;&gt;
    &lt;option value=&quot;off&quot;&gt;&lt;/option&gt;
    &lt;option value=&quot;on&quot;&gt;&lt;/option&gt;
 &lt;/select&gt;
-&lt;script&gt;
-   var toggle = document.getElementById(&quot;flip-11&quot;),
-       toggleWidget = tau.widget.ToggleSwitch(toggle);
-   toggleWidget.disable();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var toggle = document.getElementById(&quot;flip-11&quot;),
+    toggleWidget = tau.widget.ToggleSwitch(toggle);
+toggleWidget.disable();
 </pre>
 						</div>
 
@@ -235,17 +239,19 @@
 						<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;select name=&quot;flip-1&quot; id=&quot;flip-1&quot; class=&quot;ui-toggleswitch&quot;&gt;
    &lt;option value=&quot;off&quot;&gt;&lt;/option&gt;
    &lt;option value=&quot;on&quot;&gt;&lt;/option&gt;
 &lt;/select&gt;
-&lt;script&gt;
-   var toggle = document.getElementById(&quot;flip-11&quot;),
-       toggleWidget = tau.widget.ToggleSwitch(toggle);
-   toggleWidget.enable();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var toggle = document.getElementById(&quot;flip-11&quot;),
+    toggleWidget = tau.widget.ToggleSwitch(toggle);
+toggleWidget.enable();
 </pre>
 						</div>
 
@@ -300,18 +306,20 @@
 						<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;select name=&quot;flip-1&quot; id=&quot;flip-1&quot; class=&quot;ui-toggleswitch&quot;&gt;
    &lt;option value=&quot;off&quot;&gt;&lt;/option&gt;
    &lt;option value=&quot;on&quot;&gt;&lt;/option&gt;
 &lt;/select&gt;
-&lt;script&gt;
-   var toggle = document.getElementById(&quot;flip-11&quot;),
-       toggleWidget = tau.widget.ToggleSwitch(toggle),
-       toggleState = toggleWidget.value();
-   console.log(toggleState);
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var toggle = document.getElementById(&quot;flip-11&quot;),
+    toggleWidget = tau.widget.ToggleSwitch(toggle),
+    toggleState = toggleWidget.value();
+console.log(toggleState);
 </pre>
 						</div>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circleprogressbar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circleprogressbar.htm
@@ -47,6 +47,7 @@
 <p>If you don't make any &quot;circleprogress&quot; with &lt;progress&gt; element, you can show default progress style.<br>
 To add a CircleProgressBar component to the application, use the following code:</p>
 
+<p>HTML code:</p>
 <pre class="prettyprint">
 &lt;div class="ui-page" id="pageCircleProgressBar"&gt;
    &lt;header class="ui-header"&gt;&lt;/header&gt;
@@ -54,26 +55,27 @@ To add a CircleProgressBar component to the application, use the following code:
       &lt;progress class="ui-circle-progress" id="circleprogress" max="20" value="2"&gt;&lt;/progress&gt;
    &lt;/div&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   (function()
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+(function()
+{
+   var page = document.getElementById("pageCircleProgressBar"),
+       progressBar = document.getElementById("circleprogress"),
+       progressBarWidget;
+
+   page.addEventListener("pageshow", function()
    {
-      var page = document.getElementById("pageCircleProgressBar"),
-          progressBar = document.getElementById("circleprogress"),
-          progressBarWidget;
+      /* Make Circle Progressbar object */
+      progressBarWidget = new tau.widget.CircleProgressBar(progressBar);
+   });
 
-      page.addEventListener("pageshow", function()
-      {
-         /* Make Circle Progressbar object */
-         progressBarWidget = new tau.widget.CircleProgressBar(progressBar);
-      });
-
-      page.addEventListener("pagehide", function()
-      {
-         /* Release object */
-         progressBarWidget.destroy();
-      });
-   }());
-&lt;/script&gt;
+   page.addEventListener("pagehide", function()
+   {
+      /* Release object */
+      progressBarWidget.destroy();
+   });
+}());
 </pre>
 
 <h3>Full(screen) size CircleProgressBar</h3>
@@ -81,32 +83,34 @@ To add a CircleProgressBar component to the application, use the following code:
 	<br> And in your javascript code, you have to add option &quot;size: full&quot;.
 	<br> Be sure to place the &lt;progress&gt; element outside of content element.
 </p>
+<p>HTML code:</p>
 <pre class="prettyprint">
 &lt;div class="ui-page" id="pageCircleProgressBar"&gt;
    &lt;header class="ui-header"&gt;&lt;/header&gt;
    &lt;div class="ui-content"&gt;&lt;/div&gt;
    &lt;progress class="ui-circle-progress" id="circleprogress" max="20" value="2"&gt;&lt;/progress&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   (function()
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+(function()
+{
+   var page = document.getElementById("pageCircleProgressBar"),
+       progressBar = document.getElementById("circleprogress"),
+       progressBarWidget;
+
+   page.addEventListener("pageshow", function()
    {
-      var page = document.getElementById("pageCircleProgressBar"),
-          progressBar = document.getElementById("circleprogress"),
-          progressBarWidget;
+      /* Make Circle Progressbar object */
+      progressBarWidget = new tau.widget.CircleProgressBar(progressBar, {size: "full"});
+   });
 
-      page.addEventListener("pageshow", function()
-      {
-         /* Make Circle Progressbar object */
-         progressBarWidget = new tau.widget.CircleProgressBar(progressBar, {size: "full"});
-      });
-
-      page.addEventListener("pagehide", function()
-      {
-         /* Release object */
-         progressBarWidget.destroy();
-      });
-   }());
-&lt;/script&gt;
+   page.addEventListener("pagehide", function()
+   {
+      /* Release object */
+      progressBarWidget.destroy();
+   });
+}());
 </pre>
 
 <h3>Using event</h3>
@@ -250,6 +254,7 @@ progressBar.addEventListener("progresschange", function()
 						<div class="example">
 							<span class="example"><p>Code
 								example:</p><p></p></span>
+</p>HTML code:</p>
 <pre name="code" class="examplecode prettyprint">
 &lt;div class="ui-page" id="pageCircleProgressBar"&gt;
    &lt;header class="ui-header"&gt;
@@ -260,19 +265,20 @@ progressBar.addEventListener("progresschange", function()
    &lt;/div&gt;
 &lt;/div&gt;
 
-&lt;script&gt;
-   var page = document.getElementById("pageCircleProgressBar");
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var page = document.getElementById("pageCircleProgressBar");
 
-   page.addEventListener("pageshow", function()
-   {
-      var progressbar = document.getElementById("circleprogress"),
-          progressbarWidget = tau.widget.CircleProgressBar(progressbar),
-          /* Return value in progress tag */
-          value = progressbarWidget.value();
-      /* Set the value for the progress */
-      progressbarWidget.value("15");
-   });
-&lt;/script&gt;
+page.addEventListener("pageshow", function()
+{
+   var progressbar = document.getElementById("circleprogress"),
+       progressbarWidget = tau.widget.CircleProgressBar(progressbar),
+       /* Return value in progress tag */
+       value = progressbarWidget.value();
+   /* Set the value for the progress */
+   progressbarWidget.value("15");
+});
 </pre>
 						</div>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_drawer.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_drawer.htm
@@ -352,6 +352,7 @@ You can declare to 'enable' option as below method.
 						<p>
 							<h5>Running example in pure JavaScript:</h5>
 						</p>
+						<p>HTML code:</p>
 						<pre class="prettyprint">
 &lt;!--Drawer handlers--&gt;
 &lt;a id=&quot;leftDrawerHandler&quot; href=&quot;#leftDrawer&quot; class=&quot;drawer-handler&quot;&gt;Left Handler&lt;/a&gt;
@@ -364,12 +365,14 @@ You can declare to 'enable' option as below method.
       &lt;p&gt;Click Close&lt;/p&gt;
    &lt;/div&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var handler = document.getElementById(&quot;leftDrawerHandler&quot;),
-       drawer = tau.widget.Drawer(document.querySelector(handler.getAttribute(&quot;href&quot;));
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var handler = document.getElementById(&quot;leftDrawerHandler&quot;),
+    drawer = tau.widget.Drawer(document.querySelector(handler.getAttribute(&quot;href&quot;));
 
-   drawer.setDragHandler(handler);
-&lt;/script&gt;</pre>
+drawer.setDragHandler(handler);
+</pre>
 					</div>
 
 					<div class="parameters">
@@ -423,6 +426,7 @@ You can declare to 'enable' option as below method.
 					<div class="description">
 						<p>
 							<h5>Running example in pure JavaScript:</h5>
+							<p>HTML code:</p>
 							<pre class="prettyprint">
 &lt;a id=&quot;leftDrawerHandler&quot; href=&quot;#leftDrawer&quot; class=&quot;drawer-handler&quot;&gt;Left Handler&lt;/a&gt;
 &lt;div id=&quot;leftDrawer&quot; class=&quot;ui-drawer&quot; data-drawer-target=&quot;#drawerSinglePage&quot; data-position=&quot;left&quot;
@@ -434,11 +438,13 @@ You can declare to 'enable' option as below method.
       &lt;p&gt;Click Close&lt;/p&gt;
    &lt;/div&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var handler = document.getElementById(&quot;leftDrawerHandler&quot;),
-       drawer = tau.widget.Drawer(document.querySelector(handler.getAttribute(&quot;href&quot;));
-   drawer.Transition(60);
-&lt;/script&gt;</pre>
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var handler = document.getElementById(&quot;leftDrawerHandler&quot;),
+    drawer = tau.widget.Drawer(document.querySelector(handler.getAttribute(&quot;href&quot;));
+drawer.Transition(60);
+</pre>
 
 						</p>
 					</div>
@@ -494,6 +500,7 @@ You can declare to 'enable' option as below method.
 					<div class="description">
 						<p>
 							<h5>Running example in pure JavaScript:</h5>
+						<p>HTML code:</p>
 						<pre class="prettyprint">
 &lt;!--Drawer handlers--&gt;
 &lt;div id=&quot;leftDrawer&quot; class=&quot;ui-drawer&quot; data-drawer-target=&quot;#drawerSinglePage&quot; data-position=&quot;left&quot;
@@ -505,12 +512,14 @@ You can declare to 'enable' option as below method.
       &lt;p&gt;Click Close&lt;/p&gt;
    &lt;/div&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var handler = document.getElementById(&quot;leftDrawerHandler&quot;),
-       drawer = tau.widget.Drawer(document.querySelector(handler.getAttribute(&quot;href&quot;));
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var handler = document.getElementById(&quot;leftDrawerHandler&quot;),
+    drawer = tau.widget.Drawer(document.querySelector(handler.getAttribute(&quot;href&quot;));
 
-   drawer.open();
-&lt;/script&gt;</pre>
+drawer.open();
+</pre>
 
 						</p>
 					</div>
@@ -542,6 +551,7 @@ You can declare to 'enable' option as below method.
 					<div class="description">
 						<p>
 						<h5>Running example in pure JavaScript:</h5>
+						<p>HTML code:</p>
 						<pre class="prettyprint">
 &lt;!--Drawer handlers--&gt;
 &lt;div id=&quot;leftDrawer&quot; class=&quot;ui-drawer&quot; data-drawer-target=&quot;#drawerSinglePage&quot; data-position=&quot;left&quot;
@@ -553,12 +563,14 @@ You can declare to 'enable' option as below method.
       &lt;p&gt;Click Close&lt;/p&gt;
    &lt;/div&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var handler = document.getElementById(&quot;leftDrawerHandler&quot;),
-       drawer = tau.widget.Drawer(document.querySelector(handler.getAttribute(&quot;href&quot;));
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var handler = document.getElementById(&quot;leftDrawerHandler&quot;),
+    drawer = tau.widget.Drawer(document.querySelector(handler.getAttribute(&quot;href&quot;));
 
-   drawer.close();
-&lt;/script&gt;</pre>
+drawer.close();
+</pre>
 
 						</p>
 					</div>
@@ -590,6 +602,7 @@ You can declare to 'enable' option as below method.
 					<div class="description">
 						<p>
 						<h5>Running example in pure JavaScript:</h5>
+						<p>HTML code:</p>
 						<pre class="prettyprint">
 &lt;!--Drawer handlers--&gt;
 &lt;div id=&quot;leftDrawer&quot; class=&quot;ui-drawer&quot; data-drawer-target=&quot;#drawerSinglePage&quot; data-position=&quot;left&quot;
@@ -601,13 +614,15 @@ You can declare to 'enable' option as below method.
       &lt;p&gt;Click Close&lt;/p&gt;
    &lt;/div&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var handler = document.getElementById(&quot;leftDrawerHandler&quot;),
-       drawer = tau.widget.Drawer(document.querySelector(handler.getAttribute(&quot;href&quot;)),
-       state;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var handler = document.getElementById(&quot;leftDrawerHandler&quot;),
+    drawer = tau.widget.Drawer(document.querySelector(handler.getAttribute(&quot;href&quot;)),
+    state;
 
-   state = drawer.getState();
-&lt;/script&gt;</pre>
+state = drawer.getState();
+</pre>
 
 						</p>
 					</div>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_marquee.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_marquee.htm
@@ -61,6 +61,7 @@ It makes &lt;div&gt; element (has some child nodes such as text and img) move ho
 <p>If you want to create Marquee component, you have to declare &quot;ui-marquee&quot; in &lt;div&gt; element and make Marquee component in JS code.
 <br>To use a Marquee component in your application, please refer following code and marquee options:</p>
 
+<p>HTML code:</p>
 <pre class="prettyprint">
 &lt;div class=&quot;ui-page ui-page-active&quot; id=&quot;marqueePage&quot; &gt;
    &lt;header class=&quot;ui-header&quot;&gt;
@@ -72,15 +73,16 @@ It makes &lt;div&gt; element (has some child nodes such as text and img) move ho
       &lt;/ul&gt;
    &lt;/div&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var page = document.querySelector(&quot;#marqueePage&quot;);
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var page = document.querySelector(&quot;#marqueePage&quot;);
 
-   page.addEventListener(&quot;pagebeforeshow&quot;, function()
-   {
-      var marqueeEl = document.getElementById("marquee"),
-      marqueeWidget = new tau.widget.Marquee(marqueeEl, {marqueeStyle: "scroll", delay: "3"});
-   });
-&lt;/script&gt;
+page.addEventListener(&quot;pagebeforeshow&quot;, function()
+{
+   var marqueeEl = document.getElementById("marquee"),
+   marqueeWidget = new tau.widget.Marquee(marqueeEl, {marqueeStyle: "scroll", delay: "3"});
+});
 </pre>
 
 
@@ -240,15 +242,17 @@ It makes &lt;div&gt; element (has some child nodes such as text and img) move ho
 			<div class="example">
 							<span class="example"><p>Code
 								example:</p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;div class="ui-marquee" id="marquee"&gt;
    &lt;p&gt;MarqueeTEST TEST message TEST for marquee&lt;/p&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var marqueeWidget = tau.widget.Marquee(document.getElementById("marquee"));
-   marqueeWidget.start();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var marqueeWidget = tau.widget.Marquee(document.getElementById("marquee"));
+marqueeWidget.start();
 </pre>
 			</div>
 
@@ -283,15 +287,17 @@ It makes &lt;div&gt; element (has some child nodes such as text and img) move ho
 						<div class="example">
 							<span class="example"><p>Code
 								example:</p></span>
+							<p>HTML code</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;div class="ui-marquee" id="marquee"&gt;
    &lt;p&gt;MarqueeTEST TEST message TEST for marquee&lt;/p&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var marqueeWidget = tau.widget.Marquee(document.getElementById("marquee"));
-   marqueeWidget.stop();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var marqueeWidget = tau.widget.Marquee(document.getElementById("marquee"));
+marqueeWidget.stop();
 </pre>
 						</div>
 
@@ -328,15 +334,17 @@ It makes &lt;div&gt; element (has some child nodes such as text and img) move ho
 						<div class="example">
 							<span class="example"><p>Code
 								example:</p></span>
+							<p>HTML code:</p>
 							<pre name="code" class="examplecode
 							prettyprint">
 &lt;div class="ui-marquee" id="marquee"&gt;
    &lt;p&gt;MarqueeTEST TEST message TEST for marquee&lt;/p&gt;
 &lt;/div&gt;
-&lt;script&gt;
-   var marqueeWidget = tau.widget.Marquee(document.getElementById("marquee"));
-   marqueeWidget.reset();
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var marqueeWidget = tau.widget.Marquee(document.getElementById("marquee"));
+marqueeWidget.reset();
 </pre>
 						</div>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_pageindicator.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_pageindicator.htm
@@ -63,20 +63,23 @@ var elPageIndicator = document.getElementById("pageindicator"),
 
 <p>To add an page indicator component to the application, use the following code:</p>
 
+<p>HTML code:</p>
 <pre class="prettyprint">
 &lt;div id=&quot;pageIndicator&quot; class=&quot;ui-page-indicator&quot;&gt;&lt;/div&gt;
-&lt;script&gt;
-   var elPageIndicator = document.getElementById(&quot;pageIndicator&quot;),
-       pageIndicator =  tau.widget.PageIndicator(elPageIndicator, {numberOfPages: 5}),
-       index = 1;
-   pageIndicator.setActive(index);
-&lt;/script&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+var elPageIndicator = document.getElementById(&quot;pageIndicator&quot;),
+    pageIndicator =  tau.widget.PageIndicator(elPageIndicator, {numberOfPages: 5}),
+    index = 1;
+pageIndicator.setActive(index);
 </pre>
 
 <p>index value means index of active page.</p>
 
 <p>In the following example, the change of page is indicated in page indicator component by using page indicator with <a href="wearable_sectionchanger.htm">section changer</a> component.</p>
 
+<p>HTML code:</p>
 <pre class="prettyprint">
 &lt;div id=&quot;pageIndicatorPage&quot; class=&quot;ui-page&quot;&gt;
    &lt;header class=&quot;ui-header&quot;&gt;
@@ -102,7 +105,10 @@ var elPageIndicator = document.getElementById("pageindicator"),
          &lt;/section&gt;
       &lt;/div&gt;
    &lt;/div&gt;
-   &lt;script&gt;
+&lt;/div&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
       (function()
       {
          var self = this,
@@ -142,8 +148,6 @@ var elPageIndicator = document.getElementById("pageindicator"),
          /* Bind the callback */
          changer.addEventListener(&quot;sectionchange&quot;, pageIndicatorHandler, false);
       })();
-   &lt;/script&gt;
-&lt;/div&gt;
 </pre>
 
 <p>If you use the following statement when you create page indicator component, a central dot is assigned to multiple pages.</p>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_popup.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_popup.htm
@@ -161,16 +161,17 @@
 
 <p>To bind the popup to a button, use the following code:</p>
 
-<pre class="prettyprint"><pre class="prettyprint lang-html" style="border:0px; margin:0px">
-&lt;!--HTML code--&gt;
+<p>HTML code:</p>
+<pre class="prettyprint">
 &lt;div id=&quot;1btnPopup&quot; class=&quot;ui-popup&quot;&gt;
    &lt;div class=&quot;ui-popup-header&quot;&gt;Power saving mode&lt;/div&gt;
    &lt;div class=&quot;ui-popup-content&quot;&gt;&lt;/div&gt;
    &lt;div class=&quot;ui-popup-footer&quot;&gt;
       &lt;button id=&quot;1btnPopup-cancel&quot; class=&quot;ui-btn&quot;&gt;Cancel&lt;/button&gt;
    &lt;/div&gt;
-&lt;/div&gt;</pre><pre class="prettyprint lang-js" style="border:0px; margin:0px">/* JavaScript code */
-&lt;script&gt;
+&lt;/div&gt;</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
    /* Popup opens with button click */
    button.addEventListener(&quot;click&quot;, function(ev)
    {
@@ -182,8 +183,7 @@
    {
       tau.closePopup();
    });
-&lt;/script&gt;
-</pre></pre>
+</pre>
 
 <h2>Popup Events</h2>
 <p>The following table lists the events related to pop-ups.</p>
@@ -222,36 +222,38 @@
 </table>
 <p>To use popup events, use the following code:</p>
 
-<pre class="prettyprint"><pre class="prettyprint lang-html" style="border:0px; margin:0px">
-&lt;!--Popup HTML code--&gt;
+<p>HTML code:</p>
+<pre class="prettyprint">
 &lt;div id=&quot;popup&quot; class=&quot;ui-popup&quot;&gt;
    &lt;div class=&quot;ui-popup-header&quot;&gt;&lt;/div&gt;
    &lt;div class=&quot;ui-popup-content&quot;&gt;&lt;/div&gt;
-&lt;/div&gt;</pre><pre class="prettyprint lang-js" style="border:0px; margin:0px">/* JavaScript code */
-&lt;script&gt;
+&lt;/div&gt;</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
    /* Use popup events */
    var popup = document.getElementById(&quot;popup&quot;);
    popup.addEventListener(&quot;popupbeforecreate&quot;, function(ev)
    {
       /* Implement code for popupbeforecreate event */
    });
-&lt;/script&gt;
-</pre></pre>
+</pre>
 
 <p>Because popup works in asynchronos way due to animation, the features of popup need to work under event like below code:<br>
 If popup is opened or closed by only openPopup() or closePopup() method,
 it might occur exceptional errors or bugs.<br>
 So it is highly recommended to handle the feature by using event.</p>
 
-<pre class="prettyprint"><pre class="prettyprint lang-html" style="border:0px; margin:0px">
+<p>HTML code:</p>
+<pre class="prettyprint">
 &lt;!--Popup HTML code--&gt;
 &lt;div id=&quot;popup&quot; class=&quot;ui-popup&quot;&gt;
    &lt;div class=&quot;ui-popup-content&quot;&gt;&lt;/div&gt;
    &lt;div class=&quot;ui-popup-footer&quot;&gt;
       &lt;div class=&quot;ui-btn&quot; id=&quot;cancel-btn&quot;&gt;&lt;/div&gt;
    &lt;/div&gt;
-&lt;/div&gt;</pre><pre class="prettyprint lang-js" style="border:0px; margin:0px">/* JavaScript code */
-&lt;script&gt;
+&lt;/div&gt;</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
    /* Use popup events */
    var popup = document.getElementById(&quot;popup&quot;),
        cancel = document.getElementById(&quot;cancel-btn&quot;);
@@ -274,8 +276,7 @@ So it is highly recommended to handle the feature by using event.</p>
    {
       console.log(window.getComputedStyle(popup).display); /* None - closed completely */
    });
-&lt;/script&gt;
-</pre></pre>
+</pre>
 <h2>Popup Transitions</h2>
 <p>Tizen Wearable Web UI framework does not apply transitions by default. To set a custom transition effect for a specific popup component, add the <span style="font-family: Courier New,Courier,monospace">data-transition</span> attribute to a link:</p>
 <pre class="prettyprint">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_sectionchanger.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_sectionchanger.htm
@@ -53,7 +53,8 @@ It gets to have a virtue of needlessness of changing page and the existance of s
 <h2 id="manual-constructor">How to Create Section Changer</h2>
 
 <p>To add a section changer component to the application, use the following code:</p>
-<pre class="prettyprint"><pre class="prettyprint lang-html" style="border:0px; margin:0px">
+<p>HTML code:</p>
+<pre class="prettyprint">
 &lt;div id=&quot;hasSectionchangerPage&quot; class=&quot;ui-page&quot;&gt;
    &lt;header class=&quot;ui-header&quot;&gt;
       &lt;h2 class=&quot;ui-title&quot;&gt;SectionChanger&lt;/h2&gt;
@@ -72,7 +73,11 @@ It gets to have a virtue of needlessness of changing page and the existance of s
          &lt;/section&gt;
       &lt;/div&gt;
    &lt;/div&gt;
-&lt;/div&gt;</pre><pre class="prettyprint lang-js" style="border:0px; margin:0px">(function()
+&lt;/div&gt;
+</pre>
+<p>JS code:</p>
+<pre class="prettyprint">
+(function()
 {
    var page = document.getElementById(&quot;hasSectionchangerPage&quot;),
        element = document.getElementById(&quot;sectionchanger&quot;),
@@ -95,7 +100,7 @@ It gets to have a virtue of needlessness of changing page and the existance of s
       sectionChanger.destroy();
    });
 })();
-</pre></pre>
+</pre>
 
 
 <h2 id="options-list">Options</h2>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_snaplistview.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_snaplistview.htm
@@ -69,10 +69,8 @@ When scroll ended, it triggers &quot;selected&quot; event and attach class to de
 
 <p>In javascript code, you can make your list as SnapListview component as follows:</p>
 <pre class="prettyprint">
-&lt;script&gt;
-   var snapList = document.getElementById("snapList"),
-       snapListComponent = tau.widget.SnapListview(snapList);
-&lt;/script&gt;
+var snapList = document.getElementById("snapList"),
+    snapListComponent = tau.widget.SnapListview(snapList);
 </pre>
 
 <h2><a id='default-using0.06779201747849584'></a>Usage of SnapListview</h2>


### PR DESCRIPTION
[Problem] HTML and JS code are mixed in documentation
[Solution] Add label "HTML code" and "JS code" if code snippet contains both JS and HTML code.

Signed-off-by: Dominik Orliński <d.orlinski@samsung.com>