### PR TITLE
 Removed ATI and Intel Graphics card information

### DIFF
--- a/docs/application/tizen-studio/setup/prerequisites.md
+++ b/docs/application/tizen-studio/setup/prerequisites.md
@@ -124,21 +124,11 @@ The following table lists the CPU, screen resolution, graphic card, driver, and 
 <td>NVIDIA</td>
 <td>NVIDIA&reg; GeForce&reg; 8300 GS, GeForce&reg; 8500 GT, GeForce&reg; GT 220, GeForce&reg; GT 430, GeForce&reg; GT 530, GeForce&reg; GT 330M, GeForce&reg; GTX 550Ti, NVIDIA&reg; Quadro&reg; NVS 290</td>
 </tr>
-<tr>
-<td>ATI</td>
-<td>RADEON HD 4850, RADEON HD 5450</td>
-</tr>
-<tr>
-<td>Intel</td>
-<td>HD Graphics 2000, HD Graphics 2500, HD Graphics 4000</td>
-</tr>
 </tbody>
 </table>
 <strong>Note</strong>
 <ul>
 <li>If the host machine is using the NVIDIA&reg; Optimus&reg; technology, the emulator works with the on-board graphics card. To prevent this, either disable the Optimus&reg; technology, or set the emulator to run with the external NVIDIA graphics card.</li>
-<li>Integrated graphic cards inside Intel's Q33/Q35/Q43/Q45 motherboards are not supported.</li>
-<li>First generation Intel HD Graphics is not supported.</li>
 </ul>
 </p>
 </td>


### PR DESCRIPTION
With reference to the following mail chain, I have modified the required information. 
I have removed the email addresses purposefully and just kept the names. 
_______________
Hello Nawab,
Your understanding is correct that we will only support Nvidia.
Thanks & Regards,
Manish

--------- Original Message ---------
Sender : Nawab Ahmad Reshi
Date : 2019-07-22 17:57 (GMT+5:30)
Title : RE: Request to update prerequisites documentation

Hello,
Thanks for the information. 
We will do the required changes and send a PR to update current live documentation and simultaneously update our revamped page that is expected to go live in coming days replacing the current live document.
In this context, we need to remove the following information from the page:
ATI
RADEON HD 4850, RADEON HD 5450
Intel
HD Graphics 2000, HD Graphics 2500, HD Graphics 4000
Which means that we only support Nvidia, correct me if I am wrong.
Thanks, 
With Regards,
Nawab       

--------- Original Message ---------

Sender: Manish Toshan Rathod 
Date : 2019-07-22 17:15 (GMT+5:30)
Title : Request to update prerequisites documentation
To : Divya G K, Nawab Ahmad Reshi
CC : Chang-Seok Oh, SANGWOOK LEE

Hello Divya/Nawab,

We need to update the prerequisites documentation at https://developer.tizen.org/development/tizen-studio/download/installing-tizen-studio/prerequisites
We want to remove the ATI and Intel Graphics section from the Supported graphic cards table.
Request you to please raise a PR for it.
Thanks & Regards,
Manish


>Note: 
>
>- As already discussed, we will be publishing the revamped content in a couple of days, we have already made the changes in revamped page too. 
>- We have made changes to the older page just that no developers come up with any issues till revamped pages go live. 