### PR TITLE
[Web API Reference] Add the missed <head> tag

### DIFF
--- a/docs/application/web/api/2.3.2/ui_fw_api/mobile/ns_widget_mobile_MultimediaView.htm
+++ b/docs/application/web/api/2.3.2/ui_fw_api/mobile/ns_widget_mobile_MultimediaView.htm
@@ -1,5 +1,6 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
 <html>
+<head>
     <script type="text/javascript" src="../snippet.js"></script>
 	<meta http-equiv="content-type" content="text/html; charset=utf-8">
 	<link href="../styles.css" rel="StyleSheet" type="text/css">
@@ -27,9 +28,9 @@
 
 <h2>Table of Contents</h2>
 <ol class="toc">
-	
+
 		<li><a href="#html-examples">HTML Examples</a></li>
-	
+
 </ol>
 
 


### PR DESCRIPTION
### Bugs Fixed ###

- Add the missed <head> tag in old Web API Reference.