### PR TITLE
Update 'Current Xamarin.Forms Limitations' for TV

### DIFF
--- a/docs/application/dotnet/api/xamarin-forms-limitations.md
+++ b/docs/application/dotnet/api/xamarin-forms-limitations.md
@@ -1320,18 +1320,11 @@ The following table lists the classes that are supported with minor limitations.
         </tr>
         <tr>
             <td class="tdclass" rowspan="2"><code class="prettyprint"><span class="typ">WebView</span></code></td>
-            <td class="tdtype" rowspan="2"><span>Property</span></td>
-            <td><code class="prettyprint"><span class="typ">Opacity</span></code></td>
+            <td class="tdtype" rowspan="2"><span>Class</span></td>
+            <td><code class="prettyprint"><span class="typ">WebView</span></code></td>
             <td>&nbsp;</td>
             <td>
-                <p><span>Ignored.</span></p>
-            </td>
-        </tr>
-        <tr>
-            <td><code class="prettyprint"><span class="typ">BackgroundColor</span></code></td>
-            <td>&nbsp;</td>
-            <td>
-                <p><span>Ignored.</span></p>
+                <p><span>Application will fail to launch.</span></p>
             </td>
         </tr>
     </tbody>

--- a/docs/application/dotnet/api/xamarin-forms-limitations.md
+++ b/docs/application/dotnet/api/xamarin-forms-limitations.md
@@ -1319,8 +1319,8 @@ The following table lists the classes that are supported with minor limitations.
             </td>
         </tr>
         <tr>
-            <td class="tdclass" rowspan="2"><code class="prettyprint"><span class="typ">WebView</span></code></td>
-            <td class="tdtype" rowspan="2"><span>Class</span></td>
+            <td class="tdclass"><code class="prettyprint"><span class="typ">WebView</span></code></td>
+            <td class="tdtype"><span>Class</span></td>
             <td><code class="prettyprint"><span class="typ">WebView</span></code></td>
             <td>&nbsp;</td>
             <td>


### PR DESCRIPTION
WebView feature of Xamarin.Forms is not supported on TV, so the corresponding document is updated.

### Change Description ###

Descriptions in 'tizen-docs/docs/application/dotnet/api/xamarin-forms-limitations.md' are updated as follow:
- Before: Some properties of the WebView class are limited.
- After: Whole WebView class is limited.