### PR TITLE
Add information whether there is signal or not to SystemInfoVideoSourceInfo object

### DIFF
--- a/docs/application/web/api/5.5/device_api/tv/tizen/systeminfo.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/systeminfo.html
@@ -3574,13 +3574,14 @@ It is written in 255.255.255.255 format.
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface SystemInfoVideoSourceInfo {
     readonly attribute <a href="#SystemInfoVideoSourceType">SystemInfoVideoSourceType</a> type;
     readonly attribute long number;
+    readonly attribute boolean? signal;
   };</pre>
 <p><span class="version">Since: </span>
  2.3
           </p>
 <div class="description">
           <p>
-If there are 2 HDMI inputs on a device, two <em>SystemInfoVideoSourceInfo</em> objects must be retrieved through <em>SystemInfoVideoSource</em><br>{type=HDMI, number=1}, {type=HDMI, number=2}
+If there are 2 HDMI inputs on a device, two <em>SystemInfoVideoSourceInfo</em> objects must be retrieved through <em>SystemInfoVideoSource</em><br>{type=HDMI, number=1, signal=null}, {type=HDMI, number=2, signal=null}
           </p>
          </div>
 <div class="attributes">
@@ -3607,6 +3608,22 @@ If the source is "HDMI 2", the <em>number</em> is 2.
            </div>
 <p><span class="version">Since: </span>
  2.3
+            </p>
+</li>
+<li class="attribute" id="SystemInfoVideoSourceInfo::signal">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">boolean </span><span class="name">signal</span><span class="optional"> [nullable]</span></span><div class="brief">
+ Represents if there is a signal provided on the source.
+            </div>
+<div class="description">
+            <p>
+The <em>signal</em> attribute can be <var>null</var>. The <var>null</var> value means that information about signal could not be retrieved at the time of returning this object.
+If the value is <var>true</var>, it means that there is signal provided. The value set to <var>false</var> means, that there is no signal.
+By default getPropertyValue functions does not support this member, and will return object with <em>signal</em> value set to <var>null</var>, it is supported only by TVWindow module. To get data about signal use <a href="./tvwindow.html#TVWindowManager::getSource">tizen.tvwindow.getSource()</a> or <a href="./tvwindow.html#TVWindowManager::setSource">tizen.tvwindow.setSource()</a>.
+            </p>
+           </div>
+<p><span class="version">Since: </span>
+ 5.5
             </p>
 </li>
 </ul>
@@ -4060,6 +4077,7 @@ To guarantee the running of the application on a device which supports Wi-Fi, de
   [NoInterfaceObject] interface SystemInfoVideoSourceInfo {
     readonly attribute <a href="#SystemInfoVideoSourceType">SystemInfoVideoSourceType</a> type;
     readonly attribute long number;
+    readonly attribute boolean? signal;
   };
   [NoInterfaceObject] interface SystemInfoVideoSource : <a href="#SystemInfoProperty">SystemInfoProperty</a> {
     readonly attribute <a href="#SystemInfoVideoSourceInfo">SystemInfoVideoSourceInfo</a>[] connected;

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tvwindow.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tvwindow.html
@@ -352,6 +352,7 @@ catch (error)
           <li class="param">
 <span class="name">successCallback</span>:
  The method to invoke when the intput source has been changed successfully.
+The result SystemInfoVideoSourceInfo object will have the <em>signal</em> property filled only when the window was shown using <a href="./tvwindow.html#TVWindowManager::show">show()</a> function.
                 </li>
           <li class="param">
 <span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
@@ -383,7 +384,7 @@ catch (error)
 function successCB(source, type)
 {
   console.log("setSource() is successfully done, source name: " + source.name +
-              ", source port number: " + source.number);
+              ", source port number: " + source.number + ", signal provided: " + source.signal);
 }
 
 function errorCB(error)
@@ -425,6 +426,16 @@ catch (error)
 }
 </pre>
 </div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>--------------- Source 0 ---------------
+type: TV
+number: 1
+--------------- Source 1 ---------------
+type: HDMI
+number: 4
+setSource() is successfully done, source type: HDMI, source port number: 4, signal provided: null
+</pre>
+</div>
 </dd>
 <dt class="method" id="TVWindowManager::getSource">
 <a class="backward-compatibility-anchor" name="::TVWindow::TVWindowManager::getSource"></a><code><b><span class="methodName">getSource</span></b></code>
@@ -457,7 +468,7 @@ catch (error)
 <ul>
 <span class="return">SystemInfoVideoSourceInfo:
                   </span>
- SystemInfoVideoSourceInfo The information about the current video source
+ The information about the current video source. Returned object will have the <em>signal</em> property, stating whether there is signal provided or not on the source, this property value will be filled only when the window was shown using <a href="./tvwindow.html#TVWindowManager::show">show()</a> function.
               </ul>
 </div>
 <div class="exceptionlist">
@@ -481,11 +492,18 @@ catch (error)
   var source = tizen.tvwindow.getSource();
   console.log("type: " + source.type);
   console.log("number: " + source.number);
+  console.log("signal: " + source.signal);
 }
 catch (error)
 {
   console.log("Error name: " + error.name + ", error message: " + error.message);
 }
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>type: HDMI
+number: 4
+signal: null
 </pre>
 </div>
 </dd>


### PR DESCRIPTION
[TWDAPI-206][5.5][TV][tvwindow][systeminfo] 

 Brief description and purpose

Brief description
Adding 1 attribute to SystemInfoVideoSourceInfo object:
signal - boolean value representing whether there is signal provided or not.
Purpose
Provide functionality that will be no longer supported by ex.B2BBroadcast plugins

Complete ACR contents

Headers containing changes
systeminfo.html
List of API changes and corresponding descriptions:
Adding 1 attribute to SystemInfoVideoSourceInfo object.

ACR: TWDAPI-206

