### PR TITLE
Add links for wearable examples (5.0)

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_button.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_button.htm
@@ -12,8 +12,12 @@
 <h1>Button</h1>
 
 <p>The button component shows on the screen a control that you can use to generate an action event when it is pressed and released.<br> The component is coded with standard HTML anchor and input elements.</p>
-<p>The following table describes the supported button classes.</p>
+
 <img src="../../images/button.png" alt="photo of button element in Tizen">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fbutton%2Ficon-button.html', '_blank')">Use example</button>
+
+<p>The following table describes the supported button classes.</p>
 <table>
 <caption>Table: Button type classes</caption>
 <tbody>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_checkbox.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_checkbox.htm
@@ -14,6 +14,8 @@
 <p>Checkbox and Radio Button components shows selectable items:</p>
 
 <img src="../../images/checkboxRadio.png" alt="photo of checkboxRadio in Tizen">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fcheckbox.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circleprogressbar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circleprogressbar.htm
@@ -15,6 +15,8 @@
 <p>The circle progress component shows a control that indicates the progress percentage of an on-going operation.<br>This component can be scaled to be fit inside a parent container.</p>
 
 <img src="../../images/CircleProgressBar.png" alt="photo of CircleProgressBar in Tizen">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fprogress%2Fprogress_medium.html', '_blank')">Use example</button>
 
 <table class="note">
 	<tbody>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
@@ -14,6 +14,7 @@
 <p>If you spin the rotary quickly, an indicator will be displayed and you can move in an index unit.</p>
 <p>The indicator will disappear if no rotary action is detected for a second.</p>
 <p>This component fires a select event when the index characters are selected.</p>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fnavcontrols%2Findexscrollbar%2Findex.html', '_blank')">Use example</button>
 
 <table class="note">
 	<tbody>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_datepicker.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_datepicker.htm
@@ -12,6 +12,8 @@
 <h1>Date Picker</h1>
 
 <img src="../../images/DatePicker.png" alt="photo of date picker element in Tizen">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fdate-picker.html', '_blank')">Use example</button>
 
 <p>To add a date picker component to the application, use the following code:</p>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_list.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_list.htm
@@ -14,6 +14,8 @@
 <p>The list component is used to display, for example, navigation data, results, and data entries. The following table describes the supported list classes.</p>
 
 <img src="../../images/List.png" alt="photo of List element in Tizen">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Flist%2Flist_normal.html', '_blank')">Use example</button>
 
 <table>
 <caption>Table: List classes</caption>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_marquee.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_marquee.htm
@@ -15,6 +15,8 @@ It makes &lt;div&gt; element (has some child nodes such as text and img) move ho
 <video autoplay muted loop controls>
 	<source src="https://developer.tizen.org/sites/default/files/documentation/marquee.mp4">
 </video>
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fmarquee%2Findex.html', '_blank')">Use example</button>
 
 <table class="note">
 	<tbody>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_numberpicker.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_numberpicker.htm
@@ -12,6 +12,8 @@
 <h1>Number Picker</h1>
 
 <img src="../../images/NumberPicker.png" alt="photo of number picker element in Tizen">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fnumberpicker%2Fsimple.html', '_blank')">Use example</button>
 
 <p>To add a number picker component to the application, use the following code:</p>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_pageindicator.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_pageindicator.htm
@@ -16,6 +16,9 @@
 <p>If the number of linked pages is more than dots which can be displayed, a central dot is assigned to multiple pages.</p>
 
 <img src="../../images/PageIndicator.png" alt="photo of Page Indicator element in TIZEN">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Findicator%2Fpageindicator_circle.html', '_blank')">Use example</button>
+
 <table class="note">
 	<tbody>
 	<tr>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_popup.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_popup.htm
@@ -13,6 +13,9 @@
 
 <p>The popup component shows in the middle of the screen a list of items in a pop-up window. It automatically optimizes the pop-up window size within the screen.  The following table describes the supported popup classes.</p>
 <img src="../../images/Popup.png" alt="image of Popup element in TIZEN">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fpopup%2Fpopup.html', '_blank')">Use example</button>
+
 <table>
 <caption>Table: Popup classes</caption>
 <tbody>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_processing.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_processing.htm
@@ -17,6 +17,8 @@
 <video autoplay muted loop controls>
 	<source src="https://developer.tizen.org/sites/default/files/documentation/processing.mp4">
 </video>
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fprocessing%2Ffull_processing.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_sectionchanger.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_sectionchanger.htm
@@ -18,6 +18,8 @@ It gets to have a virtue of needlessness of changing page and the existance of s
 <video autoplay muted loop controls>
 	<source src="https://developer.tizen.org/sites/default/files/documentation/sectionchanger.mp4">
 </video>
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fnavcontrols%2Fsectionchanger%2Fhsection.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_selector.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_selector.htm
@@ -21,6 +21,8 @@ Indicator arrow is special indicator style that has the arrow. It is used for pr
 <video autoplay muted loop controls>
 	<source src="https://developer.tizen.org/sites/default/files/documentation/selector.mp4">
 </video>
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fselector%2Fselector.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_slider.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_slider.htm
@@ -17,7 +17,8 @@
 <video autoplay muted loop controls>
        <source src="https://developer.tizen.org/sites/default/files/documentation/slider.mp4">
 </video>
-
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fslider%2Fslider.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_snaplistview.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_snaplistview.htm
@@ -18,6 +18,8 @@ When scroll ended, it triggers &quot;selected&quot; event and attach class to de
 <video autoplay muted loop controls>
 	<source src="https://developer.tizen.org/sites/default/files/documentation/snaplistview.mp4">
 </video>
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Flist%2Fsnaplistview.html', '_blank')">Use example</button>
 
 <table class="note">
         <tbody>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_timepicker.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_timepicker.htm
@@ -12,6 +12,8 @@
 <h1>Time Picker</h1>
 
 <img src="../../images/TimePicker.png" alt="photo of time picker element in Tizen">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Ftime-picker.html', '_blank')">Use example</button>
 
 <p>To add a time picker component to the application, use the following code:</p>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_toggleswitch.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_toggleswitch.htm
@@ -16,6 +16,8 @@
 <video autoplay muted loop controls>
 	<source src="https://developer.tizen.org/sites/default/files/documentation/toggleswitch.mp4">
 </video>
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Ftoggle.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_virtuallist.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_virtuallist.htm
@@ -19,7 +19,10 @@
 <video autoplay muted loop controls>
 	<source src="https://developer.tizen.org/sites/default/files/documentation/virtuallist.mp4">
 </video>
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Flist%2Fvirtual%2Fnormal.html', '_blank')">Use example</button>
 
+<h2>Table of Contents</h2>
 <ol class="toc">
 
 		<li><a href="#manual-constructor">How to Create Virtual List</a>


### PR DESCRIPTION
Issue: https://github.com/Samsung/TAU/issues/199
Problem: No links for wearable examples
Solution: Add links in documentation

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>
