### PR TITLE
[Content] [5.5] Cleaning code examples from modification of readonly members

### DIFF
--- a/docs/application/web/api/5.5/device_api/mobile/tizen/content.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/content.html
@@ -474,10 +474,10 @@ contain an invalid value.
         </div>
 <div class="example">
 <span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">/* Assume the content is a Content object as a result of find method. */
-/* Check if the description is editable, and then set a description. */
-if (content.editableAttributes.indexOf("description") &gt;= 0)
+/* Check if the isFavorite attribute is editable, and then set it as favorite. */
+if (content.editableAttributes.indexOf("isFavorite") &gt;= 0)
 {
-  content.description = "Sample content";
+  content.isFavorite = true;
 }
 tizen.content.update(content);
 </pre>
@@ -564,10 +564,10 @@ function successCB()
 }
 
 /* Assume the content is a Content object as a result of find method. */
-/* Check if the rating is editable, and then increase by 1. */
-if (content.editableAttributes.indexOf("rating") &gt;= 0)
+/* Check if the isFavorite attribute is editable, and then negate it. */
+if (content.editableAttributes.indexOf("isFavorite") &gt;= 0)
 {
-  content.rating++;
+  content.isFavorite = !content.isFavorite;
 }
 tizen.content.updateBatch([content], successCB, errorCB);
 </pre>
@@ -674,6 +674,10 @@ UnknownError: In any other error case.              </li>
             </p>
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/content.read
+            </p>
+<p><span class="remark">Remark: </span>
+ Attributes available for <em>Content</em> objects filtering are listed in
+<a href="https://developer.tizen.org/development/guides/web-application/data-storage-and-management/data-filtering-and-sorting#content_filter">Data Filtering and Sorting guide</a>.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/content.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/content.html
@@ -472,10 +472,10 @@ contain an invalid value.
         </div>
 <div class="example">
 <span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">/* Assume the content is a Content object as a result of find method. */
-/* Check if the description is editable, and then set a description. */
-if (content.editableAttributes.indexOf("description") &gt;= 0)
+/* Check if the isFavorite attribute is editable, and then set it as favorite. */
+if (content.editableAttributes.indexOf("isFavorite") &gt;= 0)
 {
-  content.description = "Sample content";
+  content.isFavorite = true;
 }
 tizen.content.update(content);
 </pre>
@@ -562,10 +562,10 @@ function successCB()
 }
 
 /* Assume the content is a Content object as a result of find method. */
-/* Check if the rating is editable, and then increase by 1. */
-if (content.editableAttributes.indexOf("rating") &gt;= 0)
+/* Check if the isFavorite attribute is editable, and then negate it. */
+if (content.editableAttributes.indexOf("isFavorite") &gt;= 0)
 {
-  content.rating++;
+  content.isFavorite = !content.isFavorite;
 }
 tizen.content.updateBatch([content], successCB, errorCB);
 </pre>
@@ -672,6 +672,10 @@ UnknownError: In any other error case.              </li>
             </p>
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/content.read
+            </p>
+<p><span class="remark">Remark: </span>
+ Attributes available for <em>Content</em> objects filtering are listed in
+<a href="https://developer.tizen.org/development/guides/web-application/data-storage-and-management/data-filtering-and-sorting#content_filter">Data Filtering and Sorting guide</a>.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/content.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/content.html
@@ -474,10 +474,10 @@ contain an invalid value.
         </div>
 <div class="example">
 <span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">/* Assume the content is a Content object as a result of find method. */
-/* Check if the description is editable, and then set a description. */
-if (content.editableAttributes.indexOf("description") &gt;= 0)
+/* Check if the isFavorite attribute is editable, and then set it as favorite. */
+if (content.editableAttributes.indexOf("isFavorite") &gt;= 0)
 {
-  content.description = "Sample content";
+  content.isFavorite = true;
 }
 tizen.content.update(content);
 </pre>
@@ -564,10 +564,10 @@ function successCB()
 }
 
 /* Assume the content is a Content object as a result of find method. */
-/* Check if the rating is editable, and then increase by 1. */
-if (content.editableAttributes.indexOf("rating") &gt;= 0)
+/* Check if the isFavorite attribute is editable, and then negate it. */
+if (content.editableAttributes.indexOf("isFavorite") &gt;= 0)
 {
-  content.rating++;
+  content.isFavorite = !content.isFavorite;
 }
 tizen.content.updateBatch([content], successCB, errorCB);
 </pre>
@@ -674,6 +674,10 @@ UnknownError: In any other error case.              </li>
             </p>
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/content.read
+            </p>
+<p><span class="remark">Remark: </span>
+ Attributes available for <em>Content</em> objects filtering are listed in
+<a href="https://developer.tizen.org/development/guides/web-application/data-storage-and-management/data-filtering-and-sorting#content_filter">Data Filtering and Sorting guide</a>.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/guides/data/data-filter.md
+++ b/docs/application/web/guides/data/data-filter.md
@@ -309,7 +309,7 @@ The following table lists the filter types you can use with specific content att
 | `contentURI`            | Yes                        | No                               |
 | `thumbnailURIs`         | Yes                        | No                               |
 | `releaseDate`           | Yes                        | Yes                              |
-| `modifedDate`           | Yes                        | Yes                              |
+| `modifiedDate`          | Yes                        | Yes                              |
 | `size`                  | No                         | No                               |
 | `description`           | No <font size="2" color="gray"><sup><i>since 5.5</i></sup></font>                        | No                               |
 | `rating`                | No <font size="2" color="gray"><sup><i>since 5.5</i></sup></font>| No <font size="2" color="gray"><sup><i>since 5.5</i></sup></font>|

--- a/docs/application/web/guides/data/stored-content.md
+++ b/docs/application/web/guides/data/stored-content.md
@@ -93,7 +93,7 @@ To browse and search for content directories and content items in directories:
 You can manage content in many ways:
 
 - You can view content item details with the `find()` method.
-- You can update some attributes of a content item, for example its rating, with the `update()` method.  
+- You can update some attributes of a content item, for example its isFavorite property, with the `update()` method.
    For more information on the content attributes, see the Content Full WebIDL Reference (in [mobile](../../api/latest/device_api/mobile/tizen/content.html#full-webidl), [wearable](../../api/latest/device_api/wearable/tizen/content.html#full-webidl), and [TV](../../api/latest/device_api/tv/tizen/content.html#full-webidl) applications).
 - If a content item is copied or moved, you cannot find it because a scan is not performed automatically. You can retrieve a copied or moved item with the `find()` method after calling the `scanFile()` method.
 - You can create a thumbnail for a content item using the `createThumbnail()` method.
@@ -127,14 +127,14 @@ To view and update content details:
    }
    ```
 
-3. To update the editable attributes of the content item, use the `update()` method. In the following example, the rating of the content item is increased.
+3. To update the editable attributes of the content item, use the `update()` method. In the following example, the isFavorite property of the content item is switched.
 
    ```
    function update(item) {
        /* Checks whether the attribute is editable */
-       if (item.editableAttributes.indexOf('rating') >= 0) {
+       if (item.editableAttributes.indexOf('isFavorite') >= 0) {
            /* Changes an attribute */
-           item.rating = 1;
+           item.isFavorite = !item.isFavorite;
 
            /* Updates the item */
            manager.update(item);


### PR DESCRIPTION
Few properties were marked as readonly since 5.5 with below ACR, but the code examples
still existed in API documentation which used to modify the properties now marked as
readonly.
Examples were fixed to use still editable attributes only.

[ACR] http://suprem.sec.samsung.net/jira/browse/TWDAPI-203
