### PR TITLE
added Tizen 5.5 Public M1 release note

### DIFF
--- a/docs/platform/toc_all.md
+++ b/docs/platform/toc_all.md
@@ -42,6 +42,7 @@
 ### [FAQ](/platform/reference/mic/mic-faq.md)
 
 # Release Notes
+## [Tizen 5.5 Public M1](/platform/release-notes/tizen-5-5-m1.md)
 ## [Tizen 5.0 Public M2](/platform/release-notes/tizen-5-0-m2.md)
 ## [Tizen 4.0 Public M3](/platform/release-notes/tizen-4-0-m3.md)
 ## [Tizen 5.0 Public M1](/platform/release-notes/tizen-5-0-m1.md)


### PR DESCRIPTION
added the link of Tizen 5.5 Public M1 release note.
## [Tizen 5.5 Public M1](/platform/release-notes/tizen-5-5-m1.md)
