### PR TITLE
[TvWindow][Systeminfo] Add subtitles and Closed Captions support insi…

### DIFF
--- a/docs/application/web/api/5.5/device_api/tv/tizen/systeminfo.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/systeminfo.html
@@ -3574,13 +3574,14 @@ It is written in 255.255.255.255 format.
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface SystemInfoVideoSourceInfo {
     readonly attribute <a href="#SystemInfoVideoSourceType">SystemInfoVideoSourceType</a> type;
     readonly attribute long number;
+    readonly attribute boolean? signal;
   };</pre>
 <p><span class="version">Since: </span>
  2.3
           </p>
 <div class="description">
           <p>
-If there are 2 HDMI inputs on a device, two <em>SystemInfoVideoSourceInfo</em> objects must be retrieved through <em>SystemInfoVideoSource</em><br>{type=HDMI, number=1}, {type=HDMI, number=2}
+If there are 2 HDMI inputs on a device, two <em>SystemInfoVideoSourceInfo</em> objects must be retrieved through <em>SystemInfoVideoSource</em><br>{type=HDMI, number=1, signal=null}, {type=HDMI, number=2, signal=null}
           </p>
          </div>
 <div class="attributes">
@@ -3607,6 +3608,22 @@ If the source is "HDMI 2", the <em>number</em> is 2.
            </div>
 <p><span class="version">Since: </span>
  2.3
+            </p>
+</li>
+<li class="attribute" id="SystemInfoVideoSourceInfo::signal">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">boolean </span><span class="name">signal</span><span class="optional"> [nullable]</span></span><div class="brief">
+ Represents if there is a signal provided on the source.
+            </div>
+<div class="description">
+            <p>
+The <em>signal</em> attribute can be <var>null</var>. The <var>null</var> value means that information about signal could not be retrieved at the time of returning this object.
+If the value is <var>true</var>, it means that there is signal provided. The value set to <var>false</var> means, that there is no signal.
+By default getPropertyValue* functions does not support this member, and will return object with <em>signal</em> value set to <var>null</var>, it is supported only by TVWindow module. To get data about signal use <a href="./tvwindow.html#TVWindowManager::getSource">tizen.tvwindow.getSource()</a> or <a href="./tvwindow.html#TVWindowManager::setSource">tizen.tvwindow.setSource()</a>.
+            </p>
+           </div>
+<p><span class="version">Since: </span>
+ 5.5
             </p>
 </li>
 </ul>
@@ -4060,6 +4077,7 @@ To guarantee the running of the application on a device which supports Wi-Fi, de
   [NoInterfaceObject] interface SystemInfoVideoSourceInfo {
     readonly attribute <a href="#SystemInfoVideoSourceType">SystemInfoVideoSourceType</a> type;
     readonly attribute long number;
+    readonly attribute boolean? signal;
   };
   [NoInterfaceObject] interface SystemInfoVideoSource : <a href="#SystemInfoProperty">SystemInfoProperty</a> {
     readonly attribute <a href="#SystemInfoVideoSourceInfo">SystemInfoVideoSourceInfo</a>[] connected;

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tvwindow.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tvwindow.html
@@ -91,6 +91,10 @@ do not want to interact with the TV image.
 <a href="#VideoResolution">VideoResolution</a> <a href="#TVWindowManager::getVideoResolution">getVideoResolution</a> (optional <a href="#WindowType">WindowType</a>? type)</div>
 <div>long <a href="#TVWindowManager::addVideoResolutionChangeListener">addVideoResolutionChangeListener</a> (<a href="#VideoResolutionChangeCallback">VideoResolutionChangeCallback</a> callback, optional <a href="#WindowType">WindowType</a>? type)</div>
 <div>void <a href="#TVWindowManager::removeVideoResolutionChangeListener">removeVideoResolutionChangeListener</a> (long listenerId)</div>
+<div>void <a href="#TVWindowManager::showCaptions">showCaptions</a> (optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
+<div>void <a href="#TVWindowManager::hideCaptions">hideCaptions</a> (optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
+<div>void <a href="#TVWindowManager::showSubtitles">showSubtitles</a> (optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
+<div>void <a href="#TVWindowManager::hideSubtitles">hideSubtitles</a> (optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
 </td>
 </tr>
 <tr>
@@ -255,6 +259,10 @@ functionality of the TV Window API.
     <a href="#VideoResolution">VideoResolution</a> getVideoResolution(optional <a href="#WindowType">WindowType</a>? type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addVideoResolutionChangeListener(<a href="#VideoResolutionChangeCallback">VideoResolutionChangeCallback</a> callback, optional <a href="#WindowType">WindowType</a>? type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeVideoResolutionChangeListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void showCaptions(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void hideCaptions(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void showSubtitles(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void hideSubtitles(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
 <p><span class="version">Since: </span>
  2.3
@@ -352,6 +360,7 @@ catch (error)
           <li class="param">
 <span class="name">successCallback</span>:
  The method to invoke when the intput source has been changed successfully.
+The result SystemInfoVideoSourceInfo object will have the <em>signal</em> property filled only when the window was shown using <a href="./tvwindow.html#TVWindowManager::show">show()</a> function.
                 </li>
           <li class="param">
 <span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
@@ -382,8 +391,8 @@ catch (error)
 <span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var connectedVideoSources;
 function successCB(source, type)
 {
-  console.log("setSource() is successfully done, source name: " + source.name +
-              ", source port number: " + source.number);
+  console.log("setSource() is successfully done, source type: " + source.type +
+              ", source port number: " + source.number + ", signal provided: " + source.signal);
 }
 
 function errorCB(error)
@@ -425,6 +434,16 @@ catch (error)
 }
 </pre>
 </div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>--------------- Source 0 ---------------
+type: TV
+number: 1
+--------------- Source 1 ---------------
+type: HDMI
+number: 4
+setSource() is successfully done, source type: HDMI, source port number: 4, signal provided: null
+</pre>
+</div>
 </dd>
 <dt class="method" id="TVWindowManager::getSource">
 <a class="backward-compatibility-anchor" name="::TVWindow::TVWindowManager::getSource"></a><code><b><span class="methodName">getSource</span></b></code>
@@ -457,7 +476,7 @@ catch (error)
 <ul>
 <span class="return">SystemInfoVideoSourceInfo:
                   </span>
- SystemInfoVideoSourceInfo The information about the current video source
+ The information about the current video source. Returned object will have the <em>signal</em> property, stating whether there is signal provided or not on the source, this property value will be filled only when the window was shown using <a href="./tvwindow.html#TVWindowManager::show">show()</a> function.
               </ul>
 </div>
 <div class="exceptionlist">
@@ -481,11 +500,18 @@ catch (error)
   var source = tizen.tvwindow.getSource();
   console.log("type: " + source.type);
   console.log("number: " + source.number);
+  console.log("signal: " + source.signal);
 }
 catch (error)
 {
   console.log("Error name: " + error.name + ", error message: " + error.message);
 }
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>type: HDMI
+number: 4
+signal: null
 </pre>
 </div>
 </dd>
@@ -965,6 +991,318 @@ Calling this function has no effect if there is no listener with given id.
 </li></ul>
         </div>
 </dd>
+<dt class="method" id="TVWindowManager::showCaptions">
+<a class="backward-compatibility-anchor" name="::TVWindow::TVWindowManager::showCaptions"></a><code><b><span class="methodName">showCaptions</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Shows captions if available in TV stream. Captions are shown inside window created by <a href="#TVWindowManager::show">show()</a>. EIA-CEA-708 (digital) and EIA-CEA-608 (analog) standards for captions are supported.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void showCaptions(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 5.5
+            </p>
+<div class="description">
+            <p>
+Depending on the stream, the captions may not be shown immediately. If there are no valid captions in the stream then method is executed with success but no effect is visible on the screen.
+            </p>
+            <p>
+The <em>errorCallback</em> is invoked with these error types:
+            </p>
+            <ul>
+              <li>
+<em>InvalidStateError</em> if TV window is not created.              </li>
+              <li>
+<em>UnknownError</em> if any other error occurs.              </li>
+            </ul>
+           </div>
+<p><span class="privilegelevel">Privilege level: </span>
+ public
+            </p>
+<p><span class="privilege">Privilege: </span>
+ http://tizen.org/privilege/tv.window
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">successCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method which will be invoked when captions has been turned on succesfully.
+                </li>
+          <li class="param">
+<span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method which will be invoked when an error occurs.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input attribute is not compatible with the expected type for this attribute.
+                </p></li>
+<li class="list"><p>
+ with error type SecurityError, if the application does not have the privilege to call this method.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">function showCaptionsSuccessCallback()
+{
+  console.log("Captions has been shown");
+}
+
+function showWindowSuccessCallback(windowRect, type)
+{
+  console.log("Window has been created");
+  try
+  {
+    tizen.tvwindow.showCaptions(showCaptionsSuccessCallback, errorCallback);
+  }
+  catch (error)
+  {
+    console.log("Error name: " + error.name + ", error message: " + error.message);
+  }
+}
+
+function errorCallback(error)
+{
+  console.log("Error: " + error.name + ", " + error.message);
+}
+
+try
+{
+  tizen.tvwindow.show(showWindowSuccessCallback, errorCallback, ["0", "0", "100%", "100%"], "MAIN");
+}
+catch (error)
+{
+  console.log("Error name: " + error.name + ", error message: " + error.message);
+}
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>Window has been created
+Captions has been shown
+</pre>
+</div>
+</dd>
+<dt class="method" id="TVWindowManager::hideCaptions">
+<a class="backward-compatibility-anchor" name="::TVWindow::TVWindowManager::hideCaptions"></a><code><b><span class="methodName">hideCaptions</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Hides captions if visible. If there are no captions visible on the screen then executing this method has no effect and will return success.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void hideCaptions(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 5.5
+            </p>
+<div class="description">
+            <p>
+The <em>errorCallback</em> is invoked with these error types:
+            </p>
+            <ul>
+              <li>
+<em>InvalidStateError</em> if TV window is not created.              </li>
+              <li>
+<em>UnknownError</em> if any other error occurs.              </li>
+            </ul>
+           </div>
+<p><span class="privilegelevel">Privilege level: </span>
+ public
+            </p>
+<p><span class="privilege">Privilege: </span>
+ http://tizen.org/privilege/tv.window
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">successCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method which will be invoked when captions has been turned off succesfully.
+                </li>
+          <li class="param">
+<span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method which will be invoked when an error occurs.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input attribute is not compatible with the expected type for this attribute.
+                </p></li>
+<li class="list"><p>
+ with error type SecurityError, if the application does not have the privilege to call this method.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+</dd>
+<dt class="method" id="TVWindowManager::showSubtitles">
+<a class="backward-compatibility-anchor" name="::TVWindow::TVWindowManager::showSubtitles"></a><code><b><span class="methodName">showSubtitles</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Shows subtitles if available in TV stream. Subtitles are shown inside window created by <a href="#TVWindowManager::show">show()</a>. DVB (ETSI EN 300 743) and TTX (ETSI EN 300 706) subtitles are supported.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void showSubtitles(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 5.5
+            </p>
+<div class="description">
+            <p>
+Depending on the stream, the subtitles may not be shown immediately. If there are no valid subtitles in the stream then method is executed with success but no effect is visible on the screen.
+            </p>
+            <p>
+The <em>errorCallback</em> is invoked with these error types:
+            </p>
+            <ul>
+              <li>
+<em>InvalidStateError</em> if TV window is not created.              </li>
+              <li>
+<em>UnknownError</em> if any other error occurs.              </li>
+            </ul>
+           </div>
+<p><span class="privilegelevel">Privilege level: </span>
+ public
+            </p>
+<p><span class="privilege">Privilege: </span>
+ http://tizen.org/privilege/tv.window
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">successCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method which will be invoked when subtitles has been turned on succesfully.
+                </li>
+          <li class="param">
+<span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method which will be invoked when an error occurs.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input attribute is not compatible with the expected type for this attribute.
+                </p></li>
+<li class="list"><p>
+ with error type SecurityError, if the application does not have the privilege to call this method.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">function showSubtitlesSuccessCallback()
+{
+  console.log("Subtitles has been shown");
+}
+
+function showWindowSuccessCallback(windowRect, type)
+{
+  console.log("Window has been created");
+  try
+  {
+    tizen.tvwindow.showSubtitles(showSubtitlesSuccessCallback, errorCallback);
+  }
+  catch (error)
+  {
+    console.log("Error name: " + error.name + ", error message: " + error.message);
+  }
+}
+
+function errorCallback(error)
+{
+  console.log("Error: " + error.name + ", " + error.message);
+}
+
+try
+{
+  tizen.tvwindow.show(showWindowSuccessCallback, errorCallback, ["0", "0", "100%", "100%"], "MAIN");
+}
+catch (error)
+{
+  console.log("Error name: " + error.name + ", error message: " + error.message);
+}
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>Window has been created
+Subtitles has been shown
+</pre>
+</div>
+</dd>
+<dt class="method" id="TVWindowManager::hideSubtitles">
+<a class="backward-compatibility-anchor" name="::TVWindow::TVWindowManager::hideSubtitles"></a><code><b><span class="methodName">hideSubtitles</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Hides subtitles if visible. If there are no subtitles visible on the screen then executing this method has no effect and will return success.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void hideSubtitles(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 5.5
+            </p>
+<div class="description">
+            <p>
+The <em>errorCallback</em> is invoked with these error types:
+            </p>
+            <ul>
+              <li>
+<em>InvalidStateError</em> if TV window is not created.              </li>
+              <li>
+<em>UnknownError</em> if any other error occurs.              </li>
+            </ul>
+           </div>
+<p><span class="privilegelevel">Privilege level: </span>
+ public
+            </p>
+<p><span class="privilege">Privilege: </span>
+ http://tizen.org/privilege/tv.window
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">successCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method which will be invoked when subtitles has been turned off succesfully.
+                </li>
+          <li class="param">
+<span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method which will be invoked when an error occurs.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input attribute is not compatible with the expected type for this attribute.
+                </p></li>
+<li class="list"><p>
+ with error type SecurityError, if the application does not have the privilege to call this method.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+</dd>
 </dl>
 </div>
 </div>
@@ -1239,6 +1577,10 @@ To guarantee the running of this application on a device with a TV picture-in-pi
     <a href="#VideoResolution">VideoResolution</a> getVideoResolution(optional <a href="#WindowType">WindowType</a>? type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addVideoResolutionChangeListener(<a href="#VideoResolutionChangeCallback">VideoResolutionChangeCallback</a> callback, optional <a href="#WindowType">WindowType</a>? type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeVideoResolutionChangeListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void showCaptions(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void hideCaptions(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void showSubtitles(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void hideSubtitles(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface VideoResolution {
     readonly attribute long width;


### PR DESCRIPTION
[TvWindow][Systeminfo] Add subtitles and Closed Captions support inside TvWindow and information about whether there is signal provided

Subtitles and CC can now be shown in TvWindow when using RF stream.
ACR: TWDAPI-200
http://suprem.sec.samsung.net/jira/browse/TWDAPI-200

Added Boolean value to SystemInfoVideoSourceInfo object.
true means that there is signal provided on given source,
false means there is no signal.
ACR: TWDAPI-206
http://suprem.sec.samsung.net/jira/browse/TWDAPI-206