### PR TITLE
Update TAU documentation with links and new source code url

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/ui_fw_api_cover.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/ui_fw_api_cover.htm
@@ -22,7 +22,9 @@
 	 <div id="toc_border"><div id="toc">
 		 <p class="toc-title">Related Info</p>
 		 <ul class="toc">
-			 <li><a href="https://developer.tizen.org/development/guides/web-application/user-interface/tizen-advanced-ui">Tizen Advanced UI framework (TAU): Guides</a></li>
+			 <li><a href="https://developer.tizen.org/development/guides/web-application/user-interface/tizen-advanced-ui">TAU guides</a></li>
+			 <li><a href="https://github.com/Samsung/TAU/">TAU source code</a></li>
+			 <li><a href="https://samsung.github.io/TAU/">TAU web page</a></li>
 		 </ul>
 	 </div></div>
  </div>

--- a/docs/application/web/guides/tau/download-tau.md
+++ b/docs/application/web/guides/tau/download-tau.md
@@ -14,7 +14,7 @@ To download and build TAU from Git:
    a. Clone a copy of the master branch in the TAU Git repository:
 
       ```
-      git clone git://git.tizen.org/platform/framework/web/tau
+      git clone git@github.com:Samsung/TAU.git
       ```
 
    b. Change to the `tau` directory:


### PR DESCRIPTION
[Problem]  TAU documentation not up to date with latest TAU release.
[Solution] Added TAU presentation page link, github url and updated
clonning information

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>