### PR TITLE
[Common] Fixes in web API reference

### DIFF
--- a/docs/application/web/api/5.5/device_api/mobile/tizen/account.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/account.html
@@ -1447,10 +1447,10 @@ To guarantee the running of the application on a device with Account feature, de
     DOMString userName;
     DOMString iconUri;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#AccountManagerObject">AccountManagerObject</a>;
   [NoInterfaceObject] interface AccountManagerObject {
     readonly attribute <a href="#AccountManager">AccountManager</a> account;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#AccountManagerObject">AccountManagerObject</a>;
   [NoInterfaceObject] interface AccountProvider {
     readonly attribute <a href="application.html#ApplicationId">ApplicationId</a> applicationId;
     readonly attribute DOMString displayName;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/account.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/account.html
@@ -481,8 +481,7 @@ Returns null if the given key is not found.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  Value of the extended data.
               </ul>
 </div>
@@ -851,8 +850,7 @@ tizen.account.getAccounts(
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Account:
-                  </span>
+<span class="return">Account<span class="optional"> [nullable]</span>:</span>
  Object with the given identifier or <var>null</var>.
               </ul>
 </div>
@@ -881,7 +879,7 @@ tizen.account.getAccounts(
  Gets the accounts associated with the provider that has a specified applicationId, asynchronously.
 If you want to get all accounts, omit the applicationId argument.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getAccounts(<a href="#AccountArraySuccessCallback">AccountArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getAccounts(<a href="#AccountArraySuccessCallback">AccountArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                  optional DOMString? applicationId);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -971,8 +969,7 @@ You can register your application as an account provider by writing account rela
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">AccountProvider:
-                  </span>
+<span class="return">AccountProvider<span class="optional"> [nullable]</span>:</span>
  Object with the given applicationId or <var>null</var>.
               </ul>
 </div>
@@ -1006,7 +1003,7 @@ if (!provider)
  Gets the providers with the given capabilities, asynchronously.
 If you want to get all the providers, omit the capability argument.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getProviders(<a href="#AccountProviderArraySuccessCallback">AccountProviderArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getProviders(<a href="#AccountProviderArraySuccessCallback">AccountProviderArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                   optional DOMString? capability);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -1093,8 +1090,7 @@ If you want to get all the providers, omit the capability argument.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Identifier to clear the watch subscription for account changes.
               </ul>
 </div>
@@ -1446,11 +1442,15 @@ To guarantee the running of the application on a device with Account feature, de
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Account {
+  typedef unsigned long AccountId;
+  dictionary AccountInit {
+    DOMString userName;
+    DOMString iconUri;
+  };
   [NoInterfaceObject] interface AccountManagerObject {
     readonly attribute <a href="#AccountManager">AccountManager</a> account;
   };
   <a href="tizen.html#Tizen">Tizen</a> implements <a href="#AccountManagerObject">AccountManagerObject</a>;
-  typedef unsigned long AccountId;
   [NoInterfaceObject] interface AccountProvider {
     readonly attribute <a href="application.html#ApplicationId">ApplicationId</a> applicationId;
     readonly attribute DOMString displayName;
@@ -1458,10 +1458,6 @@ To guarantee the running of the application on a device with Account feature, de
     readonly attribute DOMString smallIconUri;
     readonly attribute DOMString[] capabilities;
     readonly attribute boolean isMultipleAccountSupported;
-  };
-  dictionary AccountInit {
-    DOMString userName;
-    DOMString iconUri;
   };
   [Constructor(<a href="#AccountProvider">AccountProvider</a> provider, optional <a href="#AccountInit">AccountInit</a>? accountInitDict)]
   interface Account {

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/alarm.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/alarm.html
@@ -527,8 +527,7 @@ console.log("remove all registered alarms in the storage.");
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Alarm:
-                  </span>
+<span class="return">Alarm:</span>
  An alarm object with the specified ID.
               </ul>
 </div>
@@ -595,8 +594,7 @@ even if the added alarm was using <a href="notification.html#StatusNotification"
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">UserNotification:
-                  </span>
+<span class="return">UserNotification:</span>
  Notification to be posted when the alarm is triggered.
               </ul>
 </div>
@@ -661,8 +659,7 @@ Alarms that have already been triggered are removed automatically from the stora
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Alarm[]:
-                  </span>
+<span class="return">Alarm[]:</span>
  All Alarm objects.
               </ul>
 </div>
@@ -802,8 +799,7 @@ If the alarm has expired, this method returns <var>null</var>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long<span class="optional"> [nullable]</span>:</span>
  The duration before the next alarm is triggered.
               </ul>
 </div>
@@ -840,7 +836,8 @@ console.log("remaining time is " + sec);
    Constructor(Date date, long period)]
   interface AlarmAbsolute : <a href="#Alarm">Alarm</a> {
     readonly attribute Date date;
-    readonly attribute <a href="#ByDayValue">ByDayValue</a>[] daysOfTheWeek;
+<span class="nocode deprecated">    readonly attribute long? period;
+</span>    readonly attribute <a href="#ByDayValue">ByDayValue</a>[] daysOfTheWeek;
     Date? getNextScheduledDate() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
 <p><span class="version">Since: </span>
@@ -957,8 +954,7 @@ If the alarm has expired, this method returns <var>null</var>. The returned date
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Date:
-                  </span>
+<span class="return">Date<span class="optional"> [nullable]</span>:</span>
  The date/time of the next alarm trigger.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/alarm.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/alarm.html
@@ -987,10 +987,10 @@ console.log("next scheduled time is " + date);
 <pre class="webidl prettyprint">module Alarm {
   typedef DOMString AlarmId;
   enum ByDayValue { "MO", "TU", "WE", "TH", "FR", "SA", "SU" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#AlarmManagerObject">AlarmManagerObject</a>;
   [NoInterfaceObject] interface AlarmManagerObject {
     readonly attribute <a href="#AlarmManager">AlarmManager</a> alarm;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#AlarmManagerObject">AlarmManagerObject</a>;
   [NoInterfaceObject] interface AlarmManager {
     const long PERIOD_MINUTE = 60;
     const long PERIOD_HOUR = 3600;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/application.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/application.html
@@ -401,7 +401,9 @@ The <em>tizen.application </em>object allows access to the Application API's fun
     void getAppsUsageInfo(<a href="#AppsUsageInfoArraySuccessCallback">AppsUsageInfoArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                           optional <a href="#ApplicationUsageMode">ApplicationUsageMode</a>? mode, optional <a href="#ApplicationUsageFilter">ApplicationUsageFilter</a>? filter, optional long? limit)
                           raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addAppStatusChangeListener(<a href="#StatusEventCallback">StatusEventCallback</a> eventCallback, optional <a href="#ApplicationId">ApplicationId</a>? appId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    long addAppInfoEventListener( eventCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void removeAppInfoEventListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    long addAppStatusChangeListener(<a href="#StatusEventCallback">StatusEventCallback</a> eventCallback, optional <a href="#ApplicationId">ApplicationId</a>? appId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeAppStatusChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
 <p><span class="version">Since: </span>
@@ -427,8 +429,7 @@ The <em>tizen.application </em>object allows access to the Application API's fun
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Application:
-                  </span>
+<span class="return">Application:</span>
  The data structure that defines the current application.
               </ul>
 </div>
@@ -607,7 +608,7 @@ tizen.application.launch("targetApp0.main", onsuccess);
 <div class="brief">
  Launches an application with the specified application control.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void launchAppControl(<a href="#ApplicationControl">ApplicationControl</a> appControl, optional <a href="#ApplicationId">ApplicationId</a>? id, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void launchAppControl(<a href="#ApplicationControl">ApplicationControl</a> appControl, optional <a href="#ApplicationId">ApplicationId</a>? id, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="#ApplicationControlDataArrayReplyCallback">ApplicationControlDataArrayReplyCallback</a>? replyCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.0
@@ -735,7 +736,7 @@ tizen.application.launchAppControl(appControl, null,
 <div class="brief">
  Finds which applications can be launched with the given application control.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void findAppControl(<a href="#ApplicationControl">ApplicationControl</a> appControl, <a href="#FindAppControlSuccessCallback">FindAppControlSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void findAppControl(<a href="#ApplicationControl">ApplicationControl</a> appControl, <a href="#FindAppControlSuccessCallback">FindAppControlSuccessCallback</a> successCallback,
                     optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.0
@@ -902,8 +903,7 @@ The list of running applications and their application IDs is obtained with <em>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ApplicationContext:
-                  </span>
+<span class="return">ApplicationContext:</span>
  A data structure that lists running application details.
               </ul>
 </div>
@@ -1008,8 +1008,7 @@ The list of installed applications and their application IDs is obtained with <e
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ApplicationInformation:
-                  </span>
+<span class="return">ApplicationInformation:</span>
  The information of an application.
               </ul>
 </div>
@@ -1088,8 +1087,7 @@ The certificate types are listed below:
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ApplicationCertificate[]:
-                  </span>
+<span class="return">ApplicationCertificate[]:</span>
  Array of certificate information of a specified application.
               </ul>
 </div>
@@ -1132,10 +1130,19 @@ for (var i = 0; i &lt; appCerts.length; i++)
             </p>
 <div class="description">
             <p>
-The shared directory is used to export data to other applications.
+The shared directory is used to export data to other applications. Its structure is described in
+<a href="https://developer.tizen.org/development/training/native-application/understanding-tizen-programming/file-system-directory-hierarchy">File System Directory Hierarchy</a>.
+            </p>
+           </div>
+<div class="description">
+            <p>
 If the ID is set to <var>null</var> or not set at all, it returns the shared directory URI for the current application.
             </p>
            </div>
+<p><span class="remark">Remark: </span>
+ Since Tizen 3.0, <var>shared/data</var> directory is not created for web applications. For other applications it will be not created by default and should be considered as optional
+(refer to <a href="https://developer.tizen.org/development/training/native-application/understanding-tizen-programming/file-system-directory-hierarchy">table about shared/data</a> for more details).
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1148,8 +1155,7 @@ If the ID is set to <var>null</var> or not set at all, it returns the shared dir
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The shared directory URI of an application.
               </ul>
 </div>
@@ -1205,8 +1211,7 @@ If the ID is set to <var>null</var> or not set at all, it returns the applicatio
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ApplicationMetaData[]:
-                  </span>
+<span class="return">ApplicationMetaData[]:</span>
  Array of meta data of a specified application. If there are no meta data for a specified application,
 an empty array is returned
               </ul>
@@ -1239,7 +1244,7 @@ console.log("Size of metadata: " + metaDataArray.length);
 <div class="brief">
  Gets information about battery usage per application.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getBatteryUsageInfo(<a href="#BatteryUsageInfoArraySuccessCallback">BatteryUsageInfoArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getBatteryUsageInfo(<a href="#BatteryUsageInfoArraySuccessCallback">BatteryUsageInfoArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                          optional long? days, optional long? limit);</pre></div>
 <p><span class="version">Since: </span>
  4.0
@@ -1341,7 +1346,7 @@ ApplicationID: org.tizen.msg-manager, usage: 0.36
 <div class="brief">
  Gets the usage statistics of applications.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getAppsUsageInfo(<a href="#AppsUsageInfoArraySuccessCallback">AppsUsageInfoArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getAppsUsageInfo(<a href="#AppsUsageInfoArraySuccessCallback">AppsUsageInfoArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                       optional <a href="#ApplicationUsageMode">ApplicationUsageMode</a>? mode, optional <a href="#ApplicationUsageFilter">ApplicationUsageFilter</a>? filter, optional long? limit);</pre></div>
 <p><span class="version">Since: </span>
  4.0
@@ -1489,8 +1494,7 @@ with the corresponding listener identifier.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  ID of the listener that can be used to remove the listener later.
               </ul>
 </div>
@@ -1609,8 +1613,7 @@ tizen.application.removeAppInfoEventListener(watchId);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Listener id that can be used to remove the listener later.
               </ul>
 </div>
@@ -1901,8 +1904,7 @@ appropriately when it is launched.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">RequestedApplicationControl:
-                  </span>
+<span class="return">RequestedApplicationControl:</span>
  The details of a requested application control.
               </ul>
 </div>
@@ -1955,8 +1957,7 @@ System events do not require an application identifier to be specified. Therefor
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Listener identifier.
               </ul>
 </div>
@@ -2502,7 +2503,7 @@ and launches the selected application.
 </div>
 <div class="constructors">
 <h4 id="ApplicationControl::constructor">Constructors</h4>
-<dl><pre class="webidl prettyprint">ApplicationControl(DOMString operation, optional DOMString? uri, optional DOMString? mime, optional DOMString? category, 
+<dl><pre class="webidl prettyprint">ApplicationControl(DOMString operation, optional DOMString? uri, optional DOMString? mime, optional DOMString? category,
                    optional <a href="#ApplicationControlData">ApplicationControlData</a>[]? data, optional <a href="#ApplicationControlLaunchMode">ApplicationControlLaunchMode</a>? launchMode);</pre></dl>
 </div>
 <div class="attributes">
@@ -3404,6 +3405,15 @@ To guarantee the running of the application on a device which has battery, decla
   typedef (<a href="#SystemEventData">SystemEventData</a> or <a href="#UserEventData">UserEventData</a>) EventData;
   enum ApplicationControlLaunchMode { "SINGLE", "GROUP" };
   enum ApplicationUsageMode { "RECENTLY", "FREQUENTLY" };
+  dictionary ApplicationUsageFilter {
+    long? timeSpan;
+    Date? startTime;
+    Date? endTime;
+  };
+  dictionary EventInfo {
+    <a href="#ApplicationId">ApplicationId</a> appId;
+    DOMString name;
+  };
   [NoInterfaceObject] interface ApplicationManagerObject {
     readonly attribute <a href="#ApplicationManager">ApplicationManager</a> application;
   };
@@ -3435,11 +3445,6 @@ To guarantee the running of the application on a device which has battery, decla
                           raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addAppStatusChangeListener(<a href="#StatusEventCallback">StatusEventCallback</a> eventCallback, optional <a href="#ApplicationId">ApplicationId</a>? appId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeAppStatusChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  dictionary ApplicationUsageFilter {
-    long? timeSpan;
-    Date? startTime;
-    Date? endTime;
   };
   [NoInterfaceObject] interface Application {
     readonly attribute <a href="#ApplicationInformation">ApplicationInformation</a> appInfo;
@@ -3534,10 +3539,6 @@ To guarantee the running of the application on a device which has battery, decla
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface StatusEventCallback {
     void onchange(<a href="#ApplicationId">ApplicationId</a> appId, boolean isActive);
-  };
-  dictionary EventInfo {
-    <a href="#ApplicationId">ApplicationId</a> appId;
-    DOMString name;
   };
 };</pre>
 </div>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/application.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/application.html
@@ -3414,10 +3414,10 @@ To guarantee the running of the application on a device which has battery, decla
     <a href="#ApplicationId">ApplicationId</a> appId;
     DOMString name;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ApplicationManagerObject">ApplicationManagerObject</a>;
   [NoInterfaceObject] interface ApplicationManagerObject {
     readonly attribute <a href="#ApplicationManager">ApplicationManager</a> application;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ApplicationManagerObject">ApplicationManagerObject</a>;
   [NoInterfaceObject] interface ApplicationManager {
     <a href="#Application">Application</a> getCurrentApplication() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void kill(<a href="#ApplicationContextId">ApplicationContextId</a> contextId, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/archive.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/archive.html
@@ -359,7 +359,7 @@ mypackage/test.c                </td>
 <div class="brief">
  Opens the archive file. After this operation, it is possible to add or get files to and from the archive.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long open(<a href="#FileReference">FileReference</a> file, <a href="filesystem.html#FileMode">FileMode</a> mode, <a href="#ArchiveFileSuccessCallback">ArchiveFileSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">long open(<a href="#FileReference">FileReference</a> file, <a href="filesystem.html#FileMode">FileMode</a> mode, <a href="#ArchiveFileSuccessCallback">ArchiveFileSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
           optional <a href="#ArchiveFileOptions">ArchiveFileOptions</a>? options);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -452,8 +452,7 @@ In this mode, <em>getEntries()</em>, <em>getEntryByName()</em>, and <em>extractA
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -583,7 +582,7 @@ The size is <var>null</var> until the archive is opened.
 <div class="brief">
  Adds a new member file to <em>ArchiveFile</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long add(<a href="#FileReference">FileReference</a> sourceFile, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">long add(<a href="#FileReference">FileReference</a> sourceFile, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
          optional <a href="#ArchiveFileProgressCallback">ArchiveFileProgressCallback</a>? onprogress, optional <a href="#ArchiveFileEntryOptions">ArchiveFileEntryOptions</a>? options);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -698,8 +697,7 @@ If the source file is big then the callback can also be called while the file is
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -753,7 +751,7 @@ tizen.archive.open("downloads/new_archive.zip", "w", createSuccess);
 <div class="brief">
  Extracts every file from this <em>ArchiveFile</em> to a given directory.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long extractAll(<a href="#FileReference">FileReference</a> destinationDirectory, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">long extractAll(<a href="#FileReference">FileReference</a> destinationDirectory, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
                 optional <a href="#ArchiveFileProgressCallback">ArchiveFileProgressCallback</a>? onprogress, optional boolean? overwrite);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -814,8 +812,7 @@ UnknownError: In any other error case              </li>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -905,8 +902,7 @@ UnknownError: In case of any error              </li>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -1000,8 +996,7 @@ UnknownError: In case of any other error              </li>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -1151,7 +1146,7 @@ This is usually the modification date of the file.
 <div class="brief">
  Extracts ArchiveFileEntry to the given location.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long extract(<a href="#FileReference">FileReference</a> destinationDirectory, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">long extract(<a href="#FileReference">FileReference</a> destinationDirectory, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
              optional <a href="#ArchiveFileProgressCallback">ArchiveFileProgressCallback</a>? onprogress, optional boolean? stripName, optional boolean? overwrite);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -1209,8 +1204,7 @@ UnknownError: In case of any other error              </li>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -1422,10 +1416,6 @@ tizen.archive.open("downloads/some_archive.zip", "r", openSuccess, errorCallback
 <pre class="webidl prettyprint">module Archive {
   typedef (DOMString or <a href="filesystem.html#File">File</a>) FileReference;
   enum ArchiveCompressionLevel { "STORE", "FAST", "NORMAL", "BEST" };
-  [NoInterfaceObject] interface ArchiveManagerObject {
-    readonly attribute <a href="#ArchiveManager">ArchiveManager</a> archive;
-  };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ArchiveManagerObject">ArchiveManagerObject</a>;
   dictionary ArchiveFileOptions {
     boolean overwrite;
   };
@@ -1434,6 +1424,10 @@ tizen.archive.open("downloads/some_archive.zip", "r", openSuccess, errorCallback
     boolean stripSourceDirectory;
     <a href="#ArchiveCompressionLevel">ArchiveCompressionLevel</a> compressionLevel;
   };
+  [NoInterfaceObject] interface ArchiveManagerObject {
+    readonly attribute <a href="#ArchiveManager">ArchiveManager</a> archive;
+  };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ArchiveManagerObject">ArchiveManagerObject</a>;
   [NoInterfaceObject] interface ArchiveManager {
     long open(<a href="#FileReference">FileReference</a> file, <a href="filesystem.html#FileMode">FileMode</a> mode, <a href="#ArchiveFileSuccessCallback">ArchiveFileSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
               optional <a href="#ArchiveFileOptions">ArchiveFileOptions</a>? options) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/archive.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/archive.html
@@ -1424,10 +1424,10 @@ tizen.archive.open("downloads/some_archive.zip", "r", openSuccess, errorCallback
     boolean stripSourceDirectory;
     <a href="#ArchiveCompressionLevel">ArchiveCompressionLevel</a> compressionLevel;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ArchiveManagerObject">ArchiveManagerObject</a>;
   [NoInterfaceObject] interface ArchiveManagerObject {
     readonly attribute <a href="#ArchiveManager">ArchiveManager</a> archive;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ArchiveManagerObject">ArchiveManagerObject</a>;
   [NoInterfaceObject] interface ArchiveManager {
     long open(<a href="#FileReference">FileReference</a> file, <a href="filesystem.html#FileMode">FileMode</a> mode, <a href="#ArchiveFileSuccessCallback">ArchiveFileSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
               optional <a href="#ArchiveFileOptions">ArchiveFileOptions</a>? options) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/badge.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/badge.html
@@ -435,10 +435,10 @@ tizen.badge.addChangeListener([appId, targetAppId], watcher);
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Badge {
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#BadgeManagerObject">BadgeManagerObject</a>;
   [NoInterfaceObject] interface BadgeManagerObject {
     readonly attribute <a href="#BadgeManager">BadgeManager</a> badge;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#BadgeManagerObject">BadgeManagerObject</a>;
   [NoInterfaceObject] interface BadgeManager {
     readonly attribute long maxBadgeCount;
     void setBadgeCount(<a href="application.html#ApplicationId">ApplicationId</a> appId, long count) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/badge.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/badge.html
@@ -210,8 +210,7 @@ tizen.badge.setBadgeCount(appid, 3);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Count of the badge.
               </ul>
 </div>
@@ -378,8 +377,7 @@ tizen.application.getAppsInfo(onListInstalledApps);
 <div class="brief">
  The BadgeChangeCallback interface specifies a set of methods that are invoked every time a badge number change occurs.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface BadgeChangeCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface BadgeChangeCallback {
     void onsuccess(<a href="application.html#ApplicationId">ApplicationId</a> appId, long count);
   };</pre>
 <p><span class="version">Since: </span>
@@ -436,7 +434,7 @@ tizen.badge.addChangeListener([appId, targetAppId], watcher);
 </div>
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
-<pre class="webidl prettyprint">module Badge{
+<pre class="webidl prettyprint">module Badge {
   [NoInterfaceObject] interface BadgeManagerObject {
     readonly attribute <a href="#BadgeManager">BadgeManager</a> badge;
   };
@@ -448,8 +446,7 @@ tizen.badge.addChangeListener([appId, targetAppId], watcher);
     void addChangeListener(<a href="application.html#ApplicationId">ApplicationId</a>[] appIdList, <a href="#BadgeChangeCallback">BadgeChangeCallback</a> successCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeChangeListener(<a href="application.html#ApplicationId">ApplicationId</a>[] appIdList) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface BadgeChangeCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface BadgeChangeCallback {
     void onsuccess(<a href="application.html#ApplicationId">ApplicationId</a> appId, long count);
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/bluetooth.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/bluetooth.html
@@ -7336,10 +7336,10 @@ To guarantee that the Bluetooth Low Energy application runs on a device with Blu
     <a href="#BluetoothLEServiceData">BluetoothLEServiceData</a>? serviceData;
     <a href="#BluetoothLEManufacturerData">BluetoothLEManufacturerData</a>? manufacturerData;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#BluetoothManagerObject">BluetoothManagerObject</a>;
   [NoInterfaceObject] interface BluetoothManagerObject {
     readonly attribute <a href="#BluetoothManager">BluetoothManager</a> bluetooth;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#BluetoothManagerObject">BluetoothManagerObject</a>;
   [Constructor(DOMString uuid, DOMString data)]
   interface BluetoothLEServiceData {
     attribute <a href="#BluetoothUUID">BluetoothUUID</a> uuid;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/bluetooth.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/bluetooth.html
@@ -383,7 +383,7 @@ OPEN - corresponds to opened bluetooth socket.            </li>
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  enum BluetoothProfileType { "HEALTH" };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  enum BluetoothProfileType { "HEALTH" };</span></pre>
 <p><span class="version">Since: </span>
  2.2
           </p>
@@ -402,7 +402,7 @@ HEALTH - corresponds to health bluetooth profile type.            </li>
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  enum BluetoothHealthChannelType { "RELIABLE", "STREAMING" };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  enum BluetoothHealthChannelType { "RELIABLE", "STREAMING" };</span></pre>
 <p><span class="version">Since: </span>
  2.2
           </p>
@@ -913,8 +913,7 @@ Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">BluetoothAdapter:
-                  </span>
+<span class="return">BluetoothAdapter:</span>
  The local <em>BluetoothAdapter </em>object.
               </ul>
 </div>
@@ -969,8 +968,7 @@ Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">BluetoothLEAdapter:
-                  </span>
+<span class="return">BluetoothLEAdapter:</span>
  The local <em>BluetoothLEAdapter </em>object.
               </ul>
 </div>
@@ -1016,7 +1014,11 @@ catch (err)
     readonly attribute boolean visible;
     void setName(DOMString name, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                  raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void setChangeListener(<a href="#BluetoothAdapterChangeCallback">BluetoothAdapterChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    void setPowered(boolean state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                    raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void setVisible(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
+                    optional unsigned short? timeout) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void setChangeListener(<a href="#BluetoothAdapterChangeCallback">BluetoothAdapterChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unsetChangeListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void discoverDevices(<a href="#BluetoothDiscoverDevicesSuccessCallback">BluetoothDiscoverDevicesSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -1031,7 +1033,8 @@ catch (err)
                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void registerRFCOMMServiceByUUID(<a href="#BluetoothUUID">BluetoothUUID</a> uuid, DOMString name, <a href="#BluetoothServiceSuccessCallback">BluetoothServiceSuccessCallback</a> successCallback,
                                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };</pre>
+<span class="nocode deprecated">    <a href="#BluetoothProfileHandler">BluetoothProfileHandler</a> getBluetoothProfileHandler(<a href="#BluetoothProfileType">BluetoothProfileType</a> profileType) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -1360,7 +1363,7 @@ else
 <p class="deprecated"><b>Deprecated.</b>
  It is deprecated since Tizen 2.3. Instead, let the user change the Bluetooth visibility through the Settings application. See the <a href="https://developer.tizen.org/development/guides/web-application/connectivity-and-wireless/bluetooth#Managing_BT_Adapter">Managing Bluetooth</a> Tutorial.
             </p>
-<div class="synopsis"><pre class="signature prettyprint">void setVisible(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void setVisible(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                 optional unsigned short? timeout);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -2337,7 +2340,7 @@ adapter.getDevice(deviceAddress, gotDevice, function(e)
 <div class="brief">
  Registers a service record in the device service record database with the specified <em>uuid</em>, <em>name</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void registerRFCOMMServiceByUUID(<a href="#BluetoothUUID">BluetoothUUID</a> uuid, DOMString name, <a href="#BluetoothServiceSuccessCallback">BluetoothServiceSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void registerRFCOMMServiceByUUID(<a href="#BluetoothUUID">BluetoothUUID</a> uuid, DOMString name, <a href="#BluetoothServiceSuccessCallback">BluetoothServiceSuccessCallback</a> successCallback,
                                  optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -2497,8 +2500,7 @@ function unregisterChatService()
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">BluetoothProfileHandler:
-                  </span>
+<span class="return">BluetoothProfileHandler:</span>
  Represents the Bluetooth profile handle.
               </ul>
 </div>
@@ -2690,8 +2692,8 @@ adapter.startScan(function onsuccess(device)
 <div class="brief">
  Starts advertising for Low Energy Devices.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void startAdvertise(<a href="#BluetoothLEAdvertiseData">BluetoothLEAdvertiseData</a> advertiseData, <a href="#BluetoothAdvertisePacketType">BluetoothAdvertisePacketType</a> packetType, 
-                    <a href="#BluetoothLEAdvertiseCallback">BluetoothLEAdvertiseCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void startAdvertise(<a href="#BluetoothLEAdvertiseData">BluetoothLEAdvertiseData</a> advertiseData, <a href="#BluetoothAdvertisePacketType">BluetoothAdvertisePacketType</a> packetType,
+                    <a href="#BluetoothLEAdvertiseCallback">BluetoothLEAdvertiseCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                     optional <a href="#BluetoothAdvertisingMode">BluetoothAdvertisingMode</a>? mode, optional boolean? connectable);</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
@@ -3287,8 +3289,7 @@ Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The watchID to be used to unregister the listener.
               </ul>
 </div>
@@ -3942,7 +3943,7 @@ adapter.getDevice("11:22:33:44:55:66", function(device)
 <div class="brief">
  Connects to a specified service identified by <em>uuid</em> on this remote device.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void connectToServiceByUUID(<a href="#BluetoothUUID">BluetoothUUID</a> uuid, <a href="#BluetoothSocketSuccessCallback">BluetoothSocketSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void connectToServiceByUUID(<a href="#BluetoothUUID">BluetoothUUID</a> uuid, <a href="#BluetoothSocketSuccessCallback">BluetoothSocketSuccessCallback</a> successCallback,
                             optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -4582,8 +4583,7 @@ Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">BluetoothGATTService:
-                  </span>
+<span class="return">BluetoothGATTService:</span>
  Retrieved service for the given UUID.
               </ul>
 </div>
@@ -4652,8 +4652,7 @@ adapter.startScan(onDeviceFound, onerror);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">BluetoothUUID[]:
-                  </span>
+<span class="return">BluetoothUUID[]:</span>
  The array of all service UUIDs that belong to the connected GATT server.
               </ul>
 </div>
@@ -4729,8 +4728,7 @@ Services length 2
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The watchID to be used to unregister the listener.
               </ul>
 </div>
@@ -4960,8 +4958,7 @@ Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">unsigned long:
-                  </span>
+<span class="return">unsigned long:</span>
  The number of bytes actually sent.
               </ul>
 </div>
@@ -5110,8 +5107,7 @@ Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">byte[]:
-                  </span>
+<span class="return">byte[]:</span>
  The sequence of bytes successfully read.
               </ul>
 </div>
@@ -5352,7 +5348,7 @@ else
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface BluetoothClass {
     readonly attribute octet major;
     readonly attribute octet minor;
-    readonly attribute unsigned short [] services;
+    readonly attribute unsigned short[] services;
     boolean hasService(unsigned short service) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
 <p><span class="version">Since: </span>
@@ -5486,8 +5482,7 @@ Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var>, if given service exists in the <em>services</em>.
               </ul>
 </div>
@@ -5875,8 +5870,9 @@ function unRegisterChatService()
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface BluetoothProfileHandler {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface BluetoothProfileHandler {
+<span class="nocode deprecated">    readonly attribute <a href="#BluetoothProfileType">BluetoothProfileType</a> profileType;
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  2.2
           </p>
@@ -5921,8 +5917,13 @@ The BluetoothHealthProfileHandler object is created by <em>BluetoothAdapter.getB
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface BluetoothHealthProfileHandler : <a href="#BluetoothProfileHandler">BluetoothProfileHandler</a> {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface BluetoothHealthProfileHandler : <a href="#BluetoothProfileHandler">BluetoothProfileHandler</a> {
+<span class="nocode deprecated">    void registerSinkApplication(unsigned short dataType, DOMString name, <a href="#BluetoothHealthApplicationSuccessCallback">BluetoothHealthApplicationSuccessCallback</a> successCallback,
+                                 optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void connectToSource(<a href="#BluetoothDevice">BluetoothDevice</a> peer, <a href="#BluetoothHealthApplication">BluetoothHealthApplication</a> application,
+                         <a href="#BluetoothHealthChannelSuccessCallback">BluetoothHealthChannelSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  2.2
           </p>
@@ -5940,7 +5941,7 @@ The BluetoothHealthProfileHandler object is created by <em>BluetoothAdapter.getB
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
             </p>
-<div class="synopsis"><pre class="signature prettyprint">void registerSinkApplication(unsigned short dataType, DOMString name, <a href="#BluetoothHealthApplicationSuccessCallback">BluetoothHealthApplicationSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void registerSinkApplication(unsigned short dataType, DOMString name, <a href="#BluetoothHealthApplicationSuccessCallback">BluetoothHealthApplicationSuccessCallback</a> successCallback,
                              optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.2
@@ -6029,7 +6030,7 @@ healthProfileHandler.registerSinkApplication(
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
             </p>
-<div class="synopsis"><pre class="signature prettyprint">void connectToSource(<a href="#BluetoothDevice">BluetoothDevice</a> peer, <a href="#BluetoothHealthApplication">BluetoothHealthApplication</a> application, 
+<div class="synopsis"><pre class="signature prettyprint">void connectToSource(<a href="#BluetoothDevice">BluetoothDevice</a> peer, <a href="#BluetoothHealthApplication">BluetoothHealthApplication</a> application,
                      <a href="#BluetoothHealthChannelSuccessCallback">BluetoothHealthChannelSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.2
@@ -6142,8 +6143,12 @@ healthProfileHandler.registerSinkApplication(
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface BluetoothHealthApplication {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface BluetoothHealthApplication {
+<span class="nocode deprecated">    readonly attribute unsigned short dataType;
+</span><span class="nocode deprecated">    readonly attribute DOMString name;
+</span><span class="nocode deprecated">    [TreatNonCallableAsNull] attribute <a href="#BluetoothHealthChannelSuccessCallback">BluetoothHealthChannelSuccessCallback</a>? onconnect raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void unregister(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  2.2
           </p>
@@ -6361,8 +6366,16 @@ function stopSink()
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface BluetoothHealthChannel {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface BluetoothHealthChannel {
+<span class="nocode deprecated">    readonly attribute <a href="#BluetoothDevice">BluetoothDevice</a> peer;
+</span><span class="nocode deprecated">    readonly attribute <a href="#BluetoothHealthChannelType">BluetoothHealthChannelType</a> channelType;
+</span><span class="nocode deprecated">    readonly attribute <a href="#BluetoothHealthApplication">BluetoothHealthApplication</a> application;
+</span><span class="nocode deprecated">    readonly attribute boolean isConnected;
+</span><span class="nocode deprecated">    void close() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    unsigned long sendData(byte[] data) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void setListener(<a href="#BluetoothHealthChannelChangeCallback">BluetoothHealthChannelChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void unsetListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  2.2
           </p>
@@ -6547,8 +6560,7 @@ Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">unsigned long:
-                  </span>
+<span class="return">unsigned long:</span>
  Number of bytes actually sent.
               </ul>
 </div>
@@ -7126,8 +7138,9 @@ After that, this device is no longer visible.
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface BluetoothHealthApplicationSuccessCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback=FunctionOnly, NoInterfaceObject] interface BluetoothHealthApplicationSuccessCallback {
+<span class="nocode deprecated">    void onsuccess(<a href="#BluetoothHealthApplication">BluetoothHealthApplication</a> application);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  2.2
           </p>
@@ -7172,8 +7185,9 @@ After that, this device is no longer visible.
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface BluetoothHealthChannelSuccessCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback=FunctionOnly, NoInterfaceObject] interface BluetoothHealthChannelSuccessCallback {
+<span class="nocode deprecated">    void onsuccess(<a href="#BluetoothHealthChannel">BluetoothHealthChannel</a> channel);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  2.2
           </p>
@@ -7218,8 +7232,10 @@ After that, this device is no longer visible.
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  [Callback, NoInterfaceObject] interface BluetoothHealthChannelChangeCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback, NoInterfaceObject] interface BluetoothHealthChannelChangeCallback {
+<span class="nocode deprecated">    void onmessage(byte[] data);
+</span><span class="nocode deprecated">    void onclose();
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  2.2
           </p>
@@ -7306,11 +7322,20 @@ To guarantee that the Bluetooth Low Energy application runs on a device with Blu
 <pre class="webidl prettyprint">module Bluetooth {
   typedef DOMString BluetoothAddress;
   typedef DOMString BluetoothUUID;
-  enum BluetoothSocketState { "CLOSED", "OPEN" };
   typedef DOMString BluetoothLESolicitationUUID;
+  enum BluetoothSocketState { "CLOSED", "OPEN" };
   enum BluetoothAdvertisePacketType { "ADVERTISE", "SCAN_RESPONSE" };
   enum BluetoothAdvertisingState { "STARTED", "STOPPED" };
   enum BluetoothAdvertisingMode { "BALANCED", "LOW_LATENCY", "LOW_ENERGY" };
+  dictionary BluetoothLEAdvertiseDataInit {
+    boolean? includeName;
+    <a href="#BluetoothUUID">BluetoothUUID</a>[]? uuids;
+    <a href="#BluetoothLESolicitationUUID">BluetoothLESolicitationUUID</a>[]? solicitationuuids;
+    unsigned long? appearance;
+    boolean? includeTxPowerLevel;
+    <a href="#BluetoothLEServiceData">BluetoothLEServiceData</a>? serviceData;
+    <a href="#BluetoothLEManufacturerData">BluetoothLEManufacturerData</a>? manufacturerData;
+  };
   [NoInterfaceObject] interface BluetoothManagerObject {
     readonly attribute <a href="#BluetoothManager">BluetoothManager</a> bluetooth;
   };
@@ -7324,15 +7349,6 @@ To guarantee that the Bluetooth Low Energy application runs on a device with Blu
   interface BluetoothLEManufacturerData {
     attribute DOMString id;
     attribute DOMString data;
-  };
-  dictionary BluetoothLEAdvertiseDataInit {
-    boolean? includeName;
-    <a href="#BluetoothUUID">BluetoothUUID</a>[]? uuids;
-    <a href="#BluetoothLESolicitationUUID">BluetoothLESolicitationUUID</a>[]? solicitationuuids;
-    unsigned long? appearance;
-    boolean? includeTxPowerLevel;
-    <a href="#BluetoothLEServiceData">BluetoothLEServiceData</a>? serviceData;
-    <a href="#BluetoothLEManufacturerData">BluetoothLEManufacturerData</a>? manufacturerData;
   };
   [Constructor(optional <a href="#BluetoothLEAdvertiseDataInit">BluetoothLEAdvertiseDataInit</a>? init)]
   interface BluetoothLEAdvertiseData {
@@ -7462,7 +7478,7 @@ To guarantee that the Bluetooth Low Energy application runs on a device with Blu
   [NoInterfaceObject] interface BluetoothClass {
     readonly attribute octet major;
     readonly attribute octet minor;
-    readonly attribute unsigned short [] services;
+    readonly attribute unsigned short[] services;
     boolean hasService(unsigned short service) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface BluetoothClassDeviceMajor {
@@ -7569,7 +7585,6 @@ To guarantee that the Bluetooth Low Energy application runs on a device with Blu
     readonly attribute boolean isConnected;
     [TreatNonCallableAsNull] attribute <a href="#BluetoothSocketSuccessCallback">BluetoothSocketSuccessCallback</a>? onconnect raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unregister(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
   };
   [Callback, NoInterfaceObject] interface BluetoothAdapterChangeCallback {
     void onstatechanged(boolean powered);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/bookmark.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/bookmark.html
@@ -177,8 +177,7 @@ In this case, the return will contain bookmarks under the root bookmark folder.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Bookmark[]:
-                  </span>
+<span class="return">Bookmark[]:</span>
   Array of Bookmarks.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/bookmark.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/bookmark.html
@@ -487,10 +487,10 @@ If the parent bookmark folder indicates the root bookmark folder, the value will
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Bookmark {
   typedef (<a href="#BookmarkItem">BookmarkItem</a> or <a href="#BookmarkFolder">BookmarkFolder</a>) Bookmark;
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#BookmarkManagerObject">BookmarkManagerObject</a>;
   [NoInterfaceObject] interface BookmarkManagerObject {
     readonly attribute <a href="#BookmarkManager">BookmarkManager</a> bookmark;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#BookmarkManagerObject">BookmarkManagerObject</a>;
   [NoInterfaceObject] interface BookmarkManager {
     <a href="#Bookmark">Bookmark</a>[] get(optional <a href="#BookmarkFolder">BookmarkFolder</a>? parentFolder, optional boolean? recursive) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void add(<a href="#Bookmark">Bookmark</a> bookmark, optional <a href="#BookmarkFolder">BookmarkFolder</a>? parentFolder) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/calendar.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/calendar.html
@@ -594,7 +594,7 @@ CANCELLED -  if the task has been cancelled            </li>
 <div class="brief">
  The CalendarManagerObject interface gives access to the Calendar API from the <em>tizen.calendar </em>object.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface CalendarManagerObject{
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface CalendarManagerObject {
     readonly attribute <a href="#CalendarManager">CalendarManager</a> calendar;
   };</pre>
 <pre class="webidl prettyprint">  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#CalendarManagerObject">CalendarManagerObject</a>;</pre>
@@ -784,8 +784,7 @@ If an item is added to the unified calendar, it will be saved in the default cal
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Calendar:
-                  </span>
+<span class="return">Calendar:</span>
  The unified Calendar object.
               </ul>
 </div>
@@ -879,8 +878,7 @@ unifiedCalendar.find(eventFoundCallback, errorCallback, filter);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Calendar:
-                  </span>
+<span class="return">Calendar:</span>
  The default Calendar object.
               </ul>
 </div>
@@ -1129,8 +1127,7 @@ tizen.account.getAccounts(
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Calendar:
-                  </span>
+<span class="return">Calendar:</span>
  The matching Calendar object.
               </ul>
 </div>
@@ -1314,8 +1311,7 @@ console.log("The calendar name is " + calendar.name);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">CalendarItem:
-                  </span>
+<span class="return">CalendarItem:</span>
  The matching <em>CalendarItem </em>object.
               </ul>
 </div>
@@ -1438,7 +1434,7 @@ console.log("Event added with uid " + ev.id.uid);
 <div class="brief">
  Adds an array of items to the calendar asynchronously.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void addBatch(<a href="#CalendarItem">CalendarItem</a>[] items, optional <a href="#CalendarItemArraySuccessCallback">CalendarItemArraySuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void addBatch(<a href="#CalendarItem">CalendarItem</a>[] items, optional <a href="#CalendarItemArraySuccessCallback">CalendarItemArraySuccessCallback</a>? successCallback,
               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -1615,7 +1611,7 @@ myCalendar.find(eventSearchSuccessCallback, errorCallback);
 <div class="brief">
  Updates an array of existing items in the calendar asynchronously with the specified values in the argument.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void updateBatch(<a href="#CalendarItem">CalendarItem</a>[] items, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void updateBatch(<a href="#CalendarItem">CalendarItem</a>[] items, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                  optional boolean? updateAllInstances);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -1888,7 +1884,7 @@ myCalendar.find(eventSearchSuccessCallback, errorCallback);
 <div class="brief">
  Finds and fetches an array of <em>CalendarItem </em>objects for items stored in the calendar according to the supplied filter if it is valid else it will return all the items stored.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#CalendarItemArraySuccessCallback">CalendarItemArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter, 
+<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#CalendarItemArraySuccessCallback">CalendarItemArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter,
           optional <a href="tizen.html#SortMode">SortMode</a>? sortMode);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -2020,8 +2016,7 @@ When executed, the implementation must immediately return a subscription identif
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -2185,7 +2180,7 @@ These attributes are shared by both calendar events and tasks.
 <div class="brief">
  The CalendarTaskInit dictionary is used for creating calendar tasks.
           </div>
-<pre class="webidl prettyprint">  dictionary CalendarTaskInit: <a href="#CalendarItemInit">CalendarItemInit</a> {
+<pre class="webidl prettyprint">  dictionary CalendarTaskInit : <a href="#CalendarItemInit">CalendarItemInit</a> {
     <a href="time.html#TZDate">TZDate</a> dueDate;
     <a href="time.html#TZDate">TZDate</a> completedDate;
     short progress;
@@ -2208,7 +2203,7 @@ All the attributes are optional and are undefined by default.
 <div class="brief">
  The CalendarEventInit dictionary is used for creating calendar events.
           </div>
-<pre class="webidl prettyprint">  dictionary CalendarEventInit: <a href="#CalendarItemInit">CalendarItemInit</a> {
+<pre class="webidl prettyprint">  dictionary CalendarEventInit : <a href="#CalendarItemInit">CalendarItemInit</a> {
     <a href="time.html#TZDate">TZDate</a> endDate;
     <a href="#EventAvailability">EventAvailability</a> availability;
     <a href="#CalendarRecurrenceRule">CalendarRecurrenceRule</a> recurrenceRule;
@@ -2622,8 +2617,7 @@ The export format is set using the format parameter.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The representation of the Calendar item.
               </ul>
 </div>
@@ -2696,8 +2690,7 @@ The <em>CalendarItem </em>object returned by the <em>clone()</em> method will ha
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">CalendarItem:
-                  </span>
+<span class="return">CalendarItem:</span>
  New clone of the <em>CalendarItem </em>object.
               </ul>
 </div>
@@ -3032,7 +3025,7 @@ event.recurrenceRule = rule;
 <div class="brief">
  Expands a recurring event and returns asynchronously the list of instances occurring in a given time interval (inclusive).
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void expandRecurrence(<a href="time.html#TZDate">TZDate</a> startDate, <a href="time.html#TZDate">TZDate</a> endDate, <a href="#CalendarEventArraySuccessCallback">CalendarEventArraySuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void expandRecurrence(<a href="time.html#TZDate">TZDate</a> startDate, <a href="time.html#TZDate">TZDate</a> endDate, <a href="#CalendarEventArraySuccessCallback">CalendarEventArraySuccessCallback</a> successCallback,
                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -3685,8 +3678,7 @@ The default value is an empty string.
 <div class="brief">
  The CalendarEventArraySuccessCallback interface that implements the success callback used in the asynchronous operation for retrieving a list of calendar events.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface CalendarEventArraySuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface CalendarEventArraySuccessCallback {
     void onsuccess(<a href="#CalendarEvent">CalendarEvent</a>[] events);
   };</pre>
 <p><span class="version">Since: </span>
@@ -3750,8 +3742,7 @@ if (event.recurrenceRule != null)
 <div class="brief">
  The CalendarItemArraySuccessCallback interface implements the success callback used in the asynchronous operation for retrieving a list of calendar items.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface CalendarItemArraySuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface CalendarItemArraySuccessCallback {
     void onsuccess(<a href="#CalendarItem">CalendarItem</a>[] items);
   };</pre>
 <p><span class="version">Since: </span>
@@ -3817,8 +3808,7 @@ calendar.addBatch([ev], calendarItemArraySuccessCB, errorCallback);
 <div class="brief">
  The CalendarArraySuccessCallback interface implements the success callback used in the asynchronous operation to get a list of calendars using the <em>getCalendars()</em> method.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface CalendarArraySuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface CalendarArraySuccessCallback {
     void onsuccess(<a href="#Calendar">Calendar</a>[] calendars);
   };</pre>
 <p><span class="version">Since: </span>
@@ -4134,7 +4124,52 @@ To guarantee the running of the application on a device with Contact feature, de
   enum CalendarItemPriority { "HIGH", "MEDIUM", "LOW", "NONE" };
   enum CalendarItemVisibility { "PUBLIC", "PRIVATE", "CONFIDENTIAL" };
   enum CalendarItemStatus { "NONE", "TENTATIVE", "CONFIRMED", "CANCELLED", "NEEDS_ACTION", "IN_PROCESS", "COMPLETED" };
-  [NoInterfaceObject] interface CalendarManagerObject{
+  dictionary CalendarItemInit {
+    DOMString description;
+    DOMString summary;
+    boolean isAllDay;
+    <a href="time.html#TZDate">TZDate</a> startDate;
+    <a href="time.html#TimeDuration">TimeDuration</a> duration;
+    DOMString location;
+    <a href="tizen.html#SimpleCoordinates">SimpleCoordinates</a> geolocation;
+    DOMString organizer;
+    <a href="#CalendarItemVisibility">CalendarItemVisibility</a> visibility;
+    <a href="#CalendarItemStatus">CalendarItemStatus</a> status;
+    <a href="#CalendarItemPriority">CalendarItemPriority</a> priority;
+    <a href="#CalendarAlarm">CalendarAlarm</a>[] alarms;
+    DOMString[] categories;
+    <a href="#CalendarAttendee">CalendarAttendee</a>[] attendees;
+  };
+  dictionary CalendarTaskInit : <a href="#CalendarItemInit">CalendarItemInit</a> {
+    <a href="time.html#TZDate">TZDate</a> dueDate;
+    <a href="time.html#TZDate">TZDate</a> completedDate;
+    short progress;
+  };
+  dictionary CalendarEventInit : <a href="#CalendarItemInit">CalendarItemInit</a> {
+    <a href="time.html#TZDate">TZDate</a> endDate;
+    <a href="#EventAvailability">EventAvailability</a> availability;
+    <a href="#CalendarRecurrenceRule">CalendarRecurrenceRule</a> recurrenceRule;
+  };
+  dictionary CalendarAttendeeInit {
+    DOMString name;
+    <a href="#AttendeeRole">AttendeeRole</a> role;
+    <a href="#AttendeeStatus">AttendeeStatus</a> status;
+    boolean RSVP;
+    <a href="#AttendeeType">AttendeeType</a> type;
+    DOMString? group;
+    DOMString delegatorURI;
+    DOMString delegateURI;
+    <a href="contact.html#ContactRef">ContactRef</a> contactRef;
+  };
+  dictionary CalendarRecurrenceRuleInit {
+    short interval;
+    <a href="time.html#TZDate">TZDate</a> untilDate;
+    long occurrenceCount;
+    <a href="#ByDayValue">ByDayValue</a>[] daysOfTheWeek;
+    short[] setPositions;
+    <a href="time.html#TZDate">TZDate</a>[] exceptions;
+  };
+  [NoInterfaceObject] interface CalendarManagerObject {
     readonly attribute <a href="#CalendarManager">CalendarManager</a> calendar;
   };
   <a href="tizen.html#Tizen">Tizen</a> implements <a href="#CalendarManagerObject">CalendarManagerObject</a>;
@@ -4166,32 +4201,6 @@ To guarantee the running of the application on a device with Contact feature, de
               optional <a href="tizen.html#SortMode">SortMode</a>? sortMode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addChangeListener(<a href="#CalendarChangeCallback">CalendarChangeCallback</a> successCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  dictionary CalendarItemInit {
-    DOMString description;
-    DOMString summary;
-    boolean isAllDay;
-    <a href="time.html#TZDate">TZDate</a> startDate;
-    <a href="time.html#TimeDuration">TimeDuration</a> duration;
-    DOMString location;
-    <a href="tizen.html#SimpleCoordinates">SimpleCoordinates</a> geolocation;
-    DOMString organizer;
-    <a href="#CalendarItemVisibility">CalendarItemVisibility</a> visibility;
-    <a href="#CalendarItemStatus">CalendarItemStatus</a> status;
-    <a href="#CalendarItemPriority">CalendarItemPriority</a> priority;
-    <a href="#CalendarAlarm">CalendarAlarm</a>[] alarms;
-    DOMString[] categories;
-    <a href="#CalendarAttendee">CalendarAttendee</a>[] attendees;
-  };
-  dictionary CalendarTaskInit: <a href="#CalendarItemInit">CalendarItemInit</a> {
-    <a href="time.html#TZDate">TZDate</a> dueDate;
-    <a href="time.html#TZDate">TZDate</a> completedDate;
-    short progress;
-  };
-  dictionary CalendarEventInit: <a href="#CalendarItemInit">CalendarItemInit</a> {
-    <a href="time.html#TZDate">TZDate</a> endDate;
-    <a href="#EventAvailability">EventAvailability</a> availability;
-    <a href="#CalendarRecurrenceRule">CalendarRecurrenceRule</a> recurrenceRule;
   };
   [NoInterfaceObject] interface CalendarItem {
     readonly attribute <a href="#CalendarItemId">CalendarItemId</a>? id;
@@ -4231,17 +4240,6 @@ To guarantee the running of the application on a device with Contact feature, de
     void expandRecurrence(<a href="time.html#TZDate">TZDate</a> startDate, <a href="time.html#TZDate">TZDate</a> endDate, <a href="#CalendarEventArraySuccessCallback">CalendarEventArraySuccessCallback</a> successCallback,
                           optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
-  dictionary CalendarAttendeeInit {
-    DOMString name;
-    <a href="#AttendeeRole">AttendeeRole</a> role;
-    <a href="#AttendeeStatus">AttendeeStatus</a> status;
-    boolean RSVP;
-    <a href="#AttendeeType">AttendeeType</a> type;
-    DOMString? group;
-    DOMString delegatorURI;
-    DOMString delegateURI;
-    <a href="contact.html#ContactRef">ContactRef</a> contactRef;
-  };
   [Constructor(DOMString uri, optional <a href="#CalendarAttendeeInit">CalendarAttendeeInit</a>? attendeeInitDict)]
   interface CalendarAttendee {
     attribute DOMString uri;
@@ -4254,14 +4252,6 @@ To guarantee the running of the application on a device with Contact feature, de
     attribute DOMString? delegatorURI;
     attribute DOMString? delegateURI;
     attribute <a href="contact.html#ContactRef">ContactRef</a>? contactRef;
-  };
-  dictionary CalendarRecurrenceRuleInit {
-    short interval;
-    <a href="time.html#TZDate">TZDate</a> untilDate;
-    long occurrenceCount;
-    <a href="#ByDayValue">ByDayValue</a>[] daysOfTheWeek;
-    short[] setPositions;
-    <a href="time.html#TZDate">TZDate</a>[] exceptions;
   };
   [Constructor(<a href="#RecurrenceRuleFrequency">RecurrenceRuleFrequency</a> frequency, optional <a href="#CalendarRecurrenceRuleInit">CalendarRecurrenceRuleInit</a>? ruleInitDict)]
   interface CalendarRecurrenceRule {
@@ -4286,16 +4276,13 @@ To guarantee the running of the application on a device with Contact feature, de
     attribute <a href="#AlarmMethod">AlarmMethod</a> method;
     attribute DOMString? description;
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface CalendarEventArraySuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface CalendarEventArraySuccessCallback {
     void onsuccess(<a href="#CalendarEvent">CalendarEvent</a>[] events);
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface CalendarItemArraySuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface CalendarItemArraySuccessCallback {
     void onsuccess(<a href="#CalendarItem">CalendarItem</a>[] items);
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface CalendarArraySuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface CalendarArraySuccessCallback {
     void onsuccess(<a href="#Calendar">Calendar</a>[] calendars);
   };
   [Callback, NoInterfaceObject] interface CalendarChangeCallback {

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/calendar.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/calendar.html
@@ -411,6 +411,9 @@ BUSY_UNAVAILABLE - if the specified time slot is not vacant and can not be sched
 BUSY_TENTATIVE - if the specified time slot is not vacant because one or more events have been tentatively scheduled for that interval            </li>
           </ul>
          </div>
+<p><span class="remark">Remark: </span>
+ <em>BUSY_UNAVAILABLE</em> and <em>BUSY_TENTATIVE</em> are supported since Tizen 5.0
+          </p>
 </div>
 <div class="enum" id="AttendeeType">
 <a class="backward-compatibility-anchor" name="::Calendar::AttendeeType"></a><h3>1.10. AttendeeType</h3>
@@ -438,9 +441,6 @@ ROOM - Room resource            </li>
 UNKNOWN - Unknown            </li>
           </ul>
          </div>
-<p><span class="remark">Remark: </span>
- <em>BUSY_UNAVAILABLE</em> and <em>BUSY_TENTATIVE</em> are supported since Tizen 5.0
-          </p>
 </div>
 <div class="enum" id="AttendeeStatus">
 <a class="backward-compatibility-anchor" name="::Calendar::AttendeeStatus"></a><h3>1.11. AttendeeStatus</h3>
@@ -4169,10 +4169,10 @@ To guarantee the running of the application on a device with Contact feature, de
     short[] setPositions;
     <a href="time.html#TZDate">TZDate</a>[] exceptions;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#CalendarManagerObject">CalendarManagerObject</a>;
   [NoInterfaceObject] interface CalendarManagerObject {
     readonly attribute <a href="#CalendarManager">CalendarManager</a> calendar;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#CalendarManagerObject">CalendarManagerObject</a>;
   [NoInterfaceObject] interface CalendarManager {
     void getCalendars(<a href="#CalendarType">CalendarType</a> type, <a href="#CalendarArraySuccessCallback">CalendarArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                       raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/callhistory.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/callhistory.html
@@ -345,8 +345,8 @@ Adding call history is owned by the back-end. Filtering is supported for all fie
 <div class="brief">
  Finds and returns call history.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#CallHistoryEntryArraySuccessCallback">CallHistoryEntryArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
-          optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter, optional <a href="tizen.html#SortMode">SortMode</a>? sortMode, optional unsigned long? limit, 
+<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#CallHistoryEntryArraySuccessCallback">CallHistoryEntryArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
+          optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter, optional <a href="tizen.html#SortMode">SortMode</a>? sortMode, optional unsigned long? limit,
           optional unsigned long? offset);</pre></div>
 <p><span class="version">Since: </span>
  2.0
@@ -694,8 +694,7 @@ UnknownError - If any other error occurs.              </li>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  A handle which can be used for unregistering.
               </ul>
 </div>
@@ -860,8 +859,7 @@ For example code, see <em>CallHistory </em>interface.
  This is a callback interface of <em> CallHistory </em>operations.
 For example code, see <em>CallHistory </em>interface.
           </div>
-<pre class="webidl prettyprint">  [Callback, NoInterfaceObject]
-  interface CallHistoryChangeCallback {
+<pre class="webidl prettyprint">  [Callback, NoInterfaceObject] interface CallHistoryChangeCallback {
     void onadded(<a href="#CallHistoryEntry">CallHistoryEntry</a>[] newItems);
     void onchanged(<a href="#CallHistoryEntry">CallHistoryEntry</a>[] changedItems);
     void onremoved(DOMString[] removedItems);
@@ -987,8 +985,7 @@ To guarantee that the call log application runs on a device with the telephony f
   [Callback=FunctionOnly, NoInterfaceObject] interface CallHistoryEntryArraySuccessCallback {
     void onsuccess(<a href="#CallHistoryEntry">CallHistoryEntry</a>[] entries);
   };
-  [Callback, NoInterfaceObject]
-  interface CallHistoryChangeCallback {
+  [Callback, NoInterfaceObject] interface CallHistoryChangeCallback {
     void onadded(<a href="#CallHistoryEntry">CallHistoryEntry</a>[] newItems);
     void onchanged(<a href="#CallHistoryEntry">CallHistoryEntry</a>[] changedItems);
     void onremoved(DOMString[] removedItems);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/callhistory.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/callhistory.html
@@ -953,10 +953,10 @@ To guarantee that the call log application runs on a device with the telephony f
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module CallHistory {
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#CallHistoryObject">CallHistoryObject</a>;
   [NoInterfaceObject] interface CallHistoryObject {
     readonly attribute <a href="#CallHistory">CallHistory</a> callhistory;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#CallHistoryObject">CallHistoryObject</a>;
   [NoInterfaceObject] interface RemoteParty {
     readonly attribute DOMString? remoteParty;
     readonly attribute <a href="contact.html#PersonId">PersonId</a>? personId;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/contact.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/contact.html
@@ -6914,10 +6914,10 @@ To guarantee the running of the application on a device with Contact feature, de
     DOMString data11;
     DOMString data12;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ContactManagerObject">ContactManagerObject</a>;
   [NoInterfaceObject] interface ContactManagerObject {
     readonly attribute <a href="#ContactManager">ContactManager</a> contact;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ContactManagerObject">ContactManagerObject</a>;
   [NoInterfaceObject] interface ContactManager {
     void getAddressBooks(<a href="#AddressBookArraySuccessCallback">AddressBookArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/contact.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/contact.html
@@ -738,8 +738,7 @@ and it is set to <var>null</var>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">AddressBook:
-                  </span>
+<span class="return">AddressBook:</span>
  The unified AddressBook object.
               </ul>
 </div>
@@ -844,8 +843,7 @@ The default address book is one of the addressBooks that is the appointed addres
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">AddressBook:
-                  </span>
+<span class="return">AddressBook:</span>
  The default AddressBook object.
               </ul>
 </div>
@@ -1106,8 +1104,7 @@ tizen.account.getAccounts(
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">AddressBook:
-                  </span>
+<span class="return">AddressBook:</span>
  The matching AddressBook object.
               </ul>
 </div>
@@ -1189,8 +1186,7 @@ person with the specified identifier.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Person:
-                  </span>
+<span class="return">Person:</span>
  The matching Person object.
               </ul>
 </div>
@@ -1644,7 +1640,7 @@ catch (err)
 <div class="brief">
  Gets an array of all <em>Person </em>objects from the contact DB or the ones that match the optionally supplied filter.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#PersonArraySuccessCallback">PersonArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter, 
+<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#PersonArraySuccessCallback">PersonArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter,
           optional <a href="tizen.html#SortMode">SortMode</a>? sortMode);</pre></div>
 <p><span class="version">Since: </span>
  2.0
@@ -1750,8 +1746,8 @@ catch (err)
 <div class="brief">
  Gets an array of <em>Person </em>objects from the contact DB which match the supplied filter. This method is for filtering usageCount property of Person objects.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void findByUsageCount(<a href="#ContactUsageCountFilter">ContactUsageCountFilter</a> filter, <a href="#PersonArraySuccessCallback">PersonArraySuccessCallback</a> successCallback, 
-                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#SortModeOrder">SortModeOrder</a>? sortModeOrder, optional unsigned long limit, 
+<div class="synopsis"><pre class="signature prettyprint">void findByUsageCount(<a href="#ContactUsageCountFilter">ContactUsageCountFilter</a> filter, <a href="#PersonArraySuccessCallback">PersonArraySuccessCallback</a> successCallback,
+                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#SortModeOrder">SortModeOrder</a>? sortModeOrder, optional unsigned long limit,
                       optional unsigned long offset);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1891,8 +1887,7 @@ asynchronously.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -2216,8 +2211,7 @@ flag set to <var>true</var>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Contact:
-                  </span>
+<span class="return">Contact:</span>
  The matching Contact object.
               </ul>
 </div>
@@ -2908,7 +2902,7 @@ catch (err)
  Finds an array of all Contact objects from the specified address book or an array of
 Contact objects that match the optionally supplied filter.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#ContactArraySuccessCallback">ContactArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter, 
+<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#ContactArraySuccessCallback">ContactArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter,
           optional <a href="tizen.html#SortMode">SortMode</a>? sortMode);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -3052,8 +3046,7 @@ asynchronously.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  An identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -3227,8 +3220,7 @@ watcherId = addressbook.addChangeListener(watcher);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ContactGroup:
-                  </span>
+<span class="return">ContactGroup:</span>
  The matching ContactGroup object.
               </ul>
 </div>
@@ -3521,8 +3513,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ContactGroup[]:
-                  </span>
+<span class="return">ContactGroup[]:</span>
  The array of ContactGroup object from this address book.
               </ul>
 </div>
@@ -3841,8 +3832,7 @@ This function returns a newly created Person object that indicates the separated
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Person:
-                  </span>
+<span class="return">Person:</span>
  Newly created Person object that indicates the separated contact
               </ul>
 </div>
@@ -3953,8 +3943,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Number of usages.
               </ul>
 </div>
@@ -4640,8 +4629,7 @@ The export format is set via the format parameter.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The string representation of the Contact item.
               </ul>
 </div>
@@ -4724,8 +4712,7 @@ set to <var>null</var> and will be detached from any address book.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Contact:
-                  </span>
+<span class="return">Contact:</span>
  A new clone of the Contact object.
               </ul>
 </div>
@@ -6859,12 +6846,74 @@ To guarantee the running of the application on a device with Contact feature, de
   typedef DOMString ContactGroupId;
   typedef (<a href="tizen.html#AttributeFilter">AttributeFilter</a> or <a href="tizen.html#AttributeRangeFilter">AttributeRangeFilter</a>) ContactUsageCountFilter;
   enum ContactTextFormat { "VCARD_30" };
-  enum ContactRelationshipType { "OTHER", "ASSISTANT", "BROTHER", "CHILD", "DOMESTIC_PARTNER", "FATHER", "FRIEND", "MANAGER", "MOTHER",
-    "PARENT", "PARTNER", "REFERRED_BY", "RELATIVE", "SISTER", "SPOUSE", "CUSTOM" };
-  enum ContactInstantMessengerType { "OTHER", "GOOGLE", "WLM", "YAHOO", "FACEBOOK", "ICQ", "AIM", "QQ", "JABBER", "SKYPE", "IRC",
-    "CUSTOM" };
+  enum ContactRelationshipType { "OTHER", "ASSISTANT", "BROTHER", "CHILD", "DOMESTIC_PARTNER", "FATHER", "FRIEND",
+    "MANAGER", "MOTHER", "PARENT", "PARTNER", "REFERRED_BY", "RELATIVE", "SISTER", "SPOUSE", "CUSTOM" };
+  enum ContactInstantMessengerType { "OTHER", "GOOGLE", "WLM", "YAHOO", "FACEBOOK", "ICQ", "AIM", "QQ", "JABBER",
+    "SKYPE", "IRC", "CUSTOM" };
   enum ContactUsageType { "OUTGOING_CALL", "OUTGOING_MSG", "OUTGOING_EMAIL", "INCOMING_CALL", "INCOMING_MSG", "INCOMING_EMAIL",
     "MISSED_CALL", "REJECTED_CALL", "BLOCKED_CALL", "BLOCKED_MSG" };
+  dictionary ContactInit {
+    <a href="#ContactName">ContactName</a> name;
+    <a href="#ContactAddress">ContactAddress</a>[] addresses;
+    DOMString photoURI;
+    <a href="#ContactPhoneNumber">ContactPhoneNumber</a>[] phoneNumbers;
+    <a href="#ContactEmailAddress">ContactEmailAddress</a>[] emails;
+    <a href="#ContactInstantMessenger">ContactInstantMessenger</a>[] messengers;
+    <a href="#ContactRelationship">ContactRelationship</a>[] relationships;
+    <a href="#ContactExtension">ContactExtension</a>[] extensions;
+    Date birthday;
+    <a href="#ContactAnniversary">ContactAnniversary</a>[] anniversaries;
+    <a href="#ContactOrganization">ContactOrganization</a>[] organizations;
+    DOMString[] notes;
+    <a href="#ContactWebSite">ContactWebSite</a>[] urls;
+    DOMString ringtoneURI;
+    DOMString messageAlertURI;
+    DOMString vibrationURI;
+    <a href="#ContactGroupId">ContactGroupId</a>[] groupIds;
+  };
+  dictionary ContactNameInit {
+    DOMString prefix;
+    DOMString suffix;
+    DOMString firstName;
+    DOMString middleName;
+    DOMString lastName;
+    DOMString[] nicknames;
+    DOMString phoneticFirstName;
+    DOMString phoneticMiddleName;
+    DOMString phoneticLastName;
+  };
+  dictionary ContactOrganizationInit {
+    DOMString name;
+    DOMString department;
+    DOMString title;
+    DOMString role;
+    DOMString logoURI;
+  };
+  dictionary ContactAddressInit {
+    DOMString country;
+    DOMString region;
+    DOMString city;
+    DOMString streetAddress;
+    DOMString additionalInformation;
+    DOMString postalCode;
+    boolean isDefault;
+    DOMString[] types;
+    DOMString label;
+  };
+  dictionary ContactExtensionInit {
+    long data1;
+    DOMString data2;
+    DOMString data3;
+    DOMString data4;
+    DOMString data5;
+    DOMString data6;
+    DOMString data7;
+    DOMString data8;
+    DOMString data9;
+    DOMString data10;
+    DOMString data11;
+    DOMString data12;
+  };
   [NoInterfaceObject] interface ContactManagerObject {
     readonly attribute <a href="#ContactManager">ContactManager</a> contact;
   };
@@ -6933,25 +6982,6 @@ To guarantee the running of the application on a device with Contact feature, de
     long getUsageCount(optional <a href="#ContactUsageType">ContactUsageType</a>? type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void resetUsageCount(optional <a href="#ContactUsageType">ContactUsageType</a>? type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
-  dictionary ContactInit {
-    <a href="#ContactName">ContactName</a> name;
-    <a href="#ContactAddress">ContactAddress</a>[] addresses;
-    DOMString photoURI;
-    <a href="#ContactPhoneNumber">ContactPhoneNumber</a>[] phoneNumbers;
-    <a href="#ContactEmailAddress">ContactEmailAddress</a>[] emails;
-    <a href="#ContactInstantMessenger">ContactInstantMessenger</a>[] messengers;
-    <a href="#ContactRelationship">ContactRelationship</a>[] relationships;
-    <a href="#ContactExtension">ContactExtension</a>[] extensions;
-    Date birthday;
-    <a href="#ContactAnniversary">ContactAnniversary</a>[] anniversaries;
-    <a href="#ContactOrganization">ContactOrganization</a>[] organizations;
-    DOMString[] notes;
-    <a href="#ContactWebSite">ContactWebSite</a>[] urls;
-    DOMString ringtoneURI;
-    DOMString messageAlertURI;
-    DOMString vibrationURI;
-    <a href="#ContactGroupId">ContactGroupId</a>[] groupIds;
-  };
   [Constructor(optional <a href="#ContactInit">ContactInit</a>? ContactInitDict),
    Constructor(DOMString stringRepresentation)]
   interface Contact {
@@ -6985,17 +7015,6 @@ To guarantee the running of the application on a device with Contact feature, de
     attribute <a href="#AddressBookId">AddressBookId</a> addressBookId;
     attribute <a href="#ContactId">ContactId</a> contactId;
   };
-  dictionary ContactNameInit {
-    DOMString prefix;
-    DOMString suffix;
-    DOMString firstName;
-    DOMString middleName;
-    DOMString lastName;
-    DOMString[] nicknames;
-    DOMString phoneticFirstName;
-    DOMString phoneticMiddleName;
-    DOMString phoneticLastName;
-  };
   [Constructor(optional <a href="#ContactNameInit">ContactNameInit</a>? nameInitDict)]
   interface ContactName {
     attribute DOMString? prefix;
@@ -7008,13 +7027,6 @@ To guarantee the running of the application on a device with Contact feature, de
     attribute DOMString? phoneticMiddleName;
     attribute DOMString? phoneticLastName;
     readonly attribute DOMString? displayName;
-  };
-  dictionary ContactOrganizationInit {
-    DOMString name;
-    DOMString department;
-    DOMString title;
-    DOMString role;
-    DOMString logoURI;
   };
   [Constructor(optional <a href="#ContactOrganizationInit">ContactOrganizationInit</a>? orgInitDict)]
   interface ContactOrganization {
@@ -7033,17 +7045,6 @@ To guarantee the running of the application on a device with Contact feature, de
   interface ContactAnniversary {
     attribute Date date;
     attribute DOMString? label;
-  };
-  dictionary ContactAddressInit {
-    DOMString country;
-    DOMString region;
-    DOMString city;
-    DOMString streetAddress;
-    DOMString additionalInformation;
-    DOMString postalCode;
-    boolean isDefault;
-    DOMString[] types;
-    DOMString label;
   };
   [Constructor(optional <a href="#ContactAddressInit">ContactAddressInit</a>? addressInitDict)]
   interface ContactAddress {
@@ -7091,20 +7092,6 @@ To guarantee the running of the application on a device with Contact feature, de
     attribute DOMString relativeName;
     attribute <a href="#ContactRelationshipType">ContactRelationshipType</a> type;
     attribute DOMString? label;
-  };
-  dictionary ContactExtensionInit {
-    long data1;
-    DOMString data2;
-    DOMString data3;
-    DOMString data4;
-    DOMString data5;
-    DOMString data6;
-    DOMString data7;
-    DOMString data8;
-    DOMString data9;
-    DOMString data10;
-    DOMString data11;
-    DOMString data12;
   };
   [Constructor(optional <a href="#ContactExtensionInit">ContactExtensionInit</a>? extensionInitDict)]
   interface ContactExtension {

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/content.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/content.html
@@ -229,7 +229,7 @@ Playlist functionality has been added in Tizen 2.3.
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 5.5.
           </p>
-<pre class="webidl prettyprint">  enum ContentDirectoryStorageType { "INTERNAL", "EXTERNAL" };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  enum ContentDirectoryStorageType { "INTERNAL", "EXTERNAL" };</span></pre>
 <p><span class="version">Since: </span>
  2.0
           </p>
@@ -401,7 +401,9 @@ The <em>tizen.content </em>object allows accessing the functionality of the Cont
     void cancelScanDirectory(DOMString contentDirURI) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addChangeListener(<a href="#ContentChangeCallback">ContentChangeCallback</a> changeCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeChangeListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getPlaylists(<a href="#PlaylistArraySuccessCallback">PlaylistArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    void setChangeListener(<a href="#ContentChangeCallback">ContentChangeCallback</a> changeCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void unsetChangeListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void getPlaylists(<a href="#PlaylistArraySuccessCallback">PlaylistArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void createPlaylist(DOMString name, <a href="#PlaylistSuccessCallback">PlaylistSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                         optional <a href="#Playlist">Playlist</a>? sourcePlaylist) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removePlaylist(<a href="#PlaylistId">PlaylistId</a> id, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
@@ -647,8 +649,8 @@ tizen.content.getDirectories(getDirectoriesCB, errorCB);
 <div class="brief">
  Finds contents that satisfy the conditions set by a filter.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#ContentArraySuccessCallback">ContentArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
-          optional <a href="#ContentDirectoryId">ContentDirectoryId</a>? directoryId, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter, optional <a href="tizen.html#SortMode">SortMode</a>? sortMode, 
+<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#ContentArraySuccessCallback">ContentArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
+          optional <a href="#ContentDirectoryId">ContentDirectoryId</a>? directoryId, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter, optional <a href="tizen.html#SortMode">SortMode</a>? sortMode,
           optional unsigned long? count, optional unsigned long? offset);</pre></div>
 <p><span class="version">Since: </span>
  2.0
@@ -855,7 +857,7 @@ tizen.filesystem.resolve("images/tizen.jpg", function(imageFile)
 <div class="brief">
  Scans a content directory to create or update content in the content database.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void scanDirectory(DOMString contentDirURI, boolean recursive, optional <a href="#ContentScanSuccessCallback">ContentScanSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void scanDirectory(DOMString contentDirURI, boolean recursive, optional <a href="#ContentScanSuccessCallback">ContentScanSuccessCallback</a>? successCallback,
                    optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1016,8 +1018,7 @@ contain an invalid value (e.g. given <em>contentDirURI</em> is an empty string).
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Identifier of the newly added listener.
               </ul>
 </div>
@@ -1349,7 +1350,7 @@ tizen.content.getPlaylists(getPlaylistsSuccess, getPlaylistsFail);
 <div class="brief">
  Creates a new playlist.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void createPlaylist(DOMString name, <a href="#PlaylistSuccessCallback">PlaylistSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void createPlaylist(DOMString name, <a href="#PlaylistSuccessCallback">PlaylistSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                     optional <a href="#Playlist">Playlist</a>? sourcePlaylist);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -1911,7 +1912,8 @@ tizen.content.find(findCB);
     readonly attribute <a href="#ContentDirectoryId">ContentDirectoryId</a> id;
     readonly attribute DOMString directoryURI;
     readonly attribute DOMString title;
-    readonly attribute Date? modifiedDate;
+<span class="nocode deprecated">    readonly attribute <a href="#ContentDirectoryStorageType">ContentDirectoryStorageType</a> storageType;
+</span>    readonly attribute Date? modifiedDate;
   };</pre>
 <p><span class="version">Since: </span>
  2.0
@@ -2472,8 +2474,7 @@ The attribute is marked as read-only since Tizen 5.5.
 <div class="brief">
  The PlaylistItem interface represents a playlist item.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject]
-  interface PlaylistItem {
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface PlaylistItem {
     readonly attribute <a href="#Content">Content</a> content;
   };</pre>
 <p><span class="version">Since: </span>
@@ -2497,8 +2498,7 @@ The attribute is marked as read-only since Tizen 5.5.
 <div class="brief">
  The Playlist interface represents a playlist.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject]
-  interface Playlist {
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface Playlist {
     readonly attribute <a href="#PlaylistId">PlaylistId</a> id;
     attribute DOMString name raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute long numberOfTracks;
@@ -2954,7 +2954,7 @@ tizen.content.getPlaylists(getPlaylistsSuccess, getPlaylistsFail);
 <div class="brief">
  Gets playlist items from a playlist.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void get(<a href="#PlaylistItemArraySuccessCallback">PlaylistItemArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional long? count, 
+<div class="synopsis"><pre class="signature prettyprint">void get(<a href="#PlaylistItemArraySuccessCallback">PlaylistItemArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional long? count,
          optional long? offset);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -3506,13 +3506,13 @@ It is used in <em>tizen.content.createPlaylist()</em>.
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Content {
-  enum ContentType { "IMAGE", "VIDEO", "AUDIO", "OTHER" };
-  enum AudioContentLyricsType { "SYNCHRONIZED", "UNSYNCHRONIZED" };
-  enum ImageContentOrientation { "NORMAL", "FLIP_HORIZONTAL", "ROTATE_180", "FLIP_VERTICAL", "TRANSPOSE", "ROTATE_90", "TRANSVERSE",
-    "ROTATE_270" };
   typedef DOMString ContentId;
   typedef DOMString ContentDirectoryId;
   typedef DOMString PlaylistId;
+  enum ContentType { "IMAGE", "VIDEO", "AUDIO", "OTHER" };
+  enum AudioContentLyricsType { "SYNCHRONIZED", "UNSYNCHRONIZED" };
+  enum ImageContentOrientation { "NORMAL", "FLIP_HORIZONTAL", "ROTATE_180", "FLIP_VERTICAL", "TRANSPOSE", "ROTATE_90",
+    "TRANSVERSE", "ROTATE_270" };
   [NoInterfaceObject] interface ContentManagerObject {
     readonly attribute <a href="#ContentManager">ContentManager</a> content;
   };
@@ -3610,12 +3610,10 @@ It is used in <em>tizen.content.createPlaylist()</em>.
     readonly attribute unsigned long height;
     readonly attribute <a href="#ImageContentOrientation">ImageContentOrientation</a> orientation;
   };
-  [NoInterfaceObject]
-  interface PlaylistItem {
+  [NoInterfaceObject] interface PlaylistItem {
     readonly attribute <a href="#Content">Content</a> content;
   };
-  [NoInterfaceObject]
-  interface Playlist {
+  [NoInterfaceObject] interface Playlist {
     readonly attribute <a href="#PlaylistId">PlaylistId</a> id;
     attribute DOMString name raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute long numberOfTracks;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/content.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/content.html
@@ -3513,10 +3513,10 @@ It is used in <em>tizen.content.createPlaylist()</em>.
   enum AudioContentLyricsType { "SYNCHRONIZED", "UNSYNCHRONIZED" };
   enum ImageContentOrientation { "NORMAL", "FLIP_HORIZONTAL", "ROTATE_180", "FLIP_VERTICAL", "TRANSPOSE", "ROTATE_90",
     "TRANSVERSE", "ROTATE_270" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ContentManagerObject">ContentManagerObject</a>;
   [NoInterfaceObject] interface ContentManagerObject {
     readonly attribute <a href="#ContentManager">ContentManager</a> content;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ContentManagerObject">ContentManagerObject</a>;
   [NoInterfaceObject] interface ContentManager {
     void update(<a href="#Content">Content</a> content) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void updateBatch(<a href="#Content">Content</a>[] contents, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/console.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/console.html
@@ -496,10 +496,10 @@ console.timeEnd("Big array initialization");
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Console {
+  Window implements <a href="#ConsoleManagerObject">ConsoleManagerObject</a>;
   [NoInterfaceObject] interface ConsoleManagerObject {
     readonly attribute <a href="#ConsoleManager">ConsoleManager</a> console;
   };
-  Window implements <a href="#ConsoleManagerObject">ConsoleManagerObject</a>;
   [NoInterfaceObject] interface ConsoleManager {
     void log(DOMString text);
     void error(DOMString text);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/cordova.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/cordova.html
@@ -99,8 +99,7 @@
 <div class="brief">
  Basic success callback, no parameters.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly,NoInterfaceObject]
-  interface SuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {
     void onsuccess();
   };</pre>
 <div class="methods">
@@ -126,8 +125,7 @@
 <div class="brief">
  Basic error callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="#DOMException">DOMException</a> error);
   };</pre>
 <div class="methods">
@@ -209,12 +207,10 @@
   Window implements <a href="#CordovaManagerObject">CordovaManagerObject</a>;
   [NoInterfaceObject] interface Cordova {
   };
-  [Callback=FunctionOnly,NoInterfaceObject]
-  interface SuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {
     void onsuccess();
   };
-  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="#DOMException">DOMException</a> error);
   };
   interface DOMException {

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/cordova.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/cordova.html
@@ -201,10 +201,10 @@
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Cordova {
+  Window implements <a href="#CordovaManagerObject">CordovaManagerObject</a>;
   [NoInterfaceObject] interface CordovaManagerObject {
     readonly attribute <a href="#Cordova">Cordova</a> cordova;
   };
-  Window implements <a href="#CordovaManagerObject">CordovaManagerObject</a>;
   [NoInterfaceObject] interface Cordova {
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/device-motion.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/device-motion.html
@@ -543,10 +543,10 @@ To guarantee that the DeviceMotion application runs on a device with the DeviceM
   dictionary AccelerationOptions {
     long frequency;
   };
+  Navigator implements <a href="#AccelerometerManagerObject">AccelerometerManagerObject</a>;
   [NoInterfaceObject] interface AccelerometerManagerObject {
     readonly attribute <a href="#Accelerometer">Accelerometer</a> accelerometer;
   };
-  Navigator implements <a href="#AccelerometerManagerObject">AccelerometerManagerObject</a>;
   [NoInterfaceObject] interface Accelerometer {
     void getCurrentAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     DOMString watchAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#AccelerationOptions">AccelerationOptions</a>? options)

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/device-motion.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/device-motion.html
@@ -110,10 +110,10 @@ Original documentation: <a href="https://cordova.apache.org/docs/en/3.0.0/cordov
  The Accelerometer object captures device motion in the x, y, and z direction.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface Accelerometer {
-    void getCurrentAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+    void getCurrentAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     DOMString watchAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#AccelerationOptions">AccelerationOptions</a>? options)
-                                raises();
-    void clearWatch(DOMString watchID) raises();
+                                raises(TypeError);
+    void clearWatch(DOMString watchID) raises(TypeError);
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -226,8 +226,7 @@ Timestamp: 1456480118000
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  DOMString The watch id that must be passed to <a href="device-motion.html#Accelerometer::clearWatch">clearWatch</a> to stop watching.
               </ul>
 </div>
@@ -494,8 +493,7 @@ Acceleration values include the effect of gravity (9.81 m/s^2), so that when a d
 <div class="brief">
  Basic error callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };</pre>
 <div class="methods">
@@ -542,15 +540,18 @@ To guarantee that the DeviceMotion application runs on a device with the DeviceM
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module DeviceMotion {
+  dictionary AccelerationOptions {
+    long frequency;
+  };
   [NoInterfaceObject] interface AccelerometerManagerObject {
     readonly attribute <a href="#Accelerometer">Accelerometer</a> accelerometer;
   };
   Navigator implements <a href="#AccelerometerManagerObject">AccelerometerManagerObject</a>;
   [NoInterfaceObject] interface Accelerometer {
-    void getCurrentAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+    void getCurrentAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     DOMString watchAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#AccelerationOptions">AccelerationOptions</a>? options)
-                                raises();
-    void clearWatch(DOMString watchID) raises();
+                                raises(TypeError);
+    void clearWatch(DOMString watchID) raises(TypeError);
   };
   [NoInterfaceObject] interface Acceleration {
     readonly attribute double x;
@@ -558,14 +559,10 @@ To guarantee that the DeviceMotion application runs on a device with the DeviceM
     readonly attribute double z;
     readonly attribute long timestamp;
   };
-  dictionary AccelerationOptions {
-    long frequency;
-  };
   [Callback=FunctionOnly, NoInterfaceObject] interface AccelerometerSuccessCallback {
     void onsuccess(<a href="#Acceleration">Acceleration</a> acceleration);
   };
-  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/device.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/device.html
@@ -245,10 +245,10 @@ function onDeviceReady()
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Device {
+  Window implements <a href="#DeviceManagerObject">DeviceManagerObject</a>;
   [NoInterfaceObject] interface DeviceManagerObject {
     readonly attribute <a href="#Device">Device</a> device;
   };
-  Window implements <a href="#DeviceManagerObject">DeviceManagerObject</a>;
   [NoInterfaceObject] interface Device {
     readonly attribute DOMString cordova;
     readonly attribute DOMString model;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/dialogs.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/dialogs.html
@@ -469,10 +469,10 @@ the index uses one-based indexing, so the values could be 1, 2, 3, etc.
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Dialogs {
+  Navigator implements <a href="#DialogsManagerObject">DialogsManagerObject</a>;
   [NoInterfaceObject] interface DialogsManagerObject {
     readonly attribute <a href="#DialogsManager">DialogsManager</a> notification;
   };
-  Navigator implements <a href="#DialogsManagerObject">DialogsManagerObject</a>;
   [NoInterfaceObject] interface DialogsManager {
     void alert(DOMString message, <a href="cordova.html#SuccessCallback">SuccessCallback</a> alertCallback, optional DOMString? title, optional DOMString? buttonName);
     void confirm(DOMString message, <a href="#ConfirmCallback">ConfirmCallback</a> confirmCallback, optional DOMString? title, optional DOMString[]? buttonNames);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/dialogs.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/dialogs.html
@@ -239,7 +239,7 @@ navigator.notification.confirm(
 <div class="brief">
  Shows a custom confirm box with set of buttons.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void prompt(DOMString message, <a href="#PromptCallback">PromptCallback</a> promptCallback, optional DOMString? title, optional DOMString[]? buttonNames, 
+<div class="synopsis"><pre class="signature prettyprint">void prompt(DOMString message, <a href="#PromptCallback">PromptCallback</a> promptCallback, optional DOMString? title, optional DOMString[]? buttonNames,
             optional DOMString? defaultText);</pre></div>
 <p><span class="version">Since: </span>
  3.0

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/events.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/events.html
@@ -194,8 +194,7 @@ offline            </td>
 <div class="brief">
  Callback for the event which fires when Cordova is fully loaded
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface DeviceReadyEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface DeviceReadyEventCallback {
     void ondeviceready();
   };</pre>
 <p><span class="version">Since: </span>
@@ -238,8 +237,7 @@ function onDeviceReady()
 <div class="brief">
  Callback for the event which fires when an application is put into the background
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface PauseEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface PauseEventCallback {
     void onpause();
   };</pre>
 <p><span class="version">Since: </span>
@@ -281,8 +279,7 @@ function onPause()
 <div class="brief">
  Callback for the event which fires when an application is retrieved from the background
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface ResumeEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface ResumeEventCallback {
     void onresume();
   };</pre>
 <p><span class="version">Since: </span>
@@ -324,8 +321,7 @@ function onResume()
 <div class="brief">
  Callback for the event which fires when the user presses the back button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface BackButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface BackButtonEventCallback {
     void onbackbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -365,8 +361,7 @@ function onBackKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the menu button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface MenuButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface MenuButtonEventCallback {
     void onmenubutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -408,8 +403,7 @@ function onMenuKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the search button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface SearchButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface SearchButtonEventCallback {
     void onsearchbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -451,8 +445,7 @@ function onSearchKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the start call button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface StartCallEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface StartCallEventCallback {
     void onstartcallbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -494,8 +487,7 @@ function onStartCallKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the end call button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface EndCallButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface EndCallButtonEventCallback {
     void onendcallbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -537,8 +529,7 @@ function onEndCallKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the volume down button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface VolumeDownButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface VolumeDownButtonEventCallback {
     void onvolumedownbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -580,8 +571,7 @@ function onVolumeDownKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the volume up button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface VolumeUpButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface VolumeUpButtonEventCallback {
     void onvolumeupbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -621,44 +611,33 @@ function onVolumeUpKeyDown()
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Events {
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface DeviceReadyEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface DeviceReadyEventCallback {
     void ondeviceready();
-  };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface PauseEventCallback {
+  };  [NoInterfaceObject, Callback=FunctionOnly] interface PauseEventCallback {
     void onpause();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface ResumeEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface ResumeEventCallback {
     void onresume();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface BackButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface BackButtonEventCallback {
     void onbackbutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface MenuButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface MenuButtonEventCallback {
     void onmenubutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface SearchButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface SearchButtonEventCallback {
     void onsearchbutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface StartCallEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface StartCallEventCallback {
     void onstartcallbutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface EndCallButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface EndCallButtonEventCallback {
     void onendcallbutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface VolumeDownButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface VolumeDownButtonEventCallback {
     void onvolumedownbutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface VolumeUpButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface VolumeUpButtonEventCallback {
     void onvolumeupbutton();
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/events.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/events.html
@@ -613,7 +613,8 @@ function onVolumeUpKeyDown()
 <pre class="webidl prettyprint">module Events {
   [NoInterfaceObject, Callback=FunctionOnly] interface DeviceReadyEventCallback {
     void ondeviceready();
-  };  [NoInterfaceObject, Callback=FunctionOnly] interface PauseEventCallback {
+  };
+  [NoInterfaceObject, Callback=FunctionOnly] interface PauseEventCallback {
     void onpause();
   };
   [NoInterfaceObject, Callback=FunctionOnly] interface ResumeEventCallback {

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/file.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/file.html
@@ -323,7 +323,7 @@ See <a href="https://www.w3.org/TR/FileAPI/#blob-section">The Blob Interface and
 <pre class="webidl prettyprint">  dictionary ProgressEventInit {
     unsigned long long loaded = false;
     unsigned long long total = false;
-     target = null;
+    EventTarget target = null;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -1059,9 +1059,9 @@ The specifics of naming filesystems is unspecified, but a name must be unique ac
     const short TEMPORARY = 0;
     const short PERSISTENT = 1;
     void requestFileSystem(short type, long long size, optional <a href="#FileSystemCallback">FileSystemCallback</a>? successCallback,
-                           optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback) raises();
+                           optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback) raises(TypeError);
     void resolveLocalFileSystemURL(DOMString uri, optional <a href="#EntryCallback">EntryCallback</a>? successCallback, optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback)
-                                   raises();
+                                   raises(TypeError);
   };</pre>
 <pre class="webidl prettyprint">  Window implements <a href="#LocalFileSystem">LocalFileSystem</a>;</pre>
 <p><span class="version">Since: </span>
@@ -1106,7 +1106,7 @@ The specifics of naming filesystems is unspecified, but a name must be unique ac
 <div class="brief">
  Request a file system in which to store application data.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void requestFileSystem(short type, long long size, optional <a href="#FileSystemCallback">FileSystemCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void requestFileSystem(short type, long long size, optional <a href="#FileSystemCallback">FileSystemCallback</a>? successCallback,
                        optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1239,13 +1239,13 @@ resolveLocalFileSystemURL(uri, successCallback, errorCallback);
     readonly attribute DOMString fullPath;
     readonly attribute DOMString name;
     readonly attribute <a href="#FileSystem">FileSystem</a> filesystem;
-    void getMetadata(<a href="#MetadataCallback">MetadataCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+    void getMetadata(<a href="#MetadataCallback">MetadataCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
     void moveTo(<a href="#DirectoryEntry">DirectoryEntry</a> parent, optional DOMString? newName, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                raises();
+                raises(FileException);
     void copyTo(<a href="#DirectoryEntry">DirectoryEntry</a> parent, optional DOMString? newName, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                raises();
-    void getParent(<a href="#EntryCallback">EntryCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
-    void remove(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+                raises(FileException);
+    void getParent(<a href="#EntryCallback">EntryCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
+    void remove(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
     DOMString toURL();
   };</pre>
 <p><span class="version">Since: </span>
@@ -1708,8 +1708,7 @@ requestFileSystem(TEMPORARY, 100, function(fs)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  URL that can be used to identify this entry.
               </ul>
 </div>
@@ -1740,10 +1739,10 @@ requestFileSystem(TEMPORARY, 100, function(fs)
 <pre class="webidl prettyprint">  interface DirectoryEntry : <a href="#Entry">Entry</a> {
     <a href="#DirectoryReader">DirectoryReader</a> createReader();
     void getDirectory(DOMString path, optional ? options, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                      raises();
+                      raises(FileException);
     void getFile(DOMString path, optional ? options, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                 raises();
-    void removeRecursively(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+                 raises(FileException);
+    void removeRecursively(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -1772,8 +1771,7 @@ requestFileSystem(TEMPORARY, 100, function(fs)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DirectoryReader:
-                  </span>
+<span class="return">DirectoryReader:</span>
  DirectoryReader.
               </ul>
 </div>
@@ -2009,7 +2007,7 @@ Otherwise, if no other error occurs, getFile must return a FileEntry correspondi
  The DirectoryReader interface provides access to the Filesystem API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface DirectoryReader {
-    void readEntries(<a href="#EntriesCallback">EntriesCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+    void readEntries(<a href="#EntriesCallback">EntriesCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
   };</pre>
 <p><span class="privilegelevel">Privilege level: </span>
  public
@@ -2224,10 +2222,10 @@ Otherwise, if no other error occurs, getFile must return a FileEntry correspondi
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onerror;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onloadend;
     void abort();
-    void readAsDataURL(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
-    void readAsText(<a href="#Blob">Blob</a> blob, optional DOMString? label) raises(, <a href="#FileError">FileError</a>);
-    void readAsBinaryString(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
-    void readAsArrayBuffer(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
+    void readAsDataURL(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsText(<a href="#Blob">Blob</a> blob, optional DOMString? label) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsBinaryString(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsArrayBuffer(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -2683,10 +2681,10 @@ ByteLength: 3
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onabort;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onerror;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onwriteend;
-    void abort() raises();
-    void seek(long offset) raises();
-    void truncate(long size) raises();
-    void write(<a href="#WriteData">WriteData</a> data) raises();
+    void abort() raises(FileException);
+    void seek(long offset) raises(FileException);
+    void truncate(long size) raises(FileException);
+    void write(<a href="#WriteData">WriteData</a> data) raises(FileException);
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -3459,7 +3457,7 @@ entry.createWriter(successCallback, errorCallback);
   dictionary ProgressEventInit {
     unsigned long long loaded = false;
     unsigned long long total = false;
-     target = null;
+    EventTarget target = null;
   };
   [Constructor(DOMString type, optional <a href="#ProgressEventInit">ProgressEventInit</a> eventInitDict)]
   interface ProgressEvent {
@@ -3472,10 +3470,10 @@ entry.createWriter(successCallback, errorCallback);
     readonly attribute unsigned long long total;
     readonly attribute  target;
   };
+  Cordova implements <a href="#ProgressEvent">ProgressEvent</a>;
   [NoInterfaceObject] interface FileSystemManagerObject {
     readonly attribute <a href="#FileSystemManager">FileSystemManager</a> file;
   };
-  <a href="cordova.html#Cordova">Cordova</a> implements <a href="#FileSystemManagerObject">FileSystemManagerObject</a>;
   [NoInterfaceObject] interface FileSystemManager {
     readonly attribute DOMString? applicationDirectory;
     readonly attribute DOMString? applicationStorageDirectory;
@@ -3524,36 +3522,35 @@ entry.createWriter(successCallback, errorCallback);
     const short TEMPORARY = 0;
     const short PERSISTENT = 1;
     void requestFileSystem(short type, long long size, optional <a href="#FileSystemCallback">FileSystemCallback</a>? successCallback,
-                           optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback) raises();
+                           optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback) raises(TypeError);
     void resolveLocalFileSystemURL(DOMString uri, optional <a href="#EntryCallback">EntryCallback</a>? successCallback, optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback)
-                                   raises();
+                                   raises(TypeError);
   };
-  Window implements <a href="#LocalFileSystem">LocalFileSystem</a>;
   [NoInterfaceObject] interface Entry {
     readonly attribute boolean isFile;
     readonly attribute boolean isDirectory;
     readonly attribute DOMString fullPath;
     readonly attribute DOMString name;
     readonly attribute <a href="#FileSystem">FileSystem</a> filesystem;
-    void getMetadata(<a href="#MetadataCallback">MetadataCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+    void getMetadata(<a href="#MetadataCallback">MetadataCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
     void moveTo(<a href="#DirectoryEntry">DirectoryEntry</a> parent, optional DOMString? newName, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                raises();
+                raises(FileException);
     void copyTo(<a href="#DirectoryEntry">DirectoryEntry</a> parent, optional DOMString? newName, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                raises();
-    void getParent(<a href="#EntryCallback">EntryCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
-    void remove(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+                raises(FileException);
+    void getParent(<a href="#EntryCallback">EntryCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
+    void remove(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
     DOMString toURL();
   };
   interface DirectoryEntry : <a href="#Entry">Entry</a> {
     <a href="#DirectoryReader">DirectoryReader</a> createReader();
     void getDirectory(DOMString path, optional ? options, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                      raises();
+                      raises(FileException);
     void getFile(DOMString path, optional ? options, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                 raises();
-    void removeRecursively(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+                 raises(FileException);
+    void removeRecursively(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
   };
   [NoInterfaceObject] interface DirectoryReader {
-    void readEntries(<a href="#EntriesCallback">EntriesCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+    void readEntries(<a href="#EntriesCallback">EntriesCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
   };
   [NoInterfaceObject] interface FileEntry : <a href="#Entry">Entry</a> {
     void createWriter(<a href="#FileWriterCallback">FileWriterCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror);
@@ -3573,10 +3570,10 @@ entry.createWriter(successCallback, errorCallback);
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onerror;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onloadend;
     void abort();
-    void readAsDataURL(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
-    void readAsText(<a href="#Blob">Blob</a> blob, optional DOMString? label) raises(, <a href="#FileError">FileError</a>);
-    void readAsBinaryString(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
-    void readAsArrayBuffer(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
+    void readAsDataURL(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsText(<a href="#Blob">Blob</a> blob, optional DOMString? label) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsBinaryString(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsArrayBuffer(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
   };
   [NoInterfaceObject] interface FileWriter {
     const short INIT = 0;
@@ -3592,10 +3589,10 @@ entry.createWriter(successCallback, errorCallback);
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onabort;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onerror;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onwriteend;
-    void abort() raises();
-    void seek(long offset) raises();
-    void truncate(long size) raises();
-    void write(<a href="#WriteData">WriteData</a> data) raises();
+    void abort() raises(FileException);
+    void seek(long offset) raises(FileException);
+    void truncate(long size) raises(FileException);
+    void write(<a href="#WriteData">WriteData</a> data) raises(FileException);
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface ProgressCallback {
     void onsuccess(<a href="#ProgressEvent">ProgressEvent</a> event);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/file.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/file.html
@@ -3459,6 +3459,8 @@ entry.createWriter(successCallback, errorCallback);
     unsigned long long total = false;
     EventTarget target = null;
   };
+  Cordova implements <a href="#FileSystemManagerObject">FileSystemManagerObject</a>;
+  Window implements <a href="#LocalFileSystem">LocalFileSystem</a>;
   [Constructor(DOMString type, optional <a href="#ProgressEventInit">ProgressEventInit</a> eventInitDict)]
   interface ProgressEvent {
     readonly attribute DOMString type;
@@ -3470,7 +3472,6 @@ entry.createWriter(successCallback, errorCallback);
     readonly attribute unsigned long long total;
     readonly attribute  target;
   };
-  Cordova implements <a href="#ProgressEvent">ProgressEvent</a>;
   [NoInterfaceObject] interface FileSystemManagerObject {
     readonly attribute <a href="#FileSystemManager">FileSystemManager</a> file;
   };

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/filetransfer.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/filetransfer.html
@@ -227,7 +227,7 @@ Sent = 1024
 <div class="constructors">
 <h4 id="FileUploadOptions::constructor">Constructors</h4>
 <dl>
-<pre class="webidl prettyprint">FileUploadOptions(DOMString fileKey, DOMString fileName, DOMString mimeType, <a href="#FileUploadParams">FileUploadParams</a> params, <a href="#HeaderFields">HeaderFields</a> headers, 
+<pre class="webidl prettyprint">FileUploadOptions(DOMString fileKey, DOMString fileName, DOMString mimeType, <a href="#FileUploadParams">FileUploadParams</a> params, <a href="#HeaderFields">HeaderFields</a> headers,
                   DOMString httpMethod);</pre>
 <div class="example">
 <span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">/* Creates a FileUploadOptions objects */
@@ -349,7 +349,7 @@ var options = new FileUploadOptions("file", "doc.txt", "text/plain", null, null,
     attribute long bytesSent;
     attribute long responseCode;
     attribute DOMString response;
-    attribute <a href="#HeaderFields">HeaderFields</a>  headers;
+    attribute <a href="#HeaderFields">HeaderFields</a> headers;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -428,17 +428,17 @@ var options = new FileUploadOptions("file", "doc.txt", "text/plain", null, null,
  A FileTransferError object is passed to an error callback when an error occurs.
           </div>
 <pre class="webidl prettyprint">  interface FileTransferError {
+    const short FILE_NOT_FOUND_ERR = 1;
+    const short INVALID_URL_ERR = 2;
+    const short CONNECTION_ERR = 3;
+    const short ABORT_ERR = 4;
+    const short NOT_MODIFIED_ERR = 5;
     attribute short code;
     attribute DOMString source;
     attribute DOMString target;
     attribute long http_status;
     attribute DOMString body;
     attribute DOMString _exception;
-    const short FILE_NOT_FOUND_ERR = 1;
-    const short INVALID_URL_ERR = 2;
-    const short CONNECTION_ERR = 3;
-    const short ABORT_ERR = 4;
-    const short NOT_MODIFIED_ERR = 5;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -684,8 +684,8 @@ Success. File uploaded
 <div class="brief">
  Sends a file to a server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void upload(DOMString fileURL, DOMString server, optional <a href="#FileUploadSuccessCallback">FileUploadSuccessCallback</a>? successCallback, 
-            optional <a href="#FileTransferErrorCallback">FileTransferErrorCallback</a>? errorCallback, optional <a href="#FileUploadOptions">FileUploadOptions</a>? options, 
+<div class="synopsis"><pre class="signature prettyprint">void upload(DOMString fileURL, DOMString server, optional <a href="#FileUploadSuccessCallback">FileUploadSuccessCallback</a>? successCallback,
+            optional <a href="#FileTransferErrorCallback">FileTransferErrorCallback</a>? errorCallback, optional <a href="#FileUploadOptions">FileUploadOptions</a>? options,
             optional boolean? trustAllHosts);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -763,8 +763,8 @@ Sent = 1024
 <div class="brief">
  Downloads a file from a server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void download(DOMString source, DOMString target, optional <a href="#FileDownloadSuccessCallback">FileDownloadSuccessCallback</a>? successCallback, 
-              optional <a href="#FileTransferErrorCallback">FileTransferErrorCallback</a>? errorCallback, optional boolean? trustAllHosts, 
+<div class="synopsis"><pre class="signature prettyprint">void download(DOMString source, DOMString target, optional <a href="#FileDownloadSuccessCallback">FileDownloadSuccessCallback</a>? successCallback,
+              optional <a href="#FileTransferErrorCallback">FileTransferErrorCallback</a>? errorCallback, optional boolean? trustAllHosts,
               optional <a href="#FileDownloadOptions">FileDownloadOptions</a>? options);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1016,25 +1016,24 @@ Upload error target http://some.server.com/file.txt
     attribute <a href="#FileUploadParams">FileUploadParams</a> params;
     attribute boolean chunkedMode;
     attribute <a href="#HeaderFields">HeaderFields</a> headers;
-  };
-  [NoInterfaceObject] interface FileUploadResult {
+  };  [NoInterfaceObject] interface FileUploadResult {
     attribute long bytesSent;
     attribute long responseCode;
     attribute DOMString response;
-    attribute <a href="#HeaderFields">HeaderFields</a>  headers;
+    attribute <a href="#HeaderFields">HeaderFields</a> headers;
   };
   interface FileTransferError {
+    const short FILE_NOT_FOUND_ERR = 1;
+    const short INVALID_URL_ERR = 2;
+    const short CONNECTION_ERR = 3;
+    const short ABORT_ERR = 4;
+    const short NOT_MODIFIED_ERR = 5;
     attribute short code;
     attribute DOMString source;
     attribute DOMString target;
     attribute long http_status;
     attribute DOMString body;
     attribute DOMString _exception;
-    const short FILE_NOT_FOUND_ERR = 1;
-    const short INVALID_URL_ERR = 2;
-    const short CONNECTION_ERR = 3;
-    const short ABORT_ERR = 4;
-    const short NOT_MODIFIED_ERR = 5;
   };
   [Constructor()]
   interface FileTransfer {

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/filetransfer.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/filetransfer.html
@@ -1016,7 +1016,8 @@ Upload error target http://some.server.com/file.txt
     attribute <a href="#FileUploadParams">FileUploadParams</a> params;
     attribute boolean chunkedMode;
     attribute <a href="#HeaderFields">HeaderFields</a> headers;
-  };  [NoInterfaceObject] interface FileUploadResult {
+  };
+  [NoInterfaceObject] interface FileUploadResult {
     attribute long bytesSent;
     attribute long responseCode;
     attribute DOMString response;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/globalization.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/globalization.html
@@ -181,25 +181,25 @@ Original documentation: <a href="https://www.npmjs.com/package/cordova-plugin-gl
  the GlobalizationManager interface embodies Globalization module methods.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface GlobalizationManager {
-    void getPreferredLanguage(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void getLocaleName(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+    void getPreferredLanguage(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void getLocaleName(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     void dateToString(Date date, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
-                      raises();
-    void getCurrencyPattern(DOMString currencyCode, <a href="#PatternSuccessCallback">PatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+                      raises(TypeError);
+    void getCurrencyPattern(DOMString currencyCode, <a href="#PatternSuccessCallback">PatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     void getDateNames(<a href="#ArrayStringSuccessCallback">ArrayStringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#GetDateNamesOptions">GetDateNamesOptions</a> options)
-                      raises();
+                      raises(TypeError);
     void getDatePattern(<a href="#GetDatePatternSuccessCallback">GetDatePatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
-                        raises();
-    void getFirstDayOfWeek(<a href="#LongSuccessCallback">LongSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+                        raises(TypeError);
+    void getFirstDayOfWeek(<a href="#LongSuccessCallback">LongSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     void getNumberPattern(<a href="#GetNumberPatternSuccessCallback">GetNumberPatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
-                          raises();
-    void isDayLightSavingsTime(Date date, <a href="#DSTSuccessCallback">DSTSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+                          raises(TypeError);
+    void isDayLightSavingsTime(Date date, <a href="#DSTSuccessCallback">DSTSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     void numberToString(double number, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
-                        raises();
+                        raises(TypeError);
     void stringToDate(DOMString dateString, <a href="#GlobalizationDateSuccessCallback">GlobalizationDateSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
-                      optional <a href="#DateOptions">DateOptions</a> options) raises();
+                      optional <a href="#DateOptions">DateOptions</a> options) raises(TypeError);
     void stringToNumber(DOMString numberString, <a href="#DoubleSuccessCallback">DoubleSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
-                        optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options) raises();
+                        optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options) raises(TypeError);
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -354,7 +354,7 @@ navigator.globalization.getLocaleName(
 <div class="brief">
  Returns a date formatted as a string according to the client's locale and timezone.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void dateToString(Date date<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint">void dateToString(Date date, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options);</pre></div>
 <p><span class="version">Since: </span>
  3.0
             </p>
@@ -896,7 +896,7 @@ navigator.globalization.isDayLightSavingsTime(new Date(),
  Returns a number formatted as a string
 according to the client's user preferences.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void numberToString(double number<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint">void numberToString(double number, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options);</pre></div>
 <p><span class="version">Since: </span>
  3.0
             </p>
@@ -1014,7 +1014,7 @@ Currency: $1,099.95
 user preferences and calendar using the time zone of the client.
 Returns the corresponding date object.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void stringToDate(DOMString dateString, <a href="#GlobalizationDateSuccessCallback">GlobalizationDateSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, 
+<div class="synopsis"><pre class="signature prettyprint">void stringToDate(DOMString dateString, <a href="#GlobalizationDateSuccessCallback">GlobalizationDateSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
                   optional <a href="#DateOptions">DateOptions</a> options);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1089,7 +1089,7 @@ navigator.globalization.stringToDate("9/25/2012",
  Parses a number formatted as a string according to the client's
 user preferences and returns the corresponding number.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void stringToNumber(DOMString numberString, <a href="#DoubleSuccessCallback">DoubleSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, 
+<div class="synopsis"><pre class="signature prettyprint">void stringToNumber(DOMString numberString, <a href="#DoubleSuccessCallback">DoubleSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
                     optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1998,12 +1998,12 @@ of a NumberPattern object.
 <div class="interface" id="GlobalizationError">
 <a class="backward-compatibility-anchor" name="::Globalization::GlobalizationError"></a><h3>1.19. GlobalizationError</h3>
 <pre class="webidl prettyprint">  interface GlobalizationError {
-    attribute long code;
-    attribute DOMString message;
     const short UNKNOWN_ERROR = 0;
     const short FORMATTING_ERROR = 1;
     const short PARSING_ERROR = 2;
     const short PATTERN_ERROR = 3;
+    attribute long code;
+    attribute DOMString message;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -2093,8 +2093,7 @@ The GlobalizationError interface
 <div class="brief">
  Basic error callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };</pre>
 <div class="methods">
@@ -2127,31 +2126,6 @@ The GlobalizationError interface
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Globalization {
-  [NoInterfaceObject] interface GlobalizationManagerObject {
-    readonly attribute <a href="#GlobalizationManager">GlobalizationManager</a> globalization;
-  };
-  Navigator implements <a href="#GlobalizationManagerObject">GlobalizationManagerObject</a>;
-  [NoInterfaceObject] interface GlobalizationManager {
-    void getPreferredLanguage(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void getLocaleName(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void dateToString(Date date, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
-                      raises();
-    void getCurrencyPattern(DOMString currencyCode, <a href="#PatternSuccessCallback">PatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void getDateNames(<a href="#ArrayStringSuccessCallback">ArrayStringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#GetDateNamesOptions">GetDateNamesOptions</a> options)
-                      raises();
-    void getDatePattern(<a href="#GetDatePatternSuccessCallback">GetDatePatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
-                        raises();
-    void getFirstDayOfWeek(<a href="#LongSuccessCallback">LongSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void getNumberPattern(<a href="#GetNumberPatternSuccessCallback">GetNumberPatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
-                          raises();
-    void isDayLightSavingsTime(Date date, <a href="#DSTSuccessCallback">DSTSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void numberToString(double number, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
-                        raises();
-    void stringToDate(DOMString dateString, <a href="#GlobalizationDateSuccessCallback">GlobalizationDateSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
-                      optional <a href="#DateOptions">DateOptions</a> options) raises();
-    void stringToNumber(DOMString numberString, <a href="#DoubleSuccessCallback">DoubleSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
-                        optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options) raises();
-  };
   dictionary DateOptions {
     DOMString formatLength;
     DOMString selector;
@@ -2196,6 +2170,31 @@ The GlobalizationError interface
     long second;
     long millisecond;
   };
+  [NoInterfaceObject] interface GlobalizationManagerObject {
+    readonly attribute <a href="#GlobalizationManager">GlobalizationManager</a> globalization;
+  };
+  Navigator implements <a href="#GlobalizationManagerObject">GlobalizationManagerObject</a>;
+  [NoInterfaceObject] interface GlobalizationManager {
+    void getPreferredLanguage(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void getLocaleName(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void dateToString(Date date, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
+                      raises(TypeError);
+    void getCurrencyPattern(DOMString currencyCode, <a href="#PatternSuccessCallback">PatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void getDateNames(<a href="#ArrayStringSuccessCallback">ArrayStringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#GetDateNamesOptions">GetDateNamesOptions</a> options)
+                      raises(TypeError);
+    void getDatePattern(<a href="#GetDatePatternSuccessCallback">GetDatePatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
+                        raises(TypeError);
+    void getFirstDayOfWeek(<a href="#LongSuccessCallback">LongSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void getNumberPattern(<a href="#GetNumberPatternSuccessCallback">GetNumberPatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
+                          raises(TypeError);
+    void isDayLightSavingsTime(Date date, <a href="#DSTSuccessCallback">DSTSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void numberToString(double number, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
+                        raises(TypeError);
+    void stringToDate(DOMString dateString, <a href="#GlobalizationDateSuccessCallback">GlobalizationDateSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
+                      optional <a href="#DateOptions">DateOptions</a> options) raises(TypeError);
+    void stringToNumber(DOMString numberString, <a href="#DoubleSuccessCallback">DoubleSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
+                        optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options) raises(TypeError);
+  };
   [Callback=FunctionOnly, NoInterfaceObject] interface DSTSuccessCallback {
     void onsuccess(object properties);
   };
@@ -2224,15 +2223,14 @@ The GlobalizationError interface
     void onsuccess(<a href="#NumberPattern">NumberPattern</a> pattern);
   };
   interface GlobalizationError {
-    attribute long code;
-    attribute DOMString message;
     const short UNKNOWN_ERROR = 0;
     const short FORMATTING_ERROR = 1;
     const short PARSING_ERROR = 2;
     const short PATTERN_ERROR = 3;
+    attribute long code;
+    attribute DOMString message;
   };
-  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/globalization.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/globalization.html
@@ -2170,10 +2170,10 @@ The GlobalizationError interface
     long second;
     long millisecond;
   };
+  Navigator implements <a href="#GlobalizationManagerObject">GlobalizationManagerObject</a>;
   [NoInterfaceObject] interface GlobalizationManagerObject {
     readonly attribute <a href="#GlobalizationManager">GlobalizationManager</a> globalization;
   };
-  Navigator implements <a href="#GlobalizationManagerObject">GlobalizationManagerObject</a>;
   [NoInterfaceObject] interface GlobalizationManager {
     void getPreferredLanguage(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     void getLocaleName(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/media.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/media.html
@@ -149,7 +149,7 @@ Storage privileges are privacy-related privileges and there is a need of asking 
 <div class="brief">
  The Media interface provides interface and functions to manage audio objects.
               </div>
-<pre class="webidl prettyprint">Media(DOMString src, optional <a href="cordova.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="#MediaErrorCallback">MediaErrorCallback</a>? errorCallback, 
+<pre class="webidl prettyprint">Media(DOMString src, optional <a href="cordova.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="#MediaErrorCallback">MediaErrorCallback</a>? errorCallback,
       optional <a href="#StatusChangeCallback">StatusChangeCallback</a>? mediaStatus);</pre>
 <div class="description">
               <ul>
@@ -786,7 +786,7 @@ setTimeout(function()
 <div class="brief">
  Basic error callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly,NoInterfaceObject] interface MediaErrorCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface MediaErrorCallback {
     void onerror(<a href="#MediaError">MediaError</a> error);
   };</pre>
 <div class="methods">
@@ -933,15 +933,14 @@ If an application uses startRecord() or stopRecord(), declare the following feat
     void startRecord();
     void stopRecord();
     void stop();
-  };
-  interface MediaError {
+  };  interface MediaError {
     const short MEDIA_ERR_ABORTED = 1;
     const short MEDIA_ERR_NETWORK = 2;
     const short MEDIA_ERR_DECODE = 3;
     const short MEDIA_ERR_NONE_SUPPORTED = 4;
     readonly attribute short code;
   };
-  [Callback=FunctionOnly,NoInterfaceObject] interface MediaErrorCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface MediaErrorCallback {
     void onerror(<a href="#MediaError">MediaError</a> error);
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface StatusChangeCallback {

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/media.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/media.html
@@ -933,7 +933,8 @@ If an application uses startRecord() or stopRecord(), declare the following feat
     void startRecord();
     void stopRecord();
     void stop();
-  };  interface MediaError {
+  };
+  interface MediaError {
     const short MEDIA_ERR_ABORTED = 1;
     const short MEDIA_ERR_NETWORK = 2;
     const short MEDIA_ERR_DECODE = 3;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/networkInformation.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/networkInformation.html
@@ -459,10 +459,10 @@ To guarantee that the NetworkInformation application runs on a device with the N
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module NetworkInformation {
+  Navigator implements <a href="#NetworkInformationManagerObject">NetworkInformationManagerObject</a>;
   [NoInterfaceObject] interface NetworkInformationManagerObject {
     readonly attribute <a href="#NetworkInformationManager">NetworkInformationManager</a> connection;
   };
-  Navigator implements <a href="#NetworkInformationManagerObject">NetworkInformationManagerObject</a>;
   [NoInterfaceObject] interface NetworkInformationManager {
     readonly attribute DOMString type;
   };

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/networkInformation.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/cordova/networkInformation.html
@@ -375,8 +375,7 @@ checkConnection();
 <div class="brief">
  Callback for the event when an application goes online, and the device becomes connected to the Internet.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface OnlineEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface OnlineEventCallback {
     void online();
   };</pre>
 <p><span class="version">Since: </span>
@@ -412,8 +411,7 @@ function onOnline()
 <div class="brief">
  Callback for the event when an application goes offline, and the device is not connected to the Internet.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface OfflineEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface OfflineEventCallback {
     void offline();
   };</pre>
 <p><span class="version">Since: </span>
@@ -478,12 +476,10 @@ To guarantee that the NetworkInformation application runs on a device with the N
     readonly attribute DOMString CELL;
     readonly attribute DOMString NONE;
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface OnlineEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface OnlineEventCallback {
     void online();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface OfflineEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface OfflineEventCallback {
     void offline();
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/datacontrol.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/datacontrol.html
@@ -1666,10 +1666,10 @@ catch (err)
     DOMString[] columns;
     DOMString[] values;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DataControlManagerObject">DataControlManagerObject</a>;
   [NoInterfaceObject] interface DataControlManagerObject {
     readonly attribute <a href="#DataControlManager">DataControlManager</a> datacontrol;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DataControlManagerObject">DataControlManagerObject</a>;
   [NoInterfaceObject] interface DataControlManager {
     <a href="#DataControlConsumerObject">DataControlConsumerObject</a> getDataControlConsumer(DOMString providerId, DOMString dataId, <a href="#DataType">DataType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/datacontrol.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/datacontrol.html
@@ -267,8 +267,7 @@ Data Control API.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DataControlConsumerObject:
-                  </span>
+<span class="return">DataControlConsumerObject:</span>
  The local <em>DataControlConsumerObject</em>.
               </ul>
 </div>
@@ -422,8 +421,7 @@ The data sending implementation determines the actual change data returned to th
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  An identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -613,7 +611,7 @@ removeChangeListener was invoked
 <div class="brief">
  Inserts new rows into a table owned by an SQL-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void insert(unsigned long reqId, <a href="#RowData">RowData</a> insertionData, optional <a href="#DataControlInsertSuccessCallback">DataControlInsertSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void insert(unsigned long reqId, <a href="#RowData">RowData</a> insertionData, optional <a href="#DataControlInsertSuccessCallback">DataControlInsertSuccessCallback</a>? successCallback,
             optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.1
@@ -698,7 +696,7 @@ catch (err)
 <div class="brief">
  Updates values of a table owned by an SQL-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void update(unsigned long reqId, <a href="#RowData">RowData</a> updateData, DOMString where, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void update(unsigned long reqId, <a href="#RowData">RowData</a> updateData, DOMString where, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback,
             optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.1
@@ -787,7 +785,7 @@ catch (err)
 <div class="brief">
  Delete rows from a table that is owned by an SQL-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void remove(unsigned long reqId, DOMString where, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void remove(unsigned long reqId, DOMString where, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback,
             optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.1
@@ -870,8 +868,8 @@ catch (err)
 <div class="brief">
  Selects the specified columns to be queried. The result set of the specified columns is retrieved from a table owned by an SQL-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void select(unsigned long reqId, DOMString[] columns, DOMString where, <a href="#DataControlSelectSuccessCallback">DataControlSelectSuccessCallback</a> successCallback, 
-            optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback, optional unsigned long? page, 
+<div class="synopsis"><pre class="signature prettyprint">void select(unsigned long reqId, DOMString[] columns, DOMString where, <a href="#DataControlSelectSuccessCallback">DataControlSelectSuccessCallback</a> successCallback,
+            optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback, optional unsigned long? page,
             optional unsigned long? maxNumberPerPage, optional DOMString? order);</pre></div>
 <p><span class="version">Since: </span>
  2.1
@@ -1022,7 +1020,7 @@ catch (err)
 <div class="brief">
  Adds the value associated with the specified key to a key-values map owned by a MAP-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void addValue(unsigned long reqId, DOMString key, DOMString value, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void addValue(unsigned long reqId, DOMString key, DOMString value, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback,
               optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.1
@@ -1109,7 +1107,7 @@ catch (err)
 <div class="brief">
  Removes the value associated with the specified key from a key-values map owned by a MAP-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void removeValue(unsigned long reqId, DOMString key, DOMString value, <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void removeValue(unsigned long reqId, DOMString key, DOMString value, <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a> successCallback,
                  optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.1
@@ -1199,7 +1197,7 @@ catch (err)
 <div class="brief">
  Gets the value associated with the specified key, from a key-values map owned by a MAP-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getValue(unsigned long reqId, DOMString key, <a href="#DataControlGetValueSuccessCallback">DataControlGetValueSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getValue(unsigned long reqId, DOMString key, <a href="#DataControlGetValueSuccessCallback">DataControlGetValueSuccessCallback</a> successCallback,
               optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.1
@@ -1285,7 +1283,7 @@ catch (err)
 <div class="brief">
  Sets the value associated with the specified key to a new value.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void updateValue(unsigned long reqId, DOMString key, DOMString oldValue, DOMString newValue, 
+<div class="synopsis"><pre class="signature prettyprint">void updateValue(unsigned long reqId, DOMString key, DOMString oldValue, DOMString newValue,
                  <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a> successCallback, optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.1
@@ -1664,6 +1662,10 @@ catch (err)
 <pre class="webidl prettyprint">module DataControl {
   enum DataType { "MAP", "SQL" };
   enum EventType { "SQL_UPDATE", "SQL_INSERT", "SQL_DELETE", "MAP_SET", "MAP_ADD", "MAP_REMOVE" };
+  dictionary RowData {
+    DOMString[] columns;
+    DOMString[] values;
+  };
   [NoInterfaceObject] interface DataControlManagerObject {
     readonly attribute <a href="#DataControlManager">DataControlManager</a> datacontrol;
   };
@@ -1718,10 +1720,6 @@ catch (err)
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface DataControlChangeCallback {
     void onsuccess(<a href="#EventType">EventType</a> type, <a href="#RowData">RowData</a> data);
-  };
-  dictionary RowData {
-    DOMString[] columns;
-    DOMString[] values;
   };
 };</pre>
 </div>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/datasync.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/datasync.html
@@ -1391,10 +1391,10 @@ To guarantee that data synch application runs on a device, declare the following
   enum SyncInterval { "5_MINUTES", "15_MINUTES", "1_HOUR", "4_HOURS", "12_HOURS", "1_DAY", "1_WEEK", "1_MONTH" };
   enum SyncServiceType { "CONTACT", "EVENT" };
   enum SyncStatus { "SUCCESS", "FAIL", "STOP", "NONE" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DataSynchronizationManagerObject">DataSynchronizationManagerObject</a>;
   [NoInterfaceObject] interface DataSynchronizationManagerObject {
     readonly attribute <a href="#DataSynchronizationManager">DataSynchronizationManager</a> datasync;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DataSynchronizationManagerObject">DataSynchronizationManagerObject</a>;
   [Constructor(DOMString url, DOMString id, DOMString password, <a href="#SyncMode">SyncMode</a> mode),
    Constructor(DOMString url, DOMString id, DOMString password, <a href="#SyncMode">SyncMode</a> mode, <a href="#SyncType">SyncType</a> type),
    Constructor(DOMString url, DOMString id, DOMString password, <a href="#SyncMode">SyncMode</a> mode, <a href="#SyncInterval">SyncInterval</a> interval)]

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/datasync.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/datasync.html
@@ -413,7 +413,7 @@ This attribute is used when the sync mode is set to the <em>PERIODIC</em> option
           </p>
 <div class="constructors">
 <h4 id="SyncServiceInfo::constructor">Constructors</h4>
-<dl><pre class="webidl prettyprint">SyncServiceInfo(boolean enable, <a href="#SyncServiceType">SyncServiceType</a> serviceType, DOMString serverDatabaseUri, optional DOMString? id, 
+<dl><pre class="webidl prettyprint">SyncServiceInfo(boolean enable, <a href="#SyncServiceType">SyncServiceType</a> serviceType, DOMString serverDatabaseUri, optional DOMString? id,
                 optional DOMString? password);</pre></dl>
 </div>
 <div class="attributes">
@@ -875,8 +875,7 @@ Normally the platform sets a limitation on the number of supported profiles. It 
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The number of supported profiles on a platform.
               </ul>
 </div>
@@ -918,8 +917,7 @@ var numMaxProfiles = tizen.datasync.getMaxProfilesNum();
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">unsigned long:
-                  </span>
+<span class="return">unsigned long:</span>
  The current number of profiles on a device.
               </ul>
 </div>
@@ -975,8 +973,7 @@ The attempt to retrieve <em>SyncProfileInfo</em> doesn't get any confidential in
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">SyncProfileInfo:
-                  </span>
+<span class="return">SyncProfileInfo:</span>
  The profile information of the given ID.
               </ul>
 </div>
@@ -1029,8 +1026,7 @@ An attempt to retrieve <em>SyncProfileInfo</em> doesn't get any confidential inf
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">SyncProfileInfo[]:
-                  </span>
+<span class="return">SyncProfileInfo[]:</span>
  The profile information array.
               </ul>
 </div>
@@ -1208,8 +1204,7 @@ tizen.datasync.stopSync(profileId);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">SyncStatistics[]:
-                  </span>
+<span class="return">SyncStatistics[]:</span>
  The sync statistics information of a given ID.
               </ul>
 </div>
@@ -1266,7 +1261,7 @@ var statistics = tizen.datasync.getLastSyncStatistics(profileId);
 <div class="brief">
  Called when a synchronization operation is started and progress is made.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void onprogress(<a href="#SyncProfileId">SyncProfileId</a> profileId, <a href="#SyncServiceType">SyncServiceType</a> serviceType, boolean isFromServer, unsigned long totalPerService, 
+<div class="synopsis"><pre class="signature prettyprint">void onprogress(<a href="#SyncProfileId">SyncProfileId</a> profileId, <a href="#SyncServiceType">SyncServiceType</a> serviceType, boolean isFromServer, unsigned long totalPerService,
                 unsigned long syncedPerService);</pre></div>
 <p><span class="version">Since: </span>
  2.1

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/download.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/download.html
@@ -223,7 +223,7 @@ The <em>tizen.download </em>object allows access to the functionality of the Dow
           </p>
 <div class="constructors">
 <h4 id="DownloadRequest::constructor">Constructors</h4>
-<dl><pre class="webidl prettyprint">DownloadRequest(DOMString url, optional DOMString? destination, optional DOMString? fileName, 
+<dl><pre class="webidl prettyprint">DownloadRequest(DOMString url, optional DOMString? destination, optional DOMString? fileName,
                 optional <a href="#DownloadNetworkType">DownloadNetworkType</a>? networkType, optional <a href="#DownloadHTTPHeaderFields">DownloadHTTPHeaderFields</a>? httpHeader);</pre></dl>
 </div>
 <div class="attributes">
@@ -368,8 +368,7 @@ req.httpHeader["X-Agent"] = "Tizen Sample App";
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  An identifier for each download operation.
 If the network is not available for downloading, the return value is -1 since Tizen 2.3.
               </ul>
@@ -607,8 +606,7 @@ tizen.download.resume(downloadId);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DownloadState:
-                  </span>
+<span class="return">DownloadState:</span>
  The current download state of the specified ID.
               </ul>
 </div>
@@ -659,8 +657,7 @@ var state = tizen.download.getState(downloadId);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DownloadRequest:
-                  </span>
+<span class="return">DownloadRequest:</span>
  The download request information of the given ID.
               </ul>
 </div>
@@ -718,8 +715,7 @@ and successfully retrieves the file header.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The MIME type of the downloaded file.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/download.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/download.html
@@ -1002,10 +1002,10 @@ DownloadNetworkType <em>CELLULAR</em> can be available on a cellular-enabled dev
   typedef object DownloadHTTPHeaderFields;
   enum DownloadState { "QUEUED", "DOWNLOADING", "PAUSED", "CANCELED", "COMPLETED", "FAILED" };
   enum DownloadNetworkType { "CELLULAR", "WIFI", "ALL" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DownloadManagerObject">DownloadManagerObject</a>;
   [NoInterfaceObject] interface DownloadManagerObject {
     readonly attribute <a href="#DownloadManager">DownloadManager</a> download;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DownloadManagerObject">DownloadManagerObject</a>;
   [Constructor(DOMString url, optional DOMString? destination, optional DOMString? fileName,
                optional <a href="#DownloadNetworkType">DownloadNetworkType</a>? networkType, optional <a href="#DownloadHTTPHeaderFields">DownloadHTTPHeaderFields</a>? httpHeader)]
   interface DownloadRequest {

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/exif.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/exif.html
@@ -865,18 +865,6 @@ This callback interface specifies a success method with the URI for the thumbnai
   enum WhiteBalanceMode { "AUTO", "MANUAL" };
   enum ExposureProgram { "NOT_DEFINED", "MANUAL", "NORMAL", "APERTURE_PRIORITY", "SHUTTER_PRIORITY", "CREATIVE_PROGRAM",
     "ACTION_PROGRAM", "PORTRAIT_MODE", "LANDSCAPE_MODE" };
-  [NoInterfaceObject] interface ExifManagerObject {
-    readonly attribute <a href="#ExifManager">ExifManager</a> exif;
-  };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ExifManagerObject">ExifManagerObject</a>;
-  [NoInterfaceObject] interface ExifManager {
-    void getExifInfo(DOMString uri, <a href="#ExifInformationSuccessCallback">ExifInformationSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                     raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void saveExifInfo(<a href="#ExifInformation">ExifInformation</a> exifInfo, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getThumbnail(DOMString uri, <a href="#ExifThumbnailSuccessCallback">ExifThumbnailSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
   dictionary ExifInit {
     DOMString uri;
     unsigned long width;
@@ -897,6 +885,18 @@ This callback interface specifies a success method with the URI for the thumbnai
     DOMString gpsProcessingMethod;
     Date gpsTime;
     DOMString userComment;
+  };
+  [NoInterfaceObject] interface ExifManagerObject {
+    readonly attribute <a href="#ExifManager">ExifManager</a> exif;
+  };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ExifManagerObject">ExifManagerObject</a>;
+  [NoInterfaceObject] interface ExifManager {
+    void getExifInfo(DOMString uri, <a href="#ExifInformationSuccessCallback">ExifInformationSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                     raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void saveExifInfo(<a href="#ExifInformation">ExifInformation</a> exifInfo, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void getThumbnail(DOMString uri, <a href="#ExifThumbnailSuccessCallback">ExifThumbnailSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [Constructor(optional <a href="#ExifInit">ExifInit</a>? ExifInitDict)]
   interface ExifInformation {

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/exif.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/exif.html
@@ -886,10 +886,10 @@ This callback interface specifies a success method with the URI for the thumbnai
     Date gpsTime;
     DOMString userComment;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ExifManagerObject">ExifManagerObject</a>;
   [NoInterfaceObject] interface ExifManagerObject {
     readonly attribute <a href="#ExifManager">ExifManager</a> exif;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ExifManagerObject">ExifManagerObject</a>;
   [NoInterfaceObject] interface ExifManager {
     void getExifInfo(DOMString uri, <a href="#ExifInformationSuccessCallback">ExifInformationSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/feedback.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/feedback.html
@@ -419,10 +419,10 @@ To guarantee the running of the application on a device which supports feedback 
   enum FeedbackPattern { "TAP", "SIP", "KEY0", "KEY1", "KEY2", "KEY3", "KEY4", "KEY5", "KEY6", "KEY7", "KEY8", "KEY9",
     "KEY_STAR", "KEY_SHARP", "KEY_BACK", "HOLD", "HW_TAP", "HW_HOLD", "MESSAGE", "EMAIL", "WAKEUP", "SCHEDULE", "TIMER",
     "GENERAL", "POWERON", "POWEROFF", "CHARGERCONN", "CHARGING_ERROR", "FULLCHARGED", "LOWBATT", "LOCK", "UNLOCK", "VIBRATION_ON", "SILENT_OFF", "BT_CONNECTED", "BT_DISCONNECTED", "LIST_REORDER", "LIST_SLIDER", "VOLUME_KEY" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#FeedbackManagerObject">FeedbackManagerObject</a>;
   [NoInterfaceObject] interface FeedbackManagerObject {
     readonly attribute <a href="#FeedbackManager">FeedbackManager</a> feedback;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#FeedbackManagerObject">FeedbackManagerObject</a>;
   [NoInterfaceObject] interface FeedbackManager {
     void play(<a href="#FeedbackPattern">FeedbackPattern</a> pattern, optional <a href="#FeedbackType">FeedbackType</a>? type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void stop() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/feedback.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/feedback.html
@@ -363,8 +363,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if the pattern is supported, <var>false</var> otherwise.
               </ul>
 </div>
@@ -417,10 +416,9 @@ To guarantee the running of the application on a device which supports feedback 
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Feedback {
   enum FeedbackType { "TYPE_SOUND", "TYPE_VIBRATION" };
-  enum FeedbackPattern { "TAP", "SIP", "KEY0", "KEY1", "KEY2", "KEY3", "KEY4", "KEY5", "KEY6", "KEY7", "KEY8", "KEY9", "KEY_STAR",
-    "KEY_SHARP", "KEY_BACK", "HOLD", "HW_TAP", "HW_HOLD", "MESSAGE", "EMAIL", "WAKEUP", "SCHEDULE", "TIMER", "GENERAL", "POWERON",
-    "POWEROFF", "CHARGERCONN", "CHARGING_ERROR", "FULLCHARGED", "LOWBATT", "LOCK", "UNLOCK", "VIBRATION_ON", "SILENT_OFF",
-    "BT_CONNECTED", "BT_DISCONNECTED", "LIST_REORDER", "LIST_SLIDER", "VOLUME_KEY" };
+  enum FeedbackPattern { "TAP", "SIP", "KEY0", "KEY1", "KEY2", "KEY3", "KEY4", "KEY5", "KEY6", "KEY7", "KEY8", "KEY9",
+    "KEY_STAR", "KEY_SHARP", "KEY_BACK", "HOLD", "HW_TAP", "HW_HOLD", "MESSAGE", "EMAIL", "WAKEUP", "SCHEDULE", "TIMER",
+    "GENERAL", "POWERON", "POWEROFF", "CHARGERCONN", "CHARGING_ERROR", "FULLCHARGED", "LOWBATT", "LOCK", "UNLOCK", "VIBRATION_ON", "SILENT_OFF", "BT_CONNECTED", "BT_DISCONNECTED", "LIST_REORDER", "LIST_SLIDER", "VOLUME_KEY" };
   [NoInterfaceObject] interface FeedbackManagerObject {
     readonly attribute <a href="#FeedbackManager">FeedbackManager</a> feedback;
   };

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/filesystem.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/filesystem.html
@@ -7026,10 +7026,10 @@ This callback interface specifies a success callback with a function taking an a
     Date startCreated;
     Date endCreated;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#FileSystemManagerObject">FileSystemManagerObject</a>;
   [NoInterfaceObject] interface FileSystemManagerObject {
     readonly attribute <a href="#FileSystemManager">FileSystemManager</a> filesystem;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#FileSystemManagerObject">FileSystemManagerObject</a>;
   [NoInterfaceObject] interface FileSystemManager {
     readonly attribute long maxNameLength;
     readonly attribute long maxPathLength;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/filesystem.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/filesystem.html
@@ -476,7 +476,9 @@ There is a <em>tizen.filesystem </em>object that allows accessing the functional
     boolean isDirectory(<a href="#Path">Path</a> path) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     boolean pathExists(<a href="#Path">Path</a> path) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     DOMString getDirName(DOMString path);
-    void getStorage(DOMString label, <a href="#FileSystemStorageSuccessCallback">FileSystemStorageSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror)
+<span class="nocode deprecated">    void resolve(DOMString location, <a href="#FileSuccessCallback">FileSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, optional <a href="#FileMode">FileMode</a>? mode)
+                 raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void getStorage(DOMString label, <a href="#FileSystemStorageSuccessCallback">FileSystemStorageSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror)
                     raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void listStorages(<a href="#FileSystemStorageArraySuccessCallback">FileSystemStorageArraySuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addStorageStateChangeListener(<a href="#FileSystemStorageSuccessCallback">FileSystemStorageSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror)
@@ -600,8 +602,7 @@ By default, <em>makeParents</em> is equal to <var>true</var>. Its value is ignor
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">FileHandle:
-                  </span>
+<span class="return">FileHandle:</span>
  Object representing open file.
               </ul>
 </div>
@@ -656,7 +657,7 @@ File content: Lorem ipsum dolor sit amet...
 <div class="brief">
  Creates directory pointed by <em>path</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void createDirectory(<a href="#Path">Path</a> path, optional boolean makeParents, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void createDirectory(<a href="#Path">Path</a> path, optional boolean makeParents, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -844,7 +845,7 @@ catch (error)
 <div class="brief">
  Deletes directory or directory tree under the current directory pointed by <em>path</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void deleteDirectory(<a href="#Path">Path</a> path, optional boolean recursive, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void deleteDirectory(<a href="#Path">Path</a> path, optional boolean recursive, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -940,7 +941,7 @@ catch (error)
 <div class="brief">
  Copies file from location pointed by <em>sourcePath</em> to <em>destinationPath</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void copyFile(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void copyFile(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback,
               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1044,7 +1045,7 @@ catch (error)
 <div class="brief">
  Recursively copies directory pointed by <em>sourcePath</em> to <em>destinationPath</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void copyDirectory(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, 
+<div class="synopsis"><pre class="signature prettyprint">void copyDirectory(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite,
                    optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1213,7 +1214,7 @@ file
 <div class="brief">
  Moves file pointed by <em>sourcePath</em> to <em>destinationPath</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void moveFile(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void moveFile(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback,
               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1318,7 +1319,7 @@ catch (error)
 <div class="brief">
  Recursively moves directory pointed by <em>sourcePath</em> to <em>destinationPath</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void moveDirectory(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, 
+<div class="synopsis"><pre class="signature prettyprint">void moveDirectory(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite,
                    optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1519,7 +1520,7 @@ catch (error)
 <div class="brief">
  Lists directory content located in <em>path</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void listDirectory(<a href="#Path">Path</a> path, <a href="#ListDirectorySuccessCallback">ListDirectorySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void listDirectory(<a href="#Path">Path</a> path, <a href="#ListDirectorySuccessCallback">ListDirectorySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                    optional <a href="#FileFilter">FileFilter</a>? filter);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1649,8 +1650,7 @@ foo_dir_a
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  <a href="https://tools.ietf.org/html/rfc8089">File URI</a> for given path.
               </ul>
 </div>
@@ -1712,8 +1712,7 @@ file:///mnt/media/SDCardA1/Documents/directory/file.ext
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if <em>path</em> points to a file, <var>false</var> otherwise.
               </ul>
 </div>
@@ -1774,8 +1773,7 @@ file:///mnt/media/SDCardA1/Documents/directory/file.ext
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if <em>path</em> points to a directory, <var>false</var> otherwise.
               </ul>
 </div>
@@ -1836,8 +1834,7 @@ file:///mnt/media/SDCardA1/Documents/directory/file.ext
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if <em>path</em> points to a existing element, <var>false</var> otherwise.
               </ul>
 </div>
@@ -1897,8 +1894,7 @@ Strips trailing '/', then breaks <em>path</em> into two components by last <em>p
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  Path to directory for given path.
               </ul>
 </div>
@@ -2228,8 +2224,7 @@ The watch operation must continue until the removeStorageStateChangeListener() m
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Subscription identifier.
               </ul>
 </div>
@@ -2468,8 +2463,7 @@ Note, that current position indicator value, can be obtained by calling <var>see
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long long:
-                  </span>
+<span class="return">long long:</span>
  File position indicator.
               </ul>
 </div>
@@ -2524,7 +2518,7 @@ Bytes between: 44,55,66
 <div class="brief">
  Sets position indicator in file stream to <var>offset</var>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void seekNonBlocking(long long offset, optional <a href="#SeekSuccessCallback">SeekSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">void seekNonBlocking(long long offset, optional <a href="#SeekSuccessCallback">SeekSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
                      optional <a href="#BaseSeekPosition">BaseSeekPosition</a> whence);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -2711,8 +2705,7 @@ Reads given number of characters.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  String with data read from file.
               </ul>
 </div>
@@ -2767,7 +2760,7 @@ File content: Lorem ipsum dolor sit amet...
 <div class="brief">
  Reads file content as string.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void readStringNonBlocking(optional <a href="#ReadStringSuccessCallback">ReadStringSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">void readStringNonBlocking(optional <a href="#ReadStringSuccessCallback">ReadStringSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
                            optional long long count, optional DOMString inputEncoding);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -2912,8 +2905,7 @@ Sets file handle position indicator at the end of written data.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long long:
-                  </span>
+<span class="return">long long:</span>
  Number of bytes written (can be more than <em>inputString</em> length for multibyte encodings and will never be less)
               </ul>
 </div>
@@ -2962,7 +2954,7 @@ File content: Lorem ipsum dolor sit amet...
 <div class="brief">
  Writes <var>inputString</var> content to a file.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void writeStringNonBlocking(DOMString inputString, optional <a href="#WriteStringSuccessCallback">WriteStringSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">void writeStringNonBlocking(DOMString inputString, optional <a href="#WriteStringSuccessCallback">WriteStringSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
                             optional DOMString outputEncoding);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -3098,8 +3090,7 @@ Sets file handle position indicator at the end of read data.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Blob:
-                  </span>
+<span class="return">Blob:</span>
  Blob object with file content.
               </ul>
 </div>
@@ -3482,8 +3473,7 @@ Sets file handle position indicator at the end of read data.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Uint8Array:
-                  </span>
+<span class="return">Uint8Array:</span>
  Read data as Uint8Array.
               </ul>
 </div>
@@ -4286,8 +4276,36 @@ File handle closed
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface File {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface File {
+<span class="nocode deprecated">    readonly attribute <a href="#File">File</a>? parent;
+</span><span class="nocode deprecated">    readonly attribute boolean readOnly;
+</span><span class="nocode deprecated">    readonly attribute boolean isFile;
+</span><span class="nocode deprecated">    readonly attribute boolean isDirectory;
+</span><span class="nocode deprecated">    readonly attribute Date? created;
+</span><span class="nocode deprecated">    readonly attribute Date? modified;
+</span><span class="nocode deprecated">    readonly attribute DOMString path;
+</span><span class="nocode deprecated">    readonly attribute DOMString name;
+</span><span class="nocode deprecated">    readonly attribute DOMString fullPath;
+</span><span class="nocode deprecated">    readonly attribute unsigned long long fileSize;
+</span><span class="nocode deprecated">    readonly attribute long length;
+</span><span class="nocode deprecated">    DOMString toURI() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void listFiles(<a href="#FileArraySuccessCallback">FileArraySuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, optional <a href="#FileFilter">FileFilter</a>? filter)
+                   raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void openStream(<a href="#FileMode">FileMode</a> mode, <a href="#FileStreamSuccessCallback">FileStreamSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, optional DOMString? encoding)
+                    raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void readAsText(<a href="#FileStringSuccessCallback">FileStringSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, optional DOMString? encoding)
+                    raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void copyTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
+                optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void moveTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
+                optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    <a href="#File">File</a> createDirectory(DOMString dirPath) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    <a href="#File">File</a> createFile(DOMString relativeFilePath) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    <a href="#File">File</a> resolve(DOMString filePath) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void deleteDirectory(DOMString directoryPath, boolean recursive, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
+                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void deleteFile(DOMString filePath, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -4722,8 +4740,7 @@ These URIs must not be accessible to other widgets, apart from the one invoking 
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  URI that identifies the file or <var>null</var> if an error occurs.
               </ul>
 </div>
@@ -5078,7 +5095,7 @@ directory from a specified location to another specified location.
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
             </p>
-<div class="synopsis"><pre class="signature prettyprint">void copyTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, 
+<div class="synopsis"><pre class="signature prettyprint">void copyTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
             optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -5197,7 +5214,7 @@ This operation is different from instantiating copyTo() and then deleting the or
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
             </p>
-<div class="synopsis"><pre class="signature prettyprint">void moveTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, 
+<div class="synopsis"><pre class="signature prettyprint">void moveTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
             optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -5355,8 +5372,7 @@ In case the directory cannot be created, an error must be thrown with the approp
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">File:
-                  </span>
+<span class="return">File:</span>
  File handle of the new directory.
 The new <em>File </em>object has "rw" access rights, as it inherits this from the <em>File </em>object on which the createDirectory() method is called.
               </ul>
@@ -5432,8 +5448,7 @@ In case the file cannot be created, an error must be thrown with the appropriate
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">File:
-                  </span>
+<span class="return">File:</span>
  File handle for the new empty file.
 The new <em>File </em>object has "rw" access rights, as it inherits this from the <em>File </em>object on which the createFile() method is
 called.
@@ -5505,8 +5520,7 @@ The encoding of file paths is <a href="http://www.ietf.org/rfc/rfc2279.txt">UTF-
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">File:
-                  </span>
+<span class="return">File:</span>
  File handle of the file.
 The new <em>File </em>object inherits its access rights from the <em>File </em>object on which this resolve() method is called.
               </ul>
@@ -5562,7 +5576,7 @@ tizen.filesystem.resolve("documents",
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
             </p>
-<div class="synopsis"><pre class="signature prettyprint">void deleteDirectory(DOMString directoryPath, boolean recursive, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, 
+<div class="synopsis"><pre class="signature prettyprint">void deleteDirectory(DOMString directoryPath, boolean recursive, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -5926,8 +5940,18 @@ Read and write operations are performed relative to a position attribute, which 
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface FileStream {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface FileStream {
+<span class="nocode deprecated">    readonly attribute boolean eof;
+</span><span class="nocode deprecated">    attribute long position;
+</span><span class="nocode deprecated">    readonly attribute long bytesAvailable;
+</span><span class="nocode deprecated">    void close();
+</span><span class="nocode deprecated">    DOMString read(long charCount) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    octet[] readBytes(long byteCount) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    DOMString readBase64(long byteCount) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void write(DOMString stringData) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void writeBytes(octet[] byteData) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void writeBase64(DOMString base64Data) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -6089,8 +6113,7 @@ The resulting string length might be shorter than <em>charCount </em>if EOF is <
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  Array of read characters as a string.
               </ul>
 </div>
@@ -6150,8 +6173,7 @@ stream.close();
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">octet[]:
-                  </span>
+<span class="return">octet[]:</span>
  Result of read bytes as a byte (or number) array.
               </ul>
 </div>
@@ -6215,8 +6237,7 @@ for (var i = 0; i &lt; raw.length; i++)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  Array of read characters as base64 encoding string.
               </ul>
 </div>
@@ -6408,8 +6429,9 @@ output.writeBase64(base64);
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileSuccessCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback=FunctionOnly, NoInterfaceObject] interface FileSuccessCallback {
+<span class="nocode deprecated">    void onsuccess(<a href="#File">File</a> file);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -6800,8 +6822,9 @@ It is used in asynchronous operation FileHandle.readDataNonBlocking().
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileStringSuccessCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback=FunctionOnly, NoInterfaceObject] interface FileStringSuccessCallback {
+<span class="nocode deprecated">    void onsuccess(DOMString fileStr);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -6848,8 +6871,9 @@ It is used in asynchronous operation File.readAsText().
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileStreamSuccessCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback=FunctionOnly, NoInterfaceObject] interface FileStreamSuccessCallback {
+<span class="nocode deprecated">    void onsuccess(<a href="#FileStream">FileStream</a> filestream);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -6943,8 +6967,9 @@ This callback interface specifies a success callback with a function taking an a
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileArraySuccessCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback=FunctionOnly, NoInterfaceObject] interface FileArraySuccessCallback {
+<span class="nocode deprecated">    void onsuccess(<a href="#File">File</a>[] files);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -6987,11 +7012,20 @@ This callback interface specifies a success callback with a function taking an a
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Filesystem {
   typedef DOMString Path;
+  typedef <a href="#Blob">Blob</a> Blob;
   enum FileMode { "a", "r", "rw", "rwo", "w" };
   enum FileSystemStorageType { "INTERNAL", "EXTERNAL" };
   enum FileSystemStorageState { "MOUNTED", "REMOVED", "UNMOUNTABLE" };
-  typedef <a href="#Blob">Blob</a> Blob;
   enum BaseSeekPosition { "BEGIN", "CURRENT", "END" };
+  dictionary FileFilter {
+    DOMString name;
+    boolean isFile;
+    boolean isDirectory;
+    Date startModified;
+    Date endModified;
+    Date startCreated;
+    Date endCreated;
+  };
   [NoInterfaceObject] interface FileSystemManagerObject {
     readonly attribute <a href="#FileSystemManager">FileSystemManager</a> filesystem;
   };
@@ -7063,15 +7097,6 @@ This callback interface specifies a success callback with a function taking an a
     void syncNonBlocking(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void close() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void closeNonBlocking(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  dictionary FileFilter {
-    DOMString name;
-    boolean isFile;
-    boolean isDirectory;
-    Date startModified;
-    Date endModified;
-    Date startCreated;
-    Date endCreated;
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface FileSystemStorageArraySuccessCallback {
     void onsuccess(<a href="#FileSystemStorage">FileSystemStorage</a>[] storages);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/fmradio.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/fmradio.html
@@ -1043,10 +1043,10 @@ To guarantee that the FM radio application runs on a device with FM radio, decla
     "RADIO_INTERRUPTED_BY_NOTIFICATION", "RADIO_INTERRUPTED_BY_EMERGENCY", "RADIO_INTERRUPTED_BY_VOICE_INFORMATION",
     "RADIO_INTERRUPTED_BY_VOICE_RECOGNITION", "RADIO_INTERRUPTED_BY_RINGTONE", "RADIO_INTERRUPTED_BY_VOIP", "RADIO_INTERRUPTED_BY_CALL",
     "RADIO_INTERRUPTED_BY_MEDIA_EXTERNAL_ONLY" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#FMRadioObject">FMRadioObject</a>;
   [NoInterfaceObject] interface FMRadioObject {
     readonly attribute <a href="#FMRadioManager">FMRadioManager</a> fmradio;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#FMRadioObject">FMRadioObject</a>;
   [NoInterfaceObject] interface FMRadioManager {
     readonly attribute double frequency;
     readonly attribute double frequencyUpperBound;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/humanactivitymonitor.html
@@ -3204,10 +3204,10 @@ To guarantee that the stress monitor vector sensor application runs on a device 
     long callbackInterval;
     long sampleInterval;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#HumanActivityMonitorManagerObject">HumanActivityMonitorManagerObject</a>;
   [NoInterfaceObject] interface HumanActivityMonitorManagerObject {
     readonly attribute <a href="#HumanActivityMonitorManager">HumanActivityMonitorManager</a> humanactivitymonitor;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#HumanActivityMonitorManagerObject">HumanActivityMonitorManagerObject</a>;
   [NoInterfaceObject] interface HumanActivityMonitorManager {
     void getHumanActivityData(<a href="#HumanActivityType">HumanActivityType</a> type, <a href="#HumanActivityMonitorSuccessCallback">HumanActivityMonitorSuccessCallback</a> successCallback,
                               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/humanactivitymonitor.html
@@ -576,7 +576,7 @@ The <em>tizen.humanactivitymonitor</em> object allows access to the human activi
 <div class="brief">
  Gets the current human activity data for certain human activity types.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getHumanActivityData(<a href="#HumanActivityType">HumanActivityType</a> type, <a href="#HumanActivityMonitorSuccessCallback">HumanActivityMonitorSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getHumanActivityData(<a href="#HumanActivityType">HumanActivityType</a> type, <a href="#HumanActivityMonitorSuccessCallback">HumanActivityMonitorSuccessCallback</a> successCallback,
                           optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -679,7 +679,7 @@ Cumulative total step count: 100
 <div class="brief">
  Starts a sensor and registers a change listener to be called when new human activity data for a given human activity type is available.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void start(<a href="#HumanActivityType">HumanActivityType</a> type, optional <a href="#HumanActivityMonitorSuccessCallback">HumanActivityMonitorSuccessCallback</a>? changedCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void start(<a href="#HumanActivityType">HumanActivityType</a> type, optional <a href="#HumanActivityMonitorSuccessCallback">HumanActivityMonitorSuccessCallback</a>? changedCallback,
            optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="#HumanActivityMonitorOption">HumanActivityMonitorOption</a>? option);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -968,7 +968,7 @@ Calling this function has no effect if listener is not set.
 <div class="brief">
  Registers a listener that is to be called when the activity is recognized.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long addActivityRecognitionListener(<a href="#ActivityRecognitionType">ActivityRecognitionType</a> type, <a href="#HumanActivityMonitorSuccessCallback">HumanActivityMonitorSuccessCallback</a> listener, 
+<div class="synopsis"><pre class="signature prettyprint">long addActivityRecognitionListener(<a href="#ActivityRecognitionType">ActivityRecognitionType</a> type, <a href="#HumanActivityMonitorSuccessCallback">HumanActivityMonitorSuccessCallback</a> listener,
                                     optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1002,8 +1002,7 @@ The <em>ErrorCallback</em> method is launched with this error type:
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  ID of the listener that can be used to remove the listener later.
               </ul>
 </div>
@@ -1251,7 +1250,7 @@ catch (err)
 <div class="brief">
  Reads the recorded human activity data with some query.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void readRecorderData(<a href="#HumanActivityRecorderType">HumanActivityRecorderType</a> type, <a href="#HumanActivityRecorderQuery">HumanActivityRecorderQuery</a>? query, 
+<div class="synopsis"><pre class="signature prettyprint">void readRecorderData(<a href="#HumanActivityRecorderType">HumanActivityRecorderType</a> type, <a href="#HumanActivityRecorderQuery">HumanActivityRecorderQuery</a>? query,
                       <a href="#HumanActivityReadRecorderSuccessCallback">HumanActivityReadRecorderSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1382,8 +1381,7 @@ This function allows to check whether a gesture type is supported on the current
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if the given gesture type is supported.
               </ul>
 </div>
@@ -1423,7 +1421,7 @@ catch (error)
 <div class="brief">
  Adds a listener to be invoked when given gesture type is detected.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long addGestureRecognitionListener(<a href="#GestureType">GestureType</a> type, <a href="#GestureRecognitionCallback">GestureRecognitionCallback</a> listener, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">long addGestureRecognitionListener(<a href="#GestureType">GestureType</a> type, <a href="#GestureRecognitionCallback">GestureRecognitionCallback</a> listener, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                                    optional boolean? alwaysOn);</pre></div>
 <p><span class="version">Since: </span>
  4.0
@@ -1461,8 +1459,7 @@ The <em>ErrorCallback</em> method is launched with this error type:
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The watch ID used to remove the listener.
               </ul>
 </div>
@@ -1718,8 +1715,7 @@ Within the range 10-15                </td>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The watch ID used to remove the listener.
               </ul>
 </div>
@@ -3184,17 +3180,30 @@ To guarantee that the stress monitor vector sensor application runs on a device 
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module HumanActivityMonitor {
-  enum HumanActivityType { "PEDOMETER", "WRIST_UP", "HRM", "GPS", "SLEEP_MONITOR", "SLEEP_DETECTOR", "STRESS_MONITOR" };
+  enum HumanActivityType { "PEDOMETER", "HRM", "GPS", "SLEEP_MONITOR", "SLEEP_DETECTOR", "STRESS_MONITOR" };
   enum HumanActivityRecorderType { "PEDOMETER", "HRM", "SLEEP_MONITOR", "PRESSURE" };
   enum PedometerStepStatus { "NOT_MOVING", "WALKING", "RUNNING", "UNKNOWN" };
   enum ActivityRecognitionType { "STATIONARY", "WALKING", "RUNNING", "IN_VEHICLE" };
   enum ActivityAccuracy { "LOW", "MEDIUM", "HIGH" };
   enum SleepStatus { "ASLEEP", "AWAKE", "UNKNOWN" };
-  enum GestureType { "GESTURE_DOUBLE_TAP", "GESTURE_MOVE_TO_EAR", "GESTURE_NO_MOVE", "GESTURE_PICK_UP", "GESTURE_SHAKE", "GESTURE_SNAP",
-    "GESTURE_TILT", "GESTURE_TURN_FACE_DOWN", "GESTURE_WRIST_UP" };
+  enum GestureType { "GESTURE_DOUBLE_TAP", "GESTURE_MOVE_TO_EAR", "GESTURE_NO_MOVE", "GESTURE_PICK_UP", "GESTURE_SHAKE",
+    "GESTURE_SNAP", "GESTURE_TILT", "GESTURE_TURN_FACE_DOWN", "GESTURE_WRIST_UP" };
   enum GestureEvent { "GESTURE_EVENT_DETECTED", "GESTURE_SHAKE_DETECTED", "GESTURE_SHAKE_FINISHED", "GESTURE_SNAP_X_NEGATIVE",
-    "GESTURE_SNAP_X_POSITIVE", "GESTURE_SNAP_Y_NEGATIVE", "GESTURE_SNAP_Y_POSITIVE", "GESTURE_SNAP_Z_NEGATIVE",
-    "GESTURE_SNAP_Z_POSITIVE" };
+    "GESTURE_SNAP_X_POSITIVE", "GESTURE_SNAP_Y_NEGATIVE", "GESTURE_SNAP_Y_POSITIVE", "GESTURE_SNAP_Z_NEGATIVE", "GESTURE_SNAP_Z_POSITIVE" };
+  dictionary HumanActivityRecorderOption {
+    long interval;
+    long retentionPeriod;
+  };
+  dictionary HumanActivityRecorderQuery {
+    long startTime;
+    long endTime;
+    long anchorTime;
+    long interval;
+  };
+  dictionary HumanActivityMonitorOption {
+    long callbackInterval;
+    long sampleInterval;
+  };
   [NoInterfaceObject] interface HumanActivityMonitorManagerObject {
     readonly attribute <a href="#HumanActivityMonitorManager">HumanActivityMonitorManager</a> humanactivitymonitor;
   };
@@ -3225,16 +3234,6 @@ To guarantee that the stress monitor vector sensor application runs on a device 
   [NoInterfaceObject] interface StepDifference {
     readonly attribute long stepCountDifference;
     readonly attribute long timestamp;
-  };
-  dictionary HumanActivityRecorderOption {
-    long interval;
-    long retentionPeriod;
-  };
-  dictionary HumanActivityRecorderQuery {
-    long startTime;
-    long endTime;
-    long anchorTime;
-    long interval;
   };
   [NoInterfaceObject] interface HumanActivityData {
   };
@@ -3284,10 +3283,6 @@ To guarantee that the stress monitor vector sensor application runs on a device 
   };
   [NoInterfaceObject] interface HumanActivityStressMonitorData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute long stressScore;
-  };
-  dictionary HumanActivityMonitorOption {
-    long callbackInterval;
-    long sampleInterval;
   };
   [NoInterfaceObject] interface HumanActivityRecognitionData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#ActivityRecognitionType">ActivityRecognitionType</a> type;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/inputdevice.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/inputdevice.html
@@ -539,10 +539,10 @@ tizen.inputdevice.unregisterKeyBatch(keys, successCB, errorCB);
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module InputDevice {
   typedef DOMString InputDeviceKeyName;
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#InputDeviceManagerObject">InputDeviceManagerObject</a>;
   [NoInterfaceObject] interface InputDeviceManagerObject {
     readonly attribute <a href="#InputDeviceManager">InputDeviceManager</a> inputdevice;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#InputDeviceManagerObject">InputDeviceManagerObject</a>;
   [NoInterfaceObject] interface InputDeviceKey {
     readonly attribute <a href="#InputDeviceKeyName">InputDeviceKeyName</a> name;
     readonly attribute long code;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/inputdevice.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/inputdevice.html
@@ -218,8 +218,7 @@ Mandatory keys will not be retrieved by this method.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">InputDeviceKey[]:
-                  </span>
+<span class="return">InputDeviceKey[]:</span>
  List of supported keys.
               </ul>
 </div>
@@ -275,8 +274,7 @@ window.addEventListener("keydown", function(keyEvent)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">InputDeviceKey:
-                  </span>
+<span class="return">InputDeviceKey<span class="optional"> [nullable]</span>:</span>
  InputDeviceKey object for the given key name or <var>null</var> if the key is not supported.
               </ul>
 </div>
@@ -393,7 +391,7 @@ for (i = 0; i &lt; keys.length; i++)
 <div class="brief">
  Registers a batch of input device keys to receive DOM keyboard event when any of them is pressed or released
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void registerKeyBatch(<a href="#InputDeviceKeyName">InputDeviceKeyName</a>[] keyNames, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void registerKeyBatch(<a href="#InputDeviceKeyName">InputDeviceKeyName</a>[] keyNames, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -470,7 +468,7 @@ tizen.inputdevice.registerKeyBatch(keys, successCB, errorCB);
 <div class="brief">
  Unregisters a batch of input device keys
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void unregisterKeyBatch(<a href="#InputDeviceKeyName">InputDeviceKeyName</a>[] keyNames, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void unregisterKeyBatch(<a href="#InputDeviceKeyName">InputDeviceKeyName</a>[] keyNames, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/iotcon.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/iotcon.html
@@ -4812,10 +4812,10 @@ To guarantee this application will run on a device with a Iotcon, add the below 
     <a href="#ResourceInterface">ResourceInterface</a>? resourceInterface;
     object? filter;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#IotconObject">IotconObject</a>;
   [NoInterfaceObject] interface IotconObject {
     readonly attribute <a href="#Iotcon">Iotcon</a> iotcon;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#IotconObject">IotconObject</a>;
   [NoInterfaceObject] interface Iotcon {
     attribute DOMString deviceName;
     void initialize(DOMString filePath) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/iotcon.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/iotcon.html
@@ -634,8 +634,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Client:
-                  </span>
+<span class="return">Client:</span>
  The <em>Client</em> object.
               </ul>
 </div>
@@ -668,8 +667,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Server:
-                  </span>
+<span class="return">Server:</span>
  The <em>Server</em> object.
               </ul>
 </div>
@@ -708,8 +706,7 @@ Without a response after the specified time, the mentioned methods would trigger
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The timeout value in seconds.
               </ul>
 </div>
@@ -795,8 +792,7 @@ console.log("Timeout value is " + timeout);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The watchID which can be used to remove the listener.
               </ul>
 </div>
@@ -870,14 +866,14 @@ watchId = tizen.iotcon.addGeneratedPinListener(RandomPinSuccess);
  The Client provides API for client side.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface Client {
-    void findResource(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findResource(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                       <a href="#FoundResourceSuccessCallback">FoundResourceSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addPresenceEventListener(DOMString? hostAddress, <a href="#ResourceType">ResourceType</a>? resourceType, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                                   <a href="#PresenceEventCallback">PresenceEventCallback</a> successCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removePresenceEventListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                         <a href="#FoundDeviceInfoSuccessCallback">FoundDeviceInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                           <a href="#FoundPlatformInfoSuccessCallback">FoundPlatformInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                           raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
@@ -894,7 +890,7 @@ watchId = tizen.iotcon.addGeneratedPinListener(RandomPinSuccess);
 <div class="brief">
  Finds resources using host address and resource type.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void findResource(DOMString? hostAddress, <a href="#Query">Query</a>? query<a href="#ConnectivityType">ConnectivityType</a> connectivityType, 
+<div class="synopsis"><pre class="signature prettyprint">void findResource(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                   <a href="#FoundResourceSuccessCallback">FoundResourceSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1022,7 +1018,7 @@ Resource interfaces:
  Adds a listener to receive a presence events from the server.
 A server sends presence events when starts or stops presence.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long addPresenceEventListener(DOMString? hostAddress, <a href="#ResourceType">ResourceType</a>? resourceType, <a href="#ConnectivityType">ConnectivityType</a> connectivityType, 
+<div class="synopsis"><pre class="signature prettyprint">long addPresenceEventListener(DOMString? hostAddress, <a href="#ResourceType">ResourceType</a>? resourceType, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                               <a href="#PresenceEventCallback">PresenceEventCallback</a> successCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1057,8 +1053,7 @@ A server sends presence events when starts or stops presence.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The watchID which can be used to remove the listener.
               </ul>
 </div>
@@ -1167,7 +1162,7 @@ Resource type: oic.wk.ad
 <div class="brief">
  Gets the device information of remote server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query<a href="#ConnectivityType">ConnectivityType</a> connectivityType, 
+<div class="synopsis"><pre class="signature prettyprint">void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                     <a href="#FoundDeviceInfoSuccessCallback">FoundDeviceInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1286,7 +1281,7 @@ Data model version: res.1.0.0
 <div class="brief">
  Gets the platform information of remote server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query<a href="#ConnectivityType">ConnectivityType</a> connectivityType, 
+<div class="synopsis"><pre class="signature prettyprint">void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                       <a href="#FoundPlatformInfoSuccessCallback">FoundPlatformInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1446,8 +1441,7 @@ There are different resource types, for example a temperature sensor, a light co
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Resource[]:
-                  </span>
+<span class="return">Resource[]:</span>
  Array of <em>Resource</em> objects registered on server.
               </ul>
 </div>
@@ -1471,7 +1465,7 @@ var resources = server.getResources();
 <div class="brief">
  Creates a resource and registers the resource on server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint"><a href="#Resource">Resource</a> createResource(DOMString uriPath, <a href="#ResourceType">ResourceType</a>[] resourceTypes, <a href="#ResourceInterface">ResourceInterface</a>[] resourceInterfaces, 
+<div class="synopsis"><pre class="signature prettyprint"><a href="#Resource">Resource</a> createResource(DOMString uriPath, <a href="#ResourceType">ResourceType</a>[] resourceTypes, <a href="#ResourceInterface">ResourceInterface</a>[] resourceInterfaces,
                         <a href="#RequestCallback">RequestCallback</a> listener, optional <a href="#ResourcePolicy">ResourcePolicy</a> policy);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1510,8 +1504,7 @@ var resources = server.getResources();
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Resource:
-                  </span>
+<span class="return">Resource:</span>
  Instance of <em>Resource</em> object.
               </ul>
 </div>
@@ -2041,7 +2034,7 @@ key: openstate, value: open
 <div class="brief">
  Puts the representation of a resource for update.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void methodPut(<a href="#Representation">Representation</a> representation, <a href="#RemoteResourceResponseCallback">RemoteResourceResponseCallback</a> responseCallback, optional <a href="#Query">Query</a>? query, 
+<div class="synopsis"><pre class="signature prettyprint">void methodPut(<a href="#Representation">Representation</a> representation, <a href="#RemoteResourceResponseCallback">RemoteResourceResponseCallback</a> responseCallback, optional <a href="#Query">Query</a>? query,
                optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -2160,7 +2153,7 @@ key: openstate, value: closed
 <div class="brief">
  Posts the representation of a resource for create.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void methodPost(<a href="#Representation">Representation</a> representation, <a href="#RemoteResourceResponseCallback">RemoteResourceResponseCallback</a> responseCallback, optional <a href="#Query">Query</a>? query, 
+<div class="synopsis"><pre class="signature prettyprint">void methodPost(<a href="#Representation">Representation</a> representation, <a href="#RemoteResourceResponseCallback">RemoteResourceResponseCallback</a> responseCallback, optional <a href="#Query">Query</a>? query,
                 optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -3812,7 +3805,7 @@ query["filter"] = filter;
  The Request interface represents a details from client.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface Request {
-    readonly attribute DOMString  hostAddress;
+    readonly attribute DOMString hostAddress;
     readonly attribute <a href="#ConnectivityType">ConnectivityType</a> connectivityType;
     readonly attribute <a href="#Representation">Representation</a>? representation;
     readonly attribute <a href="#IotconOption">IotconOption</a>[] options;
@@ -4798,14 +4791,27 @@ To guarantee this application will run on a device with a Iotcon, add the below 
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Iotcon {
   typedef DOMString ResourceType;
+  typedef DOMString ResourceInterface;
   enum QosLevel { "HIGH", "LOW" };
   enum ResponseResult { "SUCCESS", "ERROR", "RESOURCE_CREATED", "RESOURCE_DELETED", "RESOURCE_CHANGED", "SLOW", "FORBIDDEN" };
   enum PresenceResponseResultType { "OK", "STOPPED", "TIMEOUT" };
   enum PresenceTriggerType { "CREATED", "UPDATED", "DESTROYED" };
   enum ConnectivityType { "IP", "PREFER_UDP", "PREFER_TCP", "IPV4_ONLY", "IPV6_ONLY", "ALL" };
-  typedef DOMString ResourceInterface;
   enum ObservePolicy { "IGNORE_OUT_OF_ORDER", "ACCEPT_OUT_OF_ORDER" };
   enum ObserveType { "NO_TYPE", "REGISTER", "DEREGISTER" };
+  dictionary ResourcePolicy {
+    boolean isObservable;
+    boolean isDiscoverable;
+    boolean isActive;
+    boolean isSlow;
+    boolean isSecure;
+    boolean isExplicitDiscoverable;
+  };
+  dictionary Query {
+    <a href="#ResourceType">ResourceType</a>? resourceType;
+    <a href="#ResourceInterface">ResourceInterface</a>? resourceInterface;
+    object? filter;
+  };
   [NoInterfaceObject] interface IotconObject {
     readonly attribute <a href="#Iotcon">Iotcon</a> iotcon;
   };
@@ -4821,14 +4827,14 @@ To guarantee this application will run on a device with a Iotcon, add the below 
     void removeGeneratedPinListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface Client {
-    void findResource(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findResource(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                       <a href="#FoundResourceSuccessCallback">FoundResourceSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addPresenceEventListener(DOMString? hostAddress, <a href="#ResourceType">ResourceType</a>? resourceType, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                                   <a href="#PresenceEventCallback">PresenceEventCallback</a> successCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removePresenceEventListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                         <a href="#FoundDeviceInfoSuccessCallback">FoundDeviceInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                           <a href="#FoundPlatformInfoSuccessCallback">FoundPlatformInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                           raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
@@ -4872,14 +4878,6 @@ To guarantee this application will run on a device with a Iotcon, add the below 
     void setResourceStateChangeListener(<a href="#ResourceStateChangeCallback">ResourceStateChangeCallback</a> successCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unsetResourceStateChangeListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
-  dictionary ResourcePolicy {
-    boolean isObservable;
-    boolean isDiscoverable;
-    boolean isActive;
-    boolean isSlow;
-    boolean isSecure;
-    boolean isExplicitDiscoverable;
-  };
   [NoInterfaceObject] interface Resource {
     readonly attribute DOMString uriPath;
     readonly attribute <a href="#ResourceType">ResourceType</a>[] resourceTypes;
@@ -4916,18 +4914,13 @@ To guarantee this application will run on a device with a Iotcon, add the below 
     readonly attribute <a href="#PresenceResponseResultType">PresenceResponseResultType</a> resultType;
     readonly attribute <a href="#PresenceTriggerType">PresenceTriggerType</a>? triggerType;
   };
-  dictionary Query {
-    <a href="#ResourceType">ResourceType</a>? resourceType;
-    <a href="#ResourceInterface">ResourceInterface</a>? resourceInterface;
-    object? filter;
-  };
   [Constructor(unsigned long id, DOMString data)]
   interface IotconOption {
     attribute unsigned long id;
     attribute DOMString data;
   };
   [NoInterfaceObject] interface Request {
-    readonly attribute DOMString  hostAddress;
+    readonly attribute DOMString hostAddress;
     readonly attribute <a href="#ConnectivityType">ConnectivityType</a> connectivityType;
     readonly attribute <a href="#Representation">Representation</a>? representation;
     readonly attribute <a href="#IotconOption">IotconOption</a>[] options;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/keymanager.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/keymanager.html
@@ -172,7 +172,7 @@ It provides access to the API functionalities through the <em>tizen.keymanager</
 <div class="brief">
  Saves and stores data as a <a href="#KeyManagerAlias">KeyManagerAlias</a> inside the KeyManager.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void saveData(DOMString name, <a href="#RawData">RawData</a> rawData, optional DOMString? password, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void saveData(DOMString name, <a href="#RawData">RawData</a> rawData, optional DOMString? password, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -338,8 +338,7 @@ If an application calls this method to retrieve raw data which it saved into the
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">RawData:
-                  </span>
+<span class="return">RawData:</span>
  Data.
               </ul>
 </div>
@@ -402,8 +401,7 @@ if (aliases.length != 0)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">KeyManagerAlias[]:
-                  </span>
+<span class="return">KeyManagerAlias[]:</span>
  Array of aliases.
               </ul>
 </div>
@@ -432,7 +430,7 @@ for (var i = 0; i &lt; aliases.length; i++)
 <div class="brief">
  Sets permissions that another application has for accessing an application's data.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void setPermission(<a href="#KeyManagerAlias">KeyManagerAlias</a> dataAlias, <a href="package.html#PackageId">PackageId</a> packageId, <a href="#PermissionType">PermissionType</a> permissionType, 
+<div class="synopsis"><pre class="signature prettyprint">void setPermission(<a href="#KeyManagerAlias">KeyManagerAlias</a> dataAlias, <a href="package.html#PackageId">PackageId</a> packageId, <a href="#PermissionType">PermissionType</a> permissionType,
                    optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -597,6 +595,11 @@ Possible values:
 <pre class="webidl prettyprint">module KeyManager {
   typedef DOMString RawData;
   enum PermissionType { "NONE", "READ", "REMOVE", "READ_REMOVE" };
+  dictionary KeyManagerAlias {
+    <a href="package.html#PackageId">PackageId</a> packageId;
+    DOMString name;
+    boolean isProtected;
+  };
   [NoInterfaceObject] interface KeyManagerObject {
     readonly attribute <a href="#KeyManager">KeyManager</a> keymanager;
   };
@@ -609,11 +612,6 @@ Possible values:
     <a href="#KeyManagerAlias">KeyManagerAlias</a>[] getDataAliasList() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void setPermission(<a href="#KeyManagerAlias">KeyManagerAlias</a> dataAlias, <a href="package.html#PackageId">PackageId</a> packageId, <a href="#PermissionType">PermissionType</a> permissionType,
                        optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  dictionary KeyManagerAlias {
-    <a href="package.html#PackageId">PackageId</a> packageId;
-    DOMString name;
-    boolean isProtected;
   };
 };</pre>
 </div>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/keymanager.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/keymanager.html
@@ -600,10 +600,10 @@ Possible values:
     DOMString name;
     boolean isProtected;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#KeyManagerObject">KeyManagerObject</a>;
   [NoInterfaceObject] interface KeyManagerObject {
     readonly attribute <a href="#KeyManager">KeyManager</a> keymanager;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#KeyManagerObject">KeyManagerObject</a>;
   [NoInterfaceObject] interface KeyManager {
     void saveData(DOMString name, <a href="#RawData">RawData</a> rawData, optional DOMString? password, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                   optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/mediacontroller.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/mediacontroller.html
@@ -414,8 +414,7 @@ There is a <em>tizen.mediacontroller</em> object that allows access to the Media
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">MediaControllerClient:
-                  </span>
+<span class="return">MediaControllerClient:</span>
  The <em>MediaController Client</em> object.
               </ul>
 </div>
@@ -467,8 +466,7 @@ and is controlled by Client.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">MediaControllerServer:
-                  </span>
+<span class="return">MediaControllerServer:</span>
  The <em>MediaController Server</em> object.
               </ul>
 </div>
@@ -516,7 +514,8 @@ catch (err)
     void updatePlaybackAgeRating(<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void updatePlaybackContentType(<a href="#MediaControllerContentType">MediaControllerContentType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void updateShuffleMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    void updateRepeatMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void updateMetadata(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addChangeRequestPlaybackInfoListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeChangeRequestPlaybackInfoListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -968,8 +967,7 @@ requests from client.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -1112,8 +1110,7 @@ See <em>MediaControllerServerInfo</em> to check how to send custom commands from
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -1228,8 +1225,7 @@ mcServer.removeCommandListener(watcherId);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">MediaControllerPlaylist:
-                  </span>
+<span class="return">MediaControllerPlaylist:</span>
  New empty <em>MediaControllerPlaylist</em> object with given name.
               </ul>
 </div>
@@ -1258,7 +1254,7 @@ var playlist = server.createPlaylist("testPlaylistName");
 <div class="brief">
  Saves playlist in local database.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                   optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1377,7 +1373,7 @@ The <em>errorCallback</em> may be triggered for one of the following errors:
 </li></ul>
         </div>
 <div class="example">
-<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var server = mediacontroller.createServer();
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var server = tizen.mediacontroller.createServer();
 var playlist = server.createPlaylist("testPlaylistName");
 function deleteSuccess()
 {
@@ -1436,7 +1432,7 @@ server.savePlaylist(playlist, saveSuccess);
 </li></ul>
         </div>
 <div class="example">
-<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var server = mediacontroller.createServer();
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var server = tizen.mediacontroller.createServer();
 var playlist = server.createPlaylist("testPlaylistName");
 var metadata =
 {
@@ -1453,10 +1449,12 @@ var metadata =
   picture: "testPicture"
 };
 playlist.addItem("index1", metadata);
-server.savePlaylist(playlist);
-server.updatePlaybackItem("testPlaylistName", "index1");
-console.log("Current playlist: " + server.playbackInfo.playlistName);
-console.log("Current index: " + server.playbackInfo.index);
+server.savePlaylist(playlist, function()
+{
+  server.updatePlaybackItem("testPlaylistName", "index1");
+  console.log("Current playlist: " + server.playbackInfo.playlistName);
+  console.log("Current index: " + server.playbackInfo.index);
+});
 </pre>
 </div>
 <div class="output">
@@ -1517,26 +1515,25 @@ var playlist = server.createPlaylist("testPlaylist");
 function saveSuccess()
 {
   console.log("savePlaylist successful");
+  function successCallback(playlists)
+  {
+    playlists.forEach(function(playlist)
+    {
+      console.log("Playlist name: " + playlist.name);
+    });
+  }
+  function errorCallback(error)
+  {
+    console.log("getAllPlaylists failed with error: " + error);
+  }
+  server.getAllPlaylists(successCallback, errorCallback);
 }
 function saveError(error)
 {
   console.log("savePlaylist failed with error: " + error);
 }
 
-server.savePlaylist(saveSuccess, saveError);
-
-function successCallback(playlists)
-{
-  playlists.forEach(function(playlist)
-  {
-    console.log("Playlist name: " + playlist.name);
-  });
-}
-function errorCallback(error)
-{
-  console.log("getAllPlaylists failed with error: " + error);
-}
-server.getAllPlaylists(successCallback, errorCallback);
+server.savePlaylist(playlist, saveSuccess, saveError);
 </pre>
 </div>
 <div class="output">
@@ -1651,8 +1648,7 @@ mcClient.findServers(successCallback, errorCallback);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">MediaControllerServerInfo:
-                  </span>
+<span class="return">MediaControllerServerInfo<span class="optional"> [nullable]</span>:</span>
  Server info or <var>null</var>.
               </ul>
 </div>
@@ -1692,7 +1688,9 @@ Provides methods to send commands to server and listen for server status change.
                               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void sendShuffleMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+<span class="nocode deprecated">    void sendRepeatMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                        raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                          optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void sendCommand(DOMString command, object data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -1788,7 +1786,7 @@ console.log(sinfo.iconURI);
 <div class="brief">
  Allows to change playback state of media controller server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                        optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1845,7 +1843,7 @@ mcServerInfo.sendPlaybackState("STOP",
 <div class="brief">
  Allows to change playback position of media controller server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                           optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -2020,7 +2018,7 @@ mcServerInfo.sendRepeatMode(false,
 <div class="brief">
  Allows to change repeat state of media controller server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -2081,7 +2079,7 @@ mcServerInfo.sendRepeatState("REPEAT_ALL",
 <div class="brief">
  Allows to send custom command to media controller server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void sendCommand(DOMString command, object data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void sendCommand(DOMString command, object data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback,
                  optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -2163,8 +2161,7 @@ mcServerInfo.sendCommand("myPlaylistFilter", exampleCustomCommandData,
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -2264,8 +2261,7 @@ mcServerInfo.removeServerStatusChangeListener(watcherId);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -2434,26 +2430,26 @@ var playlist = server.createPlaylist("testPlaylist");
 function saveSuccess()
 {
   console.log("savePlaylist successful");
+  function successCallback(playlists)
+  {
+    playlists.forEach(function(playlist)
+    {
+      console.log("Playlist name: " + playlist.name);
+    });
+  }
+  function errorCallback(error)
+  {
+    console.log("getAllPlaylists failed with error: " + error);
+  }
+  serverInfo.getAllPlaylists(successCallback, errorCallback);
 }
+
 function saveError(error)
 {
   console.log("savePlaylist failed with error: " + error);
 }
 
-server.savePlaylist(saveSuccess, saveError);
-
-function successCallback(playlists)
-{
-  playlists.forEach(function(playlist)
-  {
-    console.log("Playlist name: " + playlist.name);
-  });
-}
-function errorCallback(error)
-{
-  console.log("getAllPlaylists failed with error: " + error);
-}
-serverInfo.getAllPlaylists(successCallback, errorCallback);
+server.savePlaylist(playlist, saveSuccess, saveError);
 </pre>
 </div>
 <div class="output">
@@ -2534,8 +2530,7 @@ serverInfo.sendPlaybackItem("testPlaylist", "1", "PLAY", 0);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -2559,7 +2554,7 @@ var listener =
 {
   onplaylistupdated: function(playlist)
   {
-    console.log("updated playlist " + playlist.name);
+    console.log("updated playlist " + playlist);
   },
   onplaylistdeleted: function(playlistName)
   {
@@ -2628,7 +2623,8 @@ serverInfo.removePlaylistUpdatedListener(listenerId);
     readonly attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating;
     readonly attribute <a href="#MediaControllerContentType">MediaControllerContentType</a> contentType;
     readonly attribute boolean shuffleMode;
-    readonly attribute <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> repeatState;
+<span class="nocode deprecated">    readonly attribute boolean repeatMode;
+</span>    readonly attribute <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> repeatState;
     readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
     readonly attribute DOMString? index;
     readonly attribute DOMString? playlistName;
@@ -3035,7 +3031,7 @@ function errorCallback(error)
 {
   console.log("savePlaylist failed with error: " + error);
 }
-server.savePlaylist(successCallback, errorCallback);
+server.savePlaylist(playlist, successCallback, errorCallback);
 </pre>
 </div>
 <div class="output">
@@ -3245,8 +3241,7 @@ See <em>MediaControllerSendCommandSuccessCallback</em> interface.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">object:
-                  </span>
+<span class="return">object<span class="optional"> [nullable]</span>:</span>
  Data object which should be send with reply to the client.
               </ul>
 </div>
@@ -3302,7 +3297,8 @@ object for receiving media controller playback info changes from server.
 <pre class="webidl prettyprint">  [Callback, NoInterfaceObject] interface MediaControllerPlaybackInfoChangeCallback {
     void onplaybackchanged(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position);
     void onshufflemodechanged(boolean mode);
-    void onrepeatstatechanged(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state);
+<span class="nocode deprecated">    void onrepeatmodechanged(boolean mode);
+</span>    void onrepeatstatechanged(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state);
     void onmetadatachanged(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata);
   };</pre>
 <p><span class="version">Since: </span>
@@ -3446,7 +3442,8 @@ object for receiving playback info change requests from client.
     void onplaybackstaterequest(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
     void onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
     void onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+<span class="nocode deprecated">    void onrepeatmoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+</span>    void onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
     void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state,
                                unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
   };</pre>
@@ -3613,7 +3610,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 <div class="brief">
  Called when client request change of playback item.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, 
+<div class="synopsis"><pre class="signature prettyprint">void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state,
                            unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -3798,8 +3795,21 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
   enum MediaControllerPlaybackState { "PLAY", "PAUSE", "STOP", "NEXT", "PREV", "FORWARD", "REWIND" };
   enum MediaControllerRepeatState { "REPEAT_OFF", "REPEAT_ONE", "REPEAT_ALL" };
   enum MediaControllerContentType { "IMAGE", "MUSIC", "VIDEO", "OTHER", "UNDECIDED" };
-  enum MediaControllerContentAgeRating { "ALL", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16",
-    "17", "18", "19" };
+  enum MediaControllerContentAgeRating { "ALL", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13",
+    "14", "15", "16", "17", "18", "19" };
+  dictionary MediaControllerMetadataInit {
+    DOMString title;
+    DOMString artist;
+    DOMString album;
+    DOMString author;
+    DOMString genre;
+    DOMString duration;
+    DOMString date;
+    DOMString copyright;
+    DOMString description;
+    DOMString trackNum;
+    DOMString picture;
+  };
   [NoInterfaceObject] interface MediaControllerObject {
     readonly attribute <a href="#MediaControllerManager">MediaControllerManager</a> mediacontroller;
   };
@@ -3890,19 +3900,6 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
   [NoInterfaceObject] interface MediaControllerPlaylistItem {
     readonly attribute DOMString index;
     readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
-  };
-  dictionary MediaControllerMetadataInit {
-    DOMString title;
-    DOMString artist;
-    DOMString album;
-    DOMString author;
-    DOMString genre;
-    DOMString duration;
-    DOMString date;
-    DOMString copyright;
-    DOMString description;
-    DOMString trackNum;
-    DOMString picture;
   };
   [NoInterfaceObject] interface MediaControllerPlaylist {
     readonly attribute DOMString name;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/mediacontroller.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/mediacontroller.html
@@ -3810,10 +3810,10 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
     DOMString trackNum;
     DOMString picture;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MediaControllerObject">MediaControllerObject</a>;
   [NoInterfaceObject] interface MediaControllerObject {
     readonly attribute <a href="#MediaControllerManager">MediaControllerManager</a> mediacontroller;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MediaControllerObject">MediaControllerObject</a>;
   [NoInterfaceObject] interface MediaControllerManager {
     <a href="#MediaControllerClient">MediaControllerClient</a> getClient() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#MediaControllerServer">MediaControllerServer</a> createServer() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/mediakey.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/mediakey.html
@@ -306,8 +306,8 @@ To guarantee that the Media Key application runs on a device with Bluetooth feat
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module MediaKey {
-  enum MediaKeyType { "MEDIA_PLAY", "MEDIA_STOP", "MEDIA_PAUSE", "MEDIA_PREVIOUS", "MEDIA_NEXT", "MEDIA_FAST_FORWARD", "MEDIA_REWIND",
-    "MEDIA_PLAY_PAUSE" };
+  enum MediaKeyType { "MEDIA_PLAY", "MEDIA_STOP", "MEDIA_PAUSE", "MEDIA_PREVIOUS", "MEDIA_NEXT", "MEDIA_FAST_FORWARD",
+    "MEDIA_REWIND", "MEDIA_PLAY_PAUSE" };
   [NoInterfaceObject] interface MediaKeyManagerObject {
     readonly attribute <a href="#MediaKeyManager">MediaKeyManager</a> mediakey;
   };

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/mediakey.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/mediakey.html
@@ -308,10 +308,10 @@ To guarantee that the Media Key application runs on a device with Bluetooth feat
 <pre class="webidl prettyprint">module MediaKey {
   enum MediaKeyType { "MEDIA_PLAY", "MEDIA_STOP", "MEDIA_PAUSE", "MEDIA_PREVIOUS", "MEDIA_NEXT", "MEDIA_FAST_FORWARD",
     "MEDIA_REWIND", "MEDIA_PLAY_PAUSE" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MediaKeyManagerObject">MediaKeyManagerObject</a>;
   [NoInterfaceObject] interface MediaKeyManagerObject {
     readonly attribute <a href="#MediaKeyManager">MediaKeyManager</a> mediakey;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MediaKeyManagerObject">MediaKeyManagerObject</a>;
   [NoInterfaceObject] interface MediaKeyManager {
     void setMediaKeyEventListener(<a href="#MediaKeyEventCallback">MediaKeyEventCallback</a> callback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unsetMediaKeyEventListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/messageport.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/messageport.html
@@ -784,10 +784,10 @@ var watchId = localMsgPort.addMessagePortListener(onreceived);
     DOMString key;
     <a href="#ByteStreamDataItemValue">ByteStreamDataItemValue</a> value;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MessagePortManagerObject">MessagePortManagerObject</a>;
   [NoInterfaceObject] interface MessagePortManagerObject {
     readonly attribute <a href="#MessagePortManager">MessagePortManager</a> messageport;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MessagePortManagerObject">MessagePortManagerObject</a>;
   [NoInterfaceObject] interface MessagePortManager {
     <a href="#LocalMessagePort">LocalMessagePort</a> requestLocalMessagePort(DOMString localMessagePortName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#LocalMessagePort">LocalMessagePort</a> requestTrustedLocalMessagePort(DOMString localMessagePortName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/messageport.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/messageport.html
@@ -222,8 +222,7 @@ The <em>tizen.messageport</em> object allows access to the functionality of the 
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">LocalMessagePort:
-                  </span>
+<span class="return">LocalMessagePort:</span>
  LocalMessagePort instance.
               </ul>
 </div>
@@ -276,8 +275,7 @@ Trusted local message port can communicate with applications that are signed wit
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">LocalMessagePort:
-                  </span>
+<span class="return">LocalMessagePort:</span>
  Trusted LocalMessagePort instance.
               </ul>
 </div>
@@ -334,8 +332,7 @@ If the message port name and application ID are the same, the platform returns t
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">RemoteMessagePort:
-                  </span>
+<span class="return">RemoteMessagePort:</span>
  RemoteMessagePort instance.
               </ul>
 </div>
@@ -390,8 +387,7 @@ Trusted remote message port can communicate with applications that are signed wi
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">RemoteMessagePort:
-                  </span>
+<span class="return">RemoteMessagePort:</span>
  Trusted RemoteMessagePort instance.
               </ul>
 </div>
@@ -483,8 +479,7 @@ var remoteMsgPort =
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  ID of the listener that is later used to remove the listener.
               </ul>
 </div>
@@ -781,6 +776,14 @@ var watchId = localMsgPort.addMessagePortListener(onreceived);
   typedef (DOMString or DOMString[]) StringDataItemValue;
   typedef (<a href="#ByteStream">ByteStream</a> or <a href="#ByteStream">ByteStream</a>[]) ByteStreamDataItemValue;
   typedef (<a href="#MessagePortStringDataItem">MessagePortStringDataItem</a> or <a href="#MessagePortByteStreamDataItem">MessagePortByteStreamDataItem</a>) MessagePortDataItem;
+  dictionary MessagePortStringDataItem {
+    DOMString key;
+    <a href="#StringDataItemValue">StringDataItemValue</a> value;
+  };
+  dictionary MessagePortByteStreamDataItem {
+    DOMString key;
+    <a href="#ByteStreamDataItemValue">ByteStreamDataItemValue</a> value;
+  };
   [NoInterfaceObject] interface MessagePortManagerObject {
     readonly attribute <a href="#MessagePortManager">MessagePortManager</a> messageport;
   };
@@ -802,14 +805,6 @@ var watchId = localMsgPort.addMessagePortListener(onreceived);
     readonly attribute <a href="application.html#ApplicationId">ApplicationId</a> appId;
     readonly attribute boolean isTrusted;
     void sendMessage(<a href="#MessagePortDataItem">MessagePortDataItem</a>[] data, optional <a href="#LocalMessagePort">LocalMessagePort</a>? localMessagePort) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  dictionary MessagePortStringDataItem {
-    DOMString key;
-    <a href="#StringDataItemValue">StringDataItemValue</a> value;
-  };
-  dictionary MessagePortByteStreamDataItem {
-    DOMString key;
-    <a href="#ByteStreamDataItemValue">ByteStreamDataItemValue</a> value;
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface MessagePortCallback {
     void onreceived(<a href="#MessagePortDataItem">MessagePortDataItem</a>[] data, <a href="#RemoteMessagePort">RemoteMessagePort</a>? remoteMessagePort);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/messaging.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/messaging.html
@@ -692,8 +692,7 @@ tizen.messaging.getMessageServices("messaging.email", serviceListCB);
 <div class="brief">
  The dictionary providing specific message attributes for message creation.
           </div>
-<pre class="webidl prettyprint">  dictionary MessageInit
-  {
+<pre class="webidl prettyprint">  dictionary MessageInit {
     DOMString subject;
     DOMString[] to;
     DOMString[] cc;
@@ -1056,7 +1055,7 @@ tizen.messaging.getMessageServices("messaging.sms", serviceListCB, errorCallback
 <div class="brief">
  Gets the messaging service of a given type for a given account, or all existing services supporting the given type, if <em>serviceId </em>is not given.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getMessageServices(<a href="#MessageServiceTag">MessageServiceTag</a> messageServiceType, <a href="#MessageServiceArraySuccessCallback">MessageServiceArraySuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getMessageServices(<a href="#MessageServiceTag">MessageServiceTag</a> messageServiceType, <a href="#MessageServiceArraySuccessCallback">MessageServiceArraySuccessCallback</a> successCallback,
                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -1170,6 +1169,7 @@ tizen.messaging.getMessageServices("messaging.email", serviceListCB, errorCallba
     readonly attribute DOMString id;
     readonly attribute <a href="#MessageServiceTag">MessageServiceTag</a> type;
     readonly attribute DOMString name;
+    readonly attribute <a href="#MessageStorage">MessageStorage</a> messageStorage getraises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void sendMessage(<a href="#Message">Message</a> message, optional <a href="#MessageRecipientsCallback">MessageRecipientsCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                      optional long? simIndex) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void loadMessageBody(<a href="#Message">Message</a> message, <a href="#MessageBodySuccessCallback">MessageBodySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
@@ -1181,7 +1181,6 @@ tizen.messaging.getMessageServices("messaging.email", serviceListCB, errorCallba
     long syncFolder(<a href="#MessageFolder">MessageFolder</a> folder, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                     optional unsigned long? limit) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void stopSync(long opId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    readonly attribute <a href="#MessageStorage">MessageStorage</a> messageStorage getraises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
 <p><span class="version">Since: </span>
  1.0
@@ -1289,7 +1288,7 @@ If the backend does not support <em>MessageStorage </em>for this messaging servi
 <div class="brief">
  Sends a specified message.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void sendMessage(<a href="#Message">Message</a> message, optional <a href="#MessageRecipientsCallback">MessageRecipientsCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void sendMessage(<a href="#Message">Message</a> message, optional <a href="#MessageRecipientsCallback">MessageRecipientsCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                  optional long? simIndex);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -1522,7 +1521,7 @@ service.messageStorage.findMessages(
 <div class="brief">
  Loads a specified message attachment.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void loadMessageAttachment(<a href="#MessageAttachment">MessageAttachment</a> attachment, <a href="#MessageAttachmentSuccessCallback">MessageAttachmentSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void loadMessageAttachment(<a href="#MessageAttachment">MessageAttachment</a> attachment, <a href="#MessageAttachmentSuccessCallback">MessageAttachmentSuccessCallback</a> successCallback,
                            optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -1666,8 +1665,7 @@ The errorCallback is launched with these error types:
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Identifier which can be used to stop initiated sync operation.
               </ul>
 </div>
@@ -1711,7 +1709,7 @@ tizen.messaging.getMessageServices("messaging.email", servicesListSuccessCB);
 <div class="brief">
  Synchronizes the folder content with an external mail server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long syncFolder(<a href="#MessageFolder">MessageFolder</a> folder, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">long syncFolder(<a href="#MessageFolder">MessageFolder</a> folder, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                 optional unsigned long? limit);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -1781,8 +1779,7 @@ The errorCallback is launched with these error types:
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Identifier which can be used to stop initiated sync operation.
               </ul>
 </div>
@@ -2127,7 +2124,7 @@ tizen.messaging.getMessageServices("messaging.sms", serviceListCB);
 <div class="brief">
  Finds messages from <em>MessageStorage</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void findMessages(<a href="tizen.html#AbstractFilter">AbstractFilter</a> filter, <a href="#MessageArraySuccessCallback">MessageArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void findMessages(<a href="tizen.html#AbstractFilter">AbstractFilter</a> filter, <a href="#MessageArraySuccessCallback">MessageArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                   optional <a href="tizen.html#SortMode">SortMode</a>? sort, optional unsigned long? limit, optional unsigned long? offset);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -2418,8 +2415,8 @@ messageStorage.findMessages(filter, messageArrayCB);
 <div class="brief">
  Finds conversations from <em>MessageStorage</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void findConversations(<a href="tizen.html#AbstractFilter">AbstractFilter</a> filter, <a href="#MessageConversationArraySuccessCallback">MessageConversationArraySuccessCallback</a> successCallback, 
-                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#SortMode">SortMode</a>? sort, optional unsigned long? limit, 
+<div class="synopsis"><pre class="signature prettyprint">void findConversations(<a href="tizen.html#AbstractFilter">AbstractFilter</a> filter, <a href="#MessageConversationArraySuccessCallback">MessageConversationArraySuccessCallback</a> successCallback,
+                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#SortMode">SortMode</a>? sort, optional unsigned long? limit,
                        optional unsigned long? offset);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -2517,7 +2514,7 @@ messageStorage.findConversations(filter, conversationsArrayCB, errorCallback);
 <div class="brief">
  Removes conversations from <em>MessageStorage</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void removeConversations(<a href="#MessageConversation">MessageConversation</a>[] conversations, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void removeConversations(<a href="#MessageConversation">MessageConversation</a>[] conversations, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                          optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -2735,8 +2732,7 @@ The errorCallback is launched with these error types:
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Subscription identifier.
               </ul>
 </div>
@@ -2786,7 +2782,7 @@ messageStorage.addMessagesChangeListener(messageChangeCallback);
 <div class="brief">
  Adds a listener to subscribe to notifications for MessageConversation changes.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long addConversationsChangeListener(<a href="#MessageConversationsChangeCallback">MessageConversationsChangeCallback</a> conversationsChangeCallback, 
+<div class="synopsis"><pre class="signature prettyprint">long addConversationsChangeListener(<a href="#MessageConversationsChangeCallback">MessageConversationsChangeCallback</a> conversationsChangeCallback,
                                     optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -2824,8 +2820,7 @@ The errorCallback is launched with these error types:
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Subscription identifier.
               </ul>
 </div>
@@ -2912,8 +2907,7 @@ The errorCallback is launched with these error types:
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Subscription identifier.
               </ul>
 </div>
@@ -3813,15 +3807,24 @@ To guarantee that the mms application runs on a device with MMS feature, define 
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Messaging {
-  [NoInterfaceObject] interface MessageManagerObject {
-    readonly attribute <a href="#Messaging">Messaging</a> messaging;
-  };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MessageManagerObject">MessageManagerObject</a>;
-  enum MessageServiceTag { "messaging.sms", "messaging.mms", "messaging.email" };
   typedef DOMString MessageId;
   typedef DOMString MessageAttachmentId;
   typedef DOMString MessageConvId;
   typedef DOMString MessageFolderId;
+  enum MessageServiceTag { "messaging.sms", "messaging.mms", "messaging.email" };
+  dictionary MessageInit {
+    DOMString subject;
+    DOMString[] to;
+    DOMString[] cc;
+    DOMString[] bcc;
+    DOMString plainBody;
+    DOMString htmlBody;
+    boolean isHighPriority;
+  };
+  [NoInterfaceObject] interface MessageManagerObject {
+    readonly attribute <a href="#Messaging">Messaging</a> messaging;
+  };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MessageManagerObject">MessageManagerObject</a>;
   [Constructor(<a href="#MessageServiceTag">MessageServiceTag</a> type, optional <a href="#MessageInit">MessageInit</a>? messageInitDict)]
   interface Message {
     readonly attribute <a href="#MessageId">MessageId</a>? id;
@@ -3841,16 +3844,6 @@ To guarantee that the mms application runs on a device with MMS feature, define 
     readonly attribute <a href="#MessageId">MessageId</a>? inResponseTo;
     readonly attribute DOMString messageStatus;
     attribute <a href="#MessageAttachment">MessageAttachment</a>[] attachments;
-  };
-  dictionary MessageInit
-  {
-    DOMString subject;
-    DOMString[] to;
-    DOMString[] cc;
-    DOMString[] bcc;
-    DOMString plainBody;
-    DOMString htmlBody;
-    boolean isHighPriority;
   };
   [NoInterfaceObject] interface MessageBody {
     readonly attribute <a href="#MessageId">MessageId</a> messageId;
@@ -3877,6 +3870,7 @@ To guarantee that the mms application runs on a device with MMS feature, define 
     readonly attribute DOMString id;
     readonly attribute <a href="#MessageServiceTag">MessageServiceTag</a> type;
     readonly attribute DOMString name;
+    readonly attribute <a href="#MessageStorage">MessageStorage</a> messageStorage getraises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void sendMessage(<a href="#Message">Message</a> message, optional <a href="#MessageRecipientsCallback">MessageRecipientsCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                      optional long? simIndex) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void loadMessageBody(<a href="#Message">Message</a> message, <a href="#MessageBodySuccessCallback">MessageBodySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
@@ -3888,7 +3882,6 @@ To guarantee that the mms application runs on a device with MMS feature, define 
     long syncFolder(<a href="#MessageFolder">MessageFolder</a> folder, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                     optional unsigned long? limit) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void stopSync(long opId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    readonly attribute <a href="#MessageStorage">MessageStorage</a> messageStorage getraises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface MessageRecipientsCallback {
     void onsuccess(DOMString[] recipients);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/messaging.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/messaging.html
@@ -3821,10 +3821,10 @@ To guarantee that the mms application runs on a device with MMS feature, define 
     DOMString htmlBody;
     boolean isHighPriority;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MessageManagerObject">MessageManagerObject</a>;
   [NoInterfaceObject] interface MessageManagerObject {
     readonly attribute <a href="#Messaging">Messaging</a> messaging;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MessageManagerObject">MessageManagerObject</a>;
   [Constructor(<a href="#MessageServiceTag">MessageServiceTag</a> type, optional <a href="#MessageInit">MessageInit</a>? messageInitDict)]
   interface Message {
     readonly attribute <a href="#MessageId">MessageId</a>? id;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/networkbearerselection.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/networkbearerselection.html
@@ -428,10 +428,10 @@ To guarantee that the NBS application runs on a device with telephony feature, d
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module NetworkBearerSelection {
   enum NetworkType { "CELLULAR", "UNKNOWN" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#NetworkBearerSelectionObject">NetworkBearerSelectionObject</a>;
   [NoInterfaceObject] interface NetworkBearerSelectionObject {
     readonly attribute <a href="#NetworkBearerSelection">NetworkBearerSelection</a> networkbearerselection;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#NetworkBearerSelectionObject">NetworkBearerSelectionObject</a>;
   [NoInterfaceObject] interface NetworkBearerSelection {
     void requestRouteToHost(<a href="#NetworkType">NetworkType</a> networkType, DOMString domainName, <a href="#NetworkSuccessCallback">NetworkSuccessCallback</a> successCallback,
                             optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/networkbearerselection.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/networkbearerselection.html
@@ -154,7 +154,7 @@ This API offers methods for network bearer selection.
 <div class="brief">
  Requests a specific network connection.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void requestRouteToHost(<a href="#NetworkType">NetworkType</a> networkType, DOMString domainName, <a href="#NetworkSuccessCallback">NetworkSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void requestRouteToHost(<a href="#NetworkType">NetworkType</a> networkType, DOMString domainName, <a href="#NetworkSuccessCallback">NetworkSuccessCallback</a> successCallback,
                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.1
@@ -262,7 +262,7 @@ tizen.networkbearerselection.requestRouteToHost("CELLULAR", "www.tizen.org", sta
 <div class="brief">
  Releases a specific network connection.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void releaseRouteToHost(<a href="#NetworkType">NetworkType</a> networkType, DOMString domainName, <a href="tizen.html#SuccessCallback">SuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void releaseRouteToHost(<a href="#NetworkType">NetworkType</a> networkType, DOMString domainName, <a href="tizen.html#SuccessCallback">SuccessCallback</a> successCallback,
                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.1

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/nfc.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/nfc.html
@@ -561,8 +561,7 @@ It provides access to the API functionalities through the tizen.nfc interface.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">NFCAdapter:
-                  </span>
+<span class="return">NFCAdapter:</span>
  The default NFCAdapter object.
               </ul>
 </div>
@@ -666,7 +665,9 @@ catch (err)
     readonly attribute boolean powered;
     attribute <a href="#CardEmulationMode">CardEmulationMode</a> cardEmulationMode raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     attribute <a href="#SecureElementType">SecureElementType</a>? activeSecureElement raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void setTagListener(<a href="#NFCTagDetectCallback">NFCTagDetectCallback</a> detectCallback, optional <a href="#NFCTagType">NFCTagType</a>[]? tagFilter) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    void setPowered(boolean state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                    raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void setTagListener(<a href="#NFCTagDetectCallback">NFCTagDetectCallback</a> detectCallback, optional <a href="#NFCTagType">NFCTagType</a>[]? tagFilter) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void setPeerListener(<a href="#NFCPeerDetectCallback">NFCPeerDetectCallback</a> detectCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unsetTagListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unsetPeerListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -1242,8 +1243,7 @@ adapter.setPeerListener(onSuccessCB);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Subscription identifier.
               </ul>
 </div>
@@ -1373,8 +1373,7 @@ Such an event may indicate initiating a financial transaction using the device.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Subscription identifier.
               </ul>
 </div>
@@ -1498,8 +1497,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Subscription identifier.
               </ul>
 </div>
@@ -1621,8 +1619,7 @@ should be returned.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">NDEFMessage:
-                  </span>
+<span class="return">NDEFMessage<span class="optional"> [nullable]</span>:</span>
  The NDEF Message that was last read.
               </ul>
 </div>
@@ -1751,8 +1748,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Subscription identifier.
               </ul>
 </div>
@@ -1984,8 +1980,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if current application is activated handler for the AID.
               </ul>
 </div>
@@ -2061,8 +2056,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if current application is activated handler for the category.
               </ul>
 </div>
@@ -2245,7 +2239,7 @@ catch (err)
 <div class="brief">
  Retrieves AIDs that were previously registered for a specific card emulation category and secure element type. An application can only retrieve the AIDs which it registered.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getAIDsForCategory(<a href="#SecureElementType">SecureElementType</a> type, <a href="#CardEmulationCategoryType">CardEmulationCategoryType</a> category, <a href="#AIDArraySuccessCallback">AIDArraySuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getAIDsForCategory(<a href="#SecureElementType">SecureElementType</a> type, <a href="#CardEmulationCategoryType">CardEmulationCategoryType</a> category, <a href="#AIDArraySuccessCallback">AIDArraySuccessCallback</a> successCallback,
                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
@@ -3179,8 +3173,7 @@ If the operation completes successfully, it returns the serial byte array of the
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">byte[]:
-                  </span>
+<span class="return">byte[]:</span>
  The raw data in the NDEFMessage.
               </ul>
 </div>
@@ -3485,7 +3478,7 @@ var newRecord = new tizen.NDEFRecordMedia("text/plain", myData);
 <div class="brief">
  The HCEEventData interface represents HCE event data.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface  HCEEventData {
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface HCEEventData {
     readonly attribute <a href="#HCEEventType">HCEEventType</a> eventType;
     readonly attribute byte[] apdu;
     readonly attribute long length;
@@ -3535,10 +3528,10 @@ var newRecord = new tizen.NDEFRecordMedia("text/plain", myData);
 <div class="brief">
  The AID data interface represents registered AID data
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface  AIDData{
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface AIDData {
     readonly attribute <a href="#SecureElementType">SecureElementType</a> type;
     readonly attribute <a href="#AID">AID</a> aid;
-    readonly attribute boolean  readOnly;
+    readonly attribute boolean readOnly;
   };</pre>
 <p><span class="version">Since: </span>
  2.3.1
@@ -4258,14 +4251,15 @@ To guarantee that the NFC host-based card emulation application runs on a device
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module NFC {
+  typedef DOMString AID;
   enum NDEFRecordTextEncoding { "UTF8", "UTF16" };
   enum NFCTagType { "GENERIC_TARGET", "ISO14443_A", "ISO14443_4A", "ISO14443_3A", "MIFARE_MINI", "MIFARE_1K", "MIFARE_4K",
-    "MIFARE_ULTRA", "MIFARE_DESFIRE", "ISO14443_B", "ISO14443_4B", "ISO14443_BPRIME", "FELICA", "JEWEL", "ISO15693", "UNKNOWN_TARGET" };
+    "MIFARE_ULTRA", "MIFARE_DESFIRE", "ISO14443_B", "ISO14443_4B", "ISO14443_BPRIME", "FELICA", "JEWEL", "ISO15693",
+    "UNKNOWN_TARGET" };
   enum CardEmulationMode { "ALWAYS_ON", "OFF" };
   enum SecureElementType { "ESE", "UICC", "HCE" };
   enum CardEmulationCategoryType { "PAYMENT", "OTHER" };
   enum HCEEventType { "DEACTIVATED", "ACTIVATED", "APDU_RECEIVED" };
-  typedef DOMString AID;
   [NoInterfaceObject] interface NFCManagerObject {
     readonly attribute <a href="#NFCManager">NFCManager</a> nfc;
   };
@@ -4358,15 +4352,15 @@ To guarantee that the NFC host-based card emulation application runs on a device
   interface NDEFRecordMedia : <a href="#NDEFRecord">NDEFRecord</a> {
     readonly attribute DOMString mimeType;
   };
-  [NoInterfaceObject] interface  HCEEventData {
+  [NoInterfaceObject] interface HCEEventData {
     readonly attribute <a href="#HCEEventType">HCEEventType</a> eventType;
     readonly attribute byte[] apdu;
     readonly attribute long length;
   };
-  [NoInterfaceObject] interface  AIDData{
+  [NoInterfaceObject] interface AIDData {
     readonly attribute <a href="#SecureElementType">SecureElementType</a> type;
     readonly attribute <a href="#AID">AID</a> aid;
-    readonly attribute boolean  readOnly;
+    readonly attribute boolean readOnly;
   };
   [Callback, NoInterfaceObject] interface NFCTagDetectCallback {
     void onattach(<a href="#NFCTag">NFCTag</a> nfcTag);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/nfc.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/nfc.html
@@ -4260,10 +4260,10 @@ To guarantee that the NFC host-based card emulation application runs on a device
   enum SecureElementType { "ESE", "UICC", "HCE" };
   enum CardEmulationCategoryType { "PAYMENT", "OTHER" };
   enum HCEEventType { "DEACTIVATED", "ACTIVATED", "APDU_RECEIVED" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#NFCManagerObject">NFCManagerObject</a>;
   [NoInterfaceObject] interface NFCManagerObject {
     readonly attribute <a href="#NFCManager">NFCManager</a> nfc;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#NFCManagerObject">NFCManagerObject</a>;
   [NoInterfaceObject] interface NFCManager {
     const short NFC_RECORD_TNF_EMPTY = 0;
     const short NFC_RECORD_TNF_WELL_KNOWN = 1;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/notification.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/notification.html
@@ -2390,10 +2390,10 @@ If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare t
     unsigned long ledOnPeriod;
     unsigned long ledOffPeriod;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#NotificationObject">NotificationObject</a>;
   [NoInterfaceObject] interface NotificationObject {
     readonly attribute <a href="#NotificationManager">NotificationManager</a> notification;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#NotificationObject">NotificationObject</a>;
   [NoInterfaceObject] interface NotificationManager {
     void post(<a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void update(<a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/notification.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/notification.html
@@ -204,7 +204,7 @@ The status notification consists of an icon, title, content, and time. The statu
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 4.0. Use <a href="#UserNotificationType">UserNotificationType</a> instead.
           </p>
-<pre class="webidl prettyprint">  enum StatusNotificationType { "SIMPLE", "THUMBNAIL", "ONGOING", "PROGRESS" };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  enum StatusNotificationType { "SIMPLE", "THUMBNAIL", "ONGOING", "PROGRESS" };</span></pre>
 <p><span class="version">Since: </span>
  2.0
           </p>
@@ -337,8 +337,10 @@ Notification API.
     void update(<a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void remove(<a href="#NotificationId">NotificationId</a> id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeAll() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    <a href="#Notification">Notification</a> getNotification(<a href="#NotificationId">NotificationId</a> id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    <a href="#Notification">Notification</a>[] getAllNotifications() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    <a href="#Notification">Notification</a> get(<a href="#NotificationId">NotificationId</a> id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    <a href="#Notification">Notification</a> getNotification(<a href="#NotificationId">NotificationId</a> id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    <a href="#Notification">Notification</a>[] getAll() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    <a href="#Notification">Notification</a>[] getAllNotifications() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void playLEDCustomEffect(long timeOn, long timeOff, DOMString color, <a href="#LEDCustomFlags">LEDCustomFlags</a>[] flags) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void stopLEDCustomEffect() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void saveNotificationAsTemplate(DOMString name, <a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -670,8 +672,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Notification:
-                  </span>
+<span class="return">Notification:</span>
  Notification posted previously by the current application.
               </ul>
 </div>
@@ -732,8 +733,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Notification:
-                  </span>
+<span class="return">Notification:</span>
  Notification previously been posted by the current application.
               </ul>
 </div>
@@ -787,8 +787,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Notification[]:
-                  </span>
+<span class="return">Notification[]:</span>
  All notifications previously been posted by the current application.
               </ul>
 </div>
@@ -847,8 +846,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Notification[]:
-                  </span>
+<span class="return">Notification[]:</span>
  All notifications posted previously by the current application.
               </ul>
 </div>
@@ -1133,8 +1131,7 @@ An application can load only templates that it has saved.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">UserNotification:
-                  </span>
+<span class="return">UserNotification:</span>
  Created notification.
               </ul>
 </div>
@@ -1242,7 +1239,7 @@ catch (err)
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 4.0. Use <a href="#UserNotificationInit">UserNotificationInit</a> instead.
           </p>
-<pre class="webidl prettyprint">  dictionary StatusNotificationInit {
+<pre class="webidl prettyprint"><span class="nocode deprecated">  dictionary StatusNotificationInit {
     DOMString? content;
     DOMString? iconPath;
     DOMString? soundPath;
@@ -1259,7 +1256,7 @@ catch (err)
     unsigned long ledOffPeriod;
     DOMString? backgroundImagePath;
     DOMString[]? thumbnails;
-  };</pre>
+  };</span></pre>
 <p><span class="version">Since: </span>
  2.0
           </p>
@@ -1733,7 +1730,7 @@ By default, this attribute is set to 0.
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 4.0. Use <a href="#UserNotification">UserNotification</a> instead.
           </p>
-<pre class="webidl prettyprint">  [Constructor(<a href="#StatusNotificationType">StatusNotificationType</a> statusType, DOMString title, optional <a href="#StatusNotificationInit">StatusNotificationInit</a>? notificationInitDict)]
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Constructor(<a href="#StatusNotificationType">StatusNotificationType</a> statusType, DOMString title, optional <a href="#StatusNotificationInit">StatusNotificationInit</a>? notificationInitDict)]
   interface StatusNotification : <a href="#Notification">Notification</a> {
     readonly attribute <a href="#StatusNotificationType">StatusNotificationType</a> statusType;
     attribute DOMString? iconPath;
@@ -1751,7 +1748,7 @@ By default, this attribute is set to 0.
     attribute <a href="application.html#ApplicationId">ApplicationId</a>? appId;
     attribute <a href="#NotificationProgressType">NotificationProgressType</a> progressType;
     attribute unsigned long? progressValue;
-  };</pre>
+  };</span></pre>
 <p><span class="version">Since: </span>
  2.0
           </p>
@@ -1766,7 +1763,7 @@ All notifications must have a title attribute.
         
       <div class="constructors">
 <h4 id="StatusNotification::constructor">Constructors</h4>
-<dl><pre class="webidl prettyprint">StatusNotification(<a href="#StatusNotificationType">StatusNotificationType</a> statusType, DOMString title, optional <a href="#StatusNotificationInit">StatusNotificationInit</a>? notificationInitDict);</pre></dl>
+<dl><pre class="webidl prettyprint"><span class="nocode deprecated">StatusNotification(<a href="#StatusNotificationType">StatusNotificationType</a> statusType, DOMString title, optional <a href="#StatusNotificationInit">StatusNotificationInit</a>? notificationInitDict);</span></pre></dl>
 </div>
 <div class="attributes">
 <h4>Attributes</h4>
@@ -2347,29 +2344,6 @@ If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare t
   enum UserNotificationType { "SIMPLE", "THUMBNAIL", "ONGOING", "PROGRESS" };
   enum NotificationProgressType { "PERCENTAGE", "BYTE" };
   enum LEDCustomFlags { "LED_CUSTOM_DUTY_ON", "LED_CUSTOM_DEFAULT" };
-  [NoInterfaceObject] interface NotificationObject {
-    readonly attribute <a href="#NotificationManager">NotificationManager</a> notification;
-  };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#NotificationObject">NotificationObject</a>;
-  [NoInterfaceObject] interface NotificationManager {
-    void post(<a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void update(<a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void remove(<a href="#NotificationId">NotificationId</a> id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removeAll() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    <a href="#Notification">Notification</a> getNotification(<a href="#NotificationId">NotificationId</a> id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    <a href="#Notification">Notification</a>[] getAllNotifications() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void playLEDCustomEffect(long timeOn, long timeOff, DOMString color, <a href="#LEDCustomFlags">LEDCustomFlags</a>[] flags) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void stopLEDCustomEffect() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void saveNotificationAsTemplate(DOMString name, <a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    <a href="#UserNotification">UserNotification</a> createNotificationFromTemplate(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  [NoInterfaceObject] interface Notification {
-    readonly attribute <a href="#NotificationId">NotificationId</a> id;
-    readonly attribute <a href="#NotificationType">NotificationType</a> type;
-    readonly attribute Date postedTime;
-    attribute DOMString title;
-    attribute DOMString? content;
-  };
   dictionary UserNotificationInit {
     DOMString? content;
     <a href="#NotificationTextContentInfo">NotificationTextContentInfo</a>? textContents;
@@ -2416,24 +2390,28 @@ If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare t
     unsigned long ledOnPeriod;
     unsigned long ledOffPeriod;
   };
-  [Constructor(<a href="#StatusNotificationType">StatusNotificationType</a> statusType, DOMString title, optional <a href="#StatusNotificationInit">StatusNotificationInit</a>? notificationInitDict)]
-  interface StatusNotification : <a href="#Notification">Notification</a> {
-    readonly attribute <a href="#StatusNotificationType">StatusNotificationType</a> statusType;
-    attribute DOMString? iconPath;
-    attribute DOMString? subIconPath;
-    attribute long? number;
-    attribute <a href="#NotificationDetailInfo">NotificationDetailInfo</a>[]? detailInfo;
-    attribute DOMString? ledColor;
-    attribute unsigned long ledOnPeriod;
-    attribute unsigned long ledOffPeriod;
-    attribute DOMString? backgroundImagePath;
-    attribute DOMString[]? thumbnails;
-    attribute DOMString? soundPath;
-    attribute boolean vibration;
-    attribute <a href="application.html#ApplicationControl">ApplicationControl</a>? appControl;
-    attribute <a href="application.html#ApplicationId">ApplicationId</a>? appId;
-    attribute <a href="#NotificationProgressType">NotificationProgressType</a> progressType;
-    attribute unsigned long? progressValue;
+  [NoInterfaceObject] interface NotificationObject {
+    readonly attribute <a href="#NotificationManager">NotificationManager</a> notification;
+  };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#NotificationObject">NotificationObject</a>;
+  [NoInterfaceObject] interface NotificationManager {
+    void post(<a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void update(<a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void remove(<a href="#NotificationId">NotificationId</a> id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removeAll() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#Notification">Notification</a> getNotification(<a href="#NotificationId">NotificationId</a> id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#Notification">Notification</a>[] getAllNotifications() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void playLEDCustomEffect(long timeOn, long timeOff, DOMString color, <a href="#LEDCustomFlags">LEDCustomFlags</a>[] flags) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void stopLEDCustomEffect() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void saveNotificationAsTemplate(DOMString name, <a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#UserNotification">UserNotification</a> createNotificationFromTemplate(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };
+  [NoInterfaceObject] interface Notification {
+    readonly attribute <a href="#NotificationId">NotificationId</a> id;
+    readonly attribute <a href="#NotificationType">NotificationType</a> type;
+    readonly attribute Date postedTime;
+    attribute DOMString title;
+    attribute DOMString? content;
   };
   [Constructor(<a href="#UserNotificationType">UserNotificationType</a> userType, DOMString title, optional <a href="#UserNotificationInit">UserNotificationInit</a>? notificationGroupedInitDict)]
   interface UserNotification : <a href="#Notification">Notification</a> {

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/package.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/package.html
@@ -460,8 +460,7 @@ The list of installed packages and their package IDs is obtained using <em>getPa
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">PackageInformation:
-                  </span>
+<span class="return">PackageInformation:</span>
  The information of a package.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/package.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/package.html
@@ -923,10 +923,10 @@ It is used in <em>tizen.package.getPackagesInfo()</em>.
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Package {
   typedef DOMString PackageId;
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PackageManagerObject">PackageManagerObject</a>;
   [NoInterfaceObject] interface PackageManagerObject {
     readonly attribute <a href="#PackageManager">PackageManager</a> package;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PackageManagerObject">PackageManagerObject</a>;
   [NoInterfaceObject] interface PackageManager {
     void install(DOMString packageFileURI, <a href="#PackageProgressCallback">PackageProgressCallback</a> progressCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                  raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/playerutil.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/playerutil.html
@@ -213,10 +213,10 @@ Changed latency mode is: HIGH
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module PlayerUtil {
   enum LatencyMode { "LOW", "MID", "HIGH" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PlayerUtilManagerObject">PlayerUtilManagerObject</a>;
   [NoInterfaceObject] interface PlayerUtilManagerObject {
     readonly attribute <a href="#PlayerUtilManager">PlayerUtilManager</a> playerutil;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PlayerUtilManagerObject">PlayerUtilManagerObject</a>;
   [NoInterfaceObject] interface PlayerUtilManager {
     <a href="#LatencyMode">LatencyMode</a> getLatencyMode() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void setLatencyMode(<a href="#LatencyMode">LatencyMode</a> mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/playerutil.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/playerutil.html
@@ -141,8 +141,7 @@ The <em>tizen.playerutil </em>object allows access to the functionality of the P
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">LatencyMode:
-                  </span>
+<span class="return">LatencyMode:</span>
  Latency mode, which is currently set on device.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/power.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/power.html
@@ -740,10 +740,10 @@ To guarantee that the application runs on a device which allows screen state cha
   enum PowerResource { "SCREEN", "CPU" };
   enum PowerScreenState { "SCREEN_OFF", "SCREEN_DIM", "SCREEN_NORMAL" };
   enum PowerCpuState { "CPU_AWAKE" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PowerManagerObject">PowerManagerObject</a>;
   [NoInterfaceObject] interface PowerManagerObject {
     readonly attribute <a href="#PowerManager">PowerManager</a> power;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PowerManagerObject">PowerManagerObject</a>;
   [NoInterfaceObject] interface PowerManager {
     void request(<a href="#PowerResource">PowerResource</a> resource, <a href="#PowerState">PowerState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void release(<a href="#PowerResource">PowerResource</a> resource) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/power.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/power.html
@@ -217,7 +217,9 @@ There will be a <em>tizen.power </em>object that allows accessing of a functiona
     void setScreenBrightness(double brightness) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     boolean isScreenOn() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void restoreScreenBrightness() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };</pre>
+<span class="nocode deprecated">    void turnScreenOn() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void turnScreenOff() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</pre>
 <p><span class="version">Since: </span>
  2.0
           </p>
@@ -432,8 +434,7 @@ tizen.power.unsetScreenStateChangeListener();
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">double:
-                  </span>
+<span class="return">double:</span>
  Current screen brightness value.
               </ul>
 </div>
@@ -529,8 +530,7 @@ tizen.power.setScreenBrightness(1);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if screen is on, otherwise <var>false</var> if the screen is off.
               </ul>
 </div>
@@ -736,10 +736,10 @@ To guarantee that the application runs on a device which allows screen state cha
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Power {
-  enum PowerResource { "SCREEN", "CPU" };
-  enum PowerScreenState { "SCREEN_OFF", "SCREEN_DIM", "SCREEN_NORMAL", "SCREEN_BRIGHT" };
-  enum PowerCpuState { "CPU_AWAKE" };
   typedef (<a href="#PowerScreenState">PowerScreenState</a> or <a href="#PowerCpuState">PowerCpuState</a>) PowerState;
+  enum PowerResource { "SCREEN", "CPU" };
+  enum PowerScreenState { "SCREEN_OFF", "SCREEN_DIM", "SCREEN_NORMAL" };
+  enum PowerCpuState { "CPU_AWAKE" };
   [NoInterfaceObject] interface PowerManagerObject {
     readonly attribute <a href="#PowerManager">PowerManager</a> power;
   };

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/ppm.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/ppm.html
@@ -223,8 +223,7 @@ For privileges not listed in application's <em>config.xml</em> file (or not priv
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">PermissionType:
-                  </span>
+<span class="return">PermissionType:</span>
  State of user's permission for using specified privilege.
               </ul>
 </div>
@@ -279,8 +278,7 @@ Maximum number of privileges that can be passed to array is 100.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">PrivilegeStatus[]:
-                  </span>
+<span class="return">PrivilegeStatus[]:</span>
  The array of status of user's permission for using specified privileges.
               </ul>
 </div>
@@ -400,7 +398,7 @@ tizen.ppm.requestPermission(
 <div class="brief">
  This method allows launching pop-up for asking user to directly grant permission for given privileges.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void requestPermissions(DOMString[] privileges, <a href="#PermissionRequestSuccessCallback">PermissionRequestSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void requestPermissions(DOMString[] privileges, <a href="#PermissionRequestSuccessCallback">PermissionRequestSuccessCallback</a> successCallback,
                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -566,8 +564,7 @@ User's action for privilege http://tizen.org/privilege/contact.write was to: PPM
 <div class="brief">
  The PermissionSuccessCallback interface that implements the success callback used in the asynchronous operation for requesting permission for using privilege.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PermissionSuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PermissionSuccessCallback {
     void onsuccess(<a href="#PermissionRequestResult">PermissionRequestResult</a> result, DOMString privilege);
   };</pre>
 <p><span class="version">Since: </span>
@@ -622,8 +619,7 @@ tizen.ppm.requestPermission("http://tizen.org/privilege/callhistory.read", permi
 <div class="brief">
  The PermissionRequestSuccessCallback interface implements the success callback used in the asynchronous operation of requesting permissions for using privilege.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PermissionRequestSuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PermissionRequestSuccessCallback {
     void onsuccess(<a href="#RequestStatus">RequestStatus</a>[] result);
   };</pre>
 <p><span class="version">Since: </span>
@@ -708,12 +704,10 @@ User's action for privilege http://tizen.org/privilege/contact.write was to: PPM
     readonly attribute DOMString privilege;
     readonly attribute <a href="#PermissionRequestResult">PermissionRequestResult</a> result;
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PermissionSuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface PermissionSuccessCallback {
     void onsuccess(<a href="#PermissionRequestResult">PermissionRequestResult</a> result, DOMString privilege);
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PermissionRequestSuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface PermissionRequestSuccessCallback {
     void onsuccess(<a href="#RequestStatus">RequestStatus</a>[] result);
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/ppm.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/ppm.html
@@ -684,10 +684,10 @@ User's action for privilege http://tizen.org/privilege/contact.write was to: PPM
 <pre class="webidl prettyprint">module PrivacyPrivilege {
   enum PermissionType { "PPM_ALLOW", "PPM_DENY", "PPM_ASK" };
   enum PermissionRequestResult { "PPM_ALLOW_FOREVER", "PPM_DENY_FOREVER", "PPM_DENY_ONCE" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PrivacyPrivilegeManagerObject">PrivacyPrivilegeManagerObject</a>;
   [NoInterfaceObject] interface PrivacyPrivilegeManagerObject {
     readonly attribute <a href="#PrivacyPrivilegeManager">PrivacyPrivilegeManager</a> ppm;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PrivacyPrivilegeManagerObject">PrivacyPrivilegeManagerObject</a>;
   [NoInterfaceObject] interface PrivacyPrivilegeManager {
     <a href="#PermissionType">PermissionType</a> checkPermission(DOMString privilege) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#PrivilegeStatus">PrivilegeStatus</a>[] checkPermissions(DOMString[] privileges) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/preference.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/preference.html
@@ -659,10 +659,10 @@ tizen.preference.getAll(successCB);
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Preference {
   typedef (DOMString or long or double or boolean) PreferenceValueType;
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PreferenceManagerObject">PreferenceManagerObject</a>;
   [NoInterfaceObject] interface PreferenceManagerObject {
     readonly attribute <a href="#PreferenceManager">PreferenceManager</a> preference;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PreferenceManagerObject">PreferenceManagerObject</a>;
   [NoInterfaceObject] interface PreferenceData {
     readonly attribute DOMString key;
     readonly attribute <a href="#PreferenceValueType">PreferenceValueType</a> value;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/preference.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/preference.html
@@ -297,8 +297,7 @@ tizen.preference.getAll(successCB);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">PreferenceValueType:
-                  </span>
+<span class="return">PreferenceValueType:</span>
  The value associated with the given key.
               </ul>
 </div>
@@ -418,8 +417,7 @@ console.log("The current value of the preference key1 is: " + currentValue);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  If <var>true</var> the key exists in the  application preference, otherwise <var>false</var>.
               </ul>
 </div>
@@ -660,11 +658,11 @@ tizen.preference.getAll(successCB);
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Preference {
+  typedef (DOMString or long or double or boolean) PreferenceValueType;
   [NoInterfaceObject] interface PreferenceManagerObject {
     readonly attribute <a href="#PreferenceManager">PreferenceManager</a> preference;
   };
   <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PreferenceManagerObject">PreferenceManagerObject</a>;
-  typedef (DOMString or long or double or boolean) PreferenceValueType;
   [NoInterfaceObject] interface PreferenceData {
     readonly attribute DOMString key;
     readonly attribute <a href="#PreferenceValueType">PreferenceValueType</a> value;

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/push.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/push.html
@@ -190,11 +190,16 @@ The <em>tizen.push </em>object allows access to the functionality of the Push AP
  The PushManager interface provides methods to manage push registration and notification.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface PushManager {
-    void register(<a href="#PushRegisterSuccessCallback">PushRegisterSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void unregister(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void connect(<a href="#PushRegistrationStateChangeCallback">PushRegistrationStateChangeCallback</a> stateChangeCallback, <a href="#PushNotificationCallback">PushNotificationCallback</a> notificationCallback,
+<span class="nocode deprecated">    void registerService(<a href="application.html#ApplicationControl">ApplicationControl</a> appControl, <a href="#PushRegisterSuccessCallback">PushRegisterSuccessCallback</a> successCallback,
+                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void register(<a href="#PushRegisterSuccessCallback">PushRegisterSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    void unregisterService(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void unregister(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    void connectService(<a href="#PushNotificationCallback">PushNotificationCallback</a> notificationCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void connect(<a href="#PushRegistrationStateChangeCallback">PushRegistrationStateChangeCallback</a> stateChangeCallback, <a href="#PushNotificationCallback">PushNotificationCallback</a> notificationCallback,
                  optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void disconnect() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    void disconnectService() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void disconnect() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#PushRegistrationId">PushRegistrationId</a> getRegistrationId() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void getUnreadNotifications() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#PushMessage">PushMessage</a>? getPushMessage() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -215,7 +220,7 @@ The <em>tizen.push </em>object allows access to the functionality of the Push AP
 <p class="deprecated"><b>Deprecated.</b>
  This function has been deprecated since 3.0. Use the <a href="push.html#PushManager::register">register()</a> function instead.
             </p>
-<div class="synopsis"><pre class="signature prettyprint">void registerService(<a href="application.html#ApplicationControl">ApplicationControl</a> appControl, <a href="#PushRegisterSuccessCallback">PushRegisterSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void registerService(<a href="application.html#ApplicationControl">ApplicationControl</a> appControl, <a href="#PushRegisterSuccessCallback">PushRegisterSuccessCallback</a> successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.1
@@ -655,7 +660,7 @@ tizen.push.registerService(service, registerSuccessCallback, errorCallback);
 <div class="brief">
  Connects to the push service and gets state change events and push notifications.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void connect(<a href="#PushRegistrationStateChangeCallback">PushRegistrationStateChangeCallback</a> stateChangeCallback, <a href="#PushNotificationCallback">PushNotificationCallback</a> notificationCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void connect(<a href="#PushRegistrationStateChangeCallback">PushRegistrationStateChangeCallback</a> stateChangeCallback, <a href="#PushNotificationCallback">PushNotificationCallback</a> notificationCallback,
              optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -829,8 +834,7 @@ tizen.push.disconnect();
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">PushRegistrationId:
-                  </span>
+<span class="return">PushRegistrationId:</span>
  ID assigned by push service.
               </ul>
 </div>
@@ -983,8 +987,7 @@ If the application was not launched by the push service, this method returns <va
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">PushMessage:
-                  </span>
+<span class="return">PushMessage<span class="optional"> [nullable]</span>:</span>
  The last message delivered from the push service or <var>null</var>.
               </ul>
 </div>
@@ -1150,8 +1153,7 @@ Details:
 <div class="brief">
  The PushRegisterSuccessCallback interface specifies the success callback for a push service registration request.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushRegisterSuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PushRegisterSuccessCallback {
     void onsuccess(<a href="#PushRegistrationId">PushRegistrationId</a> id);
   };</pre>
 <p><span class="version">Since: </span>
@@ -1194,8 +1196,7 @@ This success callback is invoked when a push service registration request is suc
 <div class="brief">
  The PushRegistrationStateChangeCallback interface specifies the state change callback for the state change event.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushRegistrationStateChangeCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PushRegistrationStateChangeCallback {
     void onsuccess(<a href="#PushRegistrationState">PushRegistrationState</a> state);
   };</pre>
 <p><span class="version">Since: </span>
@@ -1239,8 +1240,7 @@ Moreover PushRegistrationStateChangeCallback would be called at least once, just
 <div class="brief">
  The PushNotificationCallback interface specifies the notification callback for the received push notification message.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushNotificationCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PushNotificationCallback {
     void onsuccess(<a href="#PushMessage">PushMessage</a> message);
   };</pre>
 <p><span class="version">Since: </span>
@@ -1320,16 +1320,13 @@ To guarantee that the push application runs on a device with the push feature, d
     readonly attribute DOMString sessionInfo;
     readonly attribute DOMString requestId;
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushRegisterSuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface PushRegisterSuccessCallback {
     void onsuccess(<a href="#PushRegistrationId">PushRegistrationId</a> id);
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushRegistrationStateChangeCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface PushRegistrationStateChangeCallback {
     void onsuccess(<a href="#PushRegistrationState">PushRegistrationState</a> state);
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushNotificationCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface PushNotificationCallback {
     void onsuccess(<a href="#PushMessage">PushMessage</a> message);
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/push.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/push.html
@@ -1297,10 +1297,10 @@ To guarantee that the push application runs on a device with the push feature, d
 <pre class="webidl prettyprint">module Push {
   typedef DOMString PushRegistrationId;
   enum PushRegistrationState { "REGISTERED", "UNREGISTERED" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PushManagerObject">PushManagerObject</a>;
   [NoInterfaceObject] interface PushManagerObject {
     readonly attribute <a href="#PushManager">PushManager</a> push;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PushManagerObject">PushManagerObject</a>;
   [NoInterfaceObject] interface PushManager {
     void register(<a href="#PushRegisterSuccessCallback">PushRegisterSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unregister(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/se.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/se.html
@@ -284,8 +284,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">unsigned long:
-                  </span>
+<span class="return">unsigned long:</span>
  An identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -486,8 +485,7 @@ This interface offers methods to control sessions on the reader.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The name of the reader.
               </ul>
 </div>
@@ -917,8 +915,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">byte[]:
-                  </span>
+<span class="return">byte[]:</span>
  The ATR of a Secure Element.
               </ul>
 </div>
@@ -1221,8 +1218,7 @@ the selection response can not be retrieved by the reader implementation.       
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">byte[]:
-                  </span>
+<span class="return">byte[]:</span>
  The data as returned by the application select command including the status words.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/se.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/se.html
@@ -1516,10 +1516,10 @@ To guarantee this application will run on a device with a Secure Element, add th
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module SecureElement {
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SEServiceManagerObject">SEServiceManagerObject</a>;
   [NoInterfaceObject] interface SEServiceManagerObject {
     readonly attribute <a href="#SEService">SEService</a> seService;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SEServiceManagerObject">SEServiceManagerObject</a>;
   [NoInterfaceObject] interface SEService {
     void getReaders(<a href="#ReaderArraySuccessCallback">ReaderArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     unsigned long registerSEListener(<a href="#SEChangeListener">SEChangeListener</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/sensor.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/sensor.html
@@ -473,8 +473,7 @@ The supported sensor types are hardware-dependent. <br><br>To check if the given
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Sensor:
-                  </span>
+<span class="return">Sensor:</span>
  Default sensor object.
               </ul>
 </div>
@@ -527,8 +526,7 @@ else
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">SensorType[]:
-                  </span>
+<span class="return">SensorType[]:</span>
  All available sensor types.
               </ul>
 </div>
@@ -2979,7 +2977,7 @@ For more information about sensor, see <a href="https://developer.tizen.org/deve
 <div class="brief">
  The SensorHardwareInfoSuccessCallback callback interface specifies a success callback with SensorHardwareInfo object as an input argument.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface SensorHardwareInfoSuccessCallback{
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface SensorHardwareInfoSuccessCallback {
     void onsuccess(<a href="#SensorHardwareInfo">SensorHardwareInfo</a> hardwareInfo);
   };</pre>
 <p><span class="version">Since: </span>
@@ -3127,8 +3125,8 @@ To guarantee that the UV sensor application runs on a device with a UV sensor, d
 <pre class="webidl prettyprint">module Sensor {
   enum MagneticSensorAccuracy { "ACCURACY_UNDEFINED", "ACCURACY_BAD", "ACCURACY_NORMAL", "ACCURACY_GOOD", "ACCURACY_VERYGOOD" };
   enum ProximityState { "FAR", "NEAR" };
-  enum SensorType { "ACCELERATION", "GRAVITY", "GYROSCOPE", "GYROSCOPE_ROTATION_VECTOR", "GYROSCOPE_UNCALIBRATED", "HRM_RAW", "LIGHT",
-    "LINEAR_ACCELERATION", "MAGNETIC", "MAGNETIC_UNCALIBRATED", "PRESSURE", "PROXIMITY", "ULTRAVIOLET" };
+  enum SensorType { "ACCELERATION", "GRAVITY", "GYROSCOPE", "GYROSCOPE_ROTATION_VECTOR", "GYROSCOPE_UNCALIBRATED",
+    "HRM_RAW", "LIGHT", "LINEAR_ACCELERATION", "MAGNETIC", "MAGNETIC_UNCALIBRATED", "PRESSURE", "PROXIMITY", "ULTRAVIOLET" };
   [NoInterfaceObject] interface SensorServiceManagerObject {
     readonly attribute <a href="#SensorService">SensorService</a> sensorservice;
   };
@@ -3276,7 +3274,7 @@ To guarantee that the UV sensor application runs on a device with a UV sensor, d
   [Callback=FunctionOnly, NoInterfaceObject] interface SensorDataSuccessCallback {
     void onsuccess(optional <a href="#SensorData">SensorData</a>? sensorData);
   };
-  [Callback=FunctionOnly, NoInterfaceObject] interface SensorHardwareInfoSuccessCallback{
+  [Callback=FunctionOnly, NoInterfaceObject] interface SensorHardwareInfoSuccessCallback {
     void onsuccess(<a href="#SensorHardwareInfo">SensorHardwareInfo</a> hardwareInfo);
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/sensor.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/sensor.html
@@ -3127,10 +3127,10 @@ To guarantee that the UV sensor application runs on a device with a UV sensor, d
   enum ProximityState { "FAR", "NEAR" };
   enum SensorType { "ACCELERATION", "GRAVITY", "GYROSCOPE", "GYROSCOPE_ROTATION_VECTOR", "GYROSCOPE_UNCALIBRATED",
     "HRM_RAW", "LIGHT", "LINEAR_ACCELERATION", "MAGNETIC", "MAGNETIC_UNCALIBRATED", "PRESSURE", "PROXIMITY", "ULTRAVIOLET" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SensorServiceManagerObject">SensorServiceManagerObject</a>;
   [NoInterfaceObject] interface SensorServiceManagerObject {
     readonly attribute <a href="#SensorService">SensorService</a> sensorservice;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SensorServiceManagerObject">SensorServiceManagerObject</a>;
   [NoInterfaceObject] interface SensorService {
     <a href="#Sensor">Sensor</a> getDefaultSensor(<a href="#SensorType">SensorType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#SensorType">SensorType</a>[] getAvailableSensors() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/sound.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/sound.html
@@ -286,8 +286,7 @@ There is a tizen.sound object that allows accessing the functionality of the Sou
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">SoundModeType:
-                  </span>
+<span class="return">SoundModeType:</span>
  The current sound mode.
               </ul>
 </div>
@@ -374,8 +373,7 @@ There is a tizen.sound object that allows accessing the functionality of the Sou
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">double:
-                  </span>
+<span class="return">double:</span>
  The current volume level.
               </ul>
 </div>
@@ -526,8 +524,7 @@ Calling this function has no effect if listener is not set.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">SoundDeviceInfo[]:
-                  </span>
+<span class="return">SoundDeviceInfo[]:</span>
  List of connected sound devices.
               </ul>
 </div>
@@ -562,8 +559,7 @@ for (var i = 0; i &lt; infoArr.length; i++)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">SoundDeviceInfo[]:
-                  </span>
+<span class="return">SoundDeviceInfo[]:</span>
  List of activated sound devices.
               </ul>
 </div>
@@ -618,8 +614,7 @@ Activation: When a device changes from being activated to being deactivated or f
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  ID of the listener that can be used to remove the listener later.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/sound.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/sound.html
@@ -898,10 +898,10 @@ tizen.sound.removeDeviceStateChangeListener(id);
   enum SoundModeType { "SOUND", "VIBRATE", "MUTE" };
   enum SoundDeviceType { "SPEAKER", "RECEIVER", "AUDIO_JACK", "BLUETOOTH", "HDMI", "MIRRORING", "USB_AUDIO", "MIC" };
   enum SoundIOType { "IN", "OUT", "BOTH" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SoundManagerObject">SoundManagerObject</a>;
   [NoInterfaceObject] interface SoundManagerObject {
     readonly attribute <a href="#SoundManager">SoundManager</a> sound;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SoundManagerObject">SoundManagerObject</a>;
   [NoInterfaceObject] interface SoundManager {
     <a href="#SoundModeType">SoundModeType</a> getSoundMode() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void setVolume(<a href="#SoundType">SoundType</a> type, double volume) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/systeminfo.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/systeminfo.html
@@ -3505,10 +3505,10 @@ To guarantee the running of the application on a device which supports Wi-Fi, de
     double highThreshold;
     double lowThreshold;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SystemInfoObject">SystemInfoObject</a>;
   [NoInterfaceObject] interface SystemInfoObject {
     readonly attribute <a href="#SystemInfo">SystemInfo</a> systeminfo;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SystemInfoObject">SystemInfoObject</a>;
   [NoInterfaceObject] interface SystemInfo {
     long long getTotalMemory() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long long getAvailableMemory() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/systeminfo.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/systeminfo.html
@@ -469,7 +469,8 @@ functionality of the System Information API.
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface SystemInfo {
     long long getTotalMemory() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long long getAvailableMemory() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    any getCapability(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    <a href="#SystemInfoDeviceCapability">SystemInfoDeviceCapability</a> getCapabilities() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    any getCapability(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long getCount(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void getPropertyValue(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertySuccessCallback">SystemInfoPropertySuccessCallback</a> successCallback,
                           optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -507,8 +508,7 @@ and for subscribing notifications of system information changes.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long long:
-                  </span>
+<span class="return">long long:</span>
  Total system memory.
               </ul>
 </div>
@@ -539,8 +539,7 @@ console.log("The total memory size is " + tizen.systeminfo.getTotalMemory() + " 
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long long:
-                  </span>
+<span class="return">long long:</span>
  Not used memory in bytes.
               </ul>
 </div>
@@ -579,8 +578,7 @@ The function must synchronously acquire the capabilities of the device.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">SystemInfoDeviceCapability:
-                  </span>
+<span class="return">SystemInfoDeviceCapability:</span>
  Capabilities of the device.
               </ul>
 </div>
@@ -630,8 +628,7 @@ The additional keys for the custom device capability are specified by OEMs and v
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">any:
-                  </span>
+<span class="return">any:</span>
  The value of the specified device capability.
               </ul>
 </div>
@@ -684,8 +681,7 @@ That is the length of array retrieved by the <a href="#SystemInfo::getPropertyVa
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The number of property values for the given property. If the property is not supported, 0 is returned.
               </ul>
 </div>
@@ -716,7 +712,7 @@ else
 <div class="brief">
  Gets the current value of a specified system property.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getPropertyValue(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertySuccessCallback">SystemInfoPropertySuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getPropertyValue(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertySuccessCallback">SystemInfoPropertySuccessCallback</a> successCallback,
                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -826,7 +822,7 @@ else
 <div class="brief">
  Gets the current values of a specified system property.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getPropertyValueArray(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertyArraySuccessCallback">SystemInfoPropertyArraySuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getPropertyValueArray(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertyArraySuccessCallback">SystemInfoPropertyArraySuccessCallback</a> successCallback,
                            optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -920,7 +916,7 @@ else
 <div class="brief">
  Adds a listener to allow tracking changes in one or more system properties.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">unsigned long addPropertyValueChangeListener(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertySuccessCallback">SystemInfoPropertySuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">unsigned long addPropertyValueChangeListener(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertySuccessCallback">SystemInfoPropertySuccessCallback</a> successCallback,
                                              optional <a href="#SystemInfoOptions">SystemInfoOptions</a>? options, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -984,8 +980,7 @@ NotSupportedError - If the given <var>property</var> is not supported (since Tiz
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">unsigned long:
-                  </span>
+<span class="return">unsigned long:</span>
  An identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -1024,8 +1019,8 @@ tizen.systeminfo.addPropertyValueChangeListener("CPU", onSuccessCallback, {lowTh
 <div class="brief">
  Adds a listener to allow tracking of changes in one or more values of a system property.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">unsigned long addPropertyValueArrayChangeListener(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, 
-                                                  <a href="#SystemInfoPropertyArraySuccessCallback">SystemInfoPropertyArraySuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">unsigned long addPropertyValueArrayChangeListener(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property,
+                                                  <a href="#SystemInfoPropertyArraySuccessCallback">SystemInfoPropertyArraySuccessCallback</a> successCallback,
                                                   optional <a href="#SystemInfoOptions">SystemInfoOptions</a>? options, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -1073,8 +1068,7 @@ any identifier of these properties, but the listener added for them will not be 
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">unsigned long:
-                  </span>
+<span class="return">unsigned long:</span>
  An identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -1167,7 +1161,7 @@ id = tizen.systeminfo.addPropertyValueChangeListener("CPU", onSuccessCallback);
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 2.3. Instead, use <a href="#SystemInfo::getCapability">getCapability()</a> to query device capabilities.
           </p>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface SystemInfoDeviceCapability {
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface SystemInfoDeviceCapability {
     readonly attribute boolean bluetooth;
     readonly attribute boolean nfc;
     readonly attribute boolean nfcReservedPush;
@@ -1236,7 +1230,7 @@ id = tizen.systeminfo.addPropertyValueChangeListener("CPU", onSuccessCallback);
     readonly attribute boolean secureElement;
     readonly attribute boolean nativeOspCompatible;
     readonly attribute <a href="#SystemInfoProfile">SystemInfoProfile</a> profile;
-  };</pre>
+  };</span></pre>
 <p><span class="version">Since: </span>
  2.0
           </p>
@@ -2281,7 +2275,8 @@ Any threshold parameter used in a watch function to monitor this property applie
     readonly attribute unsigned long long capacity;
     readonly attribute unsigned long long availableCapacity;
     readonly attribute boolean isRemovable;
-  };</pre>
+<span class="nocode deprecated">    readonly attribute boolean isRemoveable;
+</span>  };</pre>
         
       <div class="attributes">
 <h4>Attributes</h4>
@@ -3496,13 +3491,20 @@ To guarantee the running of the application on a device which supports Wi-Fi, de
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module SystemInfo {
-  enum SystemInfoPropertyId { "BATTERY", "CPU", "STORAGE", "DISPLAY", "DEVICE_ORIENTATION", "BUILD", "LOCALE", "NETWORK", "WIFI_NETWORK",
-    "ETHERNET_NETWORK", "CELLULAR_NETWORK", "NET_PROXY_NETWORK", "SIM", "PERIPHERAL", "MEMORY", "CAMERA_FLASH", "ADS" };
+  enum SystemInfoPropertyId { "BATTERY", "CPU", "STORAGE", "DISPLAY", "DEVICE_ORIENTATION", "BUILD", "LOCALE", "NETWORK",
+    "WIFI_NETWORK", "ETHERNET_NETWORK", "CELLULAR_NETWORK", "NET_PROXY_NETWORK", "SIM", "PERIPHERAL", "MEMORY", "CAMERA_FLASH",
+    "ADS" };
   enum SystemInfoNetworkType { "NONE", "2G", "2.5G", "3G", "4G", "WIFI", "ETHERNET", "NET_PROXY", "UNKNOWN" };
   enum SystemInfoDeviceOrientationStatus { "PORTRAIT_PRIMARY", "PORTRAIT_SECONDARY", "LANDSCAPE_PRIMARY", "LANDSCAPE_SECONDARY" };
-  enum SystemInfoSimState { "ABSENT", "INITIALIZING", "READY", "PIN_REQUIRED", "PUK_REQUIRED", "NETWORK_LOCKED", "SIM_LOCKED", "UNKNOWN" };
-  enum SystemInfoProfile { "MOBILE_FULL", "MOBILE_WEB", "MOBILE", "WEARABLE", "TV" };
+  enum SystemInfoSimState { "ABSENT", "INITIALIZING", "READY", "PIN_REQUIRED", "PUK_REQUIRED", "NETWORK_LOCKED",
+    "SIM_LOCKED", "UNKNOWN" };
+  enum SystemInfoProfile { "MOBILE", "WEARABLE", "TV" };
   enum SystemInfoLowMemoryStatus { "NORMAL", "WARNING" };
+  dictionary SystemInfoOptions {
+    unsigned long timeout;
+    double highThreshold;
+    double lowThreshold;
+  };
   [NoInterfaceObject] interface SystemInfoObject {
     readonly attribute <a href="#SystemInfo">SystemInfo</a> systeminfo;
   };
@@ -3524,11 +3526,6 @@ To guarantee the running of the application on a device which supports Wi-Fi, de
                                                       optional <a href="#SystemInfoOptions">SystemInfoOptions</a>? options, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                                                       raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removePropertyValueChangeListener(unsigned long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  dictionary SystemInfoOptions {
-    unsigned long timeout;
-    double highThreshold;
-    double lowThreshold;
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface SystemInfoPropertySuccessCallback {
     void onsuccess(<a href="#SystemInfoProperty">SystemInfoProperty</a> property);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/systemsetting.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/systemsetting.html
@@ -428,10 +428,10 @@ tizen.systemsetting.getProperty("HOME_SCREEN", getPropertySuccessCallback, error
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module SystemSetting {
   enum SystemSettingType { "HOME_SCREEN", "LOCK_SCREEN", "INCOMING_CALL", "NOTIFICATION_EMAIL" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SystemSettingObject">SystemSettingObject</a>;
   [NoInterfaceObject] interface SystemSettingObject {
     readonly attribute <a href="#SystemSettingManager">SystemSettingManager</a> systemsetting;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SystemSettingObject">SystemSettingObject</a>;
   [NoInterfaceObject] interface SystemSettingManager {
     void setProperty(<a href="#SystemSettingType">SystemSettingType</a> type, DOMString value, <a href="tizen.html#SuccessCallback">SuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/systemsetting.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/systemsetting.html
@@ -427,11 +427,11 @@ tizen.systemsetting.getProperty("HOME_SCREEN", getPropertySuccessCallback, error
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module SystemSetting {
+  enum SystemSettingType { "HOME_SCREEN", "LOCK_SCREEN", "INCOMING_CALL", "NOTIFICATION_EMAIL" };
   [NoInterfaceObject] interface SystemSettingObject {
     readonly attribute <a href="#SystemSettingManager">SystemSettingManager</a> systemsetting;
   };
   <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SystemSettingObject">SystemSettingObject</a>;
-  enum SystemSettingType { "HOME_SCREEN", "LOCK_SCREEN", "INCOMING_CALL", "NOTIFICATION_EMAIL" };
   [NoInterfaceObject] interface SystemSettingManager {
     void setProperty(<a href="#SystemSettingType">SystemSettingType</a> type, DOMString value, <a href="tizen.html#SuccessCallback">SuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/time.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/time.html
@@ -273,8 +273,7 @@ Get timezones using getLocalTimezone() and getAvailableTimezones().            <
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate:</span>
  The current TZDate object.
               </ul>
 </div>
@@ -305,8 +304,7 @@ console.log("current date/time is " + current_dt.toLocaleString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The local timezone.
               </ul>
 </div>
@@ -353,8 +351,7 @@ with the most general descriptor first and the most specific one last. For examp
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString[]:
-                  </span>
+<span class="return">DOMString[]:</span>
  Array of time zone identifiers.
               </ul>
 </div>
@@ -430,8 +427,7 @@ date format (23/10/2011) instead of a long date format ("Monday, October 23 2011
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The date format according to the system's locale settings.
               </ul>
 </div>
@@ -485,8 +481,7 @@ Examples of string formats include: "h:m:s ap", "h:m:s".
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The time format according to the system's locale settings.
               </ul>
 </div>
@@ -528,8 +523,7 @@ console.log(timeFormat);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var>, if the year is a leap year.
               </ul>
 </div>
@@ -813,7 +807,8 @@ If its date/time exceeds the platform limit, TZDate will be invalid.
     DOMString toDateString();
     DOMString toTimeString();
     DOMString toString();
-    long secondsFromUTC() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    DOMString getTimezoneAbbreviation() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    long secondsFromUTC() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     boolean isDST() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#TZDate">TZDate</a>? getPreviousDSTTransition() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#TZDate">TZDate</a>? getNextDSTTransition() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -849,7 +844,7 @@ var myDate = new tizen.TZDate(1999, 11, 31, 23, 59, 59, 999, "Europe/Berlin");
           </ul>
 </div>
 <pre class="webidl prettyprint">TZDate(optional Date? datetime, optional DOMString? timezone);</pre>
-<pre class="webidl prettyprint">TZDate(long year, long month, long day, optional long? hours, optional long? minutes, optional long? seconds, 
+<pre class="webidl prettyprint">TZDate(long year, long month, long day, optional long? hours, optional long? minutes, optional long? seconds,
        optional long? milliseconds, optional DOMString? timezone);</pre>
 </dl>
 </div>
@@ -870,8 +865,7 @@ var myDate = new tizen.TZDate(1999, 11, 31, 23, 59, 59, 999, "Europe/Berlin");
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The day of the month.
               </ul>
 </div>
@@ -928,8 +922,7 @@ console.log(someDate.getDate());  /* Outputs 1. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The day of the week.
               </ul>
 </div>
@@ -959,8 +952,7 @@ For example, 1 = AD 1, 0 = BC 1, -1 = BC 2.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The year.
               </ul>
 </div>
@@ -1011,8 +1003,7 @@ console.log(someDate.getFullYear());  /* Outputs 2099. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The hour.
               </ul>
 </div>
@@ -1069,8 +1060,7 @@ console.log(someDate.getHours());  /* Outputs 15. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The milliseconds.
               </ul>
 </div>
@@ -1127,8 +1117,7 @@ console.log(someDate.getMilliseconds());  /* Outputs 42. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The minutes.
               </ul>
 </div>
@@ -1185,8 +1174,7 @@ console.log(someDate.getMinutes());  /* Outputs 58. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The month.
               </ul>
 </div>
@@ -1243,8 +1231,7 @@ console.log(someDate.getMonth());  /* Outputs 2. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The seconds.
               </ul>
 </div>
@@ -1301,8 +1288,7 @@ console.log(someDate.getSeconds());  /* Outputs 23. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The day of the month, according to universal time.
               </ul>
 </div>
@@ -1359,8 +1345,7 @@ console.log(someDate.getUTCDate());  /* Outputs 5. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The day of the week, according to universal time.
               </ul>
 </div>
@@ -1390,8 +1375,7 @@ For example, 1 = AD 1, 0 = BC 1, -1 = BC 2.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The year, according to universal time.
               </ul>
 </div>
@@ -1442,8 +1426,7 @@ console.log(someDate.getUTCFullYear());  /* Outputs 2099. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The hour, according to universal time.
               </ul>
 </div>
@@ -1500,8 +1483,7 @@ console.log(someDate.getUTCHours());  /* Outputs 15. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The milliseconds, according to universal time.
               </ul>
 </div>
@@ -1558,8 +1540,7 @@ console.log(someDate.getUTCMilliseconds());  /* Outputs 42. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The minutes, according to universal time.
               </ul>
 </div>
@@ -1616,8 +1597,7 @@ console.log(someDate.getUTCMinutes());  /* Outputs 58. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The month, according to universal time.
               </ul>
 </div>
@@ -1674,8 +1654,7 @@ console.log(someDate.getUTCMonth());  /* Outputs 2. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The seconds, according to universal time.
               </ul>
 </div>
@@ -1742,8 +1721,7 @@ This attribute uniquely identifies the timezone.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The string timezone identifier. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -1780,8 +1758,7 @@ console.log(someDate.getTimezone());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate:</span>
  The new TZDate in given Timezone.
               </ul>
 </div>
@@ -1827,8 +1804,7 @@ console.log(someDate.toString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate:</span>
  The new TZDate in local Timezone.
               </ul>
 </div>
@@ -1866,8 +1842,7 @@ console.log(localDate.toString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate:</span>
  The Date/Time in UTC.
               </ul>
 </div>
@@ -1931,8 +1906,7 @@ Positive, if other is in the past              </li>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TimeDuration:
-                  </span>
+<span class="return">TimeDuration:</span>
  The duration in milliseconds between the two date/time objects
 (or in days for comparison between dates with no time component).
               </ul>
@@ -2008,8 +1982,7 @@ the two TZDate objects represent the same instant in different timezones.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if the 2 date/times are the same.
               </ul>
 </div>
@@ -2089,8 +2062,7 @@ This method takes the timezones into consideration.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var>, if the Date/Time is earlier than the one passed in argument.
               </ul>
 </div>
@@ -2150,8 +2122,7 @@ This method takes the timezones into consideration.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var>, if the Date/Time is later than the one passed in argument.
               </ul>
 </div>
@@ -2215,8 +2186,7 @@ Note that calling this method does not alter the current object.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate:</span>
  The new TZDate by adding a duration.
               </ul>
 </div>
@@ -2253,8 +2223,7 @@ var in_one_week = now.addDuration(new tizen.TimeDuration(7, "DAYS"));
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The date portion of the TZDate object as a string, using locale conventions. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2282,8 +2251,7 @@ console.log(someDate.toLocaleDateString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The time portion of the TZDate object as a string, using locale conventions. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2311,8 +2279,7 @@ console.log(someDate.toLocaleTimeString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The string representation of the TZDate object, using locale conventions. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2340,8 +2307,7 @@ console.log(someDate.toLocaleString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The date portion of the TZDate object as a string. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2367,8 +2333,7 @@ console.log(someDate.toDateString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The time portion of the TZDate object as a string. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2394,8 +2359,7 @@ console.log(someDate.toTimeString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The string representation of the TZDate object. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2430,8 +2394,7 @@ summer months when daylight savings time is in effect.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  DOMString The abbreviation of the time zone (such as "EST") <br>If TZDate is invalid, it will return 'Invalid Date'.
               </ul>
 </div>
@@ -2474,8 +2437,7 @@ savings if it is in the timezone. For example, if time zone is GMT+8, it will re
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The offset from UTC in seconds.
               </ul>
 </div>
@@ -2514,8 +2476,7 @@ identified by the TZDate object.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  The flag indicating whether the daylight saving are in effect.
               </ul>
 </div>
@@ -2549,8 +2510,7 @@ var isDstActiveInWinter = wintertime.isDST();  /* false. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate<span class="optional"> [nullable]</span>:</span>
  The date of the previous daylight saving transition (before the instant identified by the TZDate).
               </ul>
 </div>
@@ -2587,8 +2547,7 @@ console.log(previousDstTransition.toString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate<span class="optional"> [nullable]</span>:</span>
  The date of the next daylight saving transition (after the instant identified by the TZDate).
               </ul>
 </div>
@@ -2722,8 +2681,7 @@ The returned TimeDuration is the biggest possible unit without losing the precis
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TimeDuration:
-                  </span>
+<span class="return">TimeDuration:</span>
  New TimeDuration object corresponding to the result of <em>this</em> - <em>other</em>.
               </ul>
 </div>
@@ -2782,8 +2740,7 @@ if the two TimeDuration objects represent the same duration in different units.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if the two TimeDuration object represent the same duration.
               </ul>
 </div>
@@ -2835,8 +2792,7 @@ This method takes the units into consideration when doing the comparison.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if the TimeDuration is less than <em>other</em>.
               </ul>
 </div>
@@ -2887,8 +2843,7 @@ This method takes the units into consideration when doing the comparison.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if the TimeDuration is greater than <em>other</em>.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/time.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/time.html
@@ -2874,10 +2874,10 @@ var ret = d1.greaterThan(d2);                  /* Returns true. */
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Time {
   enum TimeDurationUnit { "MSECS", "SECS", "MINS", "HOURS", "DAYS" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#TimeManagerObject">TimeManagerObject</a>;
   [NoInterfaceObject] interface TimeManagerObject {
     readonly attribute <a href="#TimeUtil">TimeUtil</a> time;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#TimeManagerObject">TimeManagerObject</a>;
   [NoInterfaceObject] interface TimeUtil {
     <a href="#TZDate">TZDate</a> getCurrentDateTime() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     DOMString getLocalTimezone() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/tizen.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/tizen.html
@@ -1703,10 +1703,10 @@ type: STRING
   enum SortModeOrder { "ASC", "DESC" };
   enum CompositeFilterType { "UNION", "INTERSECTION" };
   enum BundleValueType { "STRING", "STRING_ARRAY", "BYTES", "BYTES_ARRAY" };
+  Window implements <a href="#TizenObject">TizenObject</a>;
   [NoInterfaceObject] interface TizenObject {
     readonly attribute <a href="#Tizen">Tizen</a> tizen;
   };
-  Window implements <a href="#TizenObject">TizenObject</a>;
   [NoInterfaceObject] interface Tizen {
   };
   [Constructor(optional object? json)]

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/tizen.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/tizen.html
@@ -331,9 +331,9 @@ It is a property of the ECMAScript global object, as specified by the <em>TizenO
           </div>
 <pre class="webidl prettyprint">  [Constructor(optional object? json)]
   interface Bundle {
-    any get(DOMString key) raises(<a href="#WebAPIException">WebAPIException</a>);
+    any get(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void set(DOMString key, any value);
-    <a href="#BundleValueType">BundleValueType</a> typeOf(DOMString key) raises(<a href="#WebAPIException">WebAPIException</a>);
+    <a href="#BundleValueType">BundleValueType</a> typeOf(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void forEach(<a href="#BundleItemCallback">BundleItemCallback</a> callback);
     object toJSON();
     DOMString toString();
@@ -377,8 +377,7 @@ All supported value types are specified in the BundleValueType enum.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">any:
-                  </span>
+<span class="return">any:</span>
  Bundle entry value for a given key.
               </ul>
 </div>
@@ -482,8 +481,7 @@ console.log(bundle.get("empty"));
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">BundleValueType:
-                  </span>
+<span class="return">BundleValueType:</span>
  Entry value type.
               </ul>
 </div>
@@ -588,8 +586,7 @@ type: STRING
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">object:
-                  </span>
+<span class="return">object:</span>
  JSON-compatible object.
               </ul>
 </div>
@@ -618,8 +615,7 @@ console.log(JSON.stringify(json));
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  JSON string representation of the bundle's data.
               </ul>
 </div>
@@ -1101,27 +1097,23 @@ catch (err)
 <div class="brief">
  Generic exception interface.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject]
-  interface WebAPIException {
-    readonly attribute unsigned short code;
-    readonly attribute DOMString name;
-    readonly attribute DOMString message;
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface WebAPIException {
     const unsigned short INDEX_SIZE_ERR = 1;
-    const unsigned short DOMSTRING_SIZE_ERR = 2; 
+    const unsigned short DOMSTRING_SIZE_ERR = 2;
     const unsigned short HIERARCHY_REQUEST_ERR = 3;
     const unsigned short WRONG_DOCUMENT_ERR = 4;
     const unsigned short INVALID_CHARACTER_ERR = 5;
-    const unsigned short NO_DATA_ALLOWED_ERR = 6; 
+    const unsigned short NO_DATA_ALLOWED_ERR = 6;
     const unsigned short NO_MODIFICATION_ALLOWED_ERR = 7;
     const unsigned short NOT_FOUND_ERR = 8;
     const unsigned short NOT_SUPPORTED_ERR = 9;
-    const unsigned short INUSE_ATTRIBUTE_ERR = 10; 
+    const unsigned short INUSE_ATTRIBUTE_ERR = 10;
     const unsigned short INVALID_STATE_ERR = 11;
     const unsigned short SYNTAX_ERR = 12;
     const unsigned short INVALID_MODIFICATION_ERR = 13;
     const unsigned short NAMESPACE_ERR = 14;
     const unsigned short INVALID_ACCESS_ERR = 15;
-    const unsigned short VALIDATION_ERR = 16; 
+    const unsigned short VALIDATION_ERR = 16;
     const unsigned short TYPE_MISMATCH_ERR = 17;
     const unsigned short SECURITY_ERR = 18;
     const unsigned short NETWORK_ERR = 19;
@@ -1131,6 +1123,9 @@ catch (err)
     const unsigned short TIMEOUT_ERR = 23;
     const unsigned short INVALID_NODE_TYPE_ERR = 24;
     const unsigned short DATA_CLONE_ERR = 25;
+    readonly attribute unsigned short code;
+    readonly attribute DOMString name;
+    readonly attribute DOMString message;
   };</pre>
 <p><span class="version">Since: </span>
  2.0
@@ -1440,8 +1435,7 @@ This attribute is mainly intended to be used for developers rather than end user
 <div class="brief">
  Generic error interface.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject]
-  interface WebAPIError {
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface WebAPIError {
     readonly attribute unsigned short code;
     readonly attribute DOMString name;
     readonly attribute DOMString message;
@@ -1522,8 +1516,7 @@ as it is mainly intended to be useful for developers rather than end users.
 <div class="brief">
  This interface is used in methods that do not require any return value in the success callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface SuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {
     void onsuccess();
   };</pre>
 <p><span class="version">Since: </span>
@@ -1572,8 +1565,7 @@ tizen.application.launch(otherAppID, onSuccess);
 <div class="brief">
  This interface is used in methods that require only an error as an input parameter in the error callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface ErrorCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="#WebAPIError">WebAPIError</a> error);
   };</pre>
 <p><span class="version">Since: </span>
@@ -1719,9 +1711,9 @@ type: STRING
   };
   [Constructor(optional object? json)]
   interface Bundle {
-    any get(DOMString key) raises(<a href="#WebAPIException">WebAPIException</a>);
+    any get(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void set(DOMString key, any value);
-    <a href="#BundleValueType">BundleValueType</a> typeOf(DOMString key) raises(<a href="#WebAPIException">WebAPIException</a>);
+    <a href="#BundleValueType">BundleValueType</a> typeOf(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void forEach(<a href="#BundleItemCallback">BundleItemCallback</a> callback);
     object toJSON();
     DOMString toString();
@@ -1755,27 +1747,23 @@ type: STRING
     attribute double latitude;
     attribute double longitude;
   };
-  [NoInterfaceObject]
-  interface WebAPIException {
-    readonly attribute unsigned short code;
-    readonly attribute DOMString name;
-    readonly attribute DOMString message;
+  [NoInterfaceObject] interface WebAPIException {
     const unsigned short INDEX_SIZE_ERR = 1;
-    const unsigned short DOMSTRING_SIZE_ERR = 2; 
+    const unsigned short DOMSTRING_SIZE_ERR = 2;
     const unsigned short HIERARCHY_REQUEST_ERR = 3;
     const unsigned short WRONG_DOCUMENT_ERR = 4;
     const unsigned short INVALID_CHARACTER_ERR = 5;
-    const unsigned short NO_DATA_ALLOWED_ERR = 6; 
+    const unsigned short NO_DATA_ALLOWED_ERR = 6;
     const unsigned short NO_MODIFICATION_ALLOWED_ERR = 7;
     const unsigned short NOT_FOUND_ERR = 8;
     const unsigned short NOT_SUPPORTED_ERR = 9;
-    const unsigned short INUSE_ATTRIBUTE_ERR = 10; 
+    const unsigned short INUSE_ATTRIBUTE_ERR = 10;
     const unsigned short INVALID_STATE_ERR = 11;
     const unsigned short SYNTAX_ERR = 12;
     const unsigned short INVALID_MODIFICATION_ERR = 13;
     const unsigned short NAMESPACE_ERR = 14;
     const unsigned short INVALID_ACCESS_ERR = 15;
-    const unsigned short VALIDATION_ERR = 16; 
+    const unsigned short VALIDATION_ERR = 16;
     const unsigned short TYPE_MISMATCH_ERR = 17;
     const unsigned short SECURITY_ERR = 18;
     const unsigned short NETWORK_ERR = 19;
@@ -1785,19 +1773,19 @@ type: STRING
     const unsigned short TIMEOUT_ERR = 23;
     const unsigned short INVALID_NODE_TYPE_ERR = 24;
     const unsigned short DATA_CLONE_ERR = 25;
-  };
-  [NoInterfaceObject]
-  interface WebAPIError {
     readonly attribute unsigned short code;
     readonly attribute DOMString name;
     readonly attribute DOMString message;
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface SuccessCallback {
+  [NoInterfaceObject] interface WebAPIError {
+    readonly attribute unsigned short code;
+    readonly attribute DOMString name;
+    readonly attribute DOMString message;
+  };
+  [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {
     void onsuccess();
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface ErrorCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="#WebAPIError">WebAPIError</a> error);
   };
   [Callback=FunctionOnly] interface BundleItemCallback {

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/voicecontrol.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/voicecontrol.html
@@ -208,8 +208,7 @@ using one of voice control client objects, it affects other objects.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">VoiceControlClient:
-                  </span>
+<span class="return">VoiceControlClient:</span>
  The object to manage voice control.
               </ul>
 </div>
@@ -279,8 +278,7 @@ For example, "ko_KR" for Korean, "en_US" for American English.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  Currently set language.
               </ul>
 </div>
@@ -451,8 +449,7 @@ client.unsetCommandList("FOREGROUND");
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -580,8 +577,7 @@ client.removeResultListener(id);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Identifier used to clear the watch subscription.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/voicecontrol.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/voicecontrol.html
@@ -887,10 +887,10 @@ To guarantee that the voice control application runs on a device with microphone
 <pre class="webidl prettyprint">module VoiceControl {
   enum VoiceControlResultEvent { "SUCCESS", "FAILURE" };
   enum VoiceControlCommandType { "FOREGROUND" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#VoiceControlClientManagerObject">VoiceControlClientManagerObject</a>;
   [NoInterfaceObject] interface VoiceControlClientManagerObject {
     readonly attribute <a href="#VoiceControlClientManager">VoiceControlClientManager</a> voicecontrol;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#VoiceControlClientManagerObject">VoiceControlClientManagerObject</a>;
   [NoInterfaceObject] interface VoiceControlClientManager {
     <a href="#VoiceControlClient">VoiceControlClient</a> getVoiceControlClient() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/websetting.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/websetting.html
@@ -232,10 +232,10 @@ tizen.websetting.removeAllCookies(successCallback);
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module WebSetting {
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#WebSettingObject">WebSettingObject</a>;
   [NoInterfaceObject] interface WebSettingObject {
     readonly attribute <a href="#WebSettingManager">WebSettingManager</a> websetting;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#WebSettingObject">WebSettingObject</a>;
   [NoInterfaceObject] interface WebSettingManager {
     void setUserAgentString(DOMString userAgent, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                             raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/widgetservice.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/widgetservice.html
@@ -1720,10 +1720,10 @@ To guarantee that the widget application runs on a system which supports Widgets
   enum WidgetSizeType { "1x1", "2x1", "2x2", "4x1", "4x2", "4x3", "4x4", "4x5", "4x6", "EASY_1x1", "EASY_3x1", "EASY_3x3",
     "FULL" };
   enum WidgetStateType { "CREATE", "DESTROY", "PAUSE", "RESUME" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#WidgetServiceManagerObject">WidgetServiceManagerObject</a>;
   [NoInterfaceObject] interface WidgetServiceManagerObject {
     readonly attribute <a href="#WidgetServiceManager">WidgetServiceManager</a> widgetservice;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#WidgetServiceManagerObject">WidgetServiceManagerObject</a>;
   [NoInterfaceObject] interface WidgetServiceManager {
     <a href="#Widget">Widget</a> getWidget(<a href="#WidgetId">WidgetId</a> widgetId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void getWidgets(<a href="#WidgetArraySuccessCallback">WidgetArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="package.html#PackageId">PackageId</a>? packageId)

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/widgetservice.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/widgetservice.html
@@ -91,7 +91,7 @@ Do not use "widget" as name for one of your global variables, as it is a global 
 <a href="#Widget">Widget</a> <a href="#WidgetServiceManager::getWidget">getWidget</a> (<a href="#WidgetId">WidgetId</a> widgetId)</div>
 <div>void <a href="#WidgetServiceManager::getWidgets">getWidgets</a> (<a href="#WidgetArraySuccessCallback">WidgetArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="package.html#PackageId">PackageId</a>? packageId)</div>
 <div>
-<a href="#WidgetId">WidgetId</a> <a href="#WidgetServiceManager::getPrimaryWidgetId">getPrimaryWidgetId</a> ((PackageId or ApplicationId) id)</div>
+<a href="#WidgetId">WidgetId</a> <a href="#WidgetServiceManager::getPrimaryWidgetId">getPrimaryWidgetId</a> ((<a href="package.html#PackageId">PackageId</a> or <a href="application.html#ApplicationId">ApplicationId</a>) id)</div>
 <div>
 <a href="#WidgetSize">WidgetSize</a> <a href="#WidgetServiceManager::getSize">getSize</a> (<a href="#WidgetSizeType">WidgetSizeType</a> sizeType)</div>
 </td>
@@ -403,8 +403,7 @@ The <em>tizen.widgetservice</em> object provides access to the Widget Service AP
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Widget:
-                  </span>
+<span class="return">Widget:</span>
  The Widget object.
               </ul>
 </div>
@@ -536,7 +535,7 @@ NotFoundError - If the device has no widgets or if a widget with the given id do
 <div class="brief">
  Returns the primary widget ID of the specified package or application.
             </div>
-<div class="synopsis"><pre class="signature prettyprint"><a href="#WidgetId">WidgetId</a> getPrimaryWidgetId((PackageId or ApplicationId) id);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#WidgetId">WidgetId</a> getPrimaryWidgetId((<a href="package.html#PackageId">PackageId</a> or <a href="application.html#ApplicationId">ApplicationId</a>) id);</pre></div>
 <p><span class="version">Since: </span>
  3.0
             </p>
@@ -558,8 +557,7 @@ NotFoundError - If the device has no widgets or if a widget with the given id do
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">WidgetId:
-                  </span>
+<span class="return">WidgetId:</span>
  The ID of the widget.
               </ul>
 </div>
@@ -623,8 +621,7 @@ catch (error)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">WidgetSize:
-                  </span>
+<span class="return">WidgetSize:</span>
  An object which contains width and height.
               </ul>
 </div>
@@ -759,8 +756,7 @@ Precondition: Widget tag in the config.xml file includes the "nodisplay" attribu
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The name of the widget.
               </ul>
 </div>
@@ -892,8 +888,7 @@ catch (error)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">WidgetVariant:
-                  </span>
+<span class="return">WidgetVariant:</span>
  Size variant info.
               </ul>
 </div>
@@ -1026,8 +1021,7 @@ catch (error)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The watch ID used to unregister the callback.
               </ul>
 </div>
@@ -1723,7 +1717,8 @@ To guarantee that the widget application runs on a system which supports Widgets
 <pre class="webidl prettyprint">module WidgetService {
   typedef DOMString WidgetId;
   typedef DOMString WidgetInstanceId;
-  enum WidgetSizeType { "1x1", "2x1", "2x2", "4x1", "4x2", "4x3", "4x4", "4x5", "4x6", "EASY_1x1", "EASY_3x1", "EASY_3x3", "FULL" };
+  enum WidgetSizeType { "1x1", "2x1", "2x2", "4x1", "4x2", "4x3", "4x4", "4x5", "4x6", "EASY_1x1", "EASY_3x1", "EASY_3x3",
+    "FULL" };
   enum WidgetStateType { "CREATE", "DESTROY", "PAUSE", "RESUME" };
   [NoInterfaceObject] interface WidgetServiceManagerObject {
     readonly attribute <a href="#WidgetServiceManager">WidgetServiceManager</a> widgetservice;

--- a/docs/application/web/api/5.5/device_api/tv/tizen/account.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/account.html
@@ -1447,10 +1447,10 @@ To guarantee the running of the application on a device with Account feature, de
     DOMString userName;
     DOMString iconUri;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#AccountManagerObject">AccountManagerObject</a>;
   [NoInterfaceObject] interface AccountManagerObject {
     readonly attribute <a href="#AccountManager">AccountManager</a> account;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#AccountManagerObject">AccountManagerObject</a>;
   [NoInterfaceObject] interface AccountProvider {
     readonly attribute <a href="application.html#ApplicationId">ApplicationId</a> applicationId;
     readonly attribute DOMString displayName;

--- a/docs/application/web/api/5.5/device_api/tv/tizen/account.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/account.html
@@ -481,8 +481,7 @@ Returns null if the given key is not found.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  Value of the extended data.
               </ul>
 </div>
@@ -851,8 +850,7 @@ tizen.account.getAccounts(
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Account:
-                  </span>
+<span class="return">Account<span class="optional"> [nullable]</span>:</span>
  Object with the given identifier or <var>null</var>.
               </ul>
 </div>
@@ -881,7 +879,7 @@ tizen.account.getAccounts(
  Gets the accounts associated with the provider that has a specified applicationId, asynchronously.
 If you want to get all accounts, omit the applicationId argument.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getAccounts(<a href="#AccountArraySuccessCallback">AccountArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getAccounts(<a href="#AccountArraySuccessCallback">AccountArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                  optional DOMString? applicationId);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -971,8 +969,7 @@ You can register your application as an account provider by writing account rela
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">AccountProvider:
-                  </span>
+<span class="return">AccountProvider<span class="optional"> [nullable]</span>:</span>
  Object with the given applicationId or <var>null</var>.
               </ul>
 </div>
@@ -1006,7 +1003,7 @@ if (!provider)
  Gets the providers with the given capabilities, asynchronously.
 If you want to get all the providers, omit the capability argument.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getProviders(<a href="#AccountProviderArraySuccessCallback">AccountProviderArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getProviders(<a href="#AccountProviderArraySuccessCallback">AccountProviderArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                   optional DOMString? capability);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1093,8 +1090,7 @@ If you want to get all the providers, omit the capability argument.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Identifier to clear the watch subscription for account changes.
               </ul>
 </div>
@@ -1446,11 +1442,15 @@ To guarantee the running of the application on a device with Account feature, de
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Account {
+  typedef unsigned long AccountId;
+  dictionary AccountInit {
+    DOMString userName;
+    DOMString iconUri;
+  };
   [NoInterfaceObject] interface AccountManagerObject {
     readonly attribute <a href="#AccountManager">AccountManager</a> account;
   };
   <a href="tizen.html#Tizen">Tizen</a> implements <a href="#AccountManagerObject">AccountManagerObject</a>;
-  typedef unsigned long AccountId;
   [NoInterfaceObject] interface AccountProvider {
     readonly attribute <a href="application.html#ApplicationId">ApplicationId</a> applicationId;
     readonly attribute DOMString displayName;
@@ -1458,10 +1458,6 @@ To guarantee the running of the application on a device with Account feature, de
     readonly attribute DOMString smallIconUri;
     readonly attribute DOMString[] capabilities;
     readonly attribute boolean isMultipleAccountSupported;
-  };
-  dictionary AccountInit {
-    DOMString userName;
-    DOMString iconUri;
   };
   [Constructor(<a href="#AccountProvider">AccountProvider</a> provider, optional <a href="#AccountInit">AccountInit</a>? accountInitDict)]
   interface Account {

--- a/docs/application/web/api/5.5/device_api/tv/tizen/alarm.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/alarm.html
@@ -814,10 +814,10 @@ console.log("next scheduled time is " + date);
 <pre class="webidl prettyprint">module Alarm {
   typedef DOMString AlarmId;
   enum ByDayValue { "MO", "TU", "WE", "TH", "FR", "SA", "SU" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#AlarmManagerObject">AlarmManagerObject</a>;
   [NoInterfaceObject] interface AlarmManagerObject {
     readonly attribute <a href="#AlarmManager">AlarmManager</a> alarm;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#AlarmManagerObject">AlarmManagerObject</a>;
   [NoInterfaceObject] interface AlarmManager {
     const long PERIOD_MINUTE = 60;
     const long PERIOD_HOUR = 3600;

--- a/docs/application/web/api/5.5/device_api/tv/tizen/alarm.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/alarm.html
@@ -440,8 +440,7 @@ console.log("remove all registered alarms in the storage.");
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Alarm:
-                  </span>
+<span class="return">Alarm:</span>
  An alarm object with the specified ID.
               </ul>
 </div>
@@ -494,8 +493,7 @@ Alarms that have already been triggered are removed automatically from the stora
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Alarm[]:
-                  </span>
+<span class="return">Alarm[]:</span>
  All Alarm objects.
               </ul>
 </div>
@@ -635,8 +633,7 @@ If the alarm has expired, this method returns <var>null</var>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long<span class="optional"> [nullable]</span>:</span>
  The duration before the next alarm is triggered.
               </ul>
 </div>
@@ -784,8 +781,7 @@ If the alarm has expired, this method returns <var>null</var>. The returned date
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Date:
-                  </span>
+<span class="return">Date<span class="optional"> [nullable]</span>:</span>
  The date/time of the next alarm trigger.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/application.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/application.html
@@ -382,7 +382,9 @@ The <em>tizen.application </em>object allows access to the Application API's fun
     <a href="#ApplicationCertificate">ApplicationCertificate</a>[] getAppCerts(optional <a href="#ApplicationId">ApplicationId</a>? id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     DOMString getAppSharedURI(optional <a href="#ApplicationId">ApplicationId</a>? id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#ApplicationMetaData">ApplicationMetaData</a>[] getAppMetaData(optional <a href="#ApplicationId">ApplicationId</a>? id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addAppStatusChangeListener(<a href="#StatusEventCallback">StatusEventCallback</a> eventCallback, optional <a href="#ApplicationId">ApplicationId</a>? appId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    long addAppInfoEventListener( eventCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void removeAppInfoEventListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    long addAppStatusChangeListener(<a href="#StatusEventCallback">StatusEventCallback</a> eventCallback, optional <a href="#ApplicationId">ApplicationId</a>? appId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeAppStatusChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
 <p><span class="version">Since: </span>
@@ -408,8 +410,7 @@ The <em>tizen.application </em>object allows access to the Application API's fun
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Application:
-                  </span>
+<span class="return">Application:</span>
  The data structure that defines the current application.
               </ul>
 </div>
@@ -588,7 +589,7 @@ tizen.application.launch("targetApp0.main", onsuccess);
 <div class="brief">
  Launches an application with the specified application control.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void launchAppControl(<a href="#ApplicationControl">ApplicationControl</a> appControl, optional <a href="#ApplicationId">ApplicationId</a>? id, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void launchAppControl(<a href="#ApplicationControl">ApplicationControl</a> appControl, optional <a href="#ApplicationId">ApplicationId</a>? id, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="#ApplicationControlDataArrayReplyCallback">ApplicationControlDataArrayReplyCallback</a>? replyCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.0
@@ -716,7 +717,7 @@ tizen.application.launchAppControl(appControl, null,
 <div class="brief">
  Finds which applications can be launched with the given application control.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void findAppControl(<a href="#ApplicationControl">ApplicationControl</a> appControl, <a href="#FindAppControlSuccessCallback">FindAppControlSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void findAppControl(<a href="#ApplicationControl">ApplicationControl</a> appControl, <a href="#FindAppControlSuccessCallback">FindAppControlSuccessCallback</a> successCallback,
                     optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.0
@@ -883,8 +884,7 @@ The list of running applications and their application IDs is obtained with <em>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ApplicationContext:
-                  </span>
+<span class="return">ApplicationContext:</span>
  A data structure that lists running application details.
               </ul>
 </div>
@@ -989,8 +989,7 @@ The list of installed applications and their application IDs is obtained with <e
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ApplicationInformation:
-                  </span>
+<span class="return">ApplicationInformation:</span>
  The information of an application.
               </ul>
 </div>
@@ -1069,8 +1068,7 @@ The certificate types are listed below:
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ApplicationCertificate[]:
-                  </span>
+<span class="return">ApplicationCertificate[]:</span>
  Array of certificate information of a specified application.
               </ul>
 </div>
@@ -1113,10 +1111,19 @@ for (var i = 0; i &lt; appCerts.length; i++)
             </p>
 <div class="description">
             <p>
-The shared directory is used to export data to other applications.
+The shared directory is used to export data to other applications. Its structure is described in
+<a href="https://developer.tizen.org/development/training/native-application/understanding-tizen-programming/file-system-directory-hierarchy">File System Directory Hierarchy</a>.
+            </p>
+           </div>
+<div class="description">
+            <p>
 If the ID is set to <var>null</var> or not set at all, it returns the shared directory URI for the current application.
             </p>
            </div>
+<p><span class="remark">Remark: </span>
+ Since Tizen 3.0, <var>shared/data</var> directory is not created for web applications. For other applications it will be not created by default and should be considered as optional
+(refer to <a href="https://developer.tizen.org/development/training/native-application/understanding-tizen-programming/file-system-directory-hierarchy">table about shared/data</a> for more details).
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1129,8 +1136,7 @@ If the ID is set to <var>null</var> or not set at all, it returns the shared dir
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The shared directory URI of an application.
               </ul>
 </div>
@@ -1186,8 +1192,7 @@ If the ID is set to <var>null</var> or not set at all, it returns the applicatio
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ApplicationMetaData[]:
-                  </span>
+<span class="return">ApplicationMetaData[]:</span>
  Array of meta data of a specified application. If there are no meta data for a specified application,
 an empty array is returned
               </ul>
@@ -1260,8 +1265,7 @@ with the corresponding listener identifier.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  ID of the listener that can be used to remove the listener later.
               </ul>
 </div>
@@ -1380,8 +1384,7 @@ tizen.application.removeAppInfoEventListener(watchId);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Listener id that can be used to remove the listener later.
               </ul>
 </div>
@@ -1672,8 +1675,7 @@ appropriately when it is launched.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">RequestedApplicationControl:
-                  </span>
+<span class="return">RequestedApplicationControl:</span>
  The details of a requested application control.
               </ul>
 </div>
@@ -1726,8 +1728,7 @@ System events do not require an application identifier to be specified. Therefor
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Listener identifier.
               </ul>
 </div>
@@ -2273,7 +2274,7 @@ and launches the selected application.
 </div>
 <div class="constructors">
 <h4 id="ApplicationControl::constructor">Constructors</h4>
-<dl><pre class="webidl prettyprint">ApplicationControl(DOMString operation, optional DOMString? uri, optional DOMString? mime, optional DOMString? category, 
+<dl><pre class="webidl prettyprint">ApplicationControl(DOMString operation, optional DOMString? uri, optional DOMString? mime, optional DOMString? category,
                    optional <a href="#ApplicationControlData">ApplicationControlData</a>[]? data, optional <a href="#ApplicationControlLaunchMode">ApplicationControlLaunchMode</a>? launchMode);</pre></dl>
 </div>
 <div class="attributes">
@@ -3073,6 +3074,15 @@ To guarantee the running of the application on a device which has battery, decla
   typedef (<a href="#SystemEventData">SystemEventData</a> or <a href="#UserEventData">UserEventData</a>) EventData;
   enum ApplicationControlLaunchMode { "SINGLE", "GROUP" };
   enum ApplicationUsageMode { "RECENTLY", "FREQUENTLY" };
+  dictionary ApplicationUsageFilter {
+    long? timeSpan;
+    Date? startTime;
+    Date? endTime;
+  };
+  dictionary EventInfo {
+    <a href="#ApplicationId">ApplicationId</a> appId;
+    DOMString name;
+  };
   [NoInterfaceObject] interface ApplicationManagerObject {
     readonly attribute <a href="#ApplicationManager">ApplicationManager</a> application;
   };
@@ -3099,11 +3109,6 @@ To guarantee the running of the application on a device which has battery, decla
     <a href="#ApplicationMetaData">ApplicationMetaData</a>[] getAppMetaData(optional <a href="#ApplicationId">ApplicationId</a>? id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addAppStatusChangeListener(<a href="#StatusEventCallback">StatusEventCallback</a> eventCallback, optional <a href="#ApplicationId">ApplicationId</a>? appId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeAppStatusChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  dictionary ApplicationUsageFilter {
-    long? timeSpan;
-    Date? startTime;
-    Date? endTime;
   };
   [NoInterfaceObject] interface Application {
     readonly attribute <a href="#ApplicationInformation">ApplicationInformation</a> appInfo;
@@ -3192,10 +3197,6 @@ To guarantee the running of the application on a device which has battery, decla
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface StatusEventCallback {
     void onchange(<a href="#ApplicationId">ApplicationId</a> appId, boolean isActive);
-  };
-  dictionary EventInfo {
-    <a href="#ApplicationId">ApplicationId</a> appId;
-    DOMString name;
   };
 };</pre>
 </div>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/application.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/application.html
@@ -3083,10 +3083,10 @@ To guarantee the running of the application on a device which has battery, decla
     <a href="#ApplicationId">ApplicationId</a> appId;
     DOMString name;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ApplicationManagerObject">ApplicationManagerObject</a>;
   [NoInterfaceObject] interface ApplicationManagerObject {
     readonly attribute <a href="#ApplicationManager">ApplicationManager</a> application;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ApplicationManagerObject">ApplicationManagerObject</a>;
   [NoInterfaceObject] interface ApplicationManager {
     <a href="#Application">Application</a> getCurrentApplication() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void kill(<a href="#ApplicationContextId">ApplicationContextId</a> contextId, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)

--- a/docs/application/web/api/5.5/device_api/tv/tizen/archive.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/archive.html
@@ -357,7 +357,7 @@ mypackage/test.c                </td>
 <div class="brief">
  Opens the archive file. After this operation, it is possible to add or get files to and from the archive.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long open(<a href="#FileReference">FileReference</a> file, <a href="filesystem.html#FileMode">FileMode</a> mode, <a href="#ArchiveFileSuccessCallback">ArchiveFileSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">long open(<a href="#FileReference">FileReference</a> file, <a href="filesystem.html#FileMode">FileMode</a> mode, <a href="#ArchiveFileSuccessCallback">ArchiveFileSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
           optional <a href="#ArchiveFileOptions">ArchiveFileOptions</a>? options);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -450,8 +450,7 @@ In this mode, <em>getEntries()</em>, <em>getEntryByName()</em>, and <em>extractA
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -581,7 +580,7 @@ The size is <var>null</var> until the archive is opened.
 <div class="brief">
  Adds a new member file to <em>ArchiveFile</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long add(<a href="#FileReference">FileReference</a> sourceFile, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">long add(<a href="#FileReference">FileReference</a> sourceFile, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
          optional <a href="#ArchiveFileProgressCallback">ArchiveFileProgressCallback</a>? onprogress, optional <a href="#ArchiveFileEntryOptions">ArchiveFileEntryOptions</a>? options);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -696,8 +695,7 @@ If the source file is big then the callback can also be called while the file is
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -751,7 +749,7 @@ tizen.archive.open("downloads/new_archive.zip", "w", createSuccess);
 <div class="brief">
  Extracts every file from this <em>ArchiveFile</em> to a given directory.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long extractAll(<a href="#FileReference">FileReference</a> destinationDirectory, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">long extractAll(<a href="#FileReference">FileReference</a> destinationDirectory, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
                 optional <a href="#ArchiveFileProgressCallback">ArchiveFileProgressCallback</a>? onprogress, optional boolean? overwrite);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -812,8 +810,7 @@ UnknownError: In any other error case              </li>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -903,8 +900,7 @@ UnknownError: In case of any error              </li>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -998,8 +994,7 @@ UnknownError: In case of any other error              </li>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -1149,7 +1144,7 @@ This is usually the modification date of the file.
 <div class="brief">
  Extracts ArchiveFileEntry to the given location.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long extract(<a href="#FileReference">FileReference</a> destinationDirectory, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">long extract(<a href="#FileReference">FileReference</a> destinationDirectory, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
              optional <a href="#ArchiveFileProgressCallback">ArchiveFileProgressCallback</a>? onprogress, optional boolean? stripName, optional boolean? overwrite);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -1207,8 +1202,7 @@ UnknownError: In case of any other error              </li>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -1420,10 +1414,6 @@ tizen.archive.open("downloads/some_archive.zip", "r", openSuccess, errorCallback
 <pre class="webidl prettyprint">module Archive {
   typedef (DOMString or <a href="filesystem.html#File">File</a>) FileReference;
   enum ArchiveCompressionLevel { "STORE", "FAST", "NORMAL", "BEST" };
-  [NoInterfaceObject] interface ArchiveManagerObject {
-    readonly attribute <a href="#ArchiveManager">ArchiveManager</a> archive;
-  };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ArchiveManagerObject">ArchiveManagerObject</a>;
   dictionary ArchiveFileOptions {
     boolean overwrite;
   };
@@ -1432,6 +1422,10 @@ tizen.archive.open("downloads/some_archive.zip", "r", openSuccess, errorCallback
     boolean stripSourceDirectory;
     <a href="#ArchiveCompressionLevel">ArchiveCompressionLevel</a> compressionLevel;
   };
+  [NoInterfaceObject] interface ArchiveManagerObject {
+    readonly attribute <a href="#ArchiveManager">ArchiveManager</a> archive;
+  };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ArchiveManagerObject">ArchiveManagerObject</a>;
   [NoInterfaceObject] interface ArchiveManager {
     long open(<a href="#FileReference">FileReference</a> file, <a href="filesystem.html#FileMode">FileMode</a> mode, <a href="#ArchiveFileSuccessCallback">ArchiveFileSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
               optional <a href="#ArchiveFileOptions">ArchiveFileOptions</a>? options) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/archive.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/archive.html
@@ -1422,10 +1422,10 @@ tizen.archive.open("downloads/some_archive.zip", "r", openSuccess, errorCallback
     boolean stripSourceDirectory;
     <a href="#ArchiveCompressionLevel">ArchiveCompressionLevel</a> compressionLevel;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ArchiveManagerObject">ArchiveManagerObject</a>;
   [NoInterfaceObject] interface ArchiveManagerObject {
     readonly attribute <a href="#ArchiveManager">ArchiveManager</a> archive;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ArchiveManagerObject">ArchiveManagerObject</a>;
   [NoInterfaceObject] interface ArchiveManager {
     long open(<a href="#FileReference">FileReference</a> file, <a href="filesystem.html#FileMode">FileMode</a> mode, <a href="#ArchiveFileSuccessCallback">ArchiveFileSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
               optional <a href="#ArchiveFileOptions">ArchiveFileOptions</a>? options) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/content.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/content.html
@@ -3511,10 +3511,10 @@ It is used in <em>tizen.content.createPlaylist()</em>.
   enum AudioContentLyricsType { "SYNCHRONIZED", "UNSYNCHRONIZED" };
   enum ImageContentOrientation { "NORMAL", "FLIP_HORIZONTAL", "ROTATE_180", "FLIP_VERTICAL", "TRANSPOSE", "ROTATE_90",
     "TRANSVERSE", "ROTATE_270" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ContentManagerObject">ContentManagerObject</a>;
   [NoInterfaceObject] interface ContentManagerObject {
     readonly attribute <a href="#ContentManager">ContentManager</a> content;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ContentManagerObject">ContentManagerObject</a>;
   [NoInterfaceObject] interface ContentManager {
     void update(<a href="#Content">Content</a> content) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void updateBatch(<a href="#Content">Content</a>[] contents, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)

--- a/docs/application/web/api/5.5/device_api/tv/tizen/content.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/content.html
@@ -227,7 +227,7 @@ Playlist functionality has been added in Tizen 2.3.
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 5.5.
           </p>
-<pre class="webidl prettyprint">  enum ContentDirectoryStorageType { "INTERNAL", "EXTERNAL" };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  enum ContentDirectoryStorageType { "INTERNAL", "EXTERNAL" };</span></pre>
 <p><span class="version">Since: </span>
  2.0
           </p>
@@ -399,7 +399,9 @@ The <em>tizen.content </em>object allows accessing the functionality of the Cont
     void cancelScanDirectory(DOMString contentDirURI) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addChangeListener(<a href="#ContentChangeCallback">ContentChangeCallback</a> changeCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeChangeListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getPlaylists(<a href="#PlaylistArraySuccessCallback">PlaylistArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    void setChangeListener(<a href="#ContentChangeCallback">ContentChangeCallback</a> changeCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void unsetChangeListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void getPlaylists(<a href="#PlaylistArraySuccessCallback">PlaylistArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void createPlaylist(DOMString name, <a href="#PlaylistSuccessCallback">PlaylistSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                         optional <a href="#Playlist">Playlist</a>? sourcePlaylist) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removePlaylist(<a href="#PlaylistId">PlaylistId</a> id, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
@@ -645,8 +647,8 @@ tizen.content.getDirectories(getDirectoriesCB, errorCB);
 <div class="brief">
  Finds contents that satisfy the conditions set by a filter.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#ContentArraySuccessCallback">ContentArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
-          optional <a href="#ContentDirectoryId">ContentDirectoryId</a>? directoryId, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter, optional <a href="tizen.html#SortMode">SortMode</a>? sortMode, 
+<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#ContentArraySuccessCallback">ContentArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
+          optional <a href="#ContentDirectoryId">ContentDirectoryId</a>? directoryId, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter, optional <a href="tizen.html#SortMode">SortMode</a>? sortMode,
           optional unsigned long? count, optional unsigned long? offset);</pre></div>
 <p><span class="version">Since: </span>
  2.0
@@ -853,7 +855,7 @@ tizen.filesystem.resolve("images/tizen.jpg", function(imageFile)
 <div class="brief">
  Scans a content directory to create or update content in the content database.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void scanDirectory(DOMString contentDirURI, boolean recursive, optional <a href="#ContentScanSuccessCallback">ContentScanSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void scanDirectory(DOMString contentDirURI, boolean recursive, optional <a href="#ContentScanSuccessCallback">ContentScanSuccessCallback</a>? successCallback,
                    optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1014,8 +1016,7 @@ contain an invalid value (e.g. given <em>contentDirURI</em> is an empty string).
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Identifier of the newly added listener.
               </ul>
 </div>
@@ -1347,7 +1348,7 @@ tizen.content.getPlaylists(getPlaylistsSuccess, getPlaylistsFail);
 <div class="brief">
  Creates a new playlist.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void createPlaylist(DOMString name, <a href="#PlaylistSuccessCallback">PlaylistSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void createPlaylist(DOMString name, <a href="#PlaylistSuccessCallback">PlaylistSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                     optional <a href="#Playlist">Playlist</a>? sourcePlaylist);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -1909,7 +1910,8 @@ tizen.content.find(findCB);
     readonly attribute <a href="#ContentDirectoryId">ContentDirectoryId</a> id;
     readonly attribute DOMString directoryURI;
     readonly attribute DOMString title;
-    readonly attribute Date? modifiedDate;
+<span class="nocode deprecated">    readonly attribute <a href="#ContentDirectoryStorageType">ContentDirectoryStorageType</a> storageType;
+</span>    readonly attribute Date? modifiedDate;
   };</pre>
 <p><span class="version">Since: </span>
  2.0
@@ -2470,8 +2472,7 @@ The attribute is marked as read-only since Tizen 5.5.
 <div class="brief">
  The PlaylistItem interface represents a playlist item.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject]
-  interface PlaylistItem {
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface PlaylistItem {
     readonly attribute <a href="#Content">Content</a> content;
   };</pre>
 <p><span class="version">Since: </span>
@@ -2495,8 +2496,7 @@ The attribute is marked as read-only since Tizen 5.5.
 <div class="brief">
  The Playlist interface represents a playlist.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject]
-  interface Playlist {
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface Playlist {
     readonly attribute <a href="#PlaylistId">PlaylistId</a> id;
     attribute DOMString name raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute long numberOfTracks;
@@ -2952,7 +2952,7 @@ tizen.content.getPlaylists(getPlaylistsSuccess, getPlaylistsFail);
 <div class="brief">
  Gets playlist items from a playlist.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void get(<a href="#PlaylistItemArraySuccessCallback">PlaylistItemArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional long? count, 
+<div class="synopsis"><pre class="signature prettyprint">void get(<a href="#PlaylistItemArraySuccessCallback">PlaylistItemArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional long? count,
          optional long? offset);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -3504,13 +3504,13 @@ It is used in <em>tizen.content.createPlaylist()</em>.
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Content {
-  enum ContentType { "IMAGE", "VIDEO", "AUDIO", "OTHER" };
-  enum AudioContentLyricsType { "SYNCHRONIZED", "UNSYNCHRONIZED" };
-  enum ImageContentOrientation { "NORMAL", "FLIP_HORIZONTAL", "ROTATE_180", "FLIP_VERTICAL", "TRANSPOSE", "ROTATE_90", "TRANSVERSE",
-    "ROTATE_270" };
   typedef DOMString ContentId;
   typedef DOMString ContentDirectoryId;
   typedef DOMString PlaylistId;
+  enum ContentType { "IMAGE", "VIDEO", "AUDIO", "OTHER" };
+  enum AudioContentLyricsType { "SYNCHRONIZED", "UNSYNCHRONIZED" };
+  enum ImageContentOrientation { "NORMAL", "FLIP_HORIZONTAL", "ROTATE_180", "FLIP_VERTICAL", "TRANSPOSE", "ROTATE_90",
+    "TRANSVERSE", "ROTATE_270" };
   [NoInterfaceObject] interface ContentManagerObject {
     readonly attribute <a href="#ContentManager">ContentManager</a> content;
   };
@@ -3608,12 +3608,10 @@ It is used in <em>tizen.content.createPlaylist()</em>.
     readonly attribute unsigned long height;
     readonly attribute <a href="#ImageContentOrientation">ImageContentOrientation</a> orientation;
   };
-  [NoInterfaceObject]
-  interface PlaylistItem {
+  [NoInterfaceObject] interface PlaylistItem {
     readonly attribute <a href="#Content">Content</a> content;
   };
-  [NoInterfaceObject]
-  interface Playlist {
+  [NoInterfaceObject] interface Playlist {
     readonly attribute <a href="#PlaylistId">PlaylistId</a> id;
     attribute DOMString name raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute long numberOfTracks;

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/console.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/console.html
@@ -496,10 +496,10 @@ console.timeEnd("Big array initialization");
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Console {
+  Window implements <a href="#ConsoleManagerObject">ConsoleManagerObject</a>;
   [NoInterfaceObject] interface ConsoleManagerObject {
     readonly attribute <a href="#ConsoleManager">ConsoleManager</a> console;
   };
-  Window implements <a href="#ConsoleManagerObject">ConsoleManagerObject</a>;
   [NoInterfaceObject] interface ConsoleManager {
     void log(DOMString text);
     void error(DOMString text);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/cordova.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/cordova.html
@@ -99,8 +99,7 @@
 <div class="brief">
  Basic success callback, no parameters.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly,NoInterfaceObject]
-  interface SuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {
     void onsuccess();
   };</pre>
 <div class="methods">
@@ -126,8 +125,7 @@
 <div class="brief">
  Basic error callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="#DOMException">DOMException</a> error);
   };</pre>
 <div class="methods">
@@ -209,12 +207,10 @@
   Window implements <a href="#CordovaManagerObject">CordovaManagerObject</a>;
   [NoInterfaceObject] interface Cordova {
   };
-  [Callback=FunctionOnly,NoInterfaceObject]
-  interface SuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {
     void onsuccess();
   };
-  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="#DOMException">DOMException</a> error);
   };
   interface DOMException {

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/cordova.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/cordova.html
@@ -201,10 +201,10 @@
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Cordova {
+  Window implements <a href="#CordovaManagerObject">CordovaManagerObject</a>;
   [NoInterfaceObject] interface CordovaManagerObject {
     readonly attribute <a href="#Cordova">Cordova</a> cordova;
   };
-  Window implements <a href="#CordovaManagerObject">CordovaManagerObject</a>;
   [NoInterfaceObject] interface Cordova {
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/device-motion.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/device-motion.html
@@ -543,10 +543,10 @@ To guarantee that the DeviceMotion application runs on a device with the DeviceM
   dictionary AccelerationOptions {
     long frequency;
   };
+  Navigator implements <a href="#AccelerometerManagerObject">AccelerometerManagerObject</a>;
   [NoInterfaceObject] interface AccelerometerManagerObject {
     readonly attribute <a href="#Accelerometer">Accelerometer</a> accelerometer;
   };
-  Navigator implements <a href="#AccelerometerManagerObject">AccelerometerManagerObject</a>;
   [NoInterfaceObject] interface Accelerometer {
     void getCurrentAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     DOMString watchAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#AccelerationOptions">AccelerationOptions</a>? options)

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/device-motion.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/device-motion.html
@@ -110,10 +110,10 @@ Original documentation: <a href="https://cordova.apache.org/docs/en/3.0.0/cordov
  The Accelerometer object captures device motion in the x, y, and z direction.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface Accelerometer {
-    void getCurrentAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+    void getCurrentAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     DOMString watchAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#AccelerationOptions">AccelerationOptions</a>? options)
-                                raises();
-    void clearWatch(DOMString watchID) raises();
+                                raises(TypeError);
+    void clearWatch(DOMString watchID) raises(TypeError);
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -226,8 +226,7 @@ Timestamp: 1456480118000
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  DOMString The watch id that must be passed to <a href="device-motion.html#Accelerometer::clearWatch">clearWatch</a> to stop watching.
               </ul>
 </div>
@@ -494,8 +493,7 @@ Acceleration values include the effect of gravity (9.81 m/s^2), so that when a d
 <div class="brief">
  Basic error callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };</pre>
 <div class="methods">
@@ -542,15 +540,18 @@ To guarantee that the DeviceMotion application runs on a device with the DeviceM
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module DeviceMotion {
+  dictionary AccelerationOptions {
+    long frequency;
+  };
   [NoInterfaceObject] interface AccelerometerManagerObject {
     readonly attribute <a href="#Accelerometer">Accelerometer</a> accelerometer;
   };
   Navigator implements <a href="#AccelerometerManagerObject">AccelerometerManagerObject</a>;
   [NoInterfaceObject] interface Accelerometer {
-    void getCurrentAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+    void getCurrentAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     DOMString watchAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#AccelerationOptions">AccelerationOptions</a>? options)
-                                raises();
-    void clearWatch(DOMString watchID) raises();
+                                raises(TypeError);
+    void clearWatch(DOMString watchID) raises(TypeError);
   };
   [NoInterfaceObject] interface Acceleration {
     readonly attribute double x;
@@ -558,14 +559,10 @@ To guarantee that the DeviceMotion application runs on a device with the DeviceM
     readonly attribute double z;
     readonly attribute long timestamp;
   };
-  dictionary AccelerationOptions {
-    long frequency;
-  };
   [Callback=FunctionOnly, NoInterfaceObject] interface AccelerometerSuccessCallback {
     void onsuccess(<a href="#Acceleration">Acceleration</a> acceleration);
   };
-  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/device.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/device.html
@@ -245,10 +245,10 @@ function onDeviceReady()
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Device {
+  Window implements <a href="#DeviceManagerObject">DeviceManagerObject</a>;
   [NoInterfaceObject] interface DeviceManagerObject {
     readonly attribute <a href="#Device">Device</a> device;
   };
-  Window implements <a href="#DeviceManagerObject">DeviceManagerObject</a>;
   [NoInterfaceObject] interface Device {
     readonly attribute DOMString cordova;
     readonly attribute DOMString model;

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/dialogs.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/dialogs.html
@@ -469,10 +469,10 @@ the index uses one-based indexing, so the values could be 1, 2, 3, etc.
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Dialogs {
+  Navigator implements <a href="#DialogsManagerObject">DialogsManagerObject</a>;
   [NoInterfaceObject] interface DialogsManagerObject {
     readonly attribute <a href="#DialogsManager">DialogsManager</a> notification;
   };
-  Navigator implements <a href="#DialogsManagerObject">DialogsManagerObject</a>;
   [NoInterfaceObject] interface DialogsManager {
     void alert(DOMString message, <a href="cordova.html#SuccessCallback">SuccessCallback</a> alertCallback, optional DOMString? title, optional DOMString? buttonName);
     void confirm(DOMString message, <a href="#ConfirmCallback">ConfirmCallback</a> confirmCallback, optional DOMString? title, optional DOMString[]? buttonNames);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/dialogs.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/dialogs.html
@@ -239,7 +239,7 @@ navigator.notification.confirm(
 <div class="brief">
  Shows a custom confirm box with set of buttons.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void prompt(DOMString message, <a href="#PromptCallback">PromptCallback</a> promptCallback, optional DOMString? title, optional DOMString[]? buttonNames, 
+<div class="synopsis"><pre class="signature prettyprint">void prompt(DOMString message, <a href="#PromptCallback">PromptCallback</a> promptCallback, optional DOMString? title, optional DOMString[]? buttonNames,
             optional DOMString? defaultText);</pre></div>
 <p><span class="version">Since: </span>
  3.0

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/events.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/events.html
@@ -194,8 +194,7 @@ offline            </td>
 <div class="brief">
  Callback for the event which fires when Cordova is fully loaded
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface DeviceReadyEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface DeviceReadyEventCallback {
     void ondeviceready();
   };</pre>
 <p><span class="version">Since: </span>
@@ -238,8 +237,7 @@ function onDeviceReady()
 <div class="brief">
  Callback for the event which fires when an application is put into the background
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface PauseEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface PauseEventCallback {
     void onpause();
   };</pre>
 <p><span class="version">Since: </span>
@@ -281,8 +279,7 @@ function onPause()
 <div class="brief">
  Callback for the event which fires when an application is retrieved from the background
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface ResumeEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface ResumeEventCallback {
     void onresume();
   };</pre>
 <p><span class="version">Since: </span>
@@ -324,8 +321,7 @@ function onResume()
 <div class="brief">
  Callback for the event which fires when the user presses the back button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface BackButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface BackButtonEventCallback {
     void onbackbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -365,8 +361,7 @@ function onBackKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the menu button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface MenuButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface MenuButtonEventCallback {
     void onmenubutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -408,8 +403,7 @@ function onMenuKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the search button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface SearchButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface SearchButtonEventCallback {
     void onsearchbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -451,8 +445,7 @@ function onSearchKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the start call button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface StartCallEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface StartCallEventCallback {
     void onstartcallbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -494,8 +487,7 @@ function onStartCallKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the end call button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface EndCallButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface EndCallButtonEventCallback {
     void onendcallbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -537,8 +529,7 @@ function onEndCallKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the volume down button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface VolumeDownButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface VolumeDownButtonEventCallback {
     void onvolumedownbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -580,8 +571,7 @@ function onVolumeDownKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the volume up button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface VolumeUpButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface VolumeUpButtonEventCallback {
     void onvolumeupbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -621,44 +611,33 @@ function onVolumeUpKeyDown()
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Events {
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface DeviceReadyEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface DeviceReadyEventCallback {
     void ondeviceready();
-  };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface PauseEventCallback {
+  };  [NoInterfaceObject, Callback=FunctionOnly] interface PauseEventCallback {
     void onpause();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface ResumeEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface ResumeEventCallback {
     void onresume();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface BackButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface BackButtonEventCallback {
     void onbackbutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface MenuButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface MenuButtonEventCallback {
     void onmenubutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface SearchButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface SearchButtonEventCallback {
     void onsearchbutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface StartCallEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface StartCallEventCallback {
     void onstartcallbutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface EndCallButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface EndCallButtonEventCallback {
     void onendcallbutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface VolumeDownButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface VolumeDownButtonEventCallback {
     void onvolumedownbutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface VolumeUpButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface VolumeUpButtonEventCallback {
     void onvolumeupbutton();
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/events.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/events.html
@@ -613,7 +613,8 @@ function onVolumeUpKeyDown()
 <pre class="webidl prettyprint">module Events {
   [NoInterfaceObject, Callback=FunctionOnly] interface DeviceReadyEventCallback {
     void ondeviceready();
-  };  [NoInterfaceObject, Callback=FunctionOnly] interface PauseEventCallback {
+  };
+  [NoInterfaceObject, Callback=FunctionOnly] interface PauseEventCallback {
     void onpause();
   };
   [NoInterfaceObject, Callback=FunctionOnly] interface ResumeEventCallback {

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/file.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/file.html
@@ -3457,6 +3457,8 @@ entry.createWriter(successCallback, errorCallback);
     unsigned long long total = false;
     EventTarget target = null;
   };
+  Cordova implements <a href="#FileSystemManagerObject">FileSystemManagerObject</a>;
+  Window implements <a href="#LocalFileSystem">LocalFileSystem</a>;
   [Constructor(DOMString type, optional <a href="#ProgressEventInit">ProgressEventInit</a> eventInitDict)]
   interface ProgressEvent {
     readonly attribute DOMString type;
@@ -3468,7 +3470,6 @@ entry.createWriter(successCallback, errorCallback);
     readonly attribute unsigned long long total;
     readonly attribute  target;
   };
-  Cordova implements <a href="#ProgressEvent">ProgressEvent</a>;
   [NoInterfaceObject] interface FileSystemManagerObject {
     readonly attribute <a href="#FileSystemManager">FileSystemManager</a> file;
   };

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/file.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/file.html
@@ -321,7 +321,7 @@ See <a href="https://www.w3.org/TR/FileAPI/#blob-section">The Blob Interface and
 <pre class="webidl prettyprint">  dictionary ProgressEventInit {
     unsigned long long loaded = false;
     unsigned long long total = false;
-     target = null;
+    EventTarget target = null;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -1057,9 +1057,9 @@ The specifics of naming filesystems is unspecified, but a name must be unique ac
     const short TEMPORARY = 0;
     const short PERSISTENT = 1;
     void requestFileSystem(short type, long long size, optional <a href="#FileSystemCallback">FileSystemCallback</a>? successCallback,
-                           optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback) raises();
+                           optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback) raises(TypeError);
     void resolveLocalFileSystemURL(DOMString uri, optional <a href="#EntryCallback">EntryCallback</a>? successCallback, optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback)
-                                   raises();
+                                   raises(TypeError);
   };</pre>
 <pre class="webidl prettyprint">  Window implements <a href="#LocalFileSystem">LocalFileSystem</a>;</pre>
 <p><span class="version">Since: </span>
@@ -1104,7 +1104,7 @@ The specifics of naming filesystems is unspecified, but a name must be unique ac
 <div class="brief">
  Request a file system in which to store application data.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void requestFileSystem(short type, long long size, optional <a href="#FileSystemCallback">FileSystemCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void requestFileSystem(short type, long long size, optional <a href="#FileSystemCallback">FileSystemCallback</a>? successCallback,
                        optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1237,13 +1237,13 @@ resolveLocalFileSystemURL(uri, successCallback, errorCallback);
     readonly attribute DOMString fullPath;
     readonly attribute DOMString name;
     readonly attribute <a href="#FileSystem">FileSystem</a> filesystem;
-    void getMetadata(<a href="#MetadataCallback">MetadataCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+    void getMetadata(<a href="#MetadataCallback">MetadataCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
     void moveTo(<a href="#DirectoryEntry">DirectoryEntry</a> parent, optional DOMString? newName, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                raises();
+                raises(FileException);
     void copyTo(<a href="#DirectoryEntry">DirectoryEntry</a> parent, optional DOMString? newName, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                raises();
-    void getParent(<a href="#EntryCallback">EntryCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
-    void remove(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+                raises(FileException);
+    void getParent(<a href="#EntryCallback">EntryCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
+    void remove(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
     DOMString toURL();
   };</pre>
 <p><span class="version">Since: </span>
@@ -1706,8 +1706,7 @@ requestFileSystem(TEMPORARY, 100, function(fs)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  URL that can be used to identify this entry.
               </ul>
 </div>
@@ -1738,10 +1737,10 @@ requestFileSystem(TEMPORARY, 100, function(fs)
 <pre class="webidl prettyprint">  interface DirectoryEntry : <a href="#Entry">Entry</a> {
     <a href="#DirectoryReader">DirectoryReader</a> createReader();
     void getDirectory(DOMString path, optional ? options, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                      raises();
+                      raises(FileException);
     void getFile(DOMString path, optional ? options, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                 raises();
-    void removeRecursively(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+                 raises(FileException);
+    void removeRecursively(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -1770,8 +1769,7 @@ requestFileSystem(TEMPORARY, 100, function(fs)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DirectoryReader:
-                  </span>
+<span class="return">DirectoryReader:</span>
  DirectoryReader.
               </ul>
 </div>
@@ -2007,7 +2005,7 @@ Otherwise, if no other error occurs, getFile must return a FileEntry correspondi
  The DirectoryReader interface provides access to the Filesystem API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface DirectoryReader {
-    void readEntries(<a href="#EntriesCallback">EntriesCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+    void readEntries(<a href="#EntriesCallback">EntriesCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
   };</pre>
 <p><span class="privilegelevel">Privilege level: </span>
  public
@@ -2222,10 +2220,10 @@ Otherwise, if no other error occurs, getFile must return a FileEntry correspondi
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onerror;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onloadend;
     void abort();
-    void readAsDataURL(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
-    void readAsText(<a href="#Blob">Blob</a> blob, optional DOMString? label) raises(, <a href="#FileError">FileError</a>);
-    void readAsBinaryString(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
-    void readAsArrayBuffer(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
+    void readAsDataURL(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsText(<a href="#Blob">Blob</a> blob, optional DOMString? label) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsBinaryString(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsArrayBuffer(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -2681,10 +2679,10 @@ ByteLength: 3
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onabort;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onerror;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onwriteend;
-    void abort() raises();
-    void seek(long offset) raises();
-    void truncate(long size) raises();
-    void write(<a href="#WriteData">WriteData</a> data) raises();
+    void abort() raises(FileException);
+    void seek(long offset) raises(FileException);
+    void truncate(long size) raises(FileException);
+    void write(<a href="#WriteData">WriteData</a> data) raises(FileException);
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -3457,7 +3455,7 @@ entry.createWriter(successCallback, errorCallback);
   dictionary ProgressEventInit {
     unsigned long long loaded = false;
     unsigned long long total = false;
-     target = null;
+    EventTarget target = null;
   };
   [Constructor(DOMString type, optional <a href="#ProgressEventInit">ProgressEventInit</a> eventInitDict)]
   interface ProgressEvent {
@@ -3470,10 +3468,10 @@ entry.createWriter(successCallback, errorCallback);
     readonly attribute unsigned long long total;
     readonly attribute  target;
   };
+  Cordova implements <a href="#ProgressEvent">ProgressEvent</a>;
   [NoInterfaceObject] interface FileSystemManagerObject {
     readonly attribute <a href="#FileSystemManager">FileSystemManager</a> file;
   };
-  <a href="cordova.html#Cordova">Cordova</a> implements <a href="#FileSystemManagerObject">FileSystemManagerObject</a>;
   [NoInterfaceObject] interface FileSystemManager {
     readonly attribute DOMString? applicationDirectory;
     readonly attribute DOMString? applicationStorageDirectory;
@@ -3522,36 +3520,35 @@ entry.createWriter(successCallback, errorCallback);
     const short TEMPORARY = 0;
     const short PERSISTENT = 1;
     void requestFileSystem(short type, long long size, optional <a href="#FileSystemCallback">FileSystemCallback</a>? successCallback,
-                           optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback) raises();
+                           optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback) raises(TypeError);
     void resolveLocalFileSystemURL(DOMString uri, optional <a href="#EntryCallback">EntryCallback</a>? successCallback, optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback)
-                                   raises();
+                                   raises(TypeError);
   };
-  Window implements <a href="#LocalFileSystem">LocalFileSystem</a>;
   [NoInterfaceObject] interface Entry {
     readonly attribute boolean isFile;
     readonly attribute boolean isDirectory;
     readonly attribute DOMString fullPath;
     readonly attribute DOMString name;
     readonly attribute <a href="#FileSystem">FileSystem</a> filesystem;
-    void getMetadata(<a href="#MetadataCallback">MetadataCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+    void getMetadata(<a href="#MetadataCallback">MetadataCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
     void moveTo(<a href="#DirectoryEntry">DirectoryEntry</a> parent, optional DOMString? newName, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                raises();
+                raises(FileException);
     void copyTo(<a href="#DirectoryEntry">DirectoryEntry</a> parent, optional DOMString? newName, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                raises();
-    void getParent(<a href="#EntryCallback">EntryCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
-    void remove(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+                raises(FileException);
+    void getParent(<a href="#EntryCallback">EntryCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
+    void remove(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
     DOMString toURL();
   };
   interface DirectoryEntry : <a href="#Entry">Entry</a> {
     <a href="#DirectoryReader">DirectoryReader</a> createReader();
     void getDirectory(DOMString path, optional ? options, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                      raises();
+                      raises(FileException);
     void getFile(DOMString path, optional ? options, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                 raises();
-    void removeRecursively(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+                 raises(FileException);
+    void removeRecursively(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
   };
   [NoInterfaceObject] interface DirectoryReader {
-    void readEntries(<a href="#EntriesCallback">EntriesCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+    void readEntries(<a href="#EntriesCallback">EntriesCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
   };
   [NoInterfaceObject] interface FileEntry : <a href="#Entry">Entry</a> {
     void createWriter(<a href="#FileWriterCallback">FileWriterCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror);
@@ -3571,10 +3568,10 @@ entry.createWriter(successCallback, errorCallback);
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onerror;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onloadend;
     void abort();
-    void readAsDataURL(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
-    void readAsText(<a href="#Blob">Blob</a> blob, optional DOMString? label) raises(, <a href="#FileError">FileError</a>);
-    void readAsBinaryString(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
-    void readAsArrayBuffer(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
+    void readAsDataURL(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsText(<a href="#Blob">Blob</a> blob, optional DOMString? label) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsBinaryString(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsArrayBuffer(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
   };
   [NoInterfaceObject] interface FileWriter {
     const short INIT = 0;
@@ -3590,10 +3587,10 @@ entry.createWriter(successCallback, errorCallback);
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onabort;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onerror;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onwriteend;
-    void abort() raises();
-    void seek(long offset) raises();
-    void truncate(long size) raises();
-    void write(<a href="#WriteData">WriteData</a> data) raises();
+    void abort() raises(FileException);
+    void seek(long offset) raises(FileException);
+    void truncate(long size) raises(FileException);
+    void write(<a href="#WriteData">WriteData</a> data) raises(FileException);
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface ProgressCallback {
     void onsuccess(<a href="#ProgressEvent">ProgressEvent</a> event);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/filetransfer.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/filetransfer.html
@@ -1014,7 +1014,8 @@ Upload error target http://some.server.com/file.txt
     attribute <a href="#FileUploadParams">FileUploadParams</a> params;
     attribute boolean chunkedMode;
     attribute <a href="#HeaderFields">HeaderFields</a> headers;
-  };  [NoInterfaceObject] interface FileUploadResult {
+  };
+  [NoInterfaceObject] interface FileUploadResult {
     attribute long bytesSent;
     attribute long responseCode;
     attribute DOMString response;

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/filetransfer.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/filetransfer.html
@@ -225,7 +225,7 @@ Sent = 1024
 <div class="constructors">
 <h4 id="FileUploadOptions::constructor">Constructors</h4>
 <dl>
-<pre class="webidl prettyprint">FileUploadOptions(DOMString fileKey, DOMString fileName, DOMString mimeType, <a href="#FileUploadParams">FileUploadParams</a> params, <a href="#HeaderFields">HeaderFields</a> headers, 
+<pre class="webidl prettyprint">FileUploadOptions(DOMString fileKey, DOMString fileName, DOMString mimeType, <a href="#FileUploadParams">FileUploadParams</a> params, <a href="#HeaderFields">HeaderFields</a> headers,
                   DOMString httpMethod);</pre>
 <div class="example">
 <span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">/* Creates a FileUploadOptions objects */
@@ -347,7 +347,7 @@ var options = new FileUploadOptions("file", "doc.txt", "text/plain", null, null,
     attribute long bytesSent;
     attribute long responseCode;
     attribute DOMString response;
-    attribute <a href="#HeaderFields">HeaderFields</a>  headers;
+    attribute <a href="#HeaderFields">HeaderFields</a> headers;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -426,17 +426,17 @@ var options = new FileUploadOptions("file", "doc.txt", "text/plain", null, null,
  A FileTransferError object is passed to an error callback when an error occurs.
           </div>
 <pre class="webidl prettyprint">  interface FileTransferError {
+    const short FILE_NOT_FOUND_ERR = 1;
+    const short INVALID_URL_ERR = 2;
+    const short CONNECTION_ERR = 3;
+    const short ABORT_ERR = 4;
+    const short NOT_MODIFIED_ERR = 5;
     attribute short code;
     attribute DOMString source;
     attribute DOMString target;
     attribute long http_status;
     attribute DOMString body;
     attribute DOMString _exception;
-    const short FILE_NOT_FOUND_ERR = 1;
-    const short INVALID_URL_ERR = 2;
-    const short CONNECTION_ERR = 3;
-    const short ABORT_ERR = 4;
-    const short NOT_MODIFIED_ERR = 5;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -682,8 +682,8 @@ Success. File uploaded
 <div class="brief">
  Sends a file to a server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void upload(DOMString fileURL, DOMString server, optional <a href="#FileUploadSuccessCallback">FileUploadSuccessCallback</a>? successCallback, 
-            optional <a href="#FileTransferErrorCallback">FileTransferErrorCallback</a>? errorCallback, optional <a href="#FileUploadOptions">FileUploadOptions</a>? options, 
+<div class="synopsis"><pre class="signature prettyprint">void upload(DOMString fileURL, DOMString server, optional <a href="#FileUploadSuccessCallback">FileUploadSuccessCallback</a>? successCallback,
+            optional <a href="#FileTransferErrorCallback">FileTransferErrorCallback</a>? errorCallback, optional <a href="#FileUploadOptions">FileUploadOptions</a>? options,
             optional boolean? trustAllHosts);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -761,8 +761,8 @@ Sent = 1024
 <div class="brief">
  Downloads a file from a server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void download(DOMString source, DOMString target, optional <a href="#FileDownloadSuccessCallback">FileDownloadSuccessCallback</a>? successCallback, 
-              optional <a href="#FileTransferErrorCallback">FileTransferErrorCallback</a>? errorCallback, optional boolean? trustAllHosts, 
+<div class="synopsis"><pre class="signature prettyprint">void download(DOMString source, DOMString target, optional <a href="#FileDownloadSuccessCallback">FileDownloadSuccessCallback</a>? successCallback,
+              optional <a href="#FileTransferErrorCallback">FileTransferErrorCallback</a>? errorCallback, optional boolean? trustAllHosts,
               optional <a href="#FileDownloadOptions">FileDownloadOptions</a>? options);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1014,25 +1014,24 @@ Upload error target http://some.server.com/file.txt
     attribute <a href="#FileUploadParams">FileUploadParams</a> params;
     attribute boolean chunkedMode;
     attribute <a href="#HeaderFields">HeaderFields</a> headers;
-  };
-  [NoInterfaceObject] interface FileUploadResult {
+  };  [NoInterfaceObject] interface FileUploadResult {
     attribute long bytesSent;
     attribute long responseCode;
     attribute DOMString response;
-    attribute <a href="#HeaderFields">HeaderFields</a>  headers;
+    attribute <a href="#HeaderFields">HeaderFields</a> headers;
   };
   interface FileTransferError {
+    const short FILE_NOT_FOUND_ERR = 1;
+    const short INVALID_URL_ERR = 2;
+    const short CONNECTION_ERR = 3;
+    const short ABORT_ERR = 4;
+    const short NOT_MODIFIED_ERR = 5;
     attribute short code;
     attribute DOMString source;
     attribute DOMString target;
     attribute long http_status;
     attribute DOMString body;
     attribute DOMString _exception;
-    const short FILE_NOT_FOUND_ERR = 1;
-    const short INVALID_URL_ERR = 2;
-    const short CONNECTION_ERR = 3;
-    const short ABORT_ERR = 4;
-    const short NOT_MODIFIED_ERR = 5;
   };
   [Constructor()]
   interface FileTransfer {

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/globalization.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/globalization.html
@@ -181,25 +181,25 @@ Original documentation: <a href="https://www.npmjs.com/package/cordova-plugin-gl
  the GlobalizationManager interface embodies Globalization module methods.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface GlobalizationManager {
-    void getPreferredLanguage(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void getLocaleName(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+    void getPreferredLanguage(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void getLocaleName(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     void dateToString(Date date, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
-                      raises();
-    void getCurrencyPattern(DOMString currencyCode, <a href="#PatternSuccessCallback">PatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+                      raises(TypeError);
+    void getCurrencyPattern(DOMString currencyCode, <a href="#PatternSuccessCallback">PatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     void getDateNames(<a href="#ArrayStringSuccessCallback">ArrayStringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#GetDateNamesOptions">GetDateNamesOptions</a> options)
-                      raises();
+                      raises(TypeError);
     void getDatePattern(<a href="#GetDatePatternSuccessCallback">GetDatePatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
-                        raises();
-    void getFirstDayOfWeek(<a href="#LongSuccessCallback">LongSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+                        raises(TypeError);
+    void getFirstDayOfWeek(<a href="#LongSuccessCallback">LongSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     void getNumberPattern(<a href="#GetNumberPatternSuccessCallback">GetNumberPatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
-                          raises();
-    void isDayLightSavingsTime(Date date, <a href="#DSTSuccessCallback">DSTSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+                          raises(TypeError);
+    void isDayLightSavingsTime(Date date, <a href="#DSTSuccessCallback">DSTSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     void numberToString(double number, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
-                        raises();
+                        raises(TypeError);
     void stringToDate(DOMString dateString, <a href="#GlobalizationDateSuccessCallback">GlobalizationDateSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
-                      optional <a href="#DateOptions">DateOptions</a> options) raises();
+                      optional <a href="#DateOptions">DateOptions</a> options) raises(TypeError);
     void stringToNumber(DOMString numberString, <a href="#DoubleSuccessCallback">DoubleSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
-                        optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options) raises();
+                        optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options) raises(TypeError);
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -354,7 +354,7 @@ navigator.globalization.getLocaleName(
 <div class="brief">
  Returns a date formatted as a string according to the client's locale and timezone.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void dateToString(Date date<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint">void dateToString(Date date, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options);</pre></div>
 <p><span class="version">Since: </span>
  3.0
             </p>
@@ -896,7 +896,7 @@ navigator.globalization.isDayLightSavingsTime(new Date(),
  Returns a number formatted as a string
 according to the client's user preferences.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void numberToString(double number<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint">void numberToString(double number, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options);</pre></div>
 <p><span class="version">Since: </span>
  3.0
             </p>
@@ -1014,7 +1014,7 @@ Currency: $1,099.95
 user preferences and calendar using the time zone of the client.
 Returns the corresponding date object.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void stringToDate(DOMString dateString, <a href="#GlobalizationDateSuccessCallback">GlobalizationDateSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, 
+<div class="synopsis"><pre class="signature prettyprint">void stringToDate(DOMString dateString, <a href="#GlobalizationDateSuccessCallback">GlobalizationDateSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
                   optional <a href="#DateOptions">DateOptions</a> options);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1089,7 +1089,7 @@ navigator.globalization.stringToDate("9/25/2012",
  Parses a number formatted as a string according to the client's
 user preferences and returns the corresponding number.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void stringToNumber(DOMString numberString, <a href="#DoubleSuccessCallback">DoubleSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, 
+<div class="synopsis"><pre class="signature prettyprint">void stringToNumber(DOMString numberString, <a href="#DoubleSuccessCallback">DoubleSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
                     optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1998,12 +1998,12 @@ of a NumberPattern object.
 <div class="interface" id="GlobalizationError">
 <a class="backward-compatibility-anchor" name="::Globalization::GlobalizationError"></a><h3>1.19. GlobalizationError</h3>
 <pre class="webidl prettyprint">  interface GlobalizationError {
-    attribute long code;
-    attribute DOMString message;
     const short UNKNOWN_ERROR = 0;
     const short FORMATTING_ERROR = 1;
     const short PARSING_ERROR = 2;
     const short PATTERN_ERROR = 3;
+    attribute long code;
+    attribute DOMString message;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -2093,8 +2093,7 @@ The GlobalizationError interface
 <div class="brief">
  Basic error callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };</pre>
 <div class="methods">
@@ -2127,31 +2126,6 @@ The GlobalizationError interface
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Globalization {
-  [NoInterfaceObject] interface GlobalizationManagerObject {
-    readonly attribute <a href="#GlobalizationManager">GlobalizationManager</a> globalization;
-  };
-  Navigator implements <a href="#GlobalizationManagerObject">GlobalizationManagerObject</a>;
-  [NoInterfaceObject] interface GlobalizationManager {
-    void getPreferredLanguage(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void getLocaleName(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void dateToString(Date date, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
-                      raises();
-    void getCurrencyPattern(DOMString currencyCode, <a href="#PatternSuccessCallback">PatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void getDateNames(<a href="#ArrayStringSuccessCallback">ArrayStringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#GetDateNamesOptions">GetDateNamesOptions</a> options)
-                      raises();
-    void getDatePattern(<a href="#GetDatePatternSuccessCallback">GetDatePatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
-                        raises();
-    void getFirstDayOfWeek(<a href="#LongSuccessCallback">LongSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void getNumberPattern(<a href="#GetNumberPatternSuccessCallback">GetNumberPatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
-                          raises();
-    void isDayLightSavingsTime(Date date, <a href="#DSTSuccessCallback">DSTSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void numberToString(double number, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
-                        raises();
-    void stringToDate(DOMString dateString, <a href="#GlobalizationDateSuccessCallback">GlobalizationDateSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
-                      optional <a href="#DateOptions">DateOptions</a> options) raises();
-    void stringToNumber(DOMString numberString, <a href="#DoubleSuccessCallback">DoubleSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
-                        optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options) raises();
-  };
   dictionary DateOptions {
     DOMString formatLength;
     DOMString selector;
@@ -2196,6 +2170,31 @@ The GlobalizationError interface
     long second;
     long millisecond;
   };
+  [NoInterfaceObject] interface GlobalizationManagerObject {
+    readonly attribute <a href="#GlobalizationManager">GlobalizationManager</a> globalization;
+  };
+  Navigator implements <a href="#GlobalizationManagerObject">GlobalizationManagerObject</a>;
+  [NoInterfaceObject] interface GlobalizationManager {
+    void getPreferredLanguage(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void getLocaleName(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void dateToString(Date date, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
+                      raises(TypeError);
+    void getCurrencyPattern(DOMString currencyCode, <a href="#PatternSuccessCallback">PatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void getDateNames(<a href="#ArrayStringSuccessCallback">ArrayStringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#GetDateNamesOptions">GetDateNamesOptions</a> options)
+                      raises(TypeError);
+    void getDatePattern(<a href="#GetDatePatternSuccessCallback">GetDatePatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
+                        raises(TypeError);
+    void getFirstDayOfWeek(<a href="#LongSuccessCallback">LongSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void getNumberPattern(<a href="#GetNumberPatternSuccessCallback">GetNumberPatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
+                          raises(TypeError);
+    void isDayLightSavingsTime(Date date, <a href="#DSTSuccessCallback">DSTSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void numberToString(double number, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
+                        raises(TypeError);
+    void stringToDate(DOMString dateString, <a href="#GlobalizationDateSuccessCallback">GlobalizationDateSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
+                      optional <a href="#DateOptions">DateOptions</a> options) raises(TypeError);
+    void stringToNumber(DOMString numberString, <a href="#DoubleSuccessCallback">DoubleSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
+                        optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options) raises(TypeError);
+  };
   [Callback=FunctionOnly, NoInterfaceObject] interface DSTSuccessCallback {
     void onsuccess(object properties);
   };
@@ -2224,15 +2223,14 @@ The GlobalizationError interface
     void onsuccess(<a href="#NumberPattern">NumberPattern</a> pattern);
   };
   interface GlobalizationError {
-    attribute long code;
-    attribute DOMString message;
     const short UNKNOWN_ERROR = 0;
     const short FORMATTING_ERROR = 1;
     const short PARSING_ERROR = 2;
     const short PATTERN_ERROR = 3;
+    attribute long code;
+    attribute DOMString message;
   };
-  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/globalization.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/globalization.html
@@ -2170,10 +2170,10 @@ The GlobalizationError interface
     long second;
     long millisecond;
   };
+  Navigator implements <a href="#GlobalizationManagerObject">GlobalizationManagerObject</a>;
   [NoInterfaceObject] interface GlobalizationManagerObject {
     readonly attribute <a href="#GlobalizationManager">GlobalizationManager</a> globalization;
   };
-  Navigator implements <a href="#GlobalizationManagerObject">GlobalizationManagerObject</a>;
   [NoInterfaceObject] interface GlobalizationManager {
     void getPreferredLanguage(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     void getLocaleName(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/media.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/media.html
@@ -147,7 +147,7 @@ for accessing internal and external storage using this API, privileges (<a href=
 <div class="brief">
  The Media interface provides interface and functions to manage audio objects.
               </div>
-<pre class="webidl prettyprint">Media(DOMString src, optional <a href="cordova.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="#MediaErrorCallback">MediaErrorCallback</a>? errorCallback, 
+<pre class="webidl prettyprint">Media(DOMString src, optional <a href="cordova.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="#MediaErrorCallback">MediaErrorCallback</a>? errorCallback,
       optional <a href="#StatusChangeCallback">StatusChangeCallback</a>? mediaStatus);</pre>
 <div class="description">
               <ul>
@@ -784,7 +784,7 @@ setTimeout(function()
 <div class="brief">
  Basic error callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly,NoInterfaceObject] interface MediaErrorCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface MediaErrorCallback {
     void onerror(<a href="#MediaError">MediaError</a> error);
   };</pre>
 <div class="methods">
@@ -931,15 +931,14 @@ If an application uses startRecord() or stopRecord(), declare the following feat
     void startRecord();
     void stopRecord();
     void stop();
-  };
-  interface MediaError {
+  };  interface MediaError {
     const short MEDIA_ERR_ABORTED = 1;
     const short MEDIA_ERR_NETWORK = 2;
     const short MEDIA_ERR_DECODE = 3;
     const short MEDIA_ERR_NONE_SUPPORTED = 4;
     readonly attribute short code;
   };
-  [Callback=FunctionOnly,NoInterfaceObject] interface MediaErrorCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface MediaErrorCallback {
     void onerror(<a href="#MediaError">MediaError</a> error);
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface StatusChangeCallback {

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/media.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/media.html
@@ -931,7 +931,8 @@ If an application uses startRecord() or stopRecord(), declare the following feat
     void startRecord();
     void stopRecord();
     void stop();
-  };  interface MediaError {
+  };
+  interface MediaError {
     const short MEDIA_ERR_ABORTED = 1;
     const short MEDIA_ERR_NETWORK = 2;
     const short MEDIA_ERR_DECODE = 3;

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/networkInformation.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/networkInformation.html
@@ -459,10 +459,10 @@ To guarantee that the NetworkInformation application runs on a device with the N
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module NetworkInformation {
+  Navigator implements <a href="#NetworkInformationManagerObject">NetworkInformationManagerObject</a>;
   [NoInterfaceObject] interface NetworkInformationManagerObject {
     readonly attribute <a href="#NetworkInformationManager">NetworkInformationManager</a> connection;
   };
-  Navigator implements <a href="#NetworkInformationManagerObject">NetworkInformationManagerObject</a>;
   [NoInterfaceObject] interface NetworkInformationManager {
     readonly attribute DOMString type;
   };

--- a/docs/application/web/api/5.5/device_api/tv/tizen/cordova/networkInformation.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/cordova/networkInformation.html
@@ -375,8 +375,7 @@ checkConnection();
 <div class="brief">
  Callback for the event when an application goes online, and the device becomes connected to the Internet.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface OnlineEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface OnlineEventCallback {
     void online();
   };</pre>
 <p><span class="version">Since: </span>
@@ -412,8 +411,7 @@ function onOnline()
 <div class="brief">
  Callback for the event when an application goes offline, and the device is not connected to the Internet.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface OfflineEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface OfflineEventCallback {
     void offline();
   };</pre>
 <p><span class="version">Since: </span>
@@ -478,12 +476,10 @@ To guarantee that the NetworkInformation application runs on a device with the N
     readonly attribute DOMString CELL;
     readonly attribute DOMString NONE;
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface OnlineEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface OnlineEventCallback {
     void online();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface OfflineEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface OfflineEventCallback {
     void offline();
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/datacontrol.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/datacontrol.html
@@ -267,8 +267,7 @@ Data Control API.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DataControlConsumerObject:
-                  </span>
+<span class="return">DataControlConsumerObject:</span>
  The local <em>DataControlConsumerObject</em>.
               </ul>
 </div>
@@ -422,8 +421,7 @@ The data sending implementation determines the actual change data returned to th
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  An identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -613,7 +611,7 @@ removeChangeListener was invoked
 <div class="brief">
  Inserts new rows into a table owned by an SQL-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void insert(unsigned long reqId, <a href="#RowData">RowData</a> insertionData, optional <a href="#DataControlInsertSuccessCallback">DataControlInsertSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void insert(unsigned long reqId, <a href="#RowData">RowData</a> insertionData, optional <a href="#DataControlInsertSuccessCallback">DataControlInsertSuccessCallback</a>? successCallback,
             optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -698,7 +696,7 @@ catch (err)
 <div class="brief">
  Updates values of a table owned by an SQL-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void update(unsigned long reqId, <a href="#RowData">RowData</a> updateData, DOMString where, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void update(unsigned long reqId, <a href="#RowData">RowData</a> updateData, DOMString where, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback,
             optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -787,7 +785,7 @@ catch (err)
 <div class="brief">
  Delete rows from a table that is owned by an SQL-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void remove(unsigned long reqId, DOMString where, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void remove(unsigned long reqId, DOMString where, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback,
             optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -870,8 +868,8 @@ catch (err)
 <div class="brief">
  Selects the specified columns to be queried. The result set of the specified columns is retrieved from a table owned by an SQL-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void select(unsigned long reqId, DOMString[] columns, DOMString where, <a href="#DataControlSelectSuccessCallback">DataControlSelectSuccessCallback</a> successCallback, 
-            optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback, optional unsigned long? page, 
+<div class="synopsis"><pre class="signature prettyprint">void select(unsigned long reqId, DOMString[] columns, DOMString where, <a href="#DataControlSelectSuccessCallback">DataControlSelectSuccessCallback</a> successCallback,
+            optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback, optional unsigned long? page,
             optional unsigned long? maxNumberPerPage, optional DOMString? order);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1022,7 +1020,7 @@ catch (err)
 <div class="brief">
  Adds the value associated with the specified key to a key-values map owned by a MAP-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void addValue(unsigned long reqId, DOMString key, DOMString value, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void addValue(unsigned long reqId, DOMString key, DOMString value, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback,
               optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1109,7 +1107,7 @@ catch (err)
 <div class="brief">
  Removes the value associated with the specified key from a key-values map owned by a MAP-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void removeValue(unsigned long reqId, DOMString key, DOMString value, <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void removeValue(unsigned long reqId, DOMString key, DOMString value, <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a> successCallback,
                  optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1199,7 +1197,7 @@ catch (err)
 <div class="brief">
  Gets the value associated with the specified key, from a key-values map owned by a MAP-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getValue(unsigned long reqId, DOMString key, <a href="#DataControlGetValueSuccessCallback">DataControlGetValueSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getValue(unsigned long reqId, DOMString key, <a href="#DataControlGetValueSuccessCallback">DataControlGetValueSuccessCallback</a> successCallback,
               optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1285,7 +1283,7 @@ catch (err)
 <div class="brief">
  Sets the value associated with the specified key to a new value.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void updateValue(unsigned long reqId, DOMString key, DOMString oldValue, DOMString newValue, 
+<div class="synopsis"><pre class="signature prettyprint">void updateValue(unsigned long reqId, DOMString key, DOMString oldValue, DOMString newValue,
                  <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a> successCallback, optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1664,6 +1662,10 @@ catch (err)
 <pre class="webidl prettyprint">module DataControl {
   enum DataType { "MAP", "SQL" };
   enum EventType { "SQL_UPDATE", "SQL_INSERT", "SQL_DELETE", "MAP_SET", "MAP_ADD", "MAP_REMOVE" };
+  dictionary RowData {
+    DOMString[] columns;
+    DOMString[] values;
+  };
   [NoInterfaceObject] interface DataControlManagerObject {
     readonly attribute <a href="#DataControlManager">DataControlManager</a> datacontrol;
   };
@@ -1718,10 +1720,6 @@ catch (err)
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface DataControlChangeCallback {
     void onsuccess(<a href="#EventType">EventType</a> type, <a href="#RowData">RowData</a> data);
-  };
-  dictionary RowData {
-    DOMString[] columns;
-    DOMString[] values;
   };
 };</pre>
 </div>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/datacontrol.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/datacontrol.html
@@ -1666,10 +1666,10 @@ catch (err)
     DOMString[] columns;
     DOMString[] values;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DataControlManagerObject">DataControlManagerObject</a>;
   [NoInterfaceObject] interface DataControlManagerObject {
     readonly attribute <a href="#DataControlManager">DataControlManager</a> datacontrol;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DataControlManagerObject">DataControlManagerObject</a>;
   [NoInterfaceObject] interface DataControlManager {
     <a href="#DataControlConsumerObject">DataControlConsumerObject</a> getDataControlConsumer(DOMString providerId, DOMString dataId, <a href="#DataType">DataType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };

--- a/docs/application/web/api/5.5/device_api/tv/tizen/download.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/download.html
@@ -221,7 +221,7 @@ The <em>tizen.download </em>object allows access to the functionality of the Dow
           </p>
 <div class="constructors">
 <h4 id="DownloadRequest::constructor">Constructors</h4>
-<dl><pre class="webidl prettyprint">DownloadRequest(DOMString url, optional DOMString? destination, optional DOMString? fileName, 
+<dl><pre class="webidl prettyprint">DownloadRequest(DOMString url, optional DOMString? destination, optional DOMString? fileName,
                 optional <a href="#DownloadNetworkType">DownloadNetworkType</a>? networkType, optional <a href="#DownloadHTTPHeaderFields">DownloadHTTPHeaderFields</a>? httpHeader);</pre></dl>
 </div>
 <div class="attributes">
@@ -366,8 +366,7 @@ req.httpHeader["X-Agent"] = "Tizen Sample App";
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  An identifier for each download operation.
 If the network is not available for downloading, the return value is -1 since Tizen 2.3.
               </ul>
@@ -605,8 +604,7 @@ tizen.download.resume(downloadId);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DownloadState:
-                  </span>
+<span class="return">DownloadState:</span>
  The current download state of the specified ID.
               </ul>
 </div>
@@ -657,8 +655,7 @@ var state = tizen.download.getState(downloadId);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DownloadRequest:
-                  </span>
+<span class="return">DownloadRequest:</span>
  The download request information of the given ID.
               </ul>
 </div>
@@ -716,8 +713,7 @@ and successfully retrieves the file header.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The MIME type of the downloaded file.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/download.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/download.html
@@ -1008,10 +1008,10 @@ DownloadNetworkType <em>ALL</em> can be available on a ethernet-enabled device. 
   typedef object DownloadHTTPHeaderFields;
   enum DownloadState { "QUEUED", "DOWNLOADING", "PAUSED", "CANCELED", "COMPLETED", "FAILED" };
   enum DownloadNetworkType { "CELLULAR", "WIFI", "ALL" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DownloadManagerObject">DownloadManagerObject</a>;
   [NoInterfaceObject] interface DownloadManagerObject {
     readonly attribute <a href="#DownloadManager">DownloadManager</a> download;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DownloadManagerObject">DownloadManagerObject</a>;
   [Constructor(DOMString url, optional DOMString? destination, optional DOMString? fileName,
                optional <a href="#DownloadNetworkType">DownloadNetworkType</a>? networkType, optional <a href="#DownloadHTTPHeaderFields">DownloadHTTPHeaderFields</a>? httpHeader)]
   interface DownloadRequest {

--- a/docs/application/web/api/5.5/device_api/tv/tizen/exif.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/exif.html
@@ -884,10 +884,10 @@ This callback interface specifies a success method with the URI for the thumbnai
     Date gpsTime;
     DOMString userComment;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ExifManagerObject">ExifManagerObject</a>;
   [NoInterfaceObject] interface ExifManagerObject {
     readonly attribute <a href="#ExifManager">ExifManager</a> exif;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ExifManagerObject">ExifManagerObject</a>;
   [NoInterfaceObject] interface ExifManager {
     void getExifInfo(DOMString uri, <a href="#ExifInformationSuccessCallback">ExifInformationSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/exif.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/exif.html
@@ -863,18 +863,6 @@ This callback interface specifies a success method with the URI for the thumbnai
   enum WhiteBalanceMode { "AUTO", "MANUAL" };
   enum ExposureProgram { "NOT_DEFINED", "MANUAL", "NORMAL", "APERTURE_PRIORITY", "SHUTTER_PRIORITY", "CREATIVE_PROGRAM",
     "ACTION_PROGRAM", "PORTRAIT_MODE", "LANDSCAPE_MODE" };
-  [NoInterfaceObject] interface ExifManagerObject {
-    readonly attribute <a href="#ExifManager">ExifManager</a> exif;
-  };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ExifManagerObject">ExifManagerObject</a>;
-  [NoInterfaceObject] interface ExifManager {
-    void getExifInfo(DOMString uri, <a href="#ExifInformationSuccessCallback">ExifInformationSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                     raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void saveExifInfo(<a href="#ExifInformation">ExifInformation</a> exifInfo, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getThumbnail(DOMString uri, <a href="#ExifThumbnailSuccessCallback">ExifThumbnailSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
   dictionary ExifInit {
     DOMString uri;
     unsigned long width;
@@ -895,6 +883,18 @@ This callback interface specifies a success method with the URI for the thumbnai
     DOMString gpsProcessingMethod;
     Date gpsTime;
     DOMString userComment;
+  };
+  [NoInterfaceObject] interface ExifManagerObject {
+    readonly attribute <a href="#ExifManager">ExifManager</a> exif;
+  };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ExifManagerObject">ExifManagerObject</a>;
+  [NoInterfaceObject] interface ExifManager {
+    void getExifInfo(DOMString uri, <a href="#ExifInformationSuccessCallback">ExifInformationSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                     raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void saveExifInfo(<a href="#ExifInformation">ExifInformation</a> exifInfo, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void getThumbnail(DOMString uri, <a href="#ExifThumbnailSuccessCallback">ExifThumbnailSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [Constructor(optional <a href="#ExifInit">ExifInit</a>? ExifInitDict)]
   interface ExifInformation {

--- a/docs/application/web/api/5.5/device_api/tv/tizen/filesystem.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/filesystem.html
@@ -472,7 +472,9 @@ There is a <em>tizen.filesystem </em>object that allows accessing the functional
     boolean isDirectory(<a href="#Path">Path</a> path) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     boolean pathExists(<a href="#Path">Path</a> path) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     DOMString getDirName(DOMString path);
-    void getStorage(DOMString label, <a href="#FileSystemStorageSuccessCallback">FileSystemStorageSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror)
+<span class="nocode deprecated">    void resolve(DOMString location, <a href="#FileSuccessCallback">FileSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, optional <a href="#FileMode">FileMode</a>? mode)
+                 raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void getStorage(DOMString label, <a href="#FileSystemStorageSuccessCallback">FileSystemStorageSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror)
                     raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void listStorages(<a href="#FileSystemStorageArraySuccessCallback">FileSystemStorageArraySuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addStorageStateChangeListener(<a href="#FileSystemStorageSuccessCallback">FileSystemStorageSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror)
@@ -596,8 +598,7 @@ By default, <em>makeParents</em> is equal to <var>true</var>. Its value is ignor
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">FileHandle:
-                  </span>
+<span class="return">FileHandle:</span>
  Object representing open file.
               </ul>
 </div>
@@ -652,7 +653,7 @@ File content: Lorem ipsum dolor sit amet...
 <div class="brief">
  Creates directory pointed by <em>path</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void createDirectory(<a href="#Path">Path</a> path, optional boolean makeParents, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void createDirectory(<a href="#Path">Path</a> path, optional boolean makeParents, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -840,7 +841,7 @@ catch (error)
 <div class="brief">
  Deletes directory or directory tree under the current directory pointed by <em>path</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void deleteDirectory(<a href="#Path">Path</a> path, optional boolean recursive, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void deleteDirectory(<a href="#Path">Path</a> path, optional boolean recursive, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -936,7 +937,7 @@ catch (error)
 <div class="brief">
  Copies file from location pointed by <em>sourcePath</em> to <em>destinationPath</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void copyFile(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void copyFile(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback,
               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1040,7 +1041,7 @@ catch (error)
 <div class="brief">
  Recursively copies directory pointed by <em>sourcePath</em> to <em>destinationPath</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void copyDirectory(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, 
+<div class="synopsis"><pre class="signature prettyprint">void copyDirectory(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite,
                    optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1209,7 +1210,7 @@ file
 <div class="brief">
  Moves file pointed by <em>sourcePath</em> to <em>destinationPath</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void moveFile(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void moveFile(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback,
               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1314,7 +1315,7 @@ catch (error)
 <div class="brief">
  Recursively moves directory pointed by <em>sourcePath</em> to <em>destinationPath</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void moveDirectory(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, 
+<div class="synopsis"><pre class="signature prettyprint">void moveDirectory(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite,
                    optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1515,7 +1516,7 @@ catch (error)
 <div class="brief">
  Lists directory content located in <em>path</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void listDirectory(<a href="#Path">Path</a> path, <a href="#ListDirectorySuccessCallback">ListDirectorySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void listDirectory(<a href="#Path">Path</a> path, <a href="#ListDirectorySuccessCallback">ListDirectorySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                    optional <a href="#FileFilter">FileFilter</a>? filter);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1645,8 +1646,7 @@ foo_dir_a
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  <a href="https://tools.ietf.org/html/rfc8089">File URI</a> for given path.
               </ul>
 </div>
@@ -1709,8 +1709,7 @@ file:///opt/media/USBDriveA1/Documents/directory/file
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if <em>path</em> points to a file, <var>false</var> otherwise.
               </ul>
 </div>
@@ -1771,8 +1770,7 @@ file:///opt/media/USBDriveA1/Documents/directory/file
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if <em>path</em> points to a directory, <var>false</var> otherwise.
               </ul>
 </div>
@@ -1833,8 +1831,7 @@ file:///opt/media/USBDriveA1/Documents/directory/file
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if <em>path</em> points to a existing element, <var>false</var> otherwise.
               </ul>
 </div>
@@ -1894,8 +1891,7 @@ Strips trailing '/', then breaks <em>path</em> into two components by last <em>p
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  Path to directory for given path.
               </ul>
 </div>
@@ -2225,8 +2221,7 @@ The watch operation must continue until the removeStorageStateChangeListener() m
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Subscription identifier.
               </ul>
 </div>
@@ -2465,8 +2460,7 @@ Note, that current position indicator value, can be obtained by calling <var>see
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long long:
-                  </span>
+<span class="return">long long:</span>
  File position indicator.
               </ul>
 </div>
@@ -2521,7 +2515,7 @@ Bytes between: 44,55,66
 <div class="brief">
  Sets position indicator in file stream to <var>offset</var>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void seekNonBlocking(long long offset, optional <a href="#SeekSuccessCallback">SeekSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">void seekNonBlocking(long long offset, optional <a href="#SeekSuccessCallback">SeekSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
                      optional <a href="#BaseSeekPosition">BaseSeekPosition</a> whence);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -2708,8 +2702,7 @@ Reads given number of characters.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  String with data read from file.
               </ul>
 </div>
@@ -2764,7 +2757,7 @@ File content: Lorem ipsum dolor sit amet...
 <div class="brief">
  Reads file content as string.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void readStringNonBlocking(optional <a href="#ReadStringSuccessCallback">ReadStringSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">void readStringNonBlocking(optional <a href="#ReadStringSuccessCallback">ReadStringSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
                            optional long long count, optional DOMString inputEncoding);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -2909,8 +2902,7 @@ Sets file handle position indicator at the end of written data.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long long:
-                  </span>
+<span class="return">long long:</span>
  Number of bytes written (can be more than <em>inputString</em> length for multibyte encodings and will never be less)
               </ul>
 </div>
@@ -2959,7 +2951,7 @@ File content: Lorem ipsum dolor sit amet...
 <div class="brief">
  Writes <var>inputString</var> content to a file.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void writeStringNonBlocking(DOMString inputString, optional <a href="#WriteStringSuccessCallback">WriteStringSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">void writeStringNonBlocking(DOMString inputString, optional <a href="#WriteStringSuccessCallback">WriteStringSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
                             optional DOMString outputEncoding);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -3095,8 +3087,7 @@ Sets file handle position indicator at the end of read data.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Blob:
-                  </span>
+<span class="return">Blob:</span>
  Blob object with file content.
               </ul>
 </div>
@@ -3479,8 +3470,7 @@ Sets file handle position indicator at the end of read data.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Uint8Array:
-                  </span>
+<span class="return">Uint8Array:</span>
  Read data as Uint8Array.
               </ul>
 </div>
@@ -4283,8 +4273,36 @@ File handle closed
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface File {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface File {
+<span class="nocode deprecated">    readonly attribute <a href="#File">File</a>? parent;
+</span><span class="nocode deprecated">    readonly attribute boolean readOnly;
+</span><span class="nocode deprecated">    readonly attribute boolean isFile;
+</span><span class="nocode deprecated">    readonly attribute boolean isDirectory;
+</span><span class="nocode deprecated">    readonly attribute Date? created;
+</span><span class="nocode deprecated">    readonly attribute Date? modified;
+</span><span class="nocode deprecated">    readonly attribute DOMString path;
+</span><span class="nocode deprecated">    readonly attribute DOMString name;
+</span><span class="nocode deprecated">    readonly attribute DOMString fullPath;
+</span><span class="nocode deprecated">    readonly attribute unsigned long long fileSize;
+</span><span class="nocode deprecated">    readonly attribute long length;
+</span><span class="nocode deprecated">    DOMString toURI() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void listFiles(<a href="#FileArraySuccessCallback">FileArraySuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, optional <a href="#FileFilter">FileFilter</a>? filter)
+                   raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void openStream(<a href="#FileMode">FileMode</a> mode, <a href="#FileStreamSuccessCallback">FileStreamSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, optional DOMString? encoding)
+                    raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void readAsText(<a href="#FileStringSuccessCallback">FileStringSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, optional DOMString? encoding)
+                    raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void copyTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
+                optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void moveTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
+                optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    <a href="#File">File</a> createDirectory(DOMString dirPath) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    <a href="#File">File</a> createFile(DOMString relativeFilePath) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    <a href="#File">File</a> resolve(DOMString filePath) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void deleteDirectory(DOMString directoryPath, boolean recursive, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
+                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void deleteFile(DOMString filePath, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -4719,8 +4737,7 @@ These URIs must not be accessible to other widgets, apart from the one invoking 
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  URI that identifies the file or <var>null</var> if an error occurs.
               </ul>
 </div>
@@ -5075,7 +5092,7 @@ directory from a specified location to another specified location.
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
             </p>
-<div class="synopsis"><pre class="signature prettyprint">void copyTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, 
+<div class="synopsis"><pre class="signature prettyprint">void copyTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
             optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -5194,7 +5211,7 @@ This operation is different from instantiating copyTo() and then deleting the or
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
             </p>
-<div class="synopsis"><pre class="signature prettyprint">void moveTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, 
+<div class="synopsis"><pre class="signature prettyprint">void moveTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
             optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -5352,8 +5369,7 @@ In case the directory cannot be created, an error must be thrown with the approp
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">File:
-                  </span>
+<span class="return">File:</span>
  File handle of the new directory.
 The new <em>File </em>object has "rw" access rights, as it inherits this from the <em>File </em>object on which the createDirectory() method is called.
               </ul>
@@ -5429,8 +5445,7 @@ In case the file cannot be created, an error must be thrown with the appropriate
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">File:
-                  </span>
+<span class="return">File:</span>
  File handle for the new empty file.
 The new <em>File </em>object has "rw" access rights, as it inherits this from the <em>File </em>object on which the createFile() method is
 called.
@@ -5502,8 +5517,7 @@ The encoding of file paths is <a href="http://www.ietf.org/rfc/rfc2279.txt">UTF-
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">File:
-                  </span>
+<span class="return">File:</span>
  File handle of the file.
 The new <em>File </em>object inherits its access rights from the <em>File </em>object on which this resolve() method is called.
               </ul>
@@ -5559,7 +5573,7 @@ tizen.filesystem.resolve("documents",
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
             </p>
-<div class="synopsis"><pre class="signature prettyprint">void deleteDirectory(DOMString directoryPath, boolean recursive, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, 
+<div class="synopsis"><pre class="signature prettyprint">void deleteDirectory(DOMString directoryPath, boolean recursive, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -5923,8 +5937,18 @@ Read and write operations are performed relative to a position attribute, which 
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface FileStream {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface FileStream {
+<span class="nocode deprecated">    readonly attribute boolean eof;
+</span><span class="nocode deprecated">    attribute long position;
+</span><span class="nocode deprecated">    readonly attribute long bytesAvailable;
+</span><span class="nocode deprecated">    void close();
+</span><span class="nocode deprecated">    DOMString read(long charCount) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    octet[] readBytes(long byteCount) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    DOMString readBase64(long byteCount) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void write(DOMString stringData) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void writeBytes(octet[] byteData) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void writeBase64(DOMString base64Data) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -6086,8 +6110,7 @@ The resulting string length might be shorter than <em>charCount </em>if EOF is <
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  Array of read characters as a string.
               </ul>
 </div>
@@ -6147,8 +6170,7 @@ stream.close();
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">octet[]:
-                  </span>
+<span class="return">octet[]:</span>
  Result of read bytes as a byte (or number) array.
               </ul>
 </div>
@@ -6212,8 +6234,7 @@ for (var i = 0; i &lt; raw.length; i++)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  Array of read characters as base64 encoding string.
               </ul>
 </div>
@@ -6405,8 +6426,9 @@ output.writeBase64(base64);
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileSuccessCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback=FunctionOnly, NoInterfaceObject] interface FileSuccessCallback {
+<span class="nocode deprecated">    void onsuccess(<a href="#File">File</a> file);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -6797,8 +6819,9 @@ It is used in asynchronous operation FileHandle.readDataNonBlocking().
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileStringSuccessCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback=FunctionOnly, NoInterfaceObject] interface FileStringSuccessCallback {
+<span class="nocode deprecated">    void onsuccess(DOMString fileStr);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -6845,8 +6868,9 @@ It is used in asynchronous operation File.readAsText().
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileStreamSuccessCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback=FunctionOnly, NoInterfaceObject] interface FileStreamSuccessCallback {
+<span class="nocode deprecated">    void onsuccess(<a href="#FileStream">FileStream</a> filestream);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -6940,8 +6964,9 @@ This callback interface specifies a success callback with a function taking an a
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileArraySuccessCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback=FunctionOnly, NoInterfaceObject] interface FileArraySuccessCallback {
+<span class="nocode deprecated">    void onsuccess(<a href="#File">File</a>[] files);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -6984,11 +7009,20 @@ This callback interface specifies a success callback with a function taking an a
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Filesystem {
   typedef DOMString Path;
+  typedef <a href="#Blob">Blob</a> Blob;
   enum FileMode { "a", "r", "rw", "rwo", "w" };
   enum FileSystemStorageType { "INTERNAL", "EXTERNAL" };
   enum FileSystemStorageState { "MOUNTED", "REMOVED", "UNMOUNTABLE" };
-  typedef <a href="#Blob">Blob</a> Blob;
   enum BaseSeekPosition { "BEGIN", "CURRENT", "END" };
+  dictionary FileFilter {
+    DOMString name;
+    boolean isFile;
+    boolean isDirectory;
+    Date startModified;
+    Date endModified;
+    Date startCreated;
+    Date endCreated;
+  };
   [NoInterfaceObject] interface FileSystemManagerObject {
     readonly attribute <a href="#FileSystemManager">FileSystemManager</a> filesystem;
   };
@@ -7060,15 +7094,6 @@ This callback interface specifies a success callback with a function taking an a
     void syncNonBlocking(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void close() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void closeNonBlocking(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  dictionary FileFilter {
-    DOMString name;
-    boolean isFile;
-    boolean isDirectory;
-    Date startModified;
-    Date endModified;
-    Date startCreated;
-    Date endCreated;
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface FileSystemStorageArraySuccessCallback {
     void onsuccess(<a href="#FileSystemStorage">FileSystemStorage</a>[] storages);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/filesystem.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/filesystem.html
@@ -7023,10 +7023,10 @@ This callback interface specifies a success callback with a function taking an a
     Date startCreated;
     Date endCreated;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#FileSystemManagerObject">FileSystemManagerObject</a>;
   [NoInterfaceObject] interface FileSystemManagerObject {
     readonly attribute <a href="#FileSystemManager">FileSystemManager</a> filesystem;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#FileSystemManagerObject">FileSystemManagerObject</a>;
   [NoInterfaceObject] interface FileSystemManager {
     readonly attribute long maxNameLength;
     readonly attribute long maxPathLength;

--- a/docs/application/web/api/5.5/device_api/tv/tizen/iotcon.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/iotcon.html
@@ -632,8 +632,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Client:
-                  </span>
+<span class="return">Client:</span>
  The <em>Client</em> object.
               </ul>
 </div>
@@ -666,8 +665,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Server:
-                  </span>
+<span class="return">Server:</span>
  The <em>Server</em> object.
               </ul>
 </div>
@@ -706,8 +704,7 @@ Without a response after the specified time, the mentioned methods would trigger
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The timeout value in seconds.
               </ul>
 </div>
@@ -793,8 +790,7 @@ console.log("Timeout value is " + timeout);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The watchID which can be used to remove the listener.
               </ul>
 </div>
@@ -868,14 +864,14 @@ watchId = tizen.iotcon.addGeneratedPinListener(RandomPinSuccess);
  The Client provides API for client side.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface Client {
-    void findResource(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findResource(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                       <a href="#FoundResourceSuccessCallback">FoundResourceSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addPresenceEventListener(DOMString? hostAddress, <a href="#ResourceType">ResourceType</a>? resourceType, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                                   <a href="#PresenceEventCallback">PresenceEventCallback</a> successCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removePresenceEventListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                         <a href="#FoundDeviceInfoSuccessCallback">FoundDeviceInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                           <a href="#FoundPlatformInfoSuccessCallback">FoundPlatformInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                           raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
@@ -892,7 +888,7 @@ watchId = tizen.iotcon.addGeneratedPinListener(RandomPinSuccess);
 <div class="brief">
  Finds resources using host address and resource type.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void findResource(DOMString? hostAddress, <a href="#Query">Query</a>? query<a href="#ConnectivityType">ConnectivityType</a> connectivityType, 
+<div class="synopsis"><pre class="signature prettyprint">void findResource(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                   <a href="#FoundResourceSuccessCallback">FoundResourceSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1020,7 +1016,7 @@ Resource interfaces:
  Adds a listener to receive a presence events from the server.
 A server sends presence events when starts or stops presence.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long addPresenceEventListener(DOMString? hostAddress, <a href="#ResourceType">ResourceType</a>? resourceType, <a href="#ConnectivityType">ConnectivityType</a> connectivityType, 
+<div class="synopsis"><pre class="signature prettyprint">long addPresenceEventListener(DOMString? hostAddress, <a href="#ResourceType">ResourceType</a>? resourceType, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                               <a href="#PresenceEventCallback">PresenceEventCallback</a> successCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1055,8 +1051,7 @@ A server sends presence events when starts or stops presence.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The watchID which can be used to remove the listener.
               </ul>
 </div>
@@ -1165,7 +1160,7 @@ Resource type: oic.wk.ad
 <div class="brief">
  Gets the device information of remote server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query<a href="#ConnectivityType">ConnectivityType</a> connectivityType, 
+<div class="synopsis"><pre class="signature prettyprint">void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                     <a href="#FoundDeviceInfoSuccessCallback">FoundDeviceInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1284,7 +1279,7 @@ Data model version: res.1.0.0
 <div class="brief">
  Gets the platform information of remote server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query<a href="#ConnectivityType">ConnectivityType</a> connectivityType, 
+<div class="synopsis"><pre class="signature prettyprint">void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                       <a href="#FoundPlatformInfoSuccessCallback">FoundPlatformInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1444,8 +1439,7 @@ There are different resource types, for example a temperature sensor, a light co
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Resource[]:
-                  </span>
+<span class="return">Resource[]:</span>
  Array of <em>Resource</em> objects registered on server.
               </ul>
 </div>
@@ -1469,7 +1463,7 @@ var resources = server.getResources();
 <div class="brief">
  Creates a resource and registers the resource on server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint"><a href="#Resource">Resource</a> createResource(DOMString uriPath, <a href="#ResourceType">ResourceType</a>[] resourceTypes, <a href="#ResourceInterface">ResourceInterface</a>[] resourceInterfaces, 
+<div class="synopsis"><pre class="signature prettyprint"><a href="#Resource">Resource</a> createResource(DOMString uriPath, <a href="#ResourceType">ResourceType</a>[] resourceTypes, <a href="#ResourceInterface">ResourceInterface</a>[] resourceInterfaces,
                         <a href="#RequestCallback">RequestCallback</a> listener, optional <a href="#ResourcePolicy">ResourcePolicy</a> policy);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1508,8 +1502,7 @@ var resources = server.getResources();
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Resource:
-                  </span>
+<span class="return">Resource:</span>
  Instance of <em>Resource</em> object.
               </ul>
 </div>
@@ -2039,7 +2032,7 @@ key: openstate, value: open
 <div class="brief">
  Puts the representation of a resource for update.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void methodPut(<a href="#Representation">Representation</a> representation, <a href="#RemoteResourceResponseCallback">RemoteResourceResponseCallback</a> responseCallback, optional <a href="#Query">Query</a>? query, 
+<div class="synopsis"><pre class="signature prettyprint">void methodPut(<a href="#Representation">Representation</a> representation, <a href="#RemoteResourceResponseCallback">RemoteResourceResponseCallback</a> responseCallback, optional <a href="#Query">Query</a>? query,
                optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -2158,7 +2151,7 @@ key: openstate, value: closed
 <div class="brief">
  Posts the representation of a resource for create.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void methodPost(<a href="#Representation">Representation</a> representation, <a href="#RemoteResourceResponseCallback">RemoteResourceResponseCallback</a> responseCallback, optional <a href="#Query">Query</a>? query, 
+<div class="synopsis"><pre class="signature prettyprint">void methodPost(<a href="#Representation">Representation</a> representation, <a href="#RemoteResourceResponseCallback">RemoteResourceResponseCallback</a> responseCallback, optional <a href="#Query">Query</a>? query,
                 optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -3810,7 +3803,7 @@ query["filter"] = filter;
  The Request interface represents a details from client.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface Request {
-    readonly attribute DOMString  hostAddress;
+    readonly attribute DOMString hostAddress;
     readonly attribute <a href="#ConnectivityType">ConnectivityType</a> connectivityType;
     readonly attribute <a href="#Representation">Representation</a>? representation;
     readonly attribute <a href="#IotconOption">IotconOption</a>[] options;
@@ -4796,14 +4789,27 @@ To guarantee this application will run on a device with a Iotcon, add the below 
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Iotcon {
   typedef DOMString ResourceType;
+  typedef DOMString ResourceInterface;
   enum QosLevel { "HIGH", "LOW" };
   enum ResponseResult { "SUCCESS", "ERROR", "RESOURCE_CREATED", "RESOURCE_DELETED", "RESOURCE_CHANGED", "SLOW", "FORBIDDEN" };
   enum PresenceResponseResultType { "OK", "STOPPED", "TIMEOUT" };
   enum PresenceTriggerType { "CREATED", "UPDATED", "DESTROYED" };
   enum ConnectivityType { "IP", "PREFER_UDP", "PREFER_TCP", "IPV4_ONLY", "IPV6_ONLY", "ALL" };
-  typedef DOMString ResourceInterface;
   enum ObservePolicy { "IGNORE_OUT_OF_ORDER", "ACCEPT_OUT_OF_ORDER" };
   enum ObserveType { "NO_TYPE", "REGISTER", "DEREGISTER" };
+  dictionary ResourcePolicy {
+    boolean isObservable;
+    boolean isDiscoverable;
+    boolean isActive;
+    boolean isSlow;
+    boolean isSecure;
+    boolean isExplicitDiscoverable;
+  };
+  dictionary Query {
+    <a href="#ResourceType">ResourceType</a>? resourceType;
+    <a href="#ResourceInterface">ResourceInterface</a>? resourceInterface;
+    object? filter;
+  };
   [NoInterfaceObject] interface IotconObject {
     readonly attribute <a href="#Iotcon">Iotcon</a> iotcon;
   };
@@ -4819,14 +4825,14 @@ To guarantee this application will run on a device with a Iotcon, add the below 
     void removeGeneratedPinListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface Client {
-    void findResource(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findResource(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                       <a href="#FoundResourceSuccessCallback">FoundResourceSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addPresenceEventListener(DOMString? hostAddress, <a href="#ResourceType">ResourceType</a>? resourceType, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                                   <a href="#PresenceEventCallback">PresenceEventCallback</a> successCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removePresenceEventListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                         <a href="#FoundDeviceInfoSuccessCallback">FoundDeviceInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                           <a href="#FoundPlatformInfoSuccessCallback">FoundPlatformInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                           raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
@@ -4870,14 +4876,6 @@ To guarantee this application will run on a device with a Iotcon, add the below 
     void setResourceStateChangeListener(<a href="#ResourceStateChangeCallback">ResourceStateChangeCallback</a> successCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unsetResourceStateChangeListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
-  dictionary ResourcePolicy {
-    boolean isObservable;
-    boolean isDiscoverable;
-    boolean isActive;
-    boolean isSlow;
-    boolean isSecure;
-    boolean isExplicitDiscoverable;
-  };
   [NoInterfaceObject] interface Resource {
     readonly attribute DOMString uriPath;
     readonly attribute <a href="#ResourceType">ResourceType</a>[] resourceTypes;
@@ -4914,18 +4912,13 @@ To guarantee this application will run on a device with a Iotcon, add the below 
     readonly attribute <a href="#PresenceResponseResultType">PresenceResponseResultType</a> resultType;
     readonly attribute <a href="#PresenceTriggerType">PresenceTriggerType</a>? triggerType;
   };
-  dictionary Query {
-    <a href="#ResourceType">ResourceType</a>? resourceType;
-    <a href="#ResourceInterface">ResourceInterface</a>? resourceInterface;
-    object? filter;
-  };
   [Constructor(unsigned long id, DOMString data)]
   interface IotconOption {
     attribute unsigned long id;
     attribute DOMString data;
   };
   [NoInterfaceObject] interface Request {
-    readonly attribute DOMString  hostAddress;
+    readonly attribute DOMString hostAddress;
     readonly attribute <a href="#ConnectivityType">ConnectivityType</a> connectivityType;
     readonly attribute <a href="#Representation">Representation</a>? representation;
     readonly attribute <a href="#IotconOption">IotconOption</a>[] options;

--- a/docs/application/web/api/5.5/device_api/tv/tizen/iotcon.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/iotcon.html
@@ -4810,10 +4810,10 @@ To guarantee this application will run on a device with a Iotcon, add the below 
     <a href="#ResourceInterface">ResourceInterface</a>? resourceInterface;
     object? filter;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#IotconObject">IotconObject</a>;
   [NoInterfaceObject] interface IotconObject {
     readonly attribute <a href="#Iotcon">Iotcon</a> iotcon;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#IotconObject">IotconObject</a>;
   [NoInterfaceObject] interface Iotcon {
     attribute DOMString deviceName;
     void initialize(DOMString filePath) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/keymanager.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/keymanager.html
@@ -172,7 +172,7 @@ It provides access to the API functionalities through the <em>tizen.keymanager</
 <div class="brief">
  Saves and stores data as a <a href="#KeyManagerAlias">KeyManagerAlias</a> inside the KeyManager.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void saveData(DOMString name, <a href="#RawData">RawData</a> rawData, optional DOMString? password, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void saveData(DOMString name, <a href="#RawData">RawData</a> rawData, optional DOMString? password, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -347,8 +347,7 @@ If an application calls this method to retrieve raw data which it saved into the
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">RawData:
-                  </span>
+<span class="return">RawData:</span>
  Data.
               </ul>
 </div>
@@ -414,8 +413,7 @@ if (aliases.length != 0)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">KeyManagerAlias[]:
-                  </span>
+<span class="return">KeyManagerAlias[]:</span>
  Array of aliases.
               </ul>
 </div>
@@ -444,7 +442,7 @@ for (var i = 0; i &lt; aliases.length; i++)
 <div class="brief">
  Sets permissions that another application has for accessing an application's data.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void setPermission(<a href="#KeyManagerAlias">KeyManagerAlias</a> dataAlias, <a href="package.html#PackageId">PackageId</a> packageId, <a href="#PermissionType">PermissionType</a> permissionType, 
+<div class="synopsis"><pre class="signature prettyprint">void setPermission(<a href="#KeyManagerAlias">KeyManagerAlias</a> dataAlias, <a href="package.html#PackageId">PackageId</a> packageId, <a href="#PermissionType">PermissionType</a> permissionType,
                    optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -612,6 +610,11 @@ Possible values:
 <pre class="webidl prettyprint">module KeyManager {
   typedef DOMString RawData;
   enum PermissionType { "NONE", "READ", "REMOVE", "READ_REMOVE" };
+  dictionary KeyManagerAlias {
+    <a href="package.html#PackageId">PackageId</a> packageId;
+    DOMString name;
+    boolean isProtected;
+  };
   [NoInterfaceObject] interface KeyManagerObject {
     readonly attribute <a href="#KeyManager">KeyManager</a> keymanager;
   };
@@ -624,11 +627,6 @@ Possible values:
     <a href="#KeyManagerAlias">KeyManagerAlias</a>[] getDataAliasList() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void setPermission(<a href="#KeyManagerAlias">KeyManagerAlias</a> dataAlias, <a href="package.html#PackageId">PackageId</a> packageId, <a href="#PermissionType">PermissionType</a> permissionType,
                        optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  dictionary KeyManagerAlias {
-    <a href="package.html#PackageId">PackageId</a> packageId;
-    DOMString name;
-    boolean isProtected;
   };
 };</pre>
 </div>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/keymanager.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/keymanager.html
@@ -615,10 +615,10 @@ Possible values:
     DOMString name;
     boolean isProtected;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#KeyManagerObject">KeyManagerObject</a>;
   [NoInterfaceObject] interface KeyManagerObject {
     readonly attribute <a href="#KeyManager">KeyManager</a> keymanager;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#KeyManagerObject">KeyManagerObject</a>;
   [NoInterfaceObject] interface KeyManager {
     void saveData(DOMString name, <a href="#RawData">RawData</a> rawData, optional DOMString? password, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                   optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/mediacontroller.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/mediacontroller.html
@@ -414,8 +414,7 @@ There is a <em>tizen.mediacontroller</em> object that allows access to the Media
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">MediaControllerClient:
-                  </span>
+<span class="return">MediaControllerClient:</span>
  The <em>MediaController Client</em> object.
               </ul>
 </div>
@@ -467,8 +466,7 @@ and is controlled by Client.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">MediaControllerServer:
-                  </span>
+<span class="return">MediaControllerServer:</span>
  The <em>MediaController Server</em> object.
               </ul>
 </div>
@@ -516,7 +514,8 @@ catch (err)
     void updatePlaybackAgeRating(<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void updatePlaybackContentType(<a href="#MediaControllerContentType">MediaControllerContentType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void updateShuffleMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    void updateRepeatMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void updateMetadata(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addChangeRequestPlaybackInfoListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeChangeRequestPlaybackInfoListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -968,8 +967,7 @@ requests from client.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -1112,8 +1110,7 @@ See <em>MediaControllerServerInfo</em> to check how to send custom commands from
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -1228,8 +1225,7 @@ mcServer.removeCommandListener(watcherId);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">MediaControllerPlaylist:
-                  </span>
+<span class="return">MediaControllerPlaylist:</span>
  New empty <em>MediaControllerPlaylist</em> object with given name.
               </ul>
 </div>
@@ -1258,7 +1254,7 @@ var playlist = server.createPlaylist("testPlaylistName");
 <div class="brief">
  Saves playlist in local database.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                   optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1377,7 +1373,7 @@ The <em>errorCallback</em> may be triggered for one of the following errors:
 </li></ul>
         </div>
 <div class="example">
-<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var server = mediacontroller.createServer();
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var server = tizen.mediacontroller.createServer();
 var playlist = server.createPlaylist("testPlaylistName");
 function deleteSuccess()
 {
@@ -1436,7 +1432,7 @@ server.savePlaylist(playlist, saveSuccess);
 </li></ul>
         </div>
 <div class="example">
-<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var server = mediacontroller.createServer();
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var server = tizen.mediacontroller.createServer();
 var playlist = server.createPlaylist("testPlaylistName");
 var metadata =
 {
@@ -1453,10 +1449,12 @@ var metadata =
   picture: "testPicture"
 };
 playlist.addItem("index1", metadata);
-server.savePlaylist(playlist);
-server.updatePlaybackItem("testPlaylistName", "index1");
-console.log("Current playlist: " + server.playbackInfo.playlistName);
-console.log("Current index: " + server.playbackInfo.index);
+server.savePlaylist(playlist, function()
+{
+  server.updatePlaybackItem("testPlaylistName", "index1");
+  console.log("Current playlist: " + server.playbackInfo.playlistName);
+  console.log("Current index: " + server.playbackInfo.index);
+});
 </pre>
 </div>
 <div class="output">
@@ -1517,26 +1515,25 @@ var playlist = server.createPlaylist("testPlaylist");
 function saveSuccess()
 {
   console.log("savePlaylist successful");
+  function successCallback(playlists)
+  {
+    playlists.forEach(function(playlist)
+    {
+      console.log("Playlist name: " + playlist.name);
+    });
+  }
+  function errorCallback(error)
+  {
+    console.log("getAllPlaylists failed with error: " + error);
+  }
+  server.getAllPlaylists(successCallback, errorCallback);
 }
 function saveError(error)
 {
   console.log("savePlaylist failed with error: " + error);
 }
 
-server.savePlaylist(saveSuccess, saveError);
-
-function successCallback(playlists)
-{
-  playlists.forEach(function(playlist)
-  {
-    console.log("Playlist name: " + playlist.name);
-  });
-}
-function errorCallback(error)
-{
-  console.log("getAllPlaylists failed with error: " + error);
-}
-server.getAllPlaylists(successCallback, errorCallback);
+server.savePlaylist(playlist, saveSuccess, saveError);
 </pre>
 </div>
 <div class="output">
@@ -1651,8 +1648,7 @@ mcClient.findServers(successCallback, errorCallback);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">MediaControllerServerInfo:
-                  </span>
+<span class="return">MediaControllerServerInfo<span class="optional"> [nullable]</span>:</span>
  Server info or <var>null</var>.
               </ul>
 </div>
@@ -1692,7 +1688,9 @@ Provides methods to send commands to server and listen for server status change.
                               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void sendShuffleMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+<span class="nocode deprecated">    void sendRepeatMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                        raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                          optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void sendCommand(DOMString command, object data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -1788,7 +1786,7 @@ console.log(sinfo.iconURI);
 <div class="brief">
  Allows to change playback state of media controller server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                        optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1845,7 +1843,7 @@ mcServerInfo.sendPlaybackState("STOP",
 <div class="brief">
  Allows to change playback position of media controller server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                           optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -2020,7 +2018,7 @@ mcServerInfo.sendRepeatMode(false,
 <div class="brief">
  Allows to change repeat state of media controller server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -2081,7 +2079,7 @@ mcServerInfo.sendRepeatState("REPEAT_ALL",
 <div class="brief">
  Allows to send custom command to media controller server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void sendCommand(DOMString command, object data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void sendCommand(DOMString command, object data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback,
                  optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -2163,8 +2161,7 @@ mcServerInfo.sendCommand("myPlaylistFilter", exampleCustomCommandData,
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -2264,8 +2261,7 @@ mcServerInfo.removeServerStatusChangeListener(watcherId);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -2434,26 +2430,26 @@ var playlist = server.createPlaylist("testPlaylist");
 function saveSuccess()
 {
   console.log("savePlaylist successful");
+  function successCallback(playlists)
+  {
+    playlists.forEach(function(playlist)
+    {
+      console.log("Playlist name: " + playlist.name);
+    });
+  }
+  function errorCallback(error)
+  {
+    console.log("getAllPlaylists failed with error: " + error);
+  }
+  serverInfo.getAllPlaylists(successCallback, errorCallback);
 }
+
 function saveError(error)
 {
   console.log("savePlaylist failed with error: " + error);
 }
 
-server.savePlaylist(saveSuccess, saveError);
-
-function successCallback(playlists)
-{
-  playlists.forEach(function(playlist)
-  {
-    console.log("Playlist name: " + playlist.name);
-  });
-}
-function errorCallback(error)
-{
-  console.log("getAllPlaylists failed with error: " + error);
-}
-serverInfo.getAllPlaylists(successCallback, errorCallback);
+server.savePlaylist(playlist, saveSuccess, saveError);
 </pre>
 </div>
 <div class="output">
@@ -2534,8 +2530,7 @@ serverInfo.sendPlaybackItem("testPlaylist", "1", "PLAY", 0);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -2559,7 +2554,7 @@ var listener =
 {
   onplaylistupdated: function(playlist)
   {
-    console.log("updated playlist " + playlist.name);
+    console.log("updated playlist " + playlist);
   },
   onplaylistdeleted: function(playlistName)
   {
@@ -2628,7 +2623,8 @@ serverInfo.removePlaylistUpdatedListener(listenerId);
     readonly attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating;
     readonly attribute <a href="#MediaControllerContentType">MediaControllerContentType</a> contentType;
     readonly attribute boolean shuffleMode;
-    readonly attribute <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> repeatState;
+<span class="nocode deprecated">    readonly attribute boolean repeatMode;
+</span>    readonly attribute <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> repeatState;
     readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
     readonly attribute DOMString? index;
     readonly attribute DOMString? playlistName;
@@ -3035,7 +3031,7 @@ function errorCallback(error)
 {
   console.log("savePlaylist failed with error: " + error);
 }
-server.savePlaylist(successCallback, errorCallback);
+server.savePlaylist(playlist, successCallback, errorCallback);
 </pre>
 </div>
 <div class="output">
@@ -3245,8 +3241,7 @@ See <em>MediaControllerSendCommandSuccessCallback</em> interface.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">object:
-                  </span>
+<span class="return">object<span class="optional"> [nullable]</span>:</span>
  Data object which should be send with reply to the client.
               </ul>
 </div>
@@ -3302,7 +3297,8 @@ object for receiving media controller playback info changes from server.
 <pre class="webidl prettyprint">  [Callback, NoInterfaceObject] interface MediaControllerPlaybackInfoChangeCallback {
     void onplaybackchanged(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position);
     void onshufflemodechanged(boolean mode);
-    void onrepeatstatechanged(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state);
+<span class="nocode deprecated">    void onrepeatmodechanged(boolean mode);
+</span>    void onrepeatstatechanged(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state);
     void onmetadatachanged(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata);
   };</pre>
 <p><span class="version">Since: </span>
@@ -3446,7 +3442,8 @@ object for receiving playback info change requests from client.
     void onplaybackstaterequest(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
     void onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
     void onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+<span class="nocode deprecated">    void onrepeatmoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+</span>    void onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
     void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state,
                                unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
   };</pre>
@@ -3613,7 +3610,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 <div class="brief">
  Called when client request change of playback item.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, 
+<div class="synopsis"><pre class="signature prettyprint">void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state,
                            unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -3798,8 +3795,21 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
   enum MediaControllerPlaybackState { "PLAY", "PAUSE", "STOP", "NEXT", "PREV", "FORWARD", "REWIND" };
   enum MediaControllerRepeatState { "REPEAT_OFF", "REPEAT_ONE", "REPEAT_ALL" };
   enum MediaControllerContentType { "IMAGE", "MUSIC", "VIDEO", "OTHER", "UNDECIDED" };
-  enum MediaControllerContentAgeRating { "ALL", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16",
-    "17", "18", "19" };
+  enum MediaControllerContentAgeRating { "ALL", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13",
+    "14", "15", "16", "17", "18", "19" };
+  dictionary MediaControllerMetadataInit {
+    DOMString title;
+    DOMString artist;
+    DOMString album;
+    DOMString author;
+    DOMString genre;
+    DOMString duration;
+    DOMString date;
+    DOMString copyright;
+    DOMString description;
+    DOMString trackNum;
+    DOMString picture;
+  };
   [NoInterfaceObject] interface MediaControllerObject {
     readonly attribute <a href="#MediaControllerManager">MediaControllerManager</a> mediacontroller;
   };
@@ -3890,19 +3900,6 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
   [NoInterfaceObject] interface MediaControllerPlaylistItem {
     readonly attribute DOMString index;
     readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
-  };
-  dictionary MediaControllerMetadataInit {
-    DOMString title;
-    DOMString artist;
-    DOMString album;
-    DOMString author;
-    DOMString genre;
-    DOMString duration;
-    DOMString date;
-    DOMString copyright;
-    DOMString description;
-    DOMString trackNum;
-    DOMString picture;
   };
   [NoInterfaceObject] interface MediaControllerPlaylist {
     readonly attribute DOMString name;

--- a/docs/application/web/api/5.5/device_api/tv/tizen/mediacontroller.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/mediacontroller.html
@@ -3810,10 +3810,10 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
     DOMString trackNum;
     DOMString picture;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MediaControllerObject">MediaControllerObject</a>;
   [NoInterfaceObject] interface MediaControllerObject {
     readonly attribute <a href="#MediaControllerManager">MediaControllerManager</a> mediacontroller;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MediaControllerObject">MediaControllerObject</a>;
   [NoInterfaceObject] interface MediaControllerManager {
     <a href="#MediaControllerClient">MediaControllerClient</a> getClient() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#MediaControllerServer">MediaControllerServer</a> createServer() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/messageport.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/messageport.html
@@ -784,10 +784,10 @@ var watchId = localMsgPort.addMessagePortListener(onreceived);
     DOMString key;
     <a href="#ByteStreamDataItemValue">ByteStreamDataItemValue</a> value;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MessagePortManagerObject">MessagePortManagerObject</a>;
   [NoInterfaceObject] interface MessagePortManagerObject {
     readonly attribute <a href="#MessagePortManager">MessagePortManager</a> messageport;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MessagePortManagerObject">MessagePortManagerObject</a>;
   [NoInterfaceObject] interface MessagePortManager {
     <a href="#LocalMessagePort">LocalMessagePort</a> requestLocalMessagePort(DOMString localMessagePortName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#LocalMessagePort">LocalMessagePort</a> requestTrustedLocalMessagePort(DOMString localMessagePortName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/messageport.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/messageport.html
@@ -222,8 +222,7 @@ The <em>tizen.messageport</em> object allows access to the functionality of the 
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">LocalMessagePort:
-                  </span>
+<span class="return">LocalMessagePort:</span>
  LocalMessagePort instance.
               </ul>
 </div>
@@ -276,8 +275,7 @@ Trusted local message port can communicate with applications that are signed wit
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">LocalMessagePort:
-                  </span>
+<span class="return">LocalMessagePort:</span>
  Trusted LocalMessagePort instance.
               </ul>
 </div>
@@ -334,8 +332,7 @@ If the message port name and application ID are the same, the platform returns t
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">RemoteMessagePort:
-                  </span>
+<span class="return">RemoteMessagePort:</span>
  RemoteMessagePort instance.
               </ul>
 </div>
@@ -390,8 +387,7 @@ Trusted remote message port can communicate with applications that are signed wi
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">RemoteMessagePort:
-                  </span>
+<span class="return">RemoteMessagePort:</span>
  Trusted RemoteMessagePort instance.
               </ul>
 </div>
@@ -483,8 +479,7 @@ var remoteMsgPort =
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  ID of the listener that is later used to remove the listener.
               </ul>
 </div>
@@ -781,6 +776,14 @@ var watchId = localMsgPort.addMessagePortListener(onreceived);
   typedef (DOMString or DOMString[]) StringDataItemValue;
   typedef (<a href="#ByteStream">ByteStream</a> or <a href="#ByteStream">ByteStream</a>[]) ByteStreamDataItemValue;
   typedef (<a href="#MessagePortStringDataItem">MessagePortStringDataItem</a> or <a href="#MessagePortByteStreamDataItem">MessagePortByteStreamDataItem</a>) MessagePortDataItem;
+  dictionary MessagePortStringDataItem {
+    DOMString key;
+    <a href="#StringDataItemValue">StringDataItemValue</a> value;
+  };
+  dictionary MessagePortByteStreamDataItem {
+    DOMString key;
+    <a href="#ByteStreamDataItemValue">ByteStreamDataItemValue</a> value;
+  };
   [NoInterfaceObject] interface MessagePortManagerObject {
     readonly attribute <a href="#MessagePortManager">MessagePortManager</a> messageport;
   };
@@ -802,14 +805,6 @@ var watchId = localMsgPort.addMessagePortListener(onreceived);
     readonly attribute <a href="application.html#ApplicationId">ApplicationId</a> appId;
     readonly attribute boolean isTrusted;
     void sendMessage(<a href="#MessagePortDataItem">MessagePortDataItem</a>[] data, optional <a href="#LocalMessagePort">LocalMessagePort</a>? localMessagePort) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  dictionary MessagePortStringDataItem {
-    DOMString key;
-    <a href="#StringDataItemValue">StringDataItemValue</a> value;
-  };
-  dictionary MessagePortByteStreamDataItem {
-    DOMString key;
-    <a href="#ByteStreamDataItemValue">ByteStreamDataItemValue</a> value;
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface MessagePortCallback {
     void onreceived(<a href="#MessagePortDataItem">MessagePortDataItem</a>[] data, <a href="#RemoteMessagePort">RemoteMessagePort</a>? remoteMessagePort);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/package.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/package.html
@@ -921,10 +921,10 @@ It is used in <em>tizen.package.getPackagesInfo()</em>.
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Package {
   typedef DOMString PackageId;
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PackageManagerObject">PackageManagerObject</a>;
   [NoInterfaceObject] interface PackageManagerObject {
     readonly attribute <a href="#PackageManager">PackageManager</a> package;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PackageManagerObject">PackageManagerObject</a>;
   [NoInterfaceObject] interface PackageManager {
     void install(DOMString packageFileURI, <a href="#PackageProgressCallback">PackageProgressCallback</a> progressCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                  raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/package.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/package.html
@@ -458,8 +458,7 @@ The list of installed packages and their package IDs is obtained using <em>getPa
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">PackageInformation:
-                  </span>
+<span class="return">PackageInformation:</span>
  The information of a package.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/push.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/push.html
@@ -1002,10 +1002,10 @@ To guarantee that the push application runs on a device with the push feature, d
 <pre class="webidl prettyprint">module Push {
   typedef DOMString PushRegistrationId;
   enum PushRegistrationState { "REGISTERED", "UNREGISTERED" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PushManagerObject">PushManagerObject</a>;
   [NoInterfaceObject] interface PushManagerObject {
     readonly attribute <a href="#PushManager">PushManager</a> push;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PushManagerObject">PushManagerObject</a>;
   [NoInterfaceObject] interface PushManager {
     void register(<a href="#PushRegisterSuccessCallback">PushRegisterSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unregister(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/push.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/push.html
@@ -403,7 +403,7 @@ tizen.push.unregister(unregisterSuccessCallback, errorCallback);
 <div class="brief">
  Connects to the push service and gets state change events and push notifications.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void connect(<a href="#PushRegistrationStateChangeCallback">PushRegistrationStateChangeCallback</a> stateChangeCallback, <a href="#PushNotificationCallback">PushNotificationCallback</a> notificationCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void connect(<a href="#PushRegistrationStateChangeCallback">PushRegistrationStateChangeCallback</a> stateChangeCallback, <a href="#PushNotificationCallback">PushNotificationCallback</a> notificationCallback,
              optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -539,8 +539,7 @@ tizen.push.disconnect();
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">PushRegistrationId:
-                  </span>
+<span class="return">PushRegistrationId:</span>
  ID assigned by push service.
               </ul>
 </div>
@@ -693,8 +692,7 @@ If the application was not launched by the push service, this method returns <va
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">PushMessage:
-                  </span>
+<span class="return">PushMessage<span class="optional"> [nullable]</span>:</span>
  The last message delivered from the push service or <var>null</var>.
               </ul>
 </div>
@@ -860,8 +858,7 @@ Details:
 <div class="brief">
  The PushRegisterSuccessCallback interface specifies the success callback for a push service registration request.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushRegisterSuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PushRegisterSuccessCallback {
     void onsuccess(<a href="#PushRegistrationId">PushRegistrationId</a> id);
   };</pre>
 <p><span class="version">Since: </span>
@@ -904,8 +901,7 @@ This success callback is invoked when a push service registration request is suc
 <div class="brief">
  The PushRegistrationStateChangeCallback interface specifies the state change callback for the state change event.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushRegistrationStateChangeCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PushRegistrationStateChangeCallback {
     void onsuccess(<a href="#PushRegistrationState">PushRegistrationState</a> state);
   };</pre>
 <p><span class="version">Since: </span>
@@ -949,8 +945,7 @@ Moreover PushRegistrationStateChangeCallback would be called at least once, just
 <div class="brief">
  The PushNotificationCallback interface specifies the notification callback for the received push notification message.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushNotificationCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PushNotificationCallback {
     void onsuccess(<a href="#PushMessage">PushMessage</a> message);
   };</pre>
 <p><span class="version">Since: </span>
@@ -1030,16 +1025,13 @@ To guarantee that the push application runs on a device with the push feature, d
     readonly attribute DOMString sessionInfo;
     readonly attribute DOMString requestId;
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushRegisterSuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface PushRegisterSuccessCallback {
     void onsuccess(<a href="#PushRegistrationId">PushRegistrationId</a> id);
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushRegistrationStateChangeCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface PushRegistrationStateChangeCallback {
     void onsuccess(<a href="#PushRegistrationState">PushRegistrationState</a> state);
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushNotificationCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface PushNotificationCallback {
     void onsuccess(<a href="#PushMessage">PushMessage</a> message);
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/systeminfo.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/systeminfo.html
@@ -3974,10 +3974,10 @@ To guarantee the running of the application on a device which supports Wi-Fi, de
     double highThreshold;
     double lowThreshold;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SystemInfoObject">SystemInfoObject</a>;
   [NoInterfaceObject] interface SystemInfoObject {
     readonly attribute <a href="#SystemInfo">SystemInfo</a> systeminfo;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SystemInfoObject">SystemInfoObject</a>;
   [NoInterfaceObject] interface SystemInfo {
     long long getTotalMemory() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long long getAvailableMemory() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/systeminfo.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/systeminfo.html
@@ -614,7 +614,8 @@ functionality of the System Information API.
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface SystemInfo {
     long long getTotalMemory() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long long getAvailableMemory() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    any getCapability(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    <a href="#SystemInfoDeviceCapability">SystemInfoDeviceCapability</a> getCapabilities() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    any getCapability(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long getCount(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void getPropertyValue(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertySuccessCallback">SystemInfoPropertySuccessCallback</a> successCallback,
                           optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -652,8 +653,7 @@ and for subscribing notifications of system information changes.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long long:
-                  </span>
+<span class="return">long long:</span>
  Total system memory.
               </ul>
 </div>
@@ -684,8 +684,7 @@ console.log("The total memory size is " + tizen.systeminfo.getTotalMemory() + " 
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long long:
-                  </span>
+<span class="return">long long:</span>
  Not used memory in bytes.
               </ul>
 </div>
@@ -724,8 +723,7 @@ The function must synchronously acquire the capabilities of the device.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">SystemInfoDeviceCapability:
-                  </span>
+<span class="return">SystemInfoDeviceCapability:</span>
  Capabilities of the device.
               </ul>
 </div>
@@ -775,8 +773,7 @@ The additional keys for the custom device capability are specified by OEMs and v
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">any:
-                  </span>
+<span class="return">any:</span>
  The value of the specified device capability.
               </ul>
 </div>
@@ -829,8 +826,7 @@ That is the length of array retrieved by the <a href="#SystemInfo::getPropertyVa
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The number of property values for the given property. If the property is not supported, 0 is returned.
               </ul>
 </div>
@@ -861,7 +857,7 @@ else
 <div class="brief">
  Gets the current value of a specified system property.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getPropertyValue(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertySuccessCallback">SystemInfoPropertySuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getPropertyValue(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertySuccessCallback">SystemInfoPropertySuccessCallback</a> successCallback,
                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -971,7 +967,7 @@ else
 <div class="brief">
  Gets the current values of a specified system property.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getPropertyValueArray(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertyArraySuccessCallback">SystemInfoPropertyArraySuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getPropertyValueArray(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertyArraySuccessCallback">SystemInfoPropertyArraySuccessCallback</a> successCallback,
                            optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -1065,7 +1061,7 @@ else
 <div class="brief">
  Adds a listener to allow tracking changes in one or more system properties.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">unsigned long addPropertyValueChangeListener(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertySuccessCallback">SystemInfoPropertySuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">unsigned long addPropertyValueChangeListener(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertySuccessCallback">SystemInfoPropertySuccessCallback</a> successCallback,
                                              optional <a href="#SystemInfoOptions">SystemInfoOptions</a>? options, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -1129,8 +1125,7 @@ NotSupportedError - If the given <var>property</var> is not supported (since Tiz
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">unsigned long:
-                  </span>
+<span class="return">unsigned long:</span>
  An identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -1169,8 +1164,8 @@ tizen.systeminfo.addPropertyValueChangeListener("CPU", onSuccessCallback, {lowTh
 <div class="brief">
  Adds a listener to allow tracking of changes in one or more values of a system property.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">unsigned long addPropertyValueArrayChangeListener(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, 
-                                                  <a href="#SystemInfoPropertyArraySuccessCallback">SystemInfoPropertyArraySuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">unsigned long addPropertyValueArrayChangeListener(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property,
+                                                  <a href="#SystemInfoPropertyArraySuccessCallback">SystemInfoPropertyArraySuccessCallback</a> successCallback,
                                                   optional <a href="#SystemInfoOptions">SystemInfoOptions</a>? options, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -1218,8 +1213,7 @@ any identifier of these properties, but the listener added for them will not be 
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">unsigned long:
-                  </span>
+<span class="return">unsigned long:</span>
  An identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -1312,7 +1306,7 @@ id = tizen.systeminfo.addPropertyValueChangeListener("CPU", onSuccessCallback);
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 2.3. Instead, use <a href="#SystemInfo::getCapability">getCapability()</a> to query device capabilities.
           </p>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface SystemInfoDeviceCapability {
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface SystemInfoDeviceCapability {
     readonly attribute boolean bluetooth;
     readonly attribute boolean nfc;
     readonly attribute boolean nfcReservedPush;
@@ -1381,7 +1375,7 @@ id = tizen.systeminfo.addPropertyValueChangeListener("CPU", onSuccessCallback);
     readonly attribute boolean secureElement;
     readonly attribute boolean nativeOspCompatible;
     readonly attribute <a href="#SystemInfoProfile">SystemInfoProfile</a> profile;
-  };</pre>
+  };</span></pre>
 <p><span class="version">Since: </span>
  2.0
           </p>
@@ -2426,7 +2420,8 @@ Any threshold parameter used in a watch function to monitor this property applie
     readonly attribute unsigned long long capacity;
     readonly attribute unsigned long long availableCapacity;
     readonly attribute boolean isRemovable;
-  };</pre>
+<span class="nocode deprecated">    readonly attribute boolean isRemoveable;
+</span>  };</pre>
         
       <div class="attributes">
 <h4>Attributes</h4>
@@ -3961,18 +3956,24 @@ To guarantee the running of the application on a device which supports Wi-Fi, de
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module SystemInfo {
-  enum SystemInfoPropertyId { "BATTERY", "CPU", "STORAGE", "DISPLAY", "DEVICE_ORIENTATION", "BUILD", "LOCALE", "NETWORK", "WIFI_NETWORK",
-    "ETHERNET_NETWORK", "CELLULAR_NETWORK", "NET_PROXY_NETWORK", "SIM", "PERIPHERAL", "MEMORY", "VIDEOSOURCE", "CAMERA_FLASH", "ADS",
-    "SERVICE_COUNTRY" };
+  enum SystemInfoPropertyId { "BATTERY", "CPU", "STORAGE", "DISPLAY", "DEVICE_ORIENTATION", "BUILD", "LOCALE", "NETWORK",
+    "WIFI_NETWORK", "ETHERNET_NETWORK", "CELLULAR_NETWORK", "NET_PROXY_NETWORK", "SIM", "PERIPHERAL", "MEMORY", "VIDEOSOURCE",
+    "CAMERA_FLASH", "ADS", "SERVICE_COUNTRY" };
   enum SystemInfoNetworkType { "NONE", "2G", "2.5G", "3G", "4G", "WIFI", "ETHERNET", "NET_PROXY", "UNKNOWN" };
   enum SystemInfoWifiSecurityMode { "NONE", "WEP", "WPA_PSK", "WPA2_PSK", "EAP" };
   enum SystemInfoWifiEncryptionType { "NONE", "WEP", "TKIP", "AES", "TKIP_AES_MIXED" };
   enum SystemInfoNetworkIpMode { "NONE", "STATIC", "DYNAMIC", "AUTO", "FIXED" };
   enum SystemInfoDeviceOrientationStatus { "PORTRAIT_PRIMARY", "PORTRAIT_SECONDARY", "LANDSCAPE_PRIMARY", "LANDSCAPE_SECONDARY" };
-  enum SystemInfoSimState { "ABSENT", "INITIALIZING", "READY", "PIN_REQUIRED", "PUK_REQUIRED", "NETWORK_LOCKED", "SIM_LOCKED", "UNKNOWN" };
-  enum SystemInfoProfile { "MOBILE_FULL", "MOBILE_WEB", "MOBILE", "WEARABLE", "TV" };
+  enum SystemInfoSimState { "ABSENT", "INITIALIZING", "READY", "PIN_REQUIRED", "PUK_REQUIRED", "NETWORK_LOCKED",
+    "SIM_LOCKED", "UNKNOWN" };
+  enum SystemInfoProfile { "MOBILE", "WEARABLE", "TV" };
   enum SystemInfoLowMemoryStatus { "NORMAL", "WARNING" };
   enum SystemInfoVideoSourceType { "TV", "AV", "SVIDEO", "COMP", "PC", "HDMI", "SCART", "DVI", "MEDIA" };
+  dictionary SystemInfoOptions {
+    unsigned long timeout;
+    double highThreshold;
+    double lowThreshold;
+  };
   [NoInterfaceObject] interface SystemInfoObject {
     readonly attribute <a href="#SystemInfo">SystemInfo</a> systeminfo;
   };
@@ -3994,11 +3995,6 @@ To guarantee the running of the application on a device which supports Wi-Fi, de
                                                       optional <a href="#SystemInfoOptions">SystemInfoOptions</a>? options, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                                                       raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removePropertyValueChangeListener(unsigned long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  dictionary SystemInfoOptions {
-    unsigned long timeout;
-    double highThreshold;
-    double lowThreshold;
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface SystemInfoPropertySuccessCallback {
     void onsuccess(<a href="#SystemInfoProperty">SystemInfoProperty</a> property);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/time.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/time.html
@@ -273,8 +273,7 @@ Get timezones using getLocalTimezone() and getAvailableTimezones().            <
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate:</span>
  The current TZDate object.
               </ul>
 </div>
@@ -305,8 +304,7 @@ console.log("current date/time is " + current_dt.toLocaleString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The local timezone.
               </ul>
 </div>
@@ -353,8 +351,7 @@ with the most general descriptor first and the most specific one last. For examp
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString[]:
-                  </span>
+<span class="return">DOMString[]:</span>
  Array of time zone identifiers.
               </ul>
 </div>
@@ -430,8 +427,7 @@ date format (23/10/2011) instead of a long date format ("Monday, October 23 2011
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The date format according to the system's locale settings.
               </ul>
 </div>
@@ -485,8 +481,7 @@ Examples of string formats include: "h:m:s ap", "h:m:s".
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The time format according to the system's locale settings.
               </ul>
 </div>
@@ -528,8 +523,7 @@ console.log(timeFormat);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var>, if the year is a leap year.
               </ul>
 </div>
@@ -813,7 +807,8 @@ If its date/time exceeds the platform limit, TZDate will be invalid.
     DOMString toDateString();
     DOMString toTimeString();
     DOMString toString();
-    long secondsFromUTC() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    DOMString getTimezoneAbbreviation() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    long secondsFromUTC() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     boolean isDST() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#TZDate">TZDate</a>? getPreviousDSTTransition() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#TZDate">TZDate</a>? getNextDSTTransition() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -849,7 +844,7 @@ var myDate = new tizen.TZDate(1999, 11, 31, 23, 59, 59, 999, "Europe/Berlin");
           </ul>
 </div>
 <pre class="webidl prettyprint">TZDate(optional Date? datetime, optional DOMString? timezone);</pre>
-<pre class="webidl prettyprint">TZDate(long year, long month, long day, optional long? hours, optional long? minutes, optional long? seconds, 
+<pre class="webidl prettyprint">TZDate(long year, long month, long day, optional long? hours, optional long? minutes, optional long? seconds,
        optional long? milliseconds, optional DOMString? timezone);</pre>
 </dl>
 </div>
@@ -870,8 +865,7 @@ var myDate = new tizen.TZDate(1999, 11, 31, 23, 59, 59, 999, "Europe/Berlin");
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The day of the month.
               </ul>
 </div>
@@ -928,8 +922,7 @@ console.log(someDate.getDate());  /* Outputs 1. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The day of the week.
               </ul>
 </div>
@@ -959,8 +952,7 @@ For example, 1 = AD 1, 0 = BC 1, -1 = BC 2.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The year.
               </ul>
 </div>
@@ -1011,8 +1003,7 @@ console.log(someDate.getFullYear());  /* Outputs 2099. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The hour.
               </ul>
 </div>
@@ -1069,8 +1060,7 @@ console.log(someDate.getHours());  /* Outputs 15. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The milliseconds.
               </ul>
 </div>
@@ -1127,8 +1117,7 @@ console.log(someDate.getMilliseconds());  /* Outputs 42. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The minutes.
               </ul>
 </div>
@@ -1185,8 +1174,7 @@ console.log(someDate.getMinutes());  /* Outputs 58. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The month.
               </ul>
 </div>
@@ -1243,8 +1231,7 @@ console.log(someDate.getMonth());  /* Outputs 2. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The seconds.
               </ul>
 </div>
@@ -1301,8 +1288,7 @@ console.log(someDate.getSeconds());  /* Outputs 23. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The day of the month, according to universal time.
               </ul>
 </div>
@@ -1359,8 +1345,7 @@ console.log(someDate.getUTCDate());  /* Outputs 5. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The day of the week, according to universal time.
               </ul>
 </div>
@@ -1390,8 +1375,7 @@ For example, 1 = AD 1, 0 = BC 1, -1 = BC 2.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The year, according to universal time.
               </ul>
 </div>
@@ -1442,8 +1426,7 @@ console.log(someDate.getUTCFullYear());  /* Outputs 2099. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The hour, according to universal time.
               </ul>
 </div>
@@ -1500,8 +1483,7 @@ console.log(someDate.getUTCHours());  /* Outputs 15. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The milliseconds, according to universal time.
               </ul>
 </div>
@@ -1558,8 +1540,7 @@ console.log(someDate.getUTCMilliseconds());  /* Outputs 42. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The minutes, according to universal time.
               </ul>
 </div>
@@ -1616,8 +1597,7 @@ console.log(someDate.getUTCMinutes());  /* Outputs 58. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The month, according to universal time.
               </ul>
 </div>
@@ -1674,8 +1654,7 @@ console.log(someDate.getUTCMonth());  /* Outputs 2. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The seconds, according to universal time.
               </ul>
 </div>
@@ -1742,8 +1721,7 @@ This attribute uniquely identifies the timezone.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The string timezone identifier. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -1780,8 +1758,7 @@ console.log(someDate.getTimezone());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate:</span>
  The new TZDate in given Timezone.
               </ul>
 </div>
@@ -1827,8 +1804,7 @@ console.log(someDate.toString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate:</span>
  The new TZDate in local Timezone.
               </ul>
 </div>
@@ -1866,8 +1842,7 @@ console.log(localDate.toString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate:</span>
  The Date/Time in UTC.
               </ul>
 </div>
@@ -1931,8 +1906,7 @@ Positive, if other is in the past              </li>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TimeDuration:
-                  </span>
+<span class="return">TimeDuration:</span>
  The duration in milliseconds between the two date/time objects
 (or in days for comparison between dates with no time component).
               </ul>
@@ -2008,8 +1982,7 @@ the two TZDate objects represent the same instant in different timezones.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if the 2 date/times are the same.
               </ul>
 </div>
@@ -2089,8 +2062,7 @@ This method takes the timezones into consideration.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var>, if the Date/Time is earlier than the one passed in argument.
               </ul>
 </div>
@@ -2150,8 +2122,7 @@ This method takes the timezones into consideration.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var>, if the Date/Time is later than the one passed in argument.
               </ul>
 </div>
@@ -2215,8 +2186,7 @@ Note that calling this method does not alter the current object.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate:</span>
  The new TZDate by adding a duration.
               </ul>
 </div>
@@ -2253,8 +2223,7 @@ var in_one_week = now.addDuration(new tizen.TimeDuration(7, "DAYS"));
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The date portion of the TZDate object as a string, using locale conventions. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2282,8 +2251,7 @@ console.log(someDate.toLocaleDateString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The time portion of the TZDate object as a string, using locale conventions. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2311,8 +2279,7 @@ console.log(someDate.toLocaleTimeString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The string representation of the TZDate object, using locale conventions. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2340,8 +2307,7 @@ console.log(someDate.toLocaleString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The date portion of the TZDate object as a string. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2367,8 +2333,7 @@ console.log(someDate.toDateString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The time portion of the TZDate object as a string. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2394,8 +2359,7 @@ console.log(someDate.toTimeString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The string representation of the TZDate object. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2430,8 +2394,7 @@ summer months when daylight savings time is in effect.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  DOMString The abbreviation of the time zone (such as "EST") <br>If TZDate is invalid, it will return 'Invalid Date'.
               </ul>
 </div>
@@ -2474,8 +2437,7 @@ savings if it is in the timezone. For example, if time zone is GMT+8, it will re
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The offset from UTC in seconds.
               </ul>
 </div>
@@ -2514,8 +2476,7 @@ identified by the TZDate object.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  The flag indicating whether the daylight saving are in effect.
               </ul>
 </div>
@@ -2549,8 +2510,7 @@ var isDstActiveInWinter = wintertime.isDST();  /* false. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate<span class="optional"> [nullable]</span>:</span>
  The date of the previous daylight saving transition (before the instant identified by the TZDate).
               </ul>
 </div>
@@ -2587,8 +2547,7 @@ console.log(previousDstTransition.toString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate<span class="optional"> [nullable]</span>:</span>
  The date of the next daylight saving transition (after the instant identified by the TZDate).
               </ul>
 </div>
@@ -2722,8 +2681,7 @@ The returned TimeDuration is the biggest possible unit without losing the precis
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TimeDuration:
-                  </span>
+<span class="return">TimeDuration:</span>
  New TimeDuration object corresponding to the result of <em>this</em> - <em>other</em>.
               </ul>
 </div>
@@ -2782,8 +2740,7 @@ if the two TimeDuration objects represent the same duration in different units.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if the two TimeDuration object represent the same duration.
               </ul>
 </div>
@@ -2835,8 +2792,7 @@ This method takes the units into consideration when doing the comparison.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if the TimeDuration is less than <em>other</em>.
               </ul>
 </div>
@@ -2887,8 +2843,7 @@ This method takes the units into consideration when doing the comparison.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if the TimeDuration is greater than <em>other</em>.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/time.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/time.html
@@ -2874,10 +2874,10 @@ var ret = d1.greaterThan(d2);                  /* Returns true. */
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Time {
   enum TimeDurationUnit { "MSECS", "SECS", "MINS", "HOURS", "DAYS" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#TimeManagerObject">TimeManagerObject</a>;
   [NoInterfaceObject] interface TimeManagerObject {
     readonly attribute <a href="#TimeUtil">TimeUtil</a> time;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#TimeManagerObject">TimeManagerObject</a>;
   [NoInterfaceObject] interface TimeUtil {
     <a href="#TZDate">TZDate</a> getCurrentDateTime() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     DOMString getLocalTimezone() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tizen.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tizen.html
@@ -1703,10 +1703,10 @@ type: STRING
   enum SortModeOrder { "ASC", "DESC" };
   enum CompositeFilterType { "UNION", "INTERSECTION" };
   enum BundleValueType { "STRING", "STRING_ARRAY", "BYTES", "BYTES_ARRAY" };
+  Window implements <a href="#TizenObject">TizenObject</a>;
   [NoInterfaceObject] interface TizenObject {
     readonly attribute <a href="#Tizen">Tizen</a> tizen;
   };
-  Window implements <a href="#TizenObject">TizenObject</a>;
   [NoInterfaceObject] interface Tizen {
   };
   [Constructor(optional object? json)]

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tizen.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tizen.html
@@ -331,9 +331,9 @@ It is a property of the ECMAScript global object, as specified by the <em>TizenO
           </div>
 <pre class="webidl prettyprint">  [Constructor(optional object? json)]
   interface Bundle {
-    any get(DOMString key) raises(<a href="#WebAPIException">WebAPIException</a>);
+    any get(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void set(DOMString key, any value);
-    <a href="#BundleValueType">BundleValueType</a> typeOf(DOMString key) raises(<a href="#WebAPIException">WebAPIException</a>);
+    <a href="#BundleValueType">BundleValueType</a> typeOf(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void forEach(<a href="#BundleItemCallback">BundleItemCallback</a> callback);
     object toJSON();
     DOMString toString();
@@ -377,8 +377,7 @@ All supported value types are specified in the BundleValueType enum.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">any:
-                  </span>
+<span class="return">any:</span>
  Bundle entry value for a given key.
               </ul>
 </div>
@@ -482,8 +481,7 @@ console.log(bundle.get("empty"));
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">BundleValueType:
-                  </span>
+<span class="return">BundleValueType:</span>
  Entry value type.
               </ul>
 </div>
@@ -588,8 +586,7 @@ type: STRING
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">object:
-                  </span>
+<span class="return">object:</span>
  JSON-compatible object.
               </ul>
 </div>
@@ -618,8 +615,7 @@ console.log(JSON.stringify(json));
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  JSON string representation of the bundle's data.
               </ul>
 </div>
@@ -1101,27 +1097,23 @@ catch (err)
 <div class="brief">
  Generic exception interface.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject]
-  interface WebAPIException {
-    readonly attribute unsigned short code;
-    readonly attribute DOMString name;
-    readonly attribute DOMString message;
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface WebAPIException {
     const unsigned short INDEX_SIZE_ERR = 1;
-    const unsigned short DOMSTRING_SIZE_ERR = 2; 
+    const unsigned short DOMSTRING_SIZE_ERR = 2;
     const unsigned short HIERARCHY_REQUEST_ERR = 3;
     const unsigned short WRONG_DOCUMENT_ERR = 4;
     const unsigned short INVALID_CHARACTER_ERR = 5;
-    const unsigned short NO_DATA_ALLOWED_ERR = 6; 
+    const unsigned short NO_DATA_ALLOWED_ERR = 6;
     const unsigned short NO_MODIFICATION_ALLOWED_ERR = 7;
     const unsigned short NOT_FOUND_ERR = 8;
     const unsigned short NOT_SUPPORTED_ERR = 9;
-    const unsigned short INUSE_ATTRIBUTE_ERR = 10; 
+    const unsigned short INUSE_ATTRIBUTE_ERR = 10;
     const unsigned short INVALID_STATE_ERR = 11;
     const unsigned short SYNTAX_ERR = 12;
     const unsigned short INVALID_MODIFICATION_ERR = 13;
     const unsigned short NAMESPACE_ERR = 14;
     const unsigned short INVALID_ACCESS_ERR = 15;
-    const unsigned short VALIDATION_ERR = 16; 
+    const unsigned short VALIDATION_ERR = 16;
     const unsigned short TYPE_MISMATCH_ERR = 17;
     const unsigned short SECURITY_ERR = 18;
     const unsigned short NETWORK_ERR = 19;
@@ -1131,6 +1123,9 @@ catch (err)
     const unsigned short TIMEOUT_ERR = 23;
     const unsigned short INVALID_NODE_TYPE_ERR = 24;
     const unsigned short DATA_CLONE_ERR = 25;
+    readonly attribute unsigned short code;
+    readonly attribute DOMString name;
+    readonly attribute DOMString message;
   };</pre>
 <p><span class="version">Since: </span>
  2.0
@@ -1440,8 +1435,7 @@ This attribute is mainly intended to be used for developers rather than end user
 <div class="brief">
  Generic error interface.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject]
-  interface WebAPIError {
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface WebAPIError {
     readonly attribute unsigned short code;
     readonly attribute DOMString name;
     readonly attribute DOMString message;
@@ -1522,8 +1516,7 @@ as it is mainly intended to be useful for developers rather than end users.
 <div class="brief">
  This interface is used in methods that do not require any return value in the success callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface SuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {
     void onsuccess();
   };</pre>
 <p><span class="version">Since: </span>
@@ -1572,8 +1565,7 @@ tizen.application.launch(otherAppID, onSuccess);
 <div class="brief">
  This interface is used in methods that require only an error as an input parameter in the error callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface ErrorCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="#WebAPIError">WebAPIError</a> error);
   };</pre>
 <p><span class="version">Since: </span>
@@ -1719,9 +1711,9 @@ type: STRING
   };
   [Constructor(optional object? json)]
   interface Bundle {
-    any get(DOMString key) raises(<a href="#WebAPIException">WebAPIException</a>);
+    any get(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void set(DOMString key, any value);
-    <a href="#BundleValueType">BundleValueType</a> typeOf(DOMString key) raises(<a href="#WebAPIException">WebAPIException</a>);
+    <a href="#BundleValueType">BundleValueType</a> typeOf(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void forEach(<a href="#BundleItemCallback">BundleItemCallback</a> callback);
     object toJSON();
     DOMString toString();
@@ -1755,27 +1747,23 @@ type: STRING
     attribute double latitude;
     attribute double longitude;
   };
-  [NoInterfaceObject]
-  interface WebAPIException {
-    readonly attribute unsigned short code;
-    readonly attribute DOMString name;
-    readonly attribute DOMString message;
+  [NoInterfaceObject] interface WebAPIException {
     const unsigned short INDEX_SIZE_ERR = 1;
-    const unsigned short DOMSTRING_SIZE_ERR = 2; 
+    const unsigned short DOMSTRING_SIZE_ERR = 2;
     const unsigned short HIERARCHY_REQUEST_ERR = 3;
     const unsigned short WRONG_DOCUMENT_ERR = 4;
     const unsigned short INVALID_CHARACTER_ERR = 5;
-    const unsigned short NO_DATA_ALLOWED_ERR = 6; 
+    const unsigned short NO_DATA_ALLOWED_ERR = 6;
     const unsigned short NO_MODIFICATION_ALLOWED_ERR = 7;
     const unsigned short NOT_FOUND_ERR = 8;
     const unsigned short NOT_SUPPORTED_ERR = 9;
-    const unsigned short INUSE_ATTRIBUTE_ERR = 10; 
+    const unsigned short INUSE_ATTRIBUTE_ERR = 10;
     const unsigned short INVALID_STATE_ERR = 11;
     const unsigned short SYNTAX_ERR = 12;
     const unsigned short INVALID_MODIFICATION_ERR = 13;
     const unsigned short NAMESPACE_ERR = 14;
     const unsigned short INVALID_ACCESS_ERR = 15;
-    const unsigned short VALIDATION_ERR = 16; 
+    const unsigned short VALIDATION_ERR = 16;
     const unsigned short TYPE_MISMATCH_ERR = 17;
     const unsigned short SECURITY_ERR = 18;
     const unsigned short NETWORK_ERR = 19;
@@ -1785,19 +1773,19 @@ type: STRING
     const unsigned short TIMEOUT_ERR = 23;
     const unsigned short INVALID_NODE_TYPE_ERR = 24;
     const unsigned short DATA_CLONE_ERR = 25;
-  };
-  [NoInterfaceObject]
-  interface WebAPIError {
     readonly attribute unsigned short code;
     readonly attribute DOMString name;
     readonly attribute DOMString message;
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface SuccessCallback {
+  [NoInterfaceObject] interface WebAPIError {
+    readonly attribute unsigned short code;
+    readonly attribute DOMString name;
+    readonly attribute DOMString message;
+  };
+  [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {
     void onsuccess();
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface ErrorCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="#WebAPIError">WebAPIError</a> error);
   };
   [Callback=FunctionOnly] interface BundleItemCallback {

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tvaudiocontrol.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tvaudiocontrol.html
@@ -840,10 +840,10 @@ To guarantee the running of this application on a device with a TV audio control
   enum AudioOutputMode { "PCM", "DOLBY", "DTS", "AAC" };
   enum AudioBeepType { "UP", "DOWN", "LEFT", "RIGHT", "PAGE_LEFT", "PAGE_RIGHT", "BACK", "SELECT", "CANCEL", "WARNING",
     "KEYPAD", "KEYPAD_ENTER", "KEYPAD_DEL", "MOVE", "PREPARING" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#AudioControlManagerObject">AudioControlManagerObject</a>;
   [NoInterfaceObject] interface AudioControlManagerObject {
     readonly attribute <a href="#AudioControlManager">AudioControlManager</a> tvaudiocontrol;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#AudioControlManagerObject">AudioControlManagerObject</a>;
   [NoInterfaceObject] interface AudioControlManager {
     void setMute(boolean mute) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     boolean isMute() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tvaudiocontrol.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tvaudiocontrol.html
@@ -277,8 +277,7 @@ tizen.tvaudiocontrol.setMute(false);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  boolean The current mute state
               </ul>
 </div>
@@ -546,8 +545,7 @@ if (tizen.tvaudiocontrol.getVolume() === 0)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">unsigned short:
-                  </span>
+<span class="return">unsigned short:</span>
  unsigned short The current volume (the volume range is 0 ~ 100)
               </ul>
 </div>
@@ -717,8 +715,7 @@ tizen.tvaudiocontrol.setVolume(expectedVolumeLevel);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">AudioOutputMode:
-                  </span>
+<span class="return">AudioOutputMode:</span>
  AudioOutputMode The current audio output mode
               </ul>
 </div>
@@ -790,7 +787,7 @@ This type of error is deprecated since Tizen 5.0.
 <div class="brief">
  This interface defines a volume change callback for getting notified information about the volume changes.
           </div>
-<pre class="webidl prettyprint">  [Callback = FunctionOnly, NoInterfaceObject] interface VolumeChangeCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface VolumeChangeCallback {
     void onchanged(unsigned short volume);
   };</pre>
 <p><span class="version">Since: </span>
@@ -841,8 +838,8 @@ To guarantee the running of this application on a device with a TV audio control
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module TVAudioControl {
   enum AudioOutputMode { "PCM", "DOLBY", "DTS", "AAC" };
-  enum AudioBeepType { "UP", "DOWN", "LEFT", "RIGHT", "PAGE_LEFT", "PAGE_RIGHT", "BACK", "SELECT", "CANCEL", "WARNING", "KEYPAD",
-    "KEYPAD_ENTER", "KEYPAD_DEL", "MOVE", "PREPARING" };
+  enum AudioBeepType { "UP", "DOWN", "LEFT", "RIGHT", "PAGE_LEFT", "PAGE_RIGHT", "BACK", "SELECT", "CANCEL", "WARNING",
+    "KEYPAD", "KEYPAD_ENTER", "KEYPAD_DEL", "MOVE", "PREPARING" };
   [NoInterfaceObject] interface AudioControlManagerObject {
     readonly attribute <a href="#AudioControlManager">AudioControlManager</a> tvaudiocontrol;
   };
@@ -859,7 +856,7 @@ To guarantee the running of this application on a device with a TV audio control
     <a href="#AudioOutputMode">AudioOutputMode</a> getOutputMode() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void playSound(<a href="#AudioBeepType">AudioBeepType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
-  [Callback = FunctionOnly, NoInterfaceObject] interface VolumeChangeCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface VolumeChangeCallback {
     void onchanged(unsigned short volume);
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tvchannel.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tvchannel.html
@@ -2345,10 +2345,10 @@ To guarantee the running of this application on a device with a tuner, define th
     long? originalNetworkID;
     DOMString? providerMBR;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#TVChannelManager">TVChannelManager</a>;
   [NoInterfaceObject] interface TVChannelManager {
     readonly attribute <a href="#ChannelManager">ChannelManager</a> tvchannel;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#TVChannelManager">TVChannelManager</a>;
   [NoInterfaceObject] interface ChannelManager {
     void tune(<a href="#TuneOption">TuneOption</a> tuneOption, <a href="#TuneCallback">TuneCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tvwindow.html#WindowType">WindowType</a>? type)
               raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tvchannel.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tvchannel.html
@@ -451,7 +451,7 @@ catch (error)
 <div class="brief">
  Changes channel up.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void tuneUp(<a href="#TuneCallback">TuneCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="#TuneMode">TuneMode</a>? tuneMode, 
+<div class="synopsis"><pre class="signature prettyprint">void tuneUp(<a href="#TuneCallback">TuneCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="#TuneMode">TuneMode</a>? tuneMode,
             optional <a href="tvwindow.html#WindowType">WindowType</a>? type);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -543,7 +543,7 @@ catch (error)
 <div class="brief">
  Changes channel down.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void tuneDown(<a href="#TuneCallback">TuneCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="#TuneMode">TuneMode</a>? tuneMode, 
+<div class="synopsis"><pre class="signature prettyprint">void tuneDown(<a href="#TuneCallback">TuneCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="#TuneMode">TuneMode</a>? tuneMode,
               optional <a href="tvwindow.html#WindowType">WindowType</a>? type);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -724,7 +724,7 @@ catch (error)
 <div class="brief">
  Gets the TV channel list.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getChannelList(<a href="#FindChannelSuccessCallback">FindChannelSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="#TuneMode">TuneMode</a>? mode, 
+<div class="synopsis"><pre class="signature prettyprint">void getChannelList(<a href="#FindChannelSuccessCallback">FindChannelSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="#TuneMode">TuneMode</a>? mode,
                     optional long? nStart, optional long? number);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -885,8 +885,7 @@ catch (error)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ChannelInfo:
-                  </span>
+<span class="return">ChannelInfo:</span>
  ChannelInfo the current channel information.
               </ul>
 </div>
@@ -927,7 +926,7 @@ catch (error)
  Gets a list of programs for a specific channel within a specified time duration.
 If this method is invoked without the <var>duration</var> parameter, all available program informations are retrieved.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getProgramList(<a href="#ChannelInfo">ChannelInfo</a> channelInfo, <a href="time.html#TZDate">TZDate</a> startTime, <a href="#ProgramListSuccessCallback">ProgramListSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getProgramList(<a href="#ChannelInfo">ChannelInfo</a> channelInfo, <a href="time.html#TZDate">TZDate</a> startTime, <a href="#ProgramListSuccessCallback">ProgramListSuccessCallback</a> successCallback,
                     optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional unsigned long? duration);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -1050,8 +1049,7 @@ If there is no TV program data grabbed from broadcaster, it will return <var>nul
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ProgramInfo:
-                  </span>
+<span class="return">ProgramInfo<span class="optional"> [nullable]</span>:</span>
  ProgramInfo the information of television program.
               </ul>
 </div>
@@ -1116,8 +1114,7 @@ catch (error)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  long The identifier to clear the watch subscription for channel changes.
               </ul>
 </div>
@@ -1236,8 +1233,7 @@ Calling this function has no effect if there is no listener with given id.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  long The identifier to clear the watch subscription for signal state changes.
               </ul>
 </div>
@@ -1343,8 +1339,7 @@ The returned array will contain at least one <a href="#FavoriteList">FavoriteLis
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">FavoriteList[]:
-                  </span>
+<span class="return">FavoriteList[]:</span>
  FavoriteList[] The array of favorite lists.
               </ul>
 </div>
@@ -1431,7 +1426,7 @@ console.log("Video standard: " + res);
 <div class="brief">
  This interface invokes the success callback that is invoked when the list of TV program informations is successfully retrieved.
           </div>
-<pre class="webidl prettyprint">  [Callback = FunctionOnly, NoInterfaceObject] interface ProgramListSuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ProgramListSuccessCallback {
     void onsuccess(<a href="#ProgramInfo">ProgramInfo</a>[] programInfos);
   };</pre>
 <p><span class="version">Since: </span>
@@ -1469,7 +1464,7 @@ console.log("Video standard: " + res);
 <div class="brief">
  The interface invokes the success callback that is invoked when all available channels are searched.
           </div>
-<pre class="webidl prettyprint">  [Callback = FunctionOnly, NoInterfaceObject] interface FindChannelSuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FindChannelSuccessCallback {
     void onsuccess(<a href="#ChannelInfo">ChannelInfo</a>[] channelInfos);
   };</pre>
 <p><span class="version">Since: </span>
@@ -1507,7 +1502,7 @@ console.log("Video standard: " + res);
 <div class="brief">
  The interface defines a channel change callback for getting notified information about the channel changes.
           </div>
-<pre class="webidl prettyprint">  [Callback = FunctionOnly, NoInterfaceObject] interface ChannelChangeCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ChannelChangeCallback {
     void onchanged(<a href="#ChannelInfo">ChannelInfo</a> channelInfo, <a href="tvwindow.html#WindowType">WindowType</a> type);
   };</pre>
 <p><span class="version">Since: </span>
@@ -1549,7 +1544,7 @@ console.log("Video standard: " + res);
 <div class="brief">
  The interface defines a signal state change callback for getting notified information about signal state changes.
           </div>
-<pre class="webidl prettyprint">  [Callback = FunctionOnly, NoInterfaceObject] interface SignalStateChangeCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface SignalStateChangeCallback {
     void onchanged(<a href="#SignalState">SignalState</a> state);
   };</pre>
 <p><span class="version">Since: </span>
@@ -2224,7 +2219,7 @@ catch (error)
 <div class="brief">
  Gets the list of TV channels in a specific favorite list.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getChannels(<a href="#FindChannelSuccessCallback">FindChannelSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional long? nStart, 
+<div class="synopsis"><pre class="signature prettyprint">void getChannels(<a href="#FindChannelSuccessCallback">FindChannelSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional long? nStart,
                  optional long? number);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -2340,6 +2335,16 @@ To guarantee the running of this application on a device with a tuner, define th
     "DVB_SERVICE_TYPE_TELETEXT", "DVB_SERVICE_TYPE_NVOD_REF", "DVB_SERVICE_TYPE_NVOD_SHIFT", "DVB_SERVICE_TYPE_MOSAIC",
     "DVB_SERVICE_TYPE_PAL", "DVB_SERVICE_TYPE_SECAM", "DVB_SERVICE_TYPE_D_D2_MAC", "DVB_SERVICE_TYPE_FM_RADIO", "DVB_SERVICE_TYPE_NTSC",
     "DVB_SERVICE_TYPE_DATA", "DVB_SERVICE_TYPE_RCS_MAP", "DVB_SERVICE_TYPE_RCS_FLS", "DVB_SERVICE_TYPE_MHP", "DVB_SERVICE_TYPE_HD" };
+  dictionary TuneOption {
+    long? major;
+    long? minor;
+    long? sourceID;
+    long? programNumber;
+    long? transportStreamID;
+    long? ptc;
+    long? originalNetworkID;
+    DOMString? providerMBR;
+  };
   [NoInterfaceObject] interface TVChannelManager {
     readonly attribute <a href="#ChannelManager">ChannelManager</a> tvchannel;
   };
@@ -2366,32 +2371,22 @@ To guarantee the running of this application on a device with a tuner, define th
     <a href="#FavoriteList">FavoriteList</a>[] getFavorites() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#BroadcastStandard">BroadcastStandard</a> getBroadcastStandard(optional <a href="tvwindow.html#WindowType">WindowType</a>? type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
-  [Callback = FunctionOnly, NoInterfaceObject] interface ProgramListSuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface ProgramListSuccessCallback {
     void onsuccess(<a href="#ProgramInfo">ProgramInfo</a>[] programInfos);
   };
-  [Callback = FunctionOnly, NoInterfaceObject] interface FindChannelSuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface FindChannelSuccessCallback {
     void onsuccess(<a href="#ChannelInfo">ChannelInfo</a>[] channelInfos);
   };
-  [Callback = FunctionOnly, NoInterfaceObject] interface ChannelChangeCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface ChannelChangeCallback {
     void onchanged(<a href="#ChannelInfo">ChannelInfo</a> channelInfo, <a href="tvwindow.html#WindowType">WindowType</a> type);
   };
-  [Callback = FunctionOnly, NoInterfaceObject] interface SignalStateChangeCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface SignalStateChangeCallback {
     void onchanged(<a href="#SignalState">SignalState</a> state);
   };
   [Callback, NoInterfaceObject] interface TuneCallback {
     void onsuccess(<a href="#ChannelInfo">ChannelInfo</a> channel, <a href="tvwindow.html#WindowType">WindowType</a> type);
     void onnosignal();
     void onprograminforeceived(<a href="#ProgramInfo">ProgramInfo</a> program, <a href="tvwindow.html#WindowType">WindowType</a> type);
-  };
-  dictionary TuneOption {
-    long? major;
-    long? minor;
-    long? sourceID;
-    long? programNumber;
-    long? transportStreamID;
-    long? ptc;
-    long? originalNetworkID;
-    DOMString? providerMBR;
   };
   [NoInterfaceObject] interface ChannelInfo {
     readonly attribute long major;

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tvdisplaycontrol.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tvdisplaycontrol.html
@@ -238,8 +238,7 @@ For example, Display Control API provides whether your device supports 3D.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Display3DEffectMode:
-                  </span>
+<span class="return">Display3DEffectMode:</span>
  Display3DEffectMode The current mode of 3D effect.
               </ul>
 </div>
@@ -295,8 +294,7 @@ catch (error)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Display3DModeState:
-                  </span>
+<span class="return">Display3DModeState:</span>
  Display3DModeState The current state to display 3D contents.
               </ul>
 </div>
@@ -475,8 +473,8 @@ To guarantee the running of this application on a device with a TV display contr
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module TVDisplayControl {
-  enum Display3DEffectMode { "OFF", "TOP_BOTTOM", "SIDE_BY_SIDE", "LINE_BY_LINE", "VERTICAL_STRIPE", "FRAME_SEQUENCE", "CHECKER_BD",
-    "FROM_2D_TO_3D" };
+  enum Display3DEffectMode { "OFF", "TOP_BOTTOM", "SIDE_BY_SIDE", "LINE_BY_LINE", "VERTICAL_STRIPE", "FRAME_SEQUENCE",
+    "CHECKER_BD", "FROM_2D_TO_3D" };
   enum Display3DModeState { "NOT_CONNECTED", "NOT_SUPPORTED", "READY" };
   [NoInterfaceObject] interface DisplayControlManagerObject {
     readonly attribute <a href="#DisplayControlManager">DisplayControlManager</a> tvdisplaycontrol;

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tvdisplaycontrol.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tvdisplaycontrol.html
@@ -476,10 +476,10 @@ To guarantee the running of this application on a device with a TV display contr
   enum Display3DEffectMode { "OFF", "TOP_BOTTOM", "SIDE_BY_SIDE", "LINE_BY_LINE", "VERTICAL_STRIPE", "FRAME_SEQUENCE",
     "CHECKER_BD", "FROM_2D_TO_3D" };
   enum Display3DModeState { "NOT_CONNECTED", "NOT_SUPPORTED", "READY" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DisplayControlManagerObject">DisplayControlManagerObject</a>;
   [NoInterfaceObject] interface DisplayControlManagerObject {
     readonly attribute <a href="#DisplayControlManager">DisplayControlManager</a> tvdisplaycontrol;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DisplayControlManagerObject">DisplayControlManagerObject</a>;
   [NoInterfaceObject] interface DisplayControlManager {
     <a href="#Display3DEffectMode">Display3DEffectMode</a> get3DEffectMode() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#Display3DModeState">Display3DModeState</a> is3DModeEnabled() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tvinfo.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tvinfo.html
@@ -577,10 +577,10 @@ To guarantee the running of this application on a device with a caption and so o
     "CAPTION_OPACITY_DEFAULT" };
   enum CaptionEdge { "CAPTION_EDGE_NONE", "CAPTION_EDGE_RAISED", "CAPTION_EDGE_DEPRESSED", "CAPTION_EDGE_UNIFORM",
     "CAPTION_EDGE_DROP_SHADOWED" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#TVInfoManagerObject">TVInfoManagerObject</a>;
   [NoInterfaceObject] interface TVInfoManagerObject {
     readonly attribute <a href="#TVInfoManager">TVInfoManager</a> tvinfo;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#TVInfoManagerObject">TVInfoManagerObject</a>;
   [NoInterfaceObject] interface TVInfoManager {
     <a href="#CaptionValue">CaptionValue</a> getCaptionValue(<a href="#CaptionInfoKey">CaptionInfoKey</a> key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addCaptionValueChangeListener(<a href="#CaptionInfoKey">CaptionInfoKey</a> key, <a href="#CaptionValueChangeCallback">CaptionValueChangeCallback</a> callback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tvinfo.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tvinfo.html
@@ -327,8 +327,7 @@ CAPTION_EDGE_DROP_SHADOWED - drop shadowed edge            </li>
 <div class="brief">
  All available values for the caption menu.
           </div>
-<pre class="webidl prettyprint">  typedef (<a href="#CaptionState">CaptionState</a> or <a href="#CaptionMode">CaptionMode</a> or <a href="#CaptionFontSize">CaptionFontSize</a> or <a href="#CaptionFontStyle">CaptionFontStyle</a> or <a href="#CaptionColor">CaptionColor</a> or
-           <a href="#CaptionOpacity">CaptionOpacity</a> or <a href="#CaptionEdge">CaptionEdge</a>) CaptionValue;</pre>
+<pre class="webidl prettyprint">  typedef (<a href="#CaptionState">CaptionState</a> or <a href="#CaptionMode">CaptionMode</a> or <a href="#CaptionFontSize">CaptionFontSize</a> or <a href="#CaptionFontStyle">CaptionFontStyle</a> or <a href="#CaptionColor">CaptionColor</a> or <a href="#CaptionOpacity">CaptionOpacity</a> or <a href="#CaptionEdge">CaptionEdge</a>) CaptionValue;</pre>
 <p><span class="version">Since: </span>
  2.4
           </p>
@@ -384,8 +383,7 @@ There is a tizen.tvinfo object that allows accessing the functionality of the TV
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">CaptionValue:
-                  </span>
+<span class="return">CaptionValue:</span>
  CaptionValue value for given caption menu key
               </ul>
 </div>
@@ -434,8 +432,7 @@ There is a tizen.tvinfo object that allows accessing the functionality of the TV
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  long Subscription identifier
               </ul>
 </div>
@@ -562,6 +559,7 @@ To guarantee the running of this application on a device with a caption and so o
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module TVInfo {
+  typedef (<a href="#CaptionState">CaptionState</a> or <a href="#CaptionMode">CaptionMode</a> or <a href="#CaptionFontSize">CaptionFontSize</a> or <a href="#CaptionFontStyle">CaptionFontStyle</a> or <a href="#CaptionColor">CaptionColor</a> or <a href="#CaptionOpacity">CaptionOpacity</a> or <a href="#CaptionEdge">CaptionEdge</a>) CaptionValue;
   enum CaptionInfoKey { "CAPTION_ONOFF_KEY", "CAPTION_MODE_KEY", "CAPTION_FONT_SIZE_KEY", "CAPTION_FONT_STYLE_KEY",
     "CAPTION_FONT_COLOR_KEY", "CAPTION_FONT_OPACITY_KEY", "CAPTION_BG_COLOR_KEY", "CAPTION_BG_OPACITY_KEY", "CAPTION_EDGE_TYPE_KEY",
     "CAPTION_EDGE_COLOR_KEY", "CAPTION_WINDOW_COLOR_KEY", "CAPTION_WINDOW_OPACITY_KEY" };
@@ -573,14 +571,12 @@ To guarantee the running of this application on a device with a caption and so o
     "CAPTION_SIZE_EXTRA_LARGE" };
   enum CaptionFontStyle { "CAPTION_FONT_DEFAULT", "CAPTION_FONT_STYLE0", "CAPTION_FONT_STYLE1", "CAPTION_FONT_STYLE2",
     "CAPTION_FONT_STYLE3", "CAPTION_FONT_STYLE4", "CAPTION_FONT_STYLE5", "CAPTION_FONT_STYLE6", "CAPTION_FONT_STYLE7" };
-  enum CaptionColor { "CAPTION_COLOR_DEFAULT", "CAPTION_COLOR_WHITE", "CAPTION_COLOR_BLACK", "CAPTION_COLOR_RED", "CAPTION_COLOR_GREEN",
-    "CAPTION_COLOR_BLUE", "CAPTION_COLOR_YELLOW", "CAPTION_COLOR_MAGENTA", "CAPTION_COLOR_CYAN" };
-  enum CaptionOpacity { "CAPTION_OPACITY_SOLID", "CAPTION_OPACITY_FLASHING", "CAPTION_OPACITY_TRANSLUCENT",
-    "CAPTION_OPACITY_TRANSPARENT", "CAPTION_OPACITY_DEFAULT" };
+  enum CaptionColor { "CAPTION_COLOR_DEFAULT", "CAPTION_COLOR_WHITE", "CAPTION_COLOR_BLACK", "CAPTION_COLOR_RED",
+    "CAPTION_COLOR_GREEN", "CAPTION_COLOR_BLUE", "CAPTION_COLOR_YELLOW", "CAPTION_COLOR_MAGENTA", "CAPTION_COLOR_CYAN" };
+  enum CaptionOpacity { "CAPTION_OPACITY_SOLID", "CAPTION_OPACITY_FLASHING", "CAPTION_OPACITY_TRANSLUCENT", "CAPTION_OPACITY_TRANSPARENT",
+    "CAPTION_OPACITY_DEFAULT" };
   enum CaptionEdge { "CAPTION_EDGE_NONE", "CAPTION_EDGE_RAISED", "CAPTION_EDGE_DEPRESSED", "CAPTION_EDGE_UNIFORM",
     "CAPTION_EDGE_DROP_SHADOWED" };
-  typedef (<a href="#CaptionState">CaptionState</a> or <a href="#CaptionMode">CaptionMode</a> or <a href="#CaptionFontSize">CaptionFontSize</a> or <a href="#CaptionFontStyle">CaptionFontStyle</a> or <a href="#CaptionColor">CaptionColor</a> or
-           <a href="#CaptionOpacity">CaptionOpacity</a> or <a href="#CaptionEdge">CaptionEdge</a>) CaptionValue;
   [NoInterfaceObject] interface TVInfoManagerObject {
     readonly attribute <a href="#TVInfoManager">TVInfoManager</a> tvinfo;
   };

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tvinputdevice.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tvinputdevice.html
@@ -286,8 +286,7 @@ window.addEventListener("keydown", function(keyEvent)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">InputDeviceKey:
-                  </span>
+<span class="return">InputDeviceKey<span class="optional"> [nullable]</span>:</span>
  InputDeviceKey InputDeviceKey object for the given key name, or null if the key is not supported.
               </ul>
 </div>
@@ -425,7 +424,7 @@ for (i = 0; i &lt; keys.length; i++)
 <div class="brief">
  Registers a batch of input device keys to receive DOM keyboard events when any of them is pressed or released.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void registerKeyBatch(<a href="#InputDeviceKeyName">InputDeviceKeyName</a>[] keyNames, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void registerKeyBatch(<a href="#InputDeviceKeyName">InputDeviceKeyName</a>[] keyNames, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -511,7 +510,7 @@ tizen.tvinputdevice.registerKeyBatch(keys, successCB, errorCB);
 <div class="brief">
  Unregisters a batch of input device keys.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void unregisterKeyBatch(<a href="#InputDeviceKeyName">InputDeviceKeyName</a>[] keyNames, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void unregisterKeyBatch(<a href="#InputDeviceKeyName">InputDeviceKeyName</a>[] keyNames, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tvinputdevice.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tvinputdevice.html
@@ -603,10 +603,10 @@ To guarantee the running of this application on a device with a TV input device 
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module TVInputDevice {
   typedef DOMString InputDeviceKeyName;
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#TVInputDeviceManagerObject">TVInputDeviceManagerObject</a>;
   [NoInterfaceObject] interface TVInputDeviceManagerObject {
     readonly attribute <a href="#TVInputDeviceManager">TVInputDeviceManager</a> tvinputdevice;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#TVInputDeviceManagerObject">TVInputDeviceManagerObject</a>;
   [NoInterfaceObject] interface InputDeviceKey {
     readonly attribute <a href="#InputDeviceKeyName">InputDeviceKeyName</a> name;
     readonly attribute long code;

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tvwindow.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tvwindow.html
@@ -1235,10 +1235,10 @@ To guarantee the running of this application on a device with a TV picture-in-pi
   enum MeasurementUnit { "px", "%" };
   enum AspectRatio { "ASPECT_RATIO_1x1", "ASPECT_RATIO_4x3", "ASPECT_RATIO_16x9", "ASPECT_RATIO_221x100", "ASPECT_RATIO_UNKNOWN" };
   enum ZPosition { "FRONT", "BEHIND" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#TVWindowManagerObject">TVWindowManagerObject</a>;
   [NoInterfaceObject] interface TVWindowManagerObject {
     readonly attribute <a href="#TVWindowManager">TVWindowManager</a> tvwindow;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#TVWindowManagerObject">TVWindowManagerObject</a>;
   [NoInterfaceObject] interface TVWindowManager {
     void getAvailableWindows(<a href="#AvailableWindowListCallback">AvailableWindowListCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                              raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tvwindow.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tvwindow.html
@@ -331,7 +331,7 @@ catch (error)
 <div class="brief">
  Changes the source of a TV window.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void setSource(<a href="systeminfo.html#SystemInfoVideoSourceInfo">SystemInfoVideoSourceInfo</a> videoSource, <a href="#SourceChangedSuccessCallback">SourceChangedSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void setSource(<a href="systeminfo.html#SystemInfoVideoSourceInfo">SystemInfoVideoSourceInfo</a> videoSource, <a href="#SourceChangedSuccessCallback">SourceChangedSuccessCallback</a> successCallback,
                optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="#WindowType">WindowType</a>? type);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -466,8 +466,7 @@ setSource() is successfully done, source type: HDMI, source port number: 4, sign
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">SystemInfoVideoSourceInfo:
-                  </span>
+<span class="return">SystemInfoVideoSourceInfo:</span>
  The information about the current video source. Returned object will have the <em>signal</em> property, stating whether there is signal provided or not on the source, this property value will be filled only when the window was shown using <a href="./tvwindow.html#TVWindowManager::show">show()</a> function.
               </ul>
 </div>
@@ -514,7 +513,7 @@ signal: null
 <div class="brief">
  Sets the display area of a TV window and shows it on the display.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void show(<a href="#WindowRectangleSuccessCallback">WindowRectangleSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional DOMString[]? rectangle, 
+<div class="synopsis"><pre class="signature prettyprint">void show(<a href="#WindowRectangleSuccessCallback">WindowRectangleSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional DOMString[]? rectangle,
           optional <a href="#WindowType">WindowType</a>? type, optional <a href="#ZPosition">ZPosition</a>? zPosition);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -712,7 +711,7 @@ catch (error)
 <div class="brief">
  Gets the area information of a TV window which is shown.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getRect(<a href="#WindowRectangleSuccessCallback">WindowRectangleSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="#MeasurementUnit">MeasurementUnit</a>? unit, 
+<div class="synopsis"><pre class="signature prettyprint">void getRect(<a href="#WindowRectangleSuccessCallback">WindowRectangleSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="#MeasurementUnit">MeasurementUnit</a>? unit,
              optional <a href="#WindowType">WindowType</a>? type);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -833,8 +832,7 @@ catch (error)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">VideoResolution:
-                  </span>
+<span class="return">VideoResolution:</span>
  VideoResolution current video resolution information
               </ul>
 </div>
@@ -897,8 +895,7 @@ if (res.aspectRatio === "ASPECT_RATIO_16x9")
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  long The identifier of the resolution change listener.
               </ul>
 </div>
@@ -1047,7 +1044,7 @@ Calling this function has no effect if there is no listener with given id.
 <div class="brief">
  This interface defines a video resolution change callback for getting notified about video resolution changes.
           </div>
-<pre class="webidl prettyprint">  [Callback = FunctionOnly, NoInterfaceObject] interface VideoResolutionChangeCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface VideoResolutionChangeCallback {
     void onchanged(<a href="#VideoResolution">VideoResolution</a> resolution, <a href="#WindowType">WindowType</a> type);
   };</pre>
 <p><span class="version">Since: </span>
@@ -1089,7 +1086,7 @@ Calling this function has no effect if there is no listener with given id.
 <div class="brief">
  This interface defines a callback that is invoked when a list of available windows is retrieved successfully.
           </div>
-<pre class="webidl prettyprint">  [Callback = FunctionOnly, NoInterfaceObject] interface AvailableWindowListCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface AvailableWindowListCallback {
     void onsuccess(<a href="#WindowType">WindowType</a>[] type);
   };</pre>
 <p><span class="version">Since: </span>
@@ -1127,7 +1124,7 @@ Calling this function has no effect if there is no listener with given id.
 <div class="brief">
  This interface includes the success callback that is invoked when the position and size of a TV window has been changed or retrieved.
           </div>
-<pre class="webidl prettyprint">  [Callback = FunctionOnly, NoInterfaceObject] interface WindowRectangleSuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface WindowRectangleSuccessCallback {
     void onsuccess(DOMString[] windowRect, <a href="#WindowType">WindowType</a> type);
   };</pre>
 <p><span class="version">Since: </span>
@@ -1175,7 +1172,7 @@ For more detailed information about <em>windowRect</em>, see the description of 
 <div class="brief">
  This interface includes the success callback that is invoked when the source has been set.
           </div>
-<pre class="webidl prettyprint">  [Callback = FunctionOnly, NoInterfaceObject] interface SourceChangedSuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface SourceChangedSuccessCallback {
     void onsuccess(<a href="systeminfo.html#SystemInfoVideoSourceInfo">SystemInfoVideoSourceInfo</a> source, <a href="#WindowType">WindowType</a> type);
   };</pre>
 <p><span class="version">Since: </span>
@@ -1264,16 +1261,16 @@ To guarantee the running of this application on a device with a TV picture-in-pi
     readonly attribute long frequency;
     readonly attribute <a href="#AspectRatio">AspectRatio</a> aspectRatio;
   };
-  [Callback = FunctionOnly, NoInterfaceObject] interface VideoResolutionChangeCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface VideoResolutionChangeCallback {
     void onchanged(<a href="#VideoResolution">VideoResolution</a> resolution, <a href="#WindowType">WindowType</a> type);
   };
-  [Callback = FunctionOnly, NoInterfaceObject] interface AvailableWindowListCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface AvailableWindowListCallback {
     void onsuccess(<a href="#WindowType">WindowType</a>[] type);
   };
-  [Callback = FunctionOnly, NoInterfaceObject] interface WindowRectangleSuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface WindowRectangleSuccessCallback {
     void onsuccess(DOMString[] windowRect, <a href="#WindowType">WindowType</a> type);
   };
-  [Callback = FunctionOnly, NoInterfaceObject] interface SourceChangedSuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface SourceChangedSuccessCallback {
     void onsuccess(<a href="systeminfo.html#SystemInfoVideoSourceInfo">SystemInfoVideoSourceInfo</a> source, <a href="#WindowType">WindowType</a> type);
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/voicecontrol.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/voicecontrol.html
@@ -208,8 +208,7 @@ using one of voice control client objects, it affects other objects.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">VoiceControlClient:
-                  </span>
+<span class="return">VoiceControlClient:</span>
  The object to manage voice control.
               </ul>
 </div>
@@ -279,8 +278,7 @@ For example, "ko_KR" for Korean, "en_US" for American English.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  Currently set language.
               </ul>
 </div>
@@ -451,8 +449,7 @@ client.unsetCommandList("FOREGROUND");
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -580,8 +577,7 @@ client.removeResultListener(id);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Identifier used to clear the watch subscription.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/voicecontrol.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/voicecontrol.html
@@ -887,10 +887,10 @@ To guarantee that the voice control application runs on a device with microphone
 <pre class="webidl prettyprint">module VoiceControl {
   enum VoiceControlResultEvent { "SUCCESS", "FAILURE" };
   enum VoiceControlCommandType { "FOREGROUND" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#VoiceControlClientManagerObject">VoiceControlClientManagerObject</a>;
   [NoInterfaceObject] interface VoiceControlClientManagerObject {
     readonly attribute <a href="#VoiceControlClientManager">VoiceControlClientManager</a> voicecontrol;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#VoiceControlClientManagerObject">VoiceControlClientManagerObject</a>;
   [NoInterfaceObject] interface VoiceControlClientManager {
     <a href="#VoiceControlClient">VoiceControlClient</a> getVoiceControlClient() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };

--- a/docs/application/web/api/5.5/device_api/tv/tizen/websetting.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/websetting.html
@@ -232,10 +232,10 @@ tizen.websetting.removeAllCookies(successCallback);
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module WebSetting {
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#WebSettingObject">WebSettingObject</a>;
   [NoInterfaceObject] interface WebSettingObject {
     readonly attribute <a href="#WebSettingManager">WebSettingManager</a> websetting;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#WebSettingObject">WebSettingObject</a>;
   [NoInterfaceObject] interface WebSettingManager {
     void setUserAgentString(DOMString userAgent, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                             raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/account.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/account.html
@@ -481,8 +481,7 @@ Returns null if the given key is not found.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  Value of the extended data.
               </ul>
 </div>
@@ -851,8 +850,7 @@ tizen.account.getAccounts(
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Account:
-                  </span>
+<span class="return">Account<span class="optional"> [nullable]</span>:</span>
  Object with the given identifier or <var>null</var>.
               </ul>
 </div>
@@ -881,7 +879,7 @@ tizen.account.getAccounts(
  Gets the accounts associated with the provider that has a specified applicationId, asynchronously.
 If you want to get all accounts, omit the applicationId argument.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getAccounts(<a href="#AccountArraySuccessCallback">AccountArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getAccounts(<a href="#AccountArraySuccessCallback">AccountArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                  optional DOMString? applicationId);</pre></div>
 <p><span class="version">Since: </span>
  4.0
@@ -971,8 +969,7 @@ You can register your application as an account provider by writing account rela
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">AccountProvider:
-                  </span>
+<span class="return">AccountProvider<span class="optional"> [nullable]</span>:</span>
  Object with the given applicationId or <var>null</var>.
               </ul>
 </div>
@@ -1006,7 +1003,7 @@ if (!provider)
  Gets the providers with the given capabilities, asynchronously.
 If you want to get all the providers, omit the capability argument.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getProviders(<a href="#AccountProviderArraySuccessCallback">AccountProviderArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getProviders(<a href="#AccountProviderArraySuccessCallback">AccountProviderArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                   optional DOMString? capability);</pre></div>
 <p><span class="version">Since: </span>
  4.0
@@ -1093,8 +1090,7 @@ If you want to get all the providers, omit the capability argument.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Identifier to clear the watch subscription for account changes.
               </ul>
 </div>
@@ -1446,11 +1442,15 @@ To guarantee the running of the application on a device with Account feature, de
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Account {
+  typedef unsigned long AccountId;
+  dictionary AccountInit {
+    DOMString userName;
+    DOMString iconUri;
+  };
   [NoInterfaceObject] interface AccountManagerObject {
     readonly attribute <a href="#AccountManager">AccountManager</a> account;
   };
   <a href="tizen.html#Tizen">Tizen</a> implements <a href="#AccountManagerObject">AccountManagerObject</a>;
-  typedef unsigned long AccountId;
   [NoInterfaceObject] interface AccountProvider {
     readonly attribute <a href="application.html#ApplicationId">ApplicationId</a> applicationId;
     readonly attribute DOMString displayName;
@@ -1458,10 +1458,6 @@ To guarantee the running of the application on a device with Account feature, de
     readonly attribute DOMString smallIconUri;
     readonly attribute DOMString[] capabilities;
     readonly attribute boolean isMultipleAccountSupported;
-  };
-  dictionary AccountInit {
-    DOMString userName;
-    DOMString iconUri;
   };
   [Constructor(<a href="#AccountProvider">AccountProvider</a> provider, optional <a href="#AccountInit">AccountInit</a>? accountInitDict)]
   interface Account {

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/account.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/account.html
@@ -1447,10 +1447,10 @@ To guarantee the running of the application on a device with Account feature, de
     DOMString userName;
     DOMString iconUri;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#AccountManagerObject">AccountManagerObject</a>;
   [NoInterfaceObject] interface AccountManagerObject {
     readonly attribute <a href="#AccountManager">AccountManager</a> account;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#AccountManagerObject">AccountManagerObject</a>;
   [NoInterfaceObject] interface AccountProvider {
     readonly attribute <a href="application.html#ApplicationId">ApplicationId</a> applicationId;
     readonly attribute DOMString displayName;

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/alarm.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/alarm.html
@@ -527,8 +527,7 @@ console.log("remove all registered alarms in the storage.");
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Alarm:
-                  </span>
+<span class="return">Alarm:</span>
  An alarm object with the specified ID.
               </ul>
 </div>
@@ -595,8 +594,7 @@ even if the added alarm was using <a href="notification.html#StatusNotification"
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">UserNotification:
-                  </span>
+<span class="return">UserNotification:</span>
  Notification to be posted when the alarm is triggered.
               </ul>
 </div>
@@ -661,8 +659,7 @@ Alarms that have already been triggered are removed automatically from the stora
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Alarm[]:
-                  </span>
+<span class="return">Alarm[]:</span>
  All Alarm objects.
               </ul>
 </div>
@@ -802,8 +799,7 @@ If the alarm has expired, this method returns <var>null</var>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long<span class="optional"> [nullable]</span>:</span>
  The duration before the next alarm is triggered.
               </ul>
 </div>
@@ -840,7 +836,8 @@ console.log("remaining time is " + sec);
    Constructor(Date date, long period)]
   interface AlarmAbsolute : <a href="#Alarm">Alarm</a> {
     readonly attribute Date date;
-    readonly attribute <a href="#ByDayValue">ByDayValue</a>[] daysOfTheWeek;
+<span class="nocode deprecated">    readonly attribute long? period;
+</span>    readonly attribute <a href="#ByDayValue">ByDayValue</a>[] daysOfTheWeek;
     Date? getNextScheduledDate() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
 <p><span class="version">Since: </span>
@@ -957,8 +954,7 @@ If the alarm has expired, this method returns <var>null</var>. The returned date
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Date:
-                  </span>
+<span class="return">Date<span class="optional"> [nullable]</span>:</span>
  The date/time of the next alarm trigger.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/alarm.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/alarm.html
@@ -987,10 +987,10 @@ console.log("next scheduled time is " + date);
 <pre class="webidl prettyprint">module Alarm {
   typedef DOMString AlarmId;
   enum ByDayValue { "MO", "TU", "WE", "TH", "FR", "SA", "SU" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#AlarmManagerObject">AlarmManagerObject</a>;
   [NoInterfaceObject] interface AlarmManagerObject {
     readonly attribute <a href="#AlarmManager">AlarmManager</a> alarm;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#AlarmManagerObject">AlarmManagerObject</a>;
   [NoInterfaceObject] interface AlarmManager {
     const long PERIOD_MINUTE = 60;
     const long PERIOD_HOUR = 3600;

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/application.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/application.html
@@ -401,7 +401,9 @@ The <em>tizen.application </em>object allows access to the Application API's fun
     void getAppsUsageInfo(<a href="#AppsUsageInfoArraySuccessCallback">AppsUsageInfoArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                           optional <a href="#ApplicationUsageMode">ApplicationUsageMode</a>? mode, optional <a href="#ApplicationUsageFilter">ApplicationUsageFilter</a>? filter, optional long? limit)
                           raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addAppStatusChangeListener(<a href="#StatusEventCallback">StatusEventCallback</a> eventCallback, optional <a href="#ApplicationId">ApplicationId</a>? appId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    long addAppInfoEventListener( eventCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void removeAppInfoEventListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    long addAppStatusChangeListener(<a href="#StatusEventCallback">StatusEventCallback</a> eventCallback, optional <a href="#ApplicationId">ApplicationId</a>? appId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeAppStatusChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
 <p><span class="version">Since: </span>
@@ -427,8 +429,7 @@ The <em>tizen.application </em>object allows access to the Application API's fun
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Application:
-                  </span>
+<span class="return">Application:</span>
  The data structure that defines the current application.
               </ul>
 </div>
@@ -607,7 +608,7 @@ tizen.application.launch("targetApp0.main", onsuccess);
 <div class="brief">
  Launches an application with the specified application control.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void launchAppControl(<a href="#ApplicationControl">ApplicationControl</a> appControl, optional <a href="#ApplicationId">ApplicationId</a>? id, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void launchAppControl(<a href="#ApplicationControl">ApplicationControl</a> appControl, optional <a href="#ApplicationId">ApplicationId</a>? id, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="#ApplicationControlDataArrayReplyCallback">ApplicationControlDataArrayReplyCallback</a>? replyCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.0
@@ -735,7 +736,7 @@ tizen.application.launchAppControl(appControl, null,
 <div class="brief">
  Finds which applications can be launched with the given application control.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void findAppControl(<a href="#ApplicationControl">ApplicationControl</a> appControl, <a href="#FindAppControlSuccessCallback">FindAppControlSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void findAppControl(<a href="#ApplicationControl">ApplicationControl</a> appControl, <a href="#FindAppControlSuccessCallback">FindAppControlSuccessCallback</a> successCallback,
                     optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.0
@@ -902,8 +903,7 @@ The list of running applications and their application IDs is obtained with <em>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ApplicationContext:
-                  </span>
+<span class="return">ApplicationContext:</span>
  A data structure that lists running application details.
               </ul>
 </div>
@@ -1008,8 +1008,7 @@ The list of installed applications and their application IDs is obtained with <e
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ApplicationInformation:
-                  </span>
+<span class="return">ApplicationInformation:</span>
  The information of an application.
               </ul>
 </div>
@@ -1088,8 +1087,7 @@ The certificate types are listed below:
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ApplicationCertificate[]:
-                  </span>
+<span class="return">ApplicationCertificate[]:</span>
  Array of certificate information of a specified application.
               </ul>
 </div>
@@ -1132,10 +1130,19 @@ for (var i = 0; i &lt; appCerts.length; i++)
             </p>
 <div class="description">
             <p>
-The shared directory is used to export data to other applications.
+The shared directory is used to export data to other applications. Its structure is described in
+<a href="https://developer.tizen.org/development/training/native-application/understanding-tizen-programming/file-system-directory-hierarchy">File System Directory Hierarchy</a>.
+            </p>
+           </div>
+<div class="description">
+            <p>
 If the ID is set to <var>null</var> or not set at all, it returns the shared directory URI for the current application.
             </p>
            </div>
+<p><span class="remark">Remark: </span>
+ Since Tizen 3.0, <var>shared/data</var> directory is not created for web applications. For other applications it will be not created by default and should be considered as optional
+(refer to <a href="https://developer.tizen.org/development/training/native-application/understanding-tizen-programming/file-system-directory-hierarchy">table about shared/data</a> for more details).
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -1148,8 +1155,7 @@ If the ID is set to <var>null</var> or not set at all, it returns the shared dir
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The shared directory URI of an application.
               </ul>
 </div>
@@ -1205,8 +1211,7 @@ If the ID is set to <var>null</var> or not set at all, it returns the applicatio
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ApplicationMetaData[]:
-                  </span>
+<span class="return">ApplicationMetaData[]:</span>
  Array of meta data of a specified application. If there are no meta data for a specified application,
 an empty array is returned
               </ul>
@@ -1239,7 +1244,7 @@ console.log("Size of metadata: " + metaDataArray.length);
 <div class="brief">
  Gets information about battery usage per application.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getBatteryUsageInfo(<a href="#BatteryUsageInfoArraySuccessCallback">BatteryUsageInfoArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getBatteryUsageInfo(<a href="#BatteryUsageInfoArraySuccessCallback">BatteryUsageInfoArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                          optional long? days, optional long? limit);</pre></div>
 <p><span class="version">Since: </span>
  4.0
@@ -1341,7 +1346,7 @@ ApplicationID: org.tizen.msg-manager, usage: 0.36
 <div class="brief">
  Gets the usage statistics of applications.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getAppsUsageInfo(<a href="#AppsUsageInfoArraySuccessCallback">AppsUsageInfoArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getAppsUsageInfo(<a href="#AppsUsageInfoArraySuccessCallback">AppsUsageInfoArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                       optional <a href="#ApplicationUsageMode">ApplicationUsageMode</a>? mode, optional <a href="#ApplicationUsageFilter">ApplicationUsageFilter</a>? filter, optional long? limit);</pre></div>
 <p><span class="version">Since: </span>
  4.0
@@ -1489,8 +1494,7 @@ with the corresponding listener identifier.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  ID of the listener that can be used to remove the listener later.
               </ul>
 </div>
@@ -1609,8 +1613,7 @@ tizen.application.removeAppInfoEventListener(watchId);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Listener id that can be used to remove the listener later.
               </ul>
 </div>
@@ -1901,8 +1904,7 @@ appropriately when it is launched.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">RequestedApplicationControl:
-                  </span>
+<span class="return">RequestedApplicationControl:</span>
  The details of a requested application control.
               </ul>
 </div>
@@ -1955,8 +1957,7 @@ System events do not require an application identifier to be specified. Therefor
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Listener identifier.
               </ul>
 </div>
@@ -2502,7 +2503,7 @@ and launches the selected application.
 </div>
 <div class="constructors">
 <h4 id="ApplicationControl::constructor">Constructors</h4>
-<dl><pre class="webidl prettyprint">ApplicationControl(DOMString operation, optional DOMString? uri, optional DOMString? mime, optional DOMString? category, 
+<dl><pre class="webidl prettyprint">ApplicationControl(DOMString operation, optional DOMString? uri, optional DOMString? mime, optional DOMString? category,
                    optional <a href="#ApplicationControlData">ApplicationControlData</a>[]? data, optional <a href="#ApplicationControlLaunchMode">ApplicationControlLaunchMode</a>? launchMode);</pre></dl>
 </div>
 <div class="attributes">
@@ -3404,6 +3405,15 @@ To guarantee the running of the application on a device which has battery, decla
   typedef (<a href="#SystemEventData">SystemEventData</a> or <a href="#UserEventData">UserEventData</a>) EventData;
   enum ApplicationControlLaunchMode { "SINGLE", "GROUP" };
   enum ApplicationUsageMode { "RECENTLY", "FREQUENTLY" };
+  dictionary ApplicationUsageFilter {
+    long? timeSpan;
+    Date? startTime;
+    Date? endTime;
+  };
+  dictionary EventInfo {
+    <a href="#ApplicationId">ApplicationId</a> appId;
+    DOMString name;
+  };
   [NoInterfaceObject] interface ApplicationManagerObject {
     readonly attribute <a href="#ApplicationManager">ApplicationManager</a> application;
   };
@@ -3435,11 +3445,6 @@ To guarantee the running of the application on a device which has battery, decla
                           raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addAppStatusChangeListener(<a href="#StatusEventCallback">StatusEventCallback</a> eventCallback, optional <a href="#ApplicationId">ApplicationId</a>? appId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeAppStatusChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  dictionary ApplicationUsageFilter {
-    long? timeSpan;
-    Date? startTime;
-    Date? endTime;
   };
   [NoInterfaceObject] interface Application {
     readonly attribute <a href="#ApplicationInformation">ApplicationInformation</a> appInfo;
@@ -3534,10 +3539,6 @@ To guarantee the running of the application on a device which has battery, decla
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface StatusEventCallback {
     void onchange(<a href="#ApplicationId">ApplicationId</a> appId, boolean isActive);
-  };
-  dictionary EventInfo {
-    <a href="#ApplicationId">ApplicationId</a> appId;
-    DOMString name;
   };
 };</pre>
 </div>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/application.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/application.html
@@ -3414,10 +3414,10 @@ To guarantee the running of the application on a device which has battery, decla
     <a href="#ApplicationId">ApplicationId</a> appId;
     DOMString name;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ApplicationManagerObject">ApplicationManagerObject</a>;
   [NoInterfaceObject] interface ApplicationManagerObject {
     readonly attribute <a href="#ApplicationManager">ApplicationManager</a> application;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ApplicationManagerObject">ApplicationManagerObject</a>;
   [NoInterfaceObject] interface ApplicationManager {
     <a href="#Application">Application</a> getCurrentApplication() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void kill(<a href="#ApplicationContextId">ApplicationContextId</a> contextId, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/archive.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/archive.html
@@ -1424,10 +1424,10 @@ tizen.archive.open("downloads/some_archive.zip", "r", openSuccess, errorCallback
     boolean stripSourceDirectory;
     <a href="#ArchiveCompressionLevel">ArchiveCompressionLevel</a> compressionLevel;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ArchiveManagerObject">ArchiveManagerObject</a>;
   [NoInterfaceObject] interface ArchiveManagerObject {
     readonly attribute <a href="#ArchiveManager">ArchiveManager</a> archive;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ArchiveManagerObject">ArchiveManagerObject</a>;
   [NoInterfaceObject] interface ArchiveManager {
     long open(<a href="#FileReference">FileReference</a> file, <a href="filesystem.html#FileMode">FileMode</a> mode, <a href="#ArchiveFileSuccessCallback">ArchiveFileSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
               optional <a href="#ArchiveFileOptions">ArchiveFileOptions</a>? options) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/archive.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/archive.html
@@ -359,7 +359,7 @@ mypackage/test.c                </td>
 <div class="brief">
  Opens the archive file. After this operation, it is possible to add or get files to and from the archive.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long open(<a href="#FileReference">FileReference</a> file, <a href="filesystem.html#FileMode">FileMode</a> mode, <a href="#ArchiveFileSuccessCallback">ArchiveFileSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">long open(<a href="#FileReference">FileReference</a> file, <a href="filesystem.html#FileMode">FileMode</a> mode, <a href="#ArchiveFileSuccessCallback">ArchiveFileSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
           optional <a href="#ArchiveFileOptions">ArchiveFileOptions</a>? options);</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
@@ -452,8 +452,7 @@ In this mode, <em>getEntries()</em>, <em>getEntryByName()</em>, and <em>extractA
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -583,7 +582,7 @@ The size is <var>null</var> until the archive is opened.
 <div class="brief">
  Adds a new member file to <em>ArchiveFile</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long add(<a href="#FileReference">FileReference</a> sourceFile, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">long add(<a href="#FileReference">FileReference</a> sourceFile, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
          optional <a href="#ArchiveFileProgressCallback">ArchiveFileProgressCallback</a>? onprogress, optional <a href="#ArchiveFileEntryOptions">ArchiveFileEntryOptions</a>? options);</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
@@ -698,8 +697,7 @@ If the source file is big then the callback can also be called while the file is
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -753,7 +751,7 @@ tizen.archive.open("downloads/new_archive.zip", "w", createSuccess);
 <div class="brief">
  Extracts every file from this <em>ArchiveFile</em> to a given directory.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long extractAll(<a href="#FileReference">FileReference</a> destinationDirectory, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">long extractAll(<a href="#FileReference">FileReference</a> destinationDirectory, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
                 optional <a href="#ArchiveFileProgressCallback">ArchiveFileProgressCallback</a>? onprogress, optional boolean? overwrite);</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
@@ -814,8 +812,7 @@ UnknownError: In any other error case              </li>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -905,8 +902,7 @@ UnknownError: In case of any error              </li>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -1000,8 +996,7 @@ UnknownError: In case of any other error              </li>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -1151,7 +1146,7 @@ This is usually the modification date of the file.
 <div class="brief">
  Extracts ArchiveFileEntry to the given location.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long extract(<a href="#FileReference">FileReference</a> destinationDirectory, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">long extract(<a href="#FileReference">FileReference</a> destinationDirectory, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
              optional <a href="#ArchiveFileProgressCallback">ArchiveFileProgressCallback</a>? onprogress, optional boolean? stripName, optional boolean? overwrite);</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
@@ -1209,8 +1204,7 @@ UnknownError: In case of any other error              </li>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Task ID which can be used to cancel the operation with abort().
               </ul>
 </div>
@@ -1422,10 +1416,6 @@ tizen.archive.open("downloads/some_archive.zip", "r", openSuccess, errorCallback
 <pre class="webidl prettyprint">module Archive {
   typedef (DOMString or <a href="filesystem.html#File">File</a>) FileReference;
   enum ArchiveCompressionLevel { "STORE", "FAST", "NORMAL", "BEST" };
-  [NoInterfaceObject] interface ArchiveManagerObject {
-    readonly attribute <a href="#ArchiveManager">ArchiveManager</a> archive;
-  };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ArchiveManagerObject">ArchiveManagerObject</a>;
   dictionary ArchiveFileOptions {
     boolean overwrite;
   };
@@ -1434,6 +1424,10 @@ tizen.archive.open("downloads/some_archive.zip", "r", openSuccess, errorCallback
     boolean stripSourceDirectory;
     <a href="#ArchiveCompressionLevel">ArchiveCompressionLevel</a> compressionLevel;
   };
+  [NoInterfaceObject] interface ArchiveManagerObject {
+    readonly attribute <a href="#ArchiveManager">ArchiveManager</a> archive;
+  };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ArchiveManagerObject">ArchiveManagerObject</a>;
   [NoInterfaceObject] interface ArchiveManager {
     long open(<a href="#FileReference">FileReference</a> file, <a href="filesystem.html#FileMode">FileMode</a> mode, <a href="#ArchiveFileSuccessCallback">ArchiveFileSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
               optional <a href="#ArchiveFileOptions">ArchiveFileOptions</a>? options) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/badge.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/badge.html
@@ -435,10 +435,10 @@ tizen.badge.addChangeListener([appId, targetAppId], watcher);
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Badge {
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#BadgeManagerObject">BadgeManagerObject</a>;
   [NoInterfaceObject] interface BadgeManagerObject {
     readonly attribute <a href="#BadgeManager">BadgeManager</a> badge;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#BadgeManagerObject">BadgeManagerObject</a>;
   [NoInterfaceObject] interface BadgeManager {
     readonly attribute long maxBadgeCount;
     void setBadgeCount(<a href="application.html#ApplicationId">ApplicationId</a> appId, long count) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/badge.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/badge.html
@@ -210,8 +210,7 @@ tizen.badge.setBadgeCount(appid, 3);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Count of the badge.
               </ul>
 </div>
@@ -378,8 +377,7 @@ tizen.application.getAppsInfo(onListInstalledApps);
 <div class="brief">
  The BadgeChangeCallback interface specifies a set of methods that are invoked every time a badge number change occurs.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface BadgeChangeCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface BadgeChangeCallback {
     void onsuccess(<a href="application.html#ApplicationId">ApplicationId</a> appId, long count);
   };</pre>
 <p><span class="version">Since: </span>
@@ -436,7 +434,7 @@ tizen.badge.addChangeListener([appId, targetAppId], watcher);
 </div>
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
-<pre class="webidl prettyprint">module Badge{
+<pre class="webidl prettyprint">module Badge {
   [NoInterfaceObject] interface BadgeManagerObject {
     readonly attribute <a href="#BadgeManager">BadgeManager</a> badge;
   };
@@ -448,8 +446,7 @@ tizen.badge.addChangeListener([appId, targetAppId], watcher);
     void addChangeListener(<a href="application.html#ApplicationId">ApplicationId</a>[] appIdList, <a href="#BadgeChangeCallback">BadgeChangeCallback</a> successCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeChangeListener(<a href="application.html#ApplicationId">ApplicationId</a>[] appIdList) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface BadgeChangeCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface BadgeChangeCallback {
     void onsuccess(<a href="application.html#ApplicationId">ApplicationId</a> appId, long count);
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/bluetooth.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/bluetooth.html
@@ -7073,10 +7073,10 @@ To guarantee that the Bluetooth Low Energy application runs on a device with Blu
     <a href="#BluetoothLEServiceData">BluetoothLEServiceData</a>? serviceData;
     <a href="#BluetoothLEManufacturerData">BluetoothLEManufacturerData</a>? manufacturerData;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#BluetoothManagerObject">BluetoothManagerObject</a>;
   [NoInterfaceObject] interface BluetoothManagerObject {
     readonly attribute <a href="#BluetoothManager">BluetoothManager</a> bluetooth;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#BluetoothManagerObject">BluetoothManagerObject</a>;
   [Constructor(DOMString uuid, DOMString data)]
   interface BluetoothLEServiceData {
     attribute <a href="#BluetoothUUID">BluetoothUUID</a> uuid;

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/bluetooth.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/bluetooth.html
@@ -383,7 +383,7 @@ OPEN - corresponds to opened bluetooth socket.            </li>
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  enum BluetoothProfileType { "HEALTH" };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  enum BluetoothProfileType { "HEALTH" };</span></pre>
 <p><span class="version">Since: </span>
  2.3.1
           </p>
@@ -402,7 +402,7 @@ HEALTH - corresponds to health bluetooth profile type.            </li>
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  enum BluetoothHealthChannelType { "RELIABLE", "STREAMING" };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  enum BluetoothHealthChannelType { "RELIABLE", "STREAMING" };</span></pre>
 <p><span class="version">Since: </span>
  2.3.1
           </p>
@@ -913,8 +913,7 @@ Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">BluetoothAdapter:
-                  </span>
+<span class="return">BluetoothAdapter:</span>
  The local <em>BluetoothAdapter </em>object.
               </ul>
 </div>
@@ -969,8 +968,7 @@ Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">BluetoothLEAdapter:
-                  </span>
+<span class="return">BluetoothLEAdapter:</span>
  The local <em>BluetoothLEAdapter </em>object.
               </ul>
 </div>
@@ -1031,7 +1029,8 @@ catch (err)
                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void registerRFCOMMServiceByUUID(<a href="#BluetoothUUID">BluetoothUUID</a> uuid, DOMString name, <a href="#BluetoothServiceSuccessCallback">BluetoothServiceSuccessCallback</a> successCallback,
                                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };</pre>
+<span class="nocode deprecated">    <a href="#BluetoothProfileHandler">BluetoothProfileHandler</a> getBluetoothProfileHandler(<a href="#BluetoothProfileType">BluetoothProfileType</a> profileType) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</pre>
 <p><span class="version">Since: </span>
  2.3.1
           </p>
@@ -2078,7 +2077,7 @@ adapter.getDevice(deviceAddress, gotDevice, function(e)
 <div class="brief">
  Registers a service record in the device service record database with the specified <em>uuid</em>, <em>name</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void registerRFCOMMServiceByUUID(<a href="#BluetoothUUID">BluetoothUUID</a> uuid, DOMString name, <a href="#BluetoothServiceSuccessCallback">BluetoothServiceSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void registerRFCOMMServiceByUUID(<a href="#BluetoothUUID">BluetoothUUID</a> uuid, DOMString name, <a href="#BluetoothServiceSuccessCallback">BluetoothServiceSuccessCallback</a> successCallback,
                                  optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
@@ -2238,8 +2237,7 @@ function unregisterChatService()
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">BluetoothProfileHandler:
-                  </span>
+<span class="return">BluetoothProfileHandler:</span>
  Represents the Bluetooth profile handle.
               </ul>
 </div>
@@ -2431,8 +2429,8 @@ adapter.startScan(function onsuccess(device)
 <div class="brief">
  Starts advertising for Low Energy Devices.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void startAdvertise(<a href="#BluetoothLEAdvertiseData">BluetoothLEAdvertiseData</a> advertiseData, <a href="#BluetoothAdvertisePacketType">BluetoothAdvertisePacketType</a> packetType, 
-                    <a href="#BluetoothLEAdvertiseCallback">BluetoothLEAdvertiseCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void startAdvertise(<a href="#BluetoothLEAdvertiseData">BluetoothLEAdvertiseData</a> advertiseData, <a href="#BluetoothAdvertisePacketType">BluetoothAdvertisePacketType</a> packetType,
+                    <a href="#BluetoothLEAdvertiseCallback">BluetoothLEAdvertiseCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                     optional <a href="#BluetoothAdvertisingMode">BluetoothAdvertisingMode</a>? mode, optional boolean? connectable);</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
@@ -3028,8 +3026,7 @@ Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The watchID to be used to unregister the listener.
               </ul>
 </div>
@@ -3683,7 +3680,7 @@ adapter.getDevice("11:22:33:44:55:66", function(device)
 <div class="brief">
  Connects to a specified service identified by <em>uuid</em> on this remote device.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void connectToServiceByUUID(<a href="#BluetoothUUID">BluetoothUUID</a> uuid, <a href="#BluetoothSocketSuccessCallback">BluetoothSocketSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void connectToServiceByUUID(<a href="#BluetoothUUID">BluetoothUUID</a> uuid, <a href="#BluetoothSocketSuccessCallback">BluetoothSocketSuccessCallback</a> successCallback,
                             optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
@@ -4323,8 +4320,7 @@ Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">BluetoothGATTService:
-                  </span>
+<span class="return">BluetoothGATTService:</span>
  Retrieved service for the given UUID.
               </ul>
 </div>
@@ -4393,8 +4389,7 @@ adapter.startScan(onDeviceFound, onerror);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">BluetoothUUID[]:
-                  </span>
+<span class="return">BluetoothUUID[]:</span>
  The array of all service UUIDs that belong to the connected GATT server.
               </ul>
 </div>
@@ -4470,8 +4465,7 @@ Services length 2
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The watchID to be used to unregister the listener.
               </ul>
 </div>
@@ -4701,8 +4695,7 @@ Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">unsigned long:
-                  </span>
+<span class="return">unsigned long:</span>
  The number of bytes actually sent.
               </ul>
 </div>
@@ -4851,8 +4844,7 @@ Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">byte[]:
-                  </span>
+<span class="return">byte[]:</span>
  The sequence of bytes successfully read.
               </ul>
 </div>
@@ -5093,7 +5085,7 @@ else
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface BluetoothClass {
     readonly attribute octet major;
     readonly attribute octet minor;
-    readonly attribute unsigned short [] services;
+    readonly attribute unsigned short[] services;
     boolean hasService(unsigned short service) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
 <p><span class="version">Since: </span>
@@ -5227,8 +5219,7 @@ Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var>, if given service exists in the <em>services</em>.
               </ul>
 </div>
@@ -5616,8 +5607,9 @@ function unRegisterChatService()
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface BluetoothProfileHandler {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface BluetoothProfileHandler {
+<span class="nocode deprecated">    readonly attribute <a href="#BluetoothProfileType">BluetoothProfileType</a> profileType;
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  2.3.1
           </p>
@@ -5662,8 +5654,13 @@ The BluetoothHealthProfileHandler object is created by <em>BluetoothAdapter.getB
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface BluetoothHealthProfileHandler : <a href="#BluetoothProfileHandler">BluetoothProfileHandler</a> {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface BluetoothHealthProfileHandler : <a href="#BluetoothProfileHandler">BluetoothProfileHandler</a> {
+<span class="nocode deprecated">    void registerSinkApplication(unsigned short dataType, DOMString name, <a href="#BluetoothHealthApplicationSuccessCallback">BluetoothHealthApplicationSuccessCallback</a> successCallback,
+                                 optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void connectToSource(<a href="#BluetoothDevice">BluetoothDevice</a> peer, <a href="#BluetoothHealthApplication">BluetoothHealthApplication</a> application,
+                         <a href="#BluetoothHealthChannelSuccessCallback">BluetoothHealthChannelSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  2.3.1
           </p>
@@ -5681,7 +5678,7 @@ The BluetoothHealthProfileHandler object is created by <em>BluetoothAdapter.getB
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
             </p>
-<div class="synopsis"><pre class="signature prettyprint">void registerSinkApplication(unsigned short dataType, DOMString name, <a href="#BluetoothHealthApplicationSuccessCallback">BluetoothHealthApplicationSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void registerSinkApplication(unsigned short dataType, DOMString name, <a href="#BluetoothHealthApplicationSuccessCallback">BluetoothHealthApplicationSuccessCallback</a> successCallback,
                              optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
@@ -5770,7 +5767,7 @@ healthProfileHandler.registerSinkApplication(
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
             </p>
-<div class="synopsis"><pre class="signature prettyprint">void connectToSource(<a href="#BluetoothDevice">BluetoothDevice</a> peer, <a href="#BluetoothHealthApplication">BluetoothHealthApplication</a> application, 
+<div class="synopsis"><pre class="signature prettyprint">void connectToSource(<a href="#BluetoothDevice">BluetoothDevice</a> peer, <a href="#BluetoothHealthApplication">BluetoothHealthApplication</a> application,
                      <a href="#BluetoothHealthChannelSuccessCallback">BluetoothHealthChannelSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
@@ -5883,8 +5880,12 @@ healthProfileHandler.registerSinkApplication(
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface BluetoothHealthApplication {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface BluetoothHealthApplication {
+<span class="nocode deprecated">    readonly attribute unsigned short dataType;
+</span><span class="nocode deprecated">    readonly attribute DOMString name;
+</span><span class="nocode deprecated">    [TreatNonCallableAsNull] attribute <a href="#BluetoothHealthChannelSuccessCallback">BluetoothHealthChannelSuccessCallback</a>? onconnect raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void unregister(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  2.3.1
           </p>
@@ -6102,8 +6103,16 @@ function stopSink()
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface BluetoothHealthChannel {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface BluetoothHealthChannel {
+<span class="nocode deprecated">    readonly attribute <a href="#BluetoothDevice">BluetoothDevice</a> peer;
+</span><span class="nocode deprecated">    readonly attribute <a href="#BluetoothHealthChannelType">BluetoothHealthChannelType</a> channelType;
+</span><span class="nocode deprecated">    readonly attribute <a href="#BluetoothHealthApplication">BluetoothHealthApplication</a> application;
+</span><span class="nocode deprecated">    readonly attribute boolean isConnected;
+</span><span class="nocode deprecated">    void close() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    unsigned long sendData(byte[] data) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void setListener(<a href="#BluetoothHealthChannelChangeCallback">BluetoothHealthChannelChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void unsetListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  2.3.1
           </p>
@@ -6288,8 +6297,7 @@ Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">unsigned long:
-                  </span>
+<span class="return">unsigned long:</span>
  Number of bytes actually sent.
               </ul>
 </div>
@@ -6867,8 +6875,9 @@ After that, this device is no longer visible.
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface BluetoothHealthApplicationSuccessCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback=FunctionOnly, NoInterfaceObject] interface BluetoothHealthApplicationSuccessCallback {
+<span class="nocode deprecated">    void onsuccess(<a href="#BluetoothHealthApplication">BluetoothHealthApplication</a> application);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  2.3.1
           </p>
@@ -6913,8 +6922,9 @@ After that, this device is no longer visible.
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface BluetoothHealthChannelSuccessCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback=FunctionOnly, NoInterfaceObject] interface BluetoothHealthChannelSuccessCallback {
+<span class="nocode deprecated">    void onsuccess(<a href="#BluetoothHealthChannel">BluetoothHealthChannel</a> channel);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  2.3.1
           </p>
@@ -6959,8 +6969,10 @@ After that, this device is no longer visible.
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 5.5.
           </p>
-<pre class="webidl prettyprint">  [Callback, NoInterfaceObject] interface BluetoothHealthChannelChangeCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback, NoInterfaceObject] interface BluetoothHealthChannelChangeCallback {
+<span class="nocode deprecated">    void onmessage(byte[] data);
+</span><span class="nocode deprecated">    void onclose();
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  2.3.1
           </p>
@@ -7047,11 +7059,20 @@ To guarantee that the Bluetooth Low Energy application runs on a device with Blu
 <pre class="webidl prettyprint">module Bluetooth {
   typedef DOMString BluetoothAddress;
   typedef DOMString BluetoothUUID;
-  enum BluetoothSocketState { "CLOSED", "OPEN" };
   typedef DOMString BluetoothLESolicitationUUID;
+  enum BluetoothSocketState { "CLOSED", "OPEN" };
   enum BluetoothAdvertisePacketType { "ADVERTISE", "SCAN_RESPONSE" };
   enum BluetoothAdvertisingState { "STARTED", "STOPPED" };
   enum BluetoothAdvertisingMode { "BALANCED", "LOW_LATENCY", "LOW_ENERGY" };
+  dictionary BluetoothLEAdvertiseDataInit {
+    boolean? includeName;
+    <a href="#BluetoothUUID">BluetoothUUID</a>[]? uuids;
+    <a href="#BluetoothLESolicitationUUID">BluetoothLESolicitationUUID</a>[]? solicitationuuids;
+    unsigned long? appearance;
+    boolean? includeTxPowerLevel;
+    <a href="#BluetoothLEServiceData">BluetoothLEServiceData</a>? serviceData;
+    <a href="#BluetoothLEManufacturerData">BluetoothLEManufacturerData</a>? manufacturerData;
+  };
   [NoInterfaceObject] interface BluetoothManagerObject {
     readonly attribute <a href="#BluetoothManager">BluetoothManager</a> bluetooth;
   };
@@ -7065,15 +7086,6 @@ To guarantee that the Bluetooth Low Energy application runs on a device with Blu
   interface BluetoothLEManufacturerData {
     attribute DOMString id;
     attribute DOMString data;
-  };
-  dictionary BluetoothLEAdvertiseDataInit {
-    boolean? includeName;
-    <a href="#BluetoothUUID">BluetoothUUID</a>[]? uuids;
-    <a href="#BluetoothLESolicitationUUID">BluetoothLESolicitationUUID</a>[]? solicitationuuids;
-    unsigned long? appearance;
-    boolean? includeTxPowerLevel;
-    <a href="#BluetoothLEServiceData">BluetoothLEServiceData</a>? serviceData;
-    <a href="#BluetoothLEManufacturerData">BluetoothLEManufacturerData</a>? manufacturerData;
   };
   [Constructor(optional <a href="#BluetoothLEAdvertiseDataInit">BluetoothLEAdvertiseDataInit</a>? init)]
   interface BluetoothLEAdvertiseData {
@@ -7203,7 +7215,7 @@ To guarantee that the Bluetooth Low Energy application runs on a device with Blu
   [NoInterfaceObject] interface BluetoothClass {
     readonly attribute octet major;
     readonly attribute octet minor;
-    readonly attribute unsigned short [] services;
+    readonly attribute unsigned short[] services;
     boolean hasService(unsigned short service) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface BluetoothClassDeviceMajor {
@@ -7310,7 +7322,6 @@ To guarantee that the Bluetooth Low Energy application runs on a device with Blu
     readonly attribute boolean isConnected;
     [TreatNonCallableAsNull] attribute <a href="#BluetoothSocketSuccessCallback">BluetoothSocketSuccessCallback</a>? onconnect raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unregister(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
   };
   [Callback, NoInterfaceObject] interface BluetoothAdapterChangeCallback {
     void onstatechanged(boolean powered);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/calendar.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/calendar.html
@@ -411,6 +411,9 @@ BUSY_UNAVAILABLE - if the specified time slot is not vacant and can not be sched
 BUSY_TENTATIVE - if the specified time slot is not vacant because one or more events have been tentatively scheduled for that interval            </li>
           </ul>
          </div>
+<p><span class="remark">Remark: </span>
+ <em>BUSY_UNAVAILABLE</em> and <em>BUSY_TENTATIVE</em> are supported since Tizen 5.0
+          </p>
 </div>
 <div class="enum" id="AttendeeType">
 <a class="backward-compatibility-anchor" name="::Calendar::AttendeeType"></a><h3>1.10. AttendeeType</h3>
@@ -438,9 +441,6 @@ ROOM - Room resource            </li>
 UNKNOWN - Unknown            </li>
           </ul>
          </div>
-<p><span class="remark">Remark: </span>
- <em>BUSY_UNAVAILABLE</em> and <em>BUSY_TENTATIVE</em> are supported since Tizen 5.0
-          </p>
 </div>
 <div class="enum" id="AttendeeStatus">
 <a class="backward-compatibility-anchor" name="::Calendar::AttendeeStatus"></a><h3>1.11. AttendeeStatus</h3>
@@ -4169,10 +4169,10 @@ To guarantee the running of the application on a device with Contact feature, de
     short[] setPositions;
     <a href="time.html#TZDate">TZDate</a>[] exceptions;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#CalendarManagerObject">CalendarManagerObject</a>;
   [NoInterfaceObject] interface CalendarManagerObject {
     readonly attribute <a href="#CalendarManager">CalendarManager</a> calendar;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#CalendarManagerObject">CalendarManagerObject</a>;
   [NoInterfaceObject] interface CalendarManager {
     void getCalendars(<a href="#CalendarType">CalendarType</a> type, <a href="#CalendarArraySuccessCallback">CalendarArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                       raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/calendar.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/calendar.html
@@ -594,7 +594,7 @@ CANCELLED -  if the task has been cancelled            </li>
 <div class="brief">
  The CalendarManagerObject interface gives access to the Calendar API from the <em>tizen.calendar </em>object.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface CalendarManagerObject{
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface CalendarManagerObject {
     readonly attribute <a href="#CalendarManager">CalendarManager</a> calendar;
   };</pre>
 <pre class="webidl prettyprint">  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#CalendarManagerObject">CalendarManagerObject</a>;</pre>
@@ -784,8 +784,7 @@ If an item is added to the unified calendar, it will be saved in the default cal
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Calendar:
-                  </span>
+<span class="return">Calendar:</span>
  The unified Calendar object.
               </ul>
 </div>
@@ -879,8 +878,7 @@ unifiedCalendar.find(eventFoundCallback, errorCallback, filter);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Calendar:
-                  </span>
+<span class="return">Calendar:</span>
  The default Calendar object.
               </ul>
 </div>
@@ -1129,8 +1127,7 @@ tizen.account.getAccounts(
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Calendar:
-                  </span>
+<span class="return">Calendar:</span>
  The matching Calendar object.
               </ul>
 </div>
@@ -1314,8 +1311,7 @@ console.log("The calendar name is " + calendar.name);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">CalendarItem:
-                  </span>
+<span class="return">CalendarItem:</span>
  The matching <em>CalendarItem </em>object.
               </ul>
 </div>
@@ -1438,7 +1434,7 @@ console.log("Event added with uid " + ev.id.uid);
 <div class="brief">
  Adds an array of items to the calendar asynchronously.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void addBatch(<a href="#CalendarItem">CalendarItem</a>[] items, optional <a href="#CalendarItemArraySuccessCallback">CalendarItemArraySuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void addBatch(<a href="#CalendarItem">CalendarItem</a>[] items, optional <a href="#CalendarItemArraySuccessCallback">CalendarItemArraySuccessCallback</a>? successCallback,
               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  4.0
@@ -1615,7 +1611,7 @@ myCalendar.find(eventSearchSuccessCallback, errorCallback);
 <div class="brief">
  Updates an array of existing items in the calendar asynchronously with the specified values in the argument.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void updateBatch(<a href="#CalendarItem">CalendarItem</a>[] items, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void updateBatch(<a href="#CalendarItem">CalendarItem</a>[] items, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                  optional boolean? updateAllInstances);</pre></div>
 <p><span class="version">Since: </span>
  4.0
@@ -1888,7 +1884,7 @@ myCalendar.find(eventSearchSuccessCallback, errorCallback);
 <div class="brief">
  Finds and fetches an array of <em>CalendarItem </em>objects for items stored in the calendar according to the supplied filter if it is valid else it will return all the items stored.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#CalendarItemArraySuccessCallback">CalendarItemArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter, 
+<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#CalendarItemArraySuccessCallback">CalendarItemArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter,
           optional <a href="tizen.html#SortMode">SortMode</a>? sortMode);</pre></div>
 <p><span class="version">Since: </span>
  4.0
@@ -2020,8 +2016,7 @@ When executed, the implementation must immediately return a subscription identif
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -2185,7 +2180,7 @@ These attributes are shared by both calendar events and tasks.
 <div class="brief">
  The CalendarTaskInit dictionary is used for creating calendar tasks.
           </div>
-<pre class="webidl prettyprint">  dictionary CalendarTaskInit: <a href="#CalendarItemInit">CalendarItemInit</a> {
+<pre class="webidl prettyprint">  dictionary CalendarTaskInit : <a href="#CalendarItemInit">CalendarItemInit</a> {
     <a href="time.html#TZDate">TZDate</a> dueDate;
     <a href="time.html#TZDate">TZDate</a> completedDate;
     short progress;
@@ -2208,7 +2203,7 @@ All the attributes are optional and are undefined by default.
 <div class="brief">
  The CalendarEventInit dictionary is used for creating calendar events.
           </div>
-<pre class="webidl prettyprint">  dictionary CalendarEventInit: <a href="#CalendarItemInit">CalendarItemInit</a> {
+<pre class="webidl prettyprint">  dictionary CalendarEventInit : <a href="#CalendarItemInit">CalendarItemInit</a> {
     <a href="time.html#TZDate">TZDate</a> endDate;
     <a href="#EventAvailability">EventAvailability</a> availability;
     <a href="#CalendarRecurrenceRule">CalendarRecurrenceRule</a> recurrenceRule;
@@ -2622,8 +2617,7 @@ The export format is set using the format parameter.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The representation of the Calendar item.
               </ul>
 </div>
@@ -2696,8 +2690,7 @@ The <em>CalendarItem </em>object returned by the <em>clone()</em> method will ha
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">CalendarItem:
-                  </span>
+<span class="return">CalendarItem:</span>
  New clone of the <em>CalendarItem </em>object.
               </ul>
 </div>
@@ -3032,7 +3025,7 @@ event.recurrenceRule = rule;
 <div class="brief">
  Expands a recurring event and returns asynchronously the list of instances occurring in a given time interval (inclusive).
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void expandRecurrence(<a href="time.html#TZDate">TZDate</a> startDate, <a href="time.html#TZDate">TZDate</a> endDate, <a href="#CalendarEventArraySuccessCallback">CalendarEventArraySuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void expandRecurrence(<a href="time.html#TZDate">TZDate</a> startDate, <a href="time.html#TZDate">TZDate</a> endDate, <a href="#CalendarEventArraySuccessCallback">CalendarEventArraySuccessCallback</a> successCallback,
                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  4.0
@@ -3685,8 +3678,7 @@ The default value is an empty string.
 <div class="brief">
  The CalendarEventArraySuccessCallback interface that implements the success callback used in the asynchronous operation for retrieving a list of calendar events.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface CalendarEventArraySuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface CalendarEventArraySuccessCallback {
     void onsuccess(<a href="#CalendarEvent">CalendarEvent</a>[] events);
   };</pre>
 <p><span class="version">Since: </span>
@@ -3750,8 +3742,7 @@ if (event.recurrenceRule != null)
 <div class="brief">
  The CalendarItemArraySuccessCallback interface implements the success callback used in the asynchronous operation for retrieving a list of calendar items.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface CalendarItemArraySuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface CalendarItemArraySuccessCallback {
     void onsuccess(<a href="#CalendarItem">CalendarItem</a>[] items);
   };</pre>
 <p><span class="version">Since: </span>
@@ -3817,8 +3808,7 @@ calendar.addBatch([ev], calendarItemArraySuccessCB, errorCallback);
 <div class="brief">
  The CalendarArraySuccessCallback interface implements the success callback used in the asynchronous operation to get a list of calendars using the <em>getCalendars()</em> method.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface CalendarArraySuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface CalendarArraySuccessCallback {
     void onsuccess(<a href="#Calendar">Calendar</a>[] calendars);
   };</pre>
 <p><span class="version">Since: </span>
@@ -4134,7 +4124,52 @@ To guarantee the running of the application on a device with Contact feature, de
   enum CalendarItemPriority { "HIGH", "MEDIUM", "LOW", "NONE" };
   enum CalendarItemVisibility { "PUBLIC", "PRIVATE", "CONFIDENTIAL" };
   enum CalendarItemStatus { "NONE", "TENTATIVE", "CONFIRMED", "CANCELLED", "NEEDS_ACTION", "IN_PROCESS", "COMPLETED" };
-  [NoInterfaceObject] interface CalendarManagerObject{
+  dictionary CalendarItemInit {
+    DOMString description;
+    DOMString summary;
+    boolean isAllDay;
+    <a href="time.html#TZDate">TZDate</a> startDate;
+    <a href="time.html#TimeDuration">TimeDuration</a> duration;
+    DOMString location;
+    <a href="tizen.html#SimpleCoordinates">SimpleCoordinates</a> geolocation;
+    DOMString organizer;
+    <a href="#CalendarItemVisibility">CalendarItemVisibility</a> visibility;
+    <a href="#CalendarItemStatus">CalendarItemStatus</a> status;
+    <a href="#CalendarItemPriority">CalendarItemPriority</a> priority;
+    <a href="#CalendarAlarm">CalendarAlarm</a>[] alarms;
+    DOMString[] categories;
+    <a href="#CalendarAttendee">CalendarAttendee</a>[] attendees;
+  };
+  dictionary CalendarTaskInit : <a href="#CalendarItemInit">CalendarItemInit</a> {
+    <a href="time.html#TZDate">TZDate</a> dueDate;
+    <a href="time.html#TZDate">TZDate</a> completedDate;
+    short progress;
+  };
+  dictionary CalendarEventInit : <a href="#CalendarItemInit">CalendarItemInit</a> {
+    <a href="time.html#TZDate">TZDate</a> endDate;
+    <a href="#EventAvailability">EventAvailability</a> availability;
+    <a href="#CalendarRecurrenceRule">CalendarRecurrenceRule</a> recurrenceRule;
+  };
+  dictionary CalendarAttendeeInit {
+    DOMString name;
+    <a href="#AttendeeRole">AttendeeRole</a> role;
+    <a href="#AttendeeStatus">AttendeeStatus</a> status;
+    boolean RSVP;
+    <a href="#AttendeeType">AttendeeType</a> type;
+    DOMString? group;
+    DOMString delegatorURI;
+    DOMString delegateURI;
+    <a href="contact.html#ContactRef">ContactRef</a> contactRef;
+  };
+  dictionary CalendarRecurrenceRuleInit {
+    short interval;
+    <a href="time.html#TZDate">TZDate</a> untilDate;
+    long occurrenceCount;
+    <a href="#ByDayValue">ByDayValue</a>[] daysOfTheWeek;
+    short[] setPositions;
+    <a href="time.html#TZDate">TZDate</a>[] exceptions;
+  };
+  [NoInterfaceObject] interface CalendarManagerObject {
     readonly attribute <a href="#CalendarManager">CalendarManager</a> calendar;
   };
   <a href="tizen.html#Tizen">Tizen</a> implements <a href="#CalendarManagerObject">CalendarManagerObject</a>;
@@ -4166,32 +4201,6 @@ To guarantee the running of the application on a device with Contact feature, de
               optional <a href="tizen.html#SortMode">SortMode</a>? sortMode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addChangeListener(<a href="#CalendarChangeCallback">CalendarChangeCallback</a> successCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  dictionary CalendarItemInit {
-    DOMString description;
-    DOMString summary;
-    boolean isAllDay;
-    <a href="time.html#TZDate">TZDate</a> startDate;
-    <a href="time.html#TimeDuration">TimeDuration</a> duration;
-    DOMString location;
-    <a href="tizen.html#SimpleCoordinates">SimpleCoordinates</a> geolocation;
-    DOMString organizer;
-    <a href="#CalendarItemVisibility">CalendarItemVisibility</a> visibility;
-    <a href="#CalendarItemStatus">CalendarItemStatus</a> status;
-    <a href="#CalendarItemPriority">CalendarItemPriority</a> priority;
-    <a href="#CalendarAlarm">CalendarAlarm</a>[] alarms;
-    DOMString[] categories;
-    <a href="#CalendarAttendee">CalendarAttendee</a>[] attendees;
-  };
-  dictionary CalendarTaskInit: <a href="#CalendarItemInit">CalendarItemInit</a> {
-    <a href="time.html#TZDate">TZDate</a> dueDate;
-    <a href="time.html#TZDate">TZDate</a> completedDate;
-    short progress;
-  };
-  dictionary CalendarEventInit: <a href="#CalendarItemInit">CalendarItemInit</a> {
-    <a href="time.html#TZDate">TZDate</a> endDate;
-    <a href="#EventAvailability">EventAvailability</a> availability;
-    <a href="#CalendarRecurrenceRule">CalendarRecurrenceRule</a> recurrenceRule;
   };
   [NoInterfaceObject] interface CalendarItem {
     readonly attribute <a href="#CalendarItemId">CalendarItemId</a>? id;
@@ -4231,17 +4240,6 @@ To guarantee the running of the application on a device with Contact feature, de
     void expandRecurrence(<a href="time.html#TZDate">TZDate</a> startDate, <a href="time.html#TZDate">TZDate</a> endDate, <a href="#CalendarEventArraySuccessCallback">CalendarEventArraySuccessCallback</a> successCallback,
                           optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
-  dictionary CalendarAttendeeInit {
-    DOMString name;
-    <a href="#AttendeeRole">AttendeeRole</a> role;
-    <a href="#AttendeeStatus">AttendeeStatus</a> status;
-    boolean RSVP;
-    <a href="#AttendeeType">AttendeeType</a> type;
-    DOMString? group;
-    DOMString delegatorURI;
-    DOMString delegateURI;
-    <a href="contact.html#ContactRef">ContactRef</a> contactRef;
-  };
   [Constructor(DOMString uri, optional <a href="#CalendarAttendeeInit">CalendarAttendeeInit</a>? attendeeInitDict)]
   interface CalendarAttendee {
     attribute DOMString uri;
@@ -4254,14 +4252,6 @@ To guarantee the running of the application on a device with Contact feature, de
     attribute DOMString? delegatorURI;
     attribute DOMString? delegateURI;
     attribute <a href="contact.html#ContactRef">ContactRef</a>? contactRef;
-  };
-  dictionary CalendarRecurrenceRuleInit {
-    short interval;
-    <a href="time.html#TZDate">TZDate</a> untilDate;
-    long occurrenceCount;
-    <a href="#ByDayValue">ByDayValue</a>[] daysOfTheWeek;
-    short[] setPositions;
-    <a href="time.html#TZDate">TZDate</a>[] exceptions;
   };
   [Constructor(<a href="#RecurrenceRuleFrequency">RecurrenceRuleFrequency</a> frequency, optional <a href="#CalendarRecurrenceRuleInit">CalendarRecurrenceRuleInit</a>? ruleInitDict)]
   interface CalendarRecurrenceRule {
@@ -4286,16 +4276,13 @@ To guarantee the running of the application on a device with Contact feature, de
     attribute <a href="#AlarmMethod">AlarmMethod</a> method;
     attribute DOMString? description;
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface CalendarEventArraySuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface CalendarEventArraySuccessCallback {
     void onsuccess(<a href="#CalendarEvent">CalendarEvent</a>[] events);
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface CalendarItemArraySuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface CalendarItemArraySuccessCallback {
     void onsuccess(<a href="#CalendarItem">CalendarItem</a>[] items);
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface CalendarArraySuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface CalendarArraySuccessCallback {
     void onsuccess(<a href="#Calendar">Calendar</a>[] calendars);
   };
   [Callback, NoInterfaceObject] interface CalendarChangeCallback {

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/contact.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/contact.html
@@ -6914,10 +6914,10 @@ To guarantee the running of the application on a device with Contact feature, de
     DOMString data11;
     DOMString data12;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ContactManagerObject">ContactManagerObject</a>;
   [NoInterfaceObject] interface ContactManagerObject {
     readonly attribute <a href="#ContactManager">ContactManager</a> contact;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ContactManagerObject">ContactManagerObject</a>;
   [NoInterfaceObject] interface ContactManager {
     void getAddressBooks(<a href="#AddressBookArraySuccessCallback">AddressBookArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/contact.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/contact.html
@@ -738,8 +738,7 @@ and it is set to <var>null</var>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">AddressBook:
-                  </span>
+<span class="return">AddressBook:</span>
  The unified AddressBook object.
               </ul>
 </div>
@@ -844,8 +843,7 @@ The default address book is one of the addressBooks that is the appointed addres
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">AddressBook:
-                  </span>
+<span class="return">AddressBook:</span>
  The default AddressBook object.
               </ul>
 </div>
@@ -1106,8 +1104,7 @@ tizen.account.getAccounts(
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">AddressBook:
-                  </span>
+<span class="return">AddressBook:</span>
  The matching AddressBook object.
               </ul>
 </div>
@@ -1189,8 +1186,7 @@ person with the specified identifier.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Person:
-                  </span>
+<span class="return">Person:</span>
  The matching Person object.
               </ul>
 </div>
@@ -1644,7 +1640,7 @@ catch (err)
 <div class="brief">
  Gets an array of all <em>Person </em>objects from the contact DB or the ones that match the optionally supplied filter.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#PersonArraySuccessCallback">PersonArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter, 
+<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#PersonArraySuccessCallback">PersonArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter,
           optional <a href="tizen.html#SortMode">SortMode</a>? sortMode);</pre></div>
 <p><span class="version">Since: </span>
  4.0
@@ -1750,8 +1746,8 @@ catch (err)
 <div class="brief">
  Gets an array of <em>Person </em>objects from the contact DB which match the supplied filter. This method is for filtering usageCount property of Person objects.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void findByUsageCount(<a href="#ContactUsageCountFilter">ContactUsageCountFilter</a> filter, <a href="#PersonArraySuccessCallback">PersonArraySuccessCallback</a> successCallback, 
-                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#SortModeOrder">SortModeOrder</a>? sortModeOrder, optional unsigned long limit, 
+<div class="synopsis"><pre class="signature prettyprint">void findByUsageCount(<a href="#ContactUsageCountFilter">ContactUsageCountFilter</a> filter, <a href="#PersonArraySuccessCallback">PersonArraySuccessCallback</a> successCallback,
+                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#SortModeOrder">SortModeOrder</a>? sortModeOrder, optional unsigned long limit,
                       optional unsigned long offset);</pre></div>
 <p><span class="version">Since: </span>
  4.0
@@ -1891,8 +1887,7 @@ asynchronously.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -2216,8 +2211,7 @@ flag set to <var>true</var>.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Contact:
-                  </span>
+<span class="return">Contact:</span>
  The matching Contact object.
               </ul>
 </div>
@@ -2908,7 +2902,7 @@ catch (err)
  Finds an array of all Contact objects from the specified address book or an array of
 Contact objects that match the optionally supplied filter.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#ContactArraySuccessCallback">ContactArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter, 
+<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#ContactArraySuccessCallback">ContactArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter,
           optional <a href="tizen.html#SortMode">SortMode</a>? sortMode);</pre></div>
 <p><span class="version">Since: </span>
  4.0
@@ -3052,8 +3046,7 @@ asynchronously.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  An identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -3227,8 +3220,7 @@ watcherId = addressbook.addChangeListener(watcher);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ContactGroup:
-                  </span>
+<span class="return">ContactGroup:</span>
  The matching ContactGroup object.
               </ul>
 </div>
@@ -3521,8 +3513,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">ContactGroup[]:
-                  </span>
+<span class="return">ContactGroup[]:</span>
  The array of ContactGroup object from this address book.
               </ul>
 </div>
@@ -3841,8 +3832,7 @@ This function returns a newly created Person object that indicates the separated
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Person:
-                  </span>
+<span class="return">Person:</span>
  Newly created Person object that indicates the separated contact
               </ul>
 </div>
@@ -3953,8 +3943,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Number of usages.
               </ul>
 </div>
@@ -4640,8 +4629,7 @@ The export format is set via the format parameter.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The string representation of the Contact item.
               </ul>
 </div>
@@ -4724,8 +4712,7 @@ set to <var>null</var> and will be detached from any address book.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Contact:
-                  </span>
+<span class="return">Contact:</span>
  A new clone of the Contact object.
               </ul>
 </div>
@@ -6859,12 +6846,74 @@ To guarantee the running of the application on a device with Contact feature, de
   typedef DOMString ContactGroupId;
   typedef (<a href="tizen.html#AttributeFilter">AttributeFilter</a> or <a href="tizen.html#AttributeRangeFilter">AttributeRangeFilter</a>) ContactUsageCountFilter;
   enum ContactTextFormat { "VCARD_30" };
-  enum ContactRelationshipType { "OTHER", "ASSISTANT", "BROTHER", "CHILD", "DOMESTIC_PARTNER", "FATHER", "FRIEND", "MANAGER", "MOTHER",
-    "PARENT", "PARTNER", "REFERRED_BY", "RELATIVE", "SISTER", "SPOUSE", "CUSTOM" };
-  enum ContactInstantMessengerType { "OTHER", "GOOGLE", "WLM", "YAHOO", "FACEBOOK", "ICQ", "AIM", "QQ", "JABBER", "SKYPE", "IRC",
-    "CUSTOM" };
+  enum ContactRelationshipType { "OTHER", "ASSISTANT", "BROTHER", "CHILD", "DOMESTIC_PARTNER", "FATHER", "FRIEND",
+    "MANAGER", "MOTHER", "PARENT", "PARTNER", "REFERRED_BY", "RELATIVE", "SISTER", "SPOUSE", "CUSTOM" };
+  enum ContactInstantMessengerType { "OTHER", "GOOGLE", "WLM", "YAHOO", "FACEBOOK", "ICQ", "AIM", "QQ", "JABBER",
+    "SKYPE", "IRC", "CUSTOM" };
   enum ContactUsageType { "OUTGOING_CALL", "OUTGOING_MSG", "OUTGOING_EMAIL", "INCOMING_CALL", "INCOMING_MSG", "INCOMING_EMAIL",
     "MISSED_CALL", "REJECTED_CALL", "BLOCKED_CALL", "BLOCKED_MSG" };
+  dictionary ContactInit {
+    <a href="#ContactName">ContactName</a> name;
+    <a href="#ContactAddress">ContactAddress</a>[] addresses;
+    DOMString photoURI;
+    <a href="#ContactPhoneNumber">ContactPhoneNumber</a>[] phoneNumbers;
+    <a href="#ContactEmailAddress">ContactEmailAddress</a>[] emails;
+    <a href="#ContactInstantMessenger">ContactInstantMessenger</a>[] messengers;
+    <a href="#ContactRelationship">ContactRelationship</a>[] relationships;
+    <a href="#ContactExtension">ContactExtension</a>[] extensions;
+    Date birthday;
+    <a href="#ContactAnniversary">ContactAnniversary</a>[] anniversaries;
+    <a href="#ContactOrganization">ContactOrganization</a>[] organizations;
+    DOMString[] notes;
+    <a href="#ContactWebSite">ContactWebSite</a>[] urls;
+    DOMString ringtoneURI;
+    DOMString messageAlertURI;
+    DOMString vibrationURI;
+    <a href="#ContactGroupId">ContactGroupId</a>[] groupIds;
+  };
+  dictionary ContactNameInit {
+    DOMString prefix;
+    DOMString suffix;
+    DOMString firstName;
+    DOMString middleName;
+    DOMString lastName;
+    DOMString[] nicknames;
+    DOMString phoneticFirstName;
+    DOMString phoneticMiddleName;
+    DOMString phoneticLastName;
+  };
+  dictionary ContactOrganizationInit {
+    DOMString name;
+    DOMString department;
+    DOMString title;
+    DOMString role;
+    DOMString logoURI;
+  };
+  dictionary ContactAddressInit {
+    DOMString country;
+    DOMString region;
+    DOMString city;
+    DOMString streetAddress;
+    DOMString additionalInformation;
+    DOMString postalCode;
+    boolean isDefault;
+    DOMString[] types;
+    DOMString label;
+  };
+  dictionary ContactExtensionInit {
+    long data1;
+    DOMString data2;
+    DOMString data3;
+    DOMString data4;
+    DOMString data5;
+    DOMString data6;
+    DOMString data7;
+    DOMString data8;
+    DOMString data9;
+    DOMString data10;
+    DOMString data11;
+    DOMString data12;
+  };
   [NoInterfaceObject] interface ContactManagerObject {
     readonly attribute <a href="#ContactManager">ContactManager</a> contact;
   };
@@ -6933,25 +6982,6 @@ To guarantee the running of the application on a device with Contact feature, de
     long getUsageCount(optional <a href="#ContactUsageType">ContactUsageType</a>? type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void resetUsageCount(optional <a href="#ContactUsageType">ContactUsageType</a>? type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
-  dictionary ContactInit {
-    <a href="#ContactName">ContactName</a> name;
-    <a href="#ContactAddress">ContactAddress</a>[] addresses;
-    DOMString photoURI;
-    <a href="#ContactPhoneNumber">ContactPhoneNumber</a>[] phoneNumbers;
-    <a href="#ContactEmailAddress">ContactEmailAddress</a>[] emails;
-    <a href="#ContactInstantMessenger">ContactInstantMessenger</a>[] messengers;
-    <a href="#ContactRelationship">ContactRelationship</a>[] relationships;
-    <a href="#ContactExtension">ContactExtension</a>[] extensions;
-    Date birthday;
-    <a href="#ContactAnniversary">ContactAnniversary</a>[] anniversaries;
-    <a href="#ContactOrganization">ContactOrganization</a>[] organizations;
-    DOMString[] notes;
-    <a href="#ContactWebSite">ContactWebSite</a>[] urls;
-    DOMString ringtoneURI;
-    DOMString messageAlertURI;
-    DOMString vibrationURI;
-    <a href="#ContactGroupId">ContactGroupId</a>[] groupIds;
-  };
   [Constructor(optional <a href="#ContactInit">ContactInit</a>? ContactInitDict),
    Constructor(DOMString stringRepresentation)]
   interface Contact {
@@ -6985,17 +7015,6 @@ To guarantee the running of the application on a device with Contact feature, de
     attribute <a href="#AddressBookId">AddressBookId</a> addressBookId;
     attribute <a href="#ContactId">ContactId</a> contactId;
   };
-  dictionary ContactNameInit {
-    DOMString prefix;
-    DOMString suffix;
-    DOMString firstName;
-    DOMString middleName;
-    DOMString lastName;
-    DOMString[] nicknames;
-    DOMString phoneticFirstName;
-    DOMString phoneticMiddleName;
-    DOMString phoneticLastName;
-  };
   [Constructor(optional <a href="#ContactNameInit">ContactNameInit</a>? nameInitDict)]
   interface ContactName {
     attribute DOMString? prefix;
@@ -7008,13 +7027,6 @@ To guarantee the running of the application on a device with Contact feature, de
     attribute DOMString? phoneticMiddleName;
     attribute DOMString? phoneticLastName;
     readonly attribute DOMString? displayName;
-  };
-  dictionary ContactOrganizationInit {
-    DOMString name;
-    DOMString department;
-    DOMString title;
-    DOMString role;
-    DOMString logoURI;
   };
   [Constructor(optional <a href="#ContactOrganizationInit">ContactOrganizationInit</a>? orgInitDict)]
   interface ContactOrganization {
@@ -7033,17 +7045,6 @@ To guarantee the running of the application on a device with Contact feature, de
   interface ContactAnniversary {
     attribute Date date;
     attribute DOMString? label;
-  };
-  dictionary ContactAddressInit {
-    DOMString country;
-    DOMString region;
-    DOMString city;
-    DOMString streetAddress;
-    DOMString additionalInformation;
-    DOMString postalCode;
-    boolean isDefault;
-    DOMString[] types;
-    DOMString label;
   };
   [Constructor(optional <a href="#ContactAddressInit">ContactAddressInit</a>? addressInitDict)]
   interface ContactAddress {
@@ -7091,20 +7092,6 @@ To guarantee the running of the application on a device with Contact feature, de
     attribute DOMString relativeName;
     attribute <a href="#ContactRelationshipType">ContactRelationshipType</a> type;
     attribute DOMString? label;
-  };
-  dictionary ContactExtensionInit {
-    long data1;
-    DOMString data2;
-    DOMString data3;
-    DOMString data4;
-    DOMString data5;
-    DOMString data6;
-    DOMString data7;
-    DOMString data8;
-    DOMString data9;
-    DOMString data10;
-    DOMString data11;
-    DOMString data12;
   };
   [Constructor(optional <a href="#ContactExtensionInit">ContactExtensionInit</a>? extensionInitDict)]
   interface ContactExtension {

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/content.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/content.html
@@ -229,7 +229,7 @@ Playlist functionality has been added in Tizen 2.3.
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 5.5.
           </p>
-<pre class="webidl prettyprint">  enum ContentDirectoryStorageType { "INTERNAL", "EXTERNAL" };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  enum ContentDirectoryStorageType { "INTERNAL", "EXTERNAL" };</span></pre>
 <p><span class="version">Since: </span>
  2.0
           </p>
@@ -401,7 +401,9 @@ The <em>tizen.content </em>object allows accessing the functionality of the Cont
     void cancelScanDirectory(DOMString contentDirURI) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addChangeListener(<a href="#ContentChangeCallback">ContentChangeCallback</a> changeCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeChangeListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getPlaylists(<a href="#PlaylistArraySuccessCallback">PlaylistArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    void setChangeListener(<a href="#ContentChangeCallback">ContentChangeCallback</a> changeCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void unsetChangeListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void getPlaylists(<a href="#PlaylistArraySuccessCallback">PlaylistArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void createPlaylist(DOMString name, <a href="#PlaylistSuccessCallback">PlaylistSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                         optional <a href="#Playlist">Playlist</a>? sourcePlaylist) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removePlaylist(<a href="#PlaylistId">PlaylistId</a> id, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
@@ -647,8 +649,8 @@ tizen.content.getDirectories(getDirectoriesCB, errorCB);
 <div class="brief">
  Finds contents that satisfy the conditions set by a filter.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#ContentArraySuccessCallback">ContentArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
-          optional <a href="#ContentDirectoryId">ContentDirectoryId</a>? directoryId, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter, optional <a href="tizen.html#SortMode">SortMode</a>? sortMode, 
+<div class="synopsis"><pre class="signature prettyprint">void find(<a href="#ContentArraySuccessCallback">ContentArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
+          optional <a href="#ContentDirectoryId">ContentDirectoryId</a>? directoryId, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter, optional <a href="tizen.html#SortMode">SortMode</a>? sortMode,
           optional unsigned long? count, optional unsigned long? offset);</pre></div>
 <p><span class="version">Since: </span>
  2.0
@@ -855,7 +857,7 @@ tizen.filesystem.resolve("images/tizen.jpg", function(imageFile)
 <div class="brief">
  Scans a content directory to create or update content in the content database.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void scanDirectory(DOMString contentDirURI, boolean recursive, optional <a href="#ContentScanSuccessCallback">ContentScanSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void scanDirectory(DOMString contentDirURI, boolean recursive, optional <a href="#ContentScanSuccessCallback">ContentScanSuccessCallback</a>? successCallback,
                    optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1016,8 +1018,7 @@ contain an invalid value (e.g. given <em>contentDirURI</em> is an empty string).
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Identifier of the newly added listener.
               </ul>
 </div>
@@ -1349,7 +1350,7 @@ tizen.content.getPlaylists(getPlaylistsSuccess, getPlaylistsFail);
 <div class="brief">
  Creates a new playlist.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void createPlaylist(DOMString name, <a href="#PlaylistSuccessCallback">PlaylistSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void createPlaylist(DOMString name, <a href="#PlaylistSuccessCallback">PlaylistSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                     optional <a href="#Playlist">Playlist</a>? sourcePlaylist);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -1911,7 +1912,8 @@ tizen.content.find(findCB);
     readonly attribute <a href="#ContentDirectoryId">ContentDirectoryId</a> id;
     readonly attribute DOMString directoryURI;
     readonly attribute DOMString title;
-    readonly attribute Date? modifiedDate;
+<span class="nocode deprecated">    readonly attribute <a href="#ContentDirectoryStorageType">ContentDirectoryStorageType</a> storageType;
+</span>    readonly attribute Date? modifiedDate;
   };</pre>
 <p><span class="version">Since: </span>
  2.0
@@ -2472,8 +2474,7 @@ The attribute is marked as read-only since Tizen 5.5.
 <div class="brief">
  The PlaylistItem interface represents a playlist item.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject]
-  interface PlaylistItem {
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface PlaylistItem {
     readonly attribute <a href="#Content">Content</a> content;
   };</pre>
 <p><span class="version">Since: </span>
@@ -2497,8 +2498,7 @@ The attribute is marked as read-only since Tizen 5.5.
 <div class="brief">
  The Playlist interface represents a playlist.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject]
-  interface Playlist {
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface Playlist {
     readonly attribute <a href="#PlaylistId">PlaylistId</a> id;
     attribute DOMString name raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute long numberOfTracks;
@@ -2954,7 +2954,7 @@ tizen.content.getPlaylists(getPlaylistsSuccess, getPlaylistsFail);
 <div class="brief">
  Gets playlist items from a playlist.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void get(<a href="#PlaylistItemArraySuccessCallback">PlaylistItemArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional long? count, 
+<div class="synopsis"><pre class="signature prettyprint">void get(<a href="#PlaylistItemArraySuccessCallback">PlaylistItemArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional long? count,
          optional long? offset);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -3506,13 +3506,13 @@ It is used in <em>tizen.content.createPlaylist()</em>.
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Content {
-  enum ContentType { "IMAGE", "VIDEO", "AUDIO", "OTHER" };
-  enum AudioContentLyricsType { "SYNCHRONIZED", "UNSYNCHRONIZED" };
-  enum ImageContentOrientation { "NORMAL", "FLIP_HORIZONTAL", "ROTATE_180", "FLIP_VERTICAL", "TRANSPOSE", "ROTATE_90", "TRANSVERSE",
-    "ROTATE_270" };
   typedef DOMString ContentId;
   typedef DOMString ContentDirectoryId;
   typedef DOMString PlaylistId;
+  enum ContentType { "IMAGE", "VIDEO", "AUDIO", "OTHER" };
+  enum AudioContentLyricsType { "SYNCHRONIZED", "UNSYNCHRONIZED" };
+  enum ImageContentOrientation { "NORMAL", "FLIP_HORIZONTAL", "ROTATE_180", "FLIP_VERTICAL", "TRANSPOSE", "ROTATE_90",
+    "TRANSVERSE", "ROTATE_270" };
   [NoInterfaceObject] interface ContentManagerObject {
     readonly attribute <a href="#ContentManager">ContentManager</a> content;
   };
@@ -3610,12 +3610,10 @@ It is used in <em>tizen.content.createPlaylist()</em>.
     readonly attribute unsigned long height;
     readonly attribute <a href="#ImageContentOrientation">ImageContentOrientation</a> orientation;
   };
-  [NoInterfaceObject]
-  interface PlaylistItem {
+  [NoInterfaceObject] interface PlaylistItem {
     readonly attribute <a href="#Content">Content</a> content;
   };
-  [NoInterfaceObject]
-  interface Playlist {
+  [NoInterfaceObject] interface Playlist {
     readonly attribute <a href="#PlaylistId">PlaylistId</a> id;
     attribute DOMString name raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute long numberOfTracks;

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/content.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/content.html
@@ -3513,10 +3513,10 @@ It is used in <em>tizen.content.createPlaylist()</em>.
   enum AudioContentLyricsType { "SYNCHRONIZED", "UNSYNCHRONIZED" };
   enum ImageContentOrientation { "NORMAL", "FLIP_HORIZONTAL", "ROTATE_180", "FLIP_VERTICAL", "TRANSPOSE", "ROTATE_90",
     "TRANSVERSE", "ROTATE_270" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ContentManagerObject">ContentManagerObject</a>;
   [NoInterfaceObject] interface ContentManagerObject {
     readonly attribute <a href="#ContentManager">ContentManager</a> content;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ContentManagerObject">ContentManagerObject</a>;
   [NoInterfaceObject] interface ContentManager {
     void update(<a href="#Content">Content</a> content) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void updateBatch(<a href="#Content">Content</a>[] contents, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/console.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/console.html
@@ -496,10 +496,10 @@ console.timeEnd("Big array initialization");
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Console {
+  Window implements <a href="#ConsoleManagerObject">ConsoleManagerObject</a>;
   [NoInterfaceObject] interface ConsoleManagerObject {
     readonly attribute <a href="#ConsoleManager">ConsoleManager</a> console;
   };
-  Window implements <a href="#ConsoleManagerObject">ConsoleManagerObject</a>;
   [NoInterfaceObject] interface ConsoleManager {
     void log(DOMString text);
     void error(DOMString text);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/cordova.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/cordova.html
@@ -99,8 +99,7 @@
 <div class="brief">
  Basic success callback, no parameters.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly,NoInterfaceObject]
-  interface SuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {
     void onsuccess();
   };</pre>
 <div class="methods">
@@ -126,8 +125,7 @@
 <div class="brief">
  Basic error callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="#DOMException">DOMException</a> error);
   };</pre>
 <div class="methods">
@@ -209,12 +207,10 @@
   Window implements <a href="#CordovaManagerObject">CordovaManagerObject</a>;
   [NoInterfaceObject] interface Cordova {
   };
-  [Callback=FunctionOnly,NoInterfaceObject]
-  interface SuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {
     void onsuccess();
   };
-  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="#DOMException">DOMException</a> error);
   };
   interface DOMException {

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/cordova.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/cordova.html
@@ -201,10 +201,10 @@
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Cordova {
+  Window implements <a href="#CordovaManagerObject">CordovaManagerObject</a>;
   [NoInterfaceObject] interface CordovaManagerObject {
     readonly attribute <a href="#Cordova">Cordova</a> cordova;
   };
-  Window implements <a href="#CordovaManagerObject">CordovaManagerObject</a>;
   [NoInterfaceObject] interface Cordova {
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/device-motion.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/device-motion.html
@@ -543,10 +543,10 @@ To guarantee that the DeviceMotion application runs on a device with the DeviceM
   dictionary AccelerationOptions {
     long frequency;
   };
+  Navigator implements <a href="#AccelerometerManagerObject">AccelerometerManagerObject</a>;
   [NoInterfaceObject] interface AccelerometerManagerObject {
     readonly attribute <a href="#Accelerometer">Accelerometer</a> accelerometer;
   };
-  Navigator implements <a href="#AccelerometerManagerObject">AccelerometerManagerObject</a>;
   [NoInterfaceObject] interface Accelerometer {
     void getCurrentAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     DOMString watchAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#AccelerationOptions">AccelerationOptions</a>? options)

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/device-motion.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/device-motion.html
@@ -110,10 +110,10 @@ Original documentation: <a href="https://cordova.apache.org/docs/en/3.0.0/cordov
  The Accelerometer object captures device motion in the x, y, and z direction.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface Accelerometer {
-    void getCurrentAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+    void getCurrentAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     DOMString watchAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#AccelerationOptions">AccelerationOptions</a>? options)
-                                raises();
-    void clearWatch(DOMString watchID) raises();
+                                raises(TypeError);
+    void clearWatch(DOMString watchID) raises(TypeError);
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -226,8 +226,7 @@ Timestamp: 1456480118000
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  DOMString The watch id that must be passed to <a href="device-motion.html#Accelerometer::clearWatch">clearWatch</a> to stop watching.
               </ul>
 </div>
@@ -494,8 +493,7 @@ Acceleration values include the effect of gravity (9.81 m/s^2), so that when a d
 <div class="brief">
  Basic error callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };</pre>
 <div class="methods">
@@ -542,15 +540,18 @@ To guarantee that the DeviceMotion application runs on a device with the DeviceM
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module DeviceMotion {
+  dictionary AccelerationOptions {
+    long frequency;
+  };
   [NoInterfaceObject] interface AccelerometerManagerObject {
     readonly attribute <a href="#Accelerometer">Accelerometer</a> accelerometer;
   };
   Navigator implements <a href="#AccelerometerManagerObject">AccelerometerManagerObject</a>;
   [NoInterfaceObject] interface Accelerometer {
-    void getCurrentAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+    void getCurrentAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     DOMString watchAcceleration(<a href="#AccelerometerSuccessCallback">AccelerometerSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#AccelerationOptions">AccelerationOptions</a>? options)
-                                raises();
-    void clearWatch(DOMString watchID) raises();
+                                raises(TypeError);
+    void clearWatch(DOMString watchID) raises(TypeError);
   };
   [NoInterfaceObject] interface Acceleration {
     readonly attribute double x;
@@ -558,14 +559,10 @@ To guarantee that the DeviceMotion application runs on a device with the DeviceM
     readonly attribute double z;
     readonly attribute long timestamp;
   };
-  dictionary AccelerationOptions {
-    long frequency;
-  };
   [Callback=FunctionOnly, NoInterfaceObject] interface AccelerometerSuccessCallback {
     void onsuccess(<a href="#Acceleration">Acceleration</a> acceleration);
   };
-  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/device.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/device.html
@@ -245,10 +245,10 @@ function onDeviceReady()
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Device {
+  Window implements <a href="#DeviceManagerObject">DeviceManagerObject</a>;
   [NoInterfaceObject] interface DeviceManagerObject {
     readonly attribute <a href="#Device">Device</a> device;
   };
-  Window implements <a href="#DeviceManagerObject">DeviceManagerObject</a>;
   [NoInterfaceObject] interface Device {
     readonly attribute DOMString cordova;
     readonly attribute DOMString model;

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/dialogs.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/dialogs.html
@@ -469,10 +469,10 @@ the index uses one-based indexing, so the values could be 1, 2, 3, etc.
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Dialogs {
+  Navigator implements <a href="#DialogsManagerObject">DialogsManagerObject</a>;
   [NoInterfaceObject] interface DialogsManagerObject {
     readonly attribute <a href="#DialogsManager">DialogsManager</a> notification;
   };
-  Navigator implements <a href="#DialogsManagerObject">DialogsManagerObject</a>;
   [NoInterfaceObject] interface DialogsManager {
     void alert(DOMString message, <a href="cordova.html#SuccessCallback">SuccessCallback</a> alertCallback, optional DOMString? title, optional DOMString? buttonName);
     void confirm(DOMString message, <a href="#ConfirmCallback">ConfirmCallback</a> confirmCallback, optional DOMString? title, optional DOMString[]? buttonNames);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/dialogs.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/dialogs.html
@@ -239,7 +239,7 @@ navigator.notification.confirm(
 <div class="brief">
  Shows a custom confirm box with set of buttons.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void prompt(DOMString message, <a href="#PromptCallback">PromptCallback</a> promptCallback, optional DOMString? title, optional DOMString[]? buttonNames, 
+<div class="synopsis"><pre class="signature prettyprint">void prompt(DOMString message, <a href="#PromptCallback">PromptCallback</a> promptCallback, optional DOMString? title, optional DOMString[]? buttonNames,
             optional DOMString? defaultText);</pre></div>
 <p><span class="version">Since: </span>
  3.0

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/events.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/events.html
@@ -194,8 +194,7 @@ offline            </td>
 <div class="brief">
  Callback for the event which fires when Cordova is fully loaded
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface DeviceReadyEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface DeviceReadyEventCallback {
     void ondeviceready();
   };</pre>
 <p><span class="version">Since: </span>
@@ -238,8 +237,7 @@ function onDeviceReady()
 <div class="brief">
  Callback for the event which fires when an application is put into the background
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface PauseEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface PauseEventCallback {
     void onpause();
   };</pre>
 <p><span class="version">Since: </span>
@@ -281,8 +279,7 @@ function onPause()
 <div class="brief">
  Callback for the event which fires when an application is retrieved from the background
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface ResumeEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface ResumeEventCallback {
     void onresume();
   };</pre>
 <p><span class="version">Since: </span>
@@ -324,8 +321,7 @@ function onResume()
 <div class="brief">
  Callback for the event which fires when the user presses the back button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface BackButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface BackButtonEventCallback {
     void onbackbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -365,8 +361,7 @@ function onBackKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the menu button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface MenuButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface MenuButtonEventCallback {
     void onmenubutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -408,8 +403,7 @@ function onMenuKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the search button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface SearchButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface SearchButtonEventCallback {
     void onsearchbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -451,8 +445,7 @@ function onSearchKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the start call button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface StartCallEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface StartCallEventCallback {
     void onstartcallbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -494,8 +487,7 @@ function onStartCallKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the end call button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface EndCallButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface EndCallButtonEventCallback {
     void onendcallbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -537,8 +529,7 @@ function onEndCallKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the volume down button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface VolumeDownButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface VolumeDownButtonEventCallback {
     void onvolumedownbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -580,8 +571,7 @@ function onVolumeDownKeyDown()
 <div class="brief">
  Callback for the event which fires when the user presses the volume up button
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface VolumeUpButtonEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface VolumeUpButtonEventCallback {
     void onvolumeupbutton();
   };</pre>
 <p><span class="version">Since: </span>
@@ -621,44 +611,33 @@ function onVolumeUpKeyDown()
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Events {
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface DeviceReadyEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface DeviceReadyEventCallback {
     void ondeviceready();
-  };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface PauseEventCallback {
+  };  [NoInterfaceObject, Callback=FunctionOnly] interface PauseEventCallback {
     void onpause();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface ResumeEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface ResumeEventCallback {
     void onresume();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface BackButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface BackButtonEventCallback {
     void onbackbutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface MenuButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface MenuButtonEventCallback {
     void onmenubutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface SearchButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface SearchButtonEventCallback {
     void onsearchbutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface StartCallEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface StartCallEventCallback {
     void onstartcallbutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface EndCallButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface EndCallButtonEventCallback {
     void onendcallbutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface VolumeDownButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface VolumeDownButtonEventCallback {
     void onvolumedownbutton();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface VolumeUpButtonEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface VolumeUpButtonEventCallback {
     void onvolumeupbutton();
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/events.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/events.html
@@ -613,7 +613,8 @@ function onVolumeUpKeyDown()
 <pre class="webidl prettyprint">module Events {
   [NoInterfaceObject, Callback=FunctionOnly] interface DeviceReadyEventCallback {
     void ondeviceready();
-  };  [NoInterfaceObject, Callback=FunctionOnly] interface PauseEventCallback {
+  };
+  [NoInterfaceObject, Callback=FunctionOnly] interface PauseEventCallback {
     void onpause();
   };
   [NoInterfaceObject, Callback=FunctionOnly] interface ResumeEventCallback {

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/file.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/file.html
@@ -323,7 +323,7 @@ See <a href="https://www.w3.org/TR/FileAPI/#blob-section">The Blob Interface and
 <pre class="webidl prettyprint">  dictionary ProgressEventInit {
     unsigned long long loaded = false;
     unsigned long long total = false;
-     target = null;
+    EventTarget target = null;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -1059,9 +1059,9 @@ The specifics of naming filesystems is unspecified, but a name must be unique ac
     const short TEMPORARY = 0;
     const short PERSISTENT = 1;
     void requestFileSystem(short type, long long size, optional <a href="#FileSystemCallback">FileSystemCallback</a>? successCallback,
-                           optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback) raises();
+                           optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback) raises(TypeError);
     void resolveLocalFileSystemURL(DOMString uri, optional <a href="#EntryCallback">EntryCallback</a>? successCallback, optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback)
-                                   raises();
+                                   raises(TypeError);
   };</pre>
 <pre class="webidl prettyprint">  Window implements <a href="#LocalFileSystem">LocalFileSystem</a>;</pre>
 <p><span class="version">Since: </span>
@@ -1106,7 +1106,7 @@ The specifics of naming filesystems is unspecified, but a name must be unique ac
 <div class="brief">
  Request a file system in which to store application data.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void requestFileSystem(short type, long long size, optional <a href="#FileSystemCallback">FileSystemCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void requestFileSystem(short type, long long size, optional <a href="#FileSystemCallback">FileSystemCallback</a>? successCallback,
                        optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1239,13 +1239,13 @@ resolveLocalFileSystemURL(uri, successCallback, errorCallback);
     readonly attribute DOMString fullPath;
     readonly attribute DOMString name;
     readonly attribute <a href="#FileSystem">FileSystem</a> filesystem;
-    void getMetadata(<a href="#MetadataCallback">MetadataCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+    void getMetadata(<a href="#MetadataCallback">MetadataCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
     void moveTo(<a href="#DirectoryEntry">DirectoryEntry</a> parent, optional DOMString? newName, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                raises();
+                raises(FileException);
     void copyTo(<a href="#DirectoryEntry">DirectoryEntry</a> parent, optional DOMString? newName, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                raises();
-    void getParent(<a href="#EntryCallback">EntryCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
-    void remove(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+                raises(FileException);
+    void getParent(<a href="#EntryCallback">EntryCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
+    void remove(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
     DOMString toURL();
   };</pre>
 <p><span class="version">Since: </span>
@@ -1708,8 +1708,7 @@ requestFileSystem(TEMPORARY, 100, function(fs)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  URL that can be used to identify this entry.
               </ul>
 </div>
@@ -1740,10 +1739,10 @@ requestFileSystem(TEMPORARY, 100, function(fs)
 <pre class="webidl prettyprint">  interface DirectoryEntry : <a href="#Entry">Entry</a> {
     <a href="#DirectoryReader">DirectoryReader</a> createReader();
     void getDirectory(DOMString path, optional ? options, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                      raises();
+                      raises(FileException);
     void getFile(DOMString path, optional ? options, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                 raises();
-    void removeRecursively(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+                 raises(FileException);
+    void removeRecursively(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -1772,8 +1771,7 @@ requestFileSystem(TEMPORARY, 100, function(fs)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DirectoryReader:
-                  </span>
+<span class="return">DirectoryReader:</span>
  DirectoryReader.
               </ul>
 </div>
@@ -2009,7 +2007,7 @@ Otherwise, if no other error occurs, getFile must return a FileEntry correspondi
  The DirectoryReader interface provides access to the Filesystem API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface DirectoryReader {
-    void readEntries(<a href="#EntriesCallback">EntriesCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+    void readEntries(<a href="#EntriesCallback">EntriesCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
   };</pre>
 <p><span class="privilegelevel">Privilege level: </span>
  public
@@ -2224,10 +2222,10 @@ Otherwise, if no other error occurs, getFile must return a FileEntry correspondi
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onerror;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onloadend;
     void abort();
-    void readAsDataURL(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
-    void readAsText(<a href="#Blob">Blob</a> blob, optional DOMString? label) raises(, <a href="#FileError">FileError</a>);
-    void readAsBinaryString(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
-    void readAsArrayBuffer(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
+    void readAsDataURL(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsText(<a href="#Blob">Blob</a> blob, optional DOMString? label) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsBinaryString(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsArrayBuffer(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -2683,10 +2681,10 @@ ByteLength: 3
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onabort;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onerror;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onwriteend;
-    void abort() raises();
-    void seek(long offset) raises();
-    void truncate(long size) raises();
-    void write(<a href="#WriteData">WriteData</a> data) raises();
+    void abort() raises(FileException);
+    void seek(long offset) raises(FileException);
+    void truncate(long size) raises(FileException);
+    void write(<a href="#WriteData">WriteData</a> data) raises(FileException);
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -3459,7 +3457,7 @@ entry.createWriter(successCallback, errorCallback);
   dictionary ProgressEventInit {
     unsigned long long loaded = false;
     unsigned long long total = false;
-     target = null;
+    EventTarget target = null;
   };
   [Constructor(DOMString type, optional <a href="#ProgressEventInit">ProgressEventInit</a> eventInitDict)]
   interface ProgressEvent {
@@ -3472,10 +3470,10 @@ entry.createWriter(successCallback, errorCallback);
     readonly attribute unsigned long long total;
     readonly attribute  target;
   };
+  Cordova implements <a href="#ProgressEvent">ProgressEvent</a>;
   [NoInterfaceObject] interface FileSystemManagerObject {
     readonly attribute <a href="#FileSystemManager">FileSystemManager</a> file;
   };
-  <a href="cordova.html#Cordova">Cordova</a> implements <a href="#FileSystemManagerObject">FileSystemManagerObject</a>;
   [NoInterfaceObject] interface FileSystemManager {
     readonly attribute DOMString? applicationDirectory;
     readonly attribute DOMString? applicationStorageDirectory;
@@ -3524,36 +3522,35 @@ entry.createWriter(successCallback, errorCallback);
     const short TEMPORARY = 0;
     const short PERSISTENT = 1;
     void requestFileSystem(short type, long long size, optional <a href="#FileSystemCallback">FileSystemCallback</a>? successCallback,
-                           optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback) raises();
+                           optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback) raises(TypeError);
     void resolveLocalFileSystemURL(DOMString uri, optional <a href="#EntryCallback">EntryCallback</a>? successCallback, optional <a href="#ErrorCallback">ErrorCallback</a>? errorCallback)
-                                   raises();
+                                   raises(TypeError);
   };
-  Window implements <a href="#LocalFileSystem">LocalFileSystem</a>;
   [NoInterfaceObject] interface Entry {
     readonly attribute boolean isFile;
     readonly attribute boolean isDirectory;
     readonly attribute DOMString fullPath;
     readonly attribute DOMString name;
     readonly attribute <a href="#FileSystem">FileSystem</a> filesystem;
-    void getMetadata(<a href="#MetadataCallback">MetadataCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+    void getMetadata(<a href="#MetadataCallback">MetadataCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
     void moveTo(<a href="#DirectoryEntry">DirectoryEntry</a> parent, optional DOMString? newName, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                raises();
+                raises(FileException);
     void copyTo(<a href="#DirectoryEntry">DirectoryEntry</a> parent, optional DOMString? newName, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                raises();
-    void getParent(<a href="#EntryCallback">EntryCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
-    void remove(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+                raises(FileException);
+    void getParent(<a href="#EntryCallback">EntryCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
+    void remove(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
     DOMString toURL();
   };
   interface DirectoryEntry : <a href="#Entry">Entry</a> {
     <a href="#DirectoryReader">DirectoryReader</a> createReader();
     void getDirectory(DOMString path, optional ? options, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                      raises();
+                      raises(FileException);
     void getFile(DOMString path, optional ? options, optional <a href="#EntryCallback">EntryCallback</a>? onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror)
-                 raises();
-    void removeRecursively(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+                 raises(FileException);
+    void removeRecursively(<a href="#VoidCallback">VoidCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
   };
   [NoInterfaceObject] interface DirectoryReader {
-    void readEntries(<a href="#EntriesCallback">EntriesCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises();
+    void readEntries(<a href="#EntriesCallback">EntriesCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
   };
   [NoInterfaceObject] interface FileEntry : <a href="#Entry">Entry</a> {
     void createWriter(<a href="#FileWriterCallback">FileWriterCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror);
@@ -3573,10 +3570,10 @@ entry.createWriter(successCallback, errorCallback);
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onerror;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onloadend;
     void abort();
-    void readAsDataURL(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
-    void readAsText(<a href="#Blob">Blob</a> blob, optional DOMString? label) raises(, <a href="#FileError">FileError</a>);
-    void readAsBinaryString(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
-    void readAsArrayBuffer(<a href="#Blob">Blob</a> blob) raises(, <a href="#FileError">FileError</a>);
+    void readAsDataURL(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsText(<a href="#Blob">Blob</a> blob, optional DOMString? label) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsBinaryString(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
+    void readAsArrayBuffer(<a href="#Blob">Blob</a> blob) raises(TypeError, <a href="#FileError">FileError</a>);
   };
   [NoInterfaceObject] interface FileWriter {
     const short INIT = 0;
@@ -3592,10 +3589,10 @@ entry.createWriter(successCallback, errorCallback);
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onabort;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onerror;
     attribute <a href="#ProgressCallback">ProgressCallback</a>? onwriteend;
-    void abort() raises();
-    void seek(long offset) raises();
-    void truncate(long size) raises();
-    void write(<a href="#WriteData">WriteData</a> data) raises();
+    void abort() raises(FileException);
+    void seek(long offset) raises(FileException);
+    void truncate(long size) raises(FileException);
+    void write(<a href="#WriteData">WriteData</a> data) raises(FileException);
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface ProgressCallback {
     void onsuccess(<a href="#ProgressEvent">ProgressEvent</a> event);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/file.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/file.html
@@ -3459,6 +3459,8 @@ entry.createWriter(successCallback, errorCallback);
     unsigned long long total = false;
     EventTarget target = null;
   };
+  Cordova implements <a href="#FileSystemManagerObject">FileSystemManagerObject</a>;
+  Window implements <a href="#LocalFileSystem">LocalFileSystem</a>;
   [Constructor(DOMString type, optional <a href="#ProgressEventInit">ProgressEventInit</a> eventInitDict)]
   interface ProgressEvent {
     readonly attribute DOMString type;
@@ -3470,7 +3472,6 @@ entry.createWriter(successCallback, errorCallback);
     readonly attribute unsigned long long total;
     readonly attribute  target;
   };
-  Cordova implements <a href="#ProgressEvent">ProgressEvent</a>;
   [NoInterfaceObject] interface FileSystemManagerObject {
     readonly attribute <a href="#FileSystemManager">FileSystemManager</a> file;
   };

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/filetransfer.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/filetransfer.html
@@ -227,7 +227,7 @@ Sent = 1024
 <div class="constructors">
 <h4 id="FileUploadOptions::constructor">Constructors</h4>
 <dl>
-<pre class="webidl prettyprint">FileUploadOptions(DOMString fileKey, DOMString fileName, DOMString mimeType, <a href="#FileUploadParams">FileUploadParams</a> params, <a href="#HeaderFields">HeaderFields</a> headers, 
+<pre class="webidl prettyprint">FileUploadOptions(DOMString fileKey, DOMString fileName, DOMString mimeType, <a href="#FileUploadParams">FileUploadParams</a> params, <a href="#HeaderFields">HeaderFields</a> headers,
                   DOMString httpMethod);</pre>
 <div class="example">
 <span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">/* Creates a FileUploadOptions objects */
@@ -349,7 +349,7 @@ var options = new FileUploadOptions("file", "doc.txt", "text/plain", null, null,
     attribute long bytesSent;
     attribute long responseCode;
     attribute DOMString response;
-    attribute <a href="#HeaderFields">HeaderFields</a>  headers;
+    attribute <a href="#HeaderFields">HeaderFields</a> headers;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -428,17 +428,17 @@ var options = new FileUploadOptions("file", "doc.txt", "text/plain", null, null,
  A FileTransferError object is passed to an error callback when an error occurs.
           </div>
 <pre class="webidl prettyprint">  interface FileTransferError {
+    const short FILE_NOT_FOUND_ERR = 1;
+    const short INVALID_URL_ERR = 2;
+    const short CONNECTION_ERR = 3;
+    const short ABORT_ERR = 4;
+    const short NOT_MODIFIED_ERR = 5;
     attribute short code;
     attribute DOMString source;
     attribute DOMString target;
     attribute long http_status;
     attribute DOMString body;
     attribute DOMString _exception;
-    const short FILE_NOT_FOUND_ERR = 1;
-    const short INVALID_URL_ERR = 2;
-    const short CONNECTION_ERR = 3;
-    const short ABORT_ERR = 4;
-    const short NOT_MODIFIED_ERR = 5;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -684,8 +684,8 @@ Success. File uploaded
 <div class="brief">
  Sends a file to a server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void upload(DOMString fileURL, DOMString server, optional <a href="#FileUploadSuccessCallback">FileUploadSuccessCallback</a>? successCallback, 
-            optional <a href="#FileTransferErrorCallback">FileTransferErrorCallback</a>? errorCallback, optional <a href="#FileUploadOptions">FileUploadOptions</a>? options, 
+<div class="synopsis"><pre class="signature prettyprint">void upload(DOMString fileURL, DOMString server, optional <a href="#FileUploadSuccessCallback">FileUploadSuccessCallback</a>? successCallback,
+            optional <a href="#FileTransferErrorCallback">FileTransferErrorCallback</a>? errorCallback, optional <a href="#FileUploadOptions">FileUploadOptions</a>? options,
             optional boolean? trustAllHosts);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -763,8 +763,8 @@ Sent = 1024
 <div class="brief">
  Downloads a file from a server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void download(DOMString source, DOMString target, optional <a href="#FileDownloadSuccessCallback">FileDownloadSuccessCallback</a>? successCallback, 
-              optional <a href="#FileTransferErrorCallback">FileTransferErrorCallback</a>? errorCallback, optional boolean? trustAllHosts, 
+<div class="synopsis"><pre class="signature prettyprint">void download(DOMString source, DOMString target, optional <a href="#FileDownloadSuccessCallback">FileDownloadSuccessCallback</a>? successCallback,
+              optional <a href="#FileTransferErrorCallback">FileTransferErrorCallback</a>? errorCallback, optional boolean? trustAllHosts,
               optional <a href="#FileDownloadOptions">FileDownloadOptions</a>? options);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1016,25 +1016,24 @@ Upload error target http://some.server.com/file.txt
     attribute <a href="#FileUploadParams">FileUploadParams</a> params;
     attribute boolean chunkedMode;
     attribute <a href="#HeaderFields">HeaderFields</a> headers;
-  };
-  [NoInterfaceObject] interface FileUploadResult {
+  };  [NoInterfaceObject] interface FileUploadResult {
     attribute long bytesSent;
     attribute long responseCode;
     attribute DOMString response;
-    attribute <a href="#HeaderFields">HeaderFields</a>  headers;
+    attribute <a href="#HeaderFields">HeaderFields</a> headers;
   };
   interface FileTransferError {
+    const short FILE_NOT_FOUND_ERR = 1;
+    const short INVALID_URL_ERR = 2;
+    const short CONNECTION_ERR = 3;
+    const short ABORT_ERR = 4;
+    const short NOT_MODIFIED_ERR = 5;
     attribute short code;
     attribute DOMString source;
     attribute DOMString target;
     attribute long http_status;
     attribute DOMString body;
     attribute DOMString _exception;
-    const short FILE_NOT_FOUND_ERR = 1;
-    const short INVALID_URL_ERR = 2;
-    const short CONNECTION_ERR = 3;
-    const short ABORT_ERR = 4;
-    const short NOT_MODIFIED_ERR = 5;
   };
   [Constructor()]
   interface FileTransfer {

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/filetransfer.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/filetransfer.html
@@ -1016,7 +1016,8 @@ Upload error target http://some.server.com/file.txt
     attribute <a href="#FileUploadParams">FileUploadParams</a> params;
     attribute boolean chunkedMode;
     attribute <a href="#HeaderFields">HeaderFields</a> headers;
-  };  [NoInterfaceObject] interface FileUploadResult {
+  };
+  [NoInterfaceObject] interface FileUploadResult {
     attribute long bytesSent;
     attribute long responseCode;
     attribute DOMString response;

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/globalization.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/globalization.html
@@ -181,25 +181,25 @@ Original documentation: <a href="https://www.npmjs.com/package/cordova-plugin-gl
  the GlobalizationManager interface embodies Globalization module methods.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface GlobalizationManager {
-    void getPreferredLanguage(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void getLocaleName(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+    void getPreferredLanguage(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void getLocaleName(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     void dateToString(Date date, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
-                      raises();
-    void getCurrencyPattern(DOMString currencyCode, <a href="#PatternSuccessCallback">PatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+                      raises(TypeError);
+    void getCurrencyPattern(DOMString currencyCode, <a href="#PatternSuccessCallback">PatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     void getDateNames(<a href="#ArrayStringSuccessCallback">ArrayStringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#GetDateNamesOptions">GetDateNamesOptions</a> options)
-                      raises();
+                      raises(TypeError);
     void getDatePattern(<a href="#GetDatePatternSuccessCallback">GetDatePatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
-                        raises();
-    void getFirstDayOfWeek(<a href="#LongSuccessCallback">LongSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+                        raises(TypeError);
+    void getFirstDayOfWeek(<a href="#LongSuccessCallback">LongSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     void getNumberPattern(<a href="#GetNumberPatternSuccessCallback">GetNumberPatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
-                          raises();
-    void isDayLightSavingsTime(Date date, <a href="#DSTSuccessCallback">DSTSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
+                          raises(TypeError);
+    void isDayLightSavingsTime(Date date, <a href="#DSTSuccessCallback">DSTSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     void numberToString(double number, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
-                        raises();
+                        raises(TypeError);
     void stringToDate(DOMString dateString, <a href="#GlobalizationDateSuccessCallback">GlobalizationDateSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
-                      optional <a href="#DateOptions">DateOptions</a> options) raises();
+                      optional <a href="#DateOptions">DateOptions</a> options) raises(TypeError);
     void stringToNumber(DOMString numberString, <a href="#DoubleSuccessCallback">DoubleSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
-                        optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options) raises();
+                        optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options) raises(TypeError);
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -354,7 +354,7 @@ navigator.globalization.getLocaleName(
 <div class="brief">
  Returns a date formatted as a string according to the client's locale and timezone.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void dateToString(Date date<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint">void dateToString(Date date, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options);</pre></div>
 <p><span class="version">Since: </span>
  3.0
             </p>
@@ -896,7 +896,7 @@ navigator.globalization.isDayLightSavingsTime(new Date(),
  Returns a number formatted as a string
 according to the client's user preferences.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void numberToString(double number<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint">void numberToString(double number, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options);</pre></div>
 <p><span class="version">Since: </span>
  3.0
             </p>
@@ -1014,7 +1014,7 @@ Currency: $1,099.95
 user preferences and calendar using the time zone of the client.
 Returns the corresponding date object.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void stringToDate(DOMString dateString, <a href="#GlobalizationDateSuccessCallback">GlobalizationDateSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, 
+<div class="synopsis"><pre class="signature prettyprint">void stringToDate(DOMString dateString, <a href="#GlobalizationDateSuccessCallback">GlobalizationDateSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
                   optional <a href="#DateOptions">DateOptions</a> options);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1089,7 +1089,7 @@ navigator.globalization.stringToDate("9/25/2012",
  Parses a number formatted as a string according to the client's
 user preferences and returns the corresponding number.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void stringToNumber(DOMString numberString, <a href="#DoubleSuccessCallback">DoubleSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, 
+<div class="synopsis"><pre class="signature prettyprint">void stringToNumber(DOMString numberString, <a href="#DoubleSuccessCallback">DoubleSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
                     optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1998,12 +1998,12 @@ of a NumberPattern object.
 <div class="interface" id="GlobalizationError">
 <a class="backward-compatibility-anchor" name="::Globalization::GlobalizationError"></a><h3>1.19. GlobalizationError</h3>
 <pre class="webidl prettyprint">  interface GlobalizationError {
-    attribute long code;
-    attribute DOMString message;
     const short UNKNOWN_ERROR = 0;
     const short FORMATTING_ERROR = 1;
     const short PARSING_ERROR = 2;
     const short PATTERN_ERROR = 3;
+    attribute long code;
+    attribute DOMString message;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -2093,8 +2093,7 @@ The GlobalizationError interface
 <div class="brief">
  Basic error callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };</pre>
 <div class="methods">
@@ -2127,31 +2126,6 @@ The GlobalizationError interface
 </div>
 <h2 id="full-webidl">2. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Globalization {
-  [NoInterfaceObject] interface GlobalizationManagerObject {
-    readonly attribute <a href="#GlobalizationManager">GlobalizationManager</a> globalization;
-  };
-  Navigator implements <a href="#GlobalizationManagerObject">GlobalizationManagerObject</a>;
-  [NoInterfaceObject] interface GlobalizationManager {
-    void getPreferredLanguage(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void getLocaleName(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void dateToString(Date date, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
-                      raises();
-    void getCurrencyPattern(DOMString currencyCode, <a href="#PatternSuccessCallback">PatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void getDateNames(<a href="#ArrayStringSuccessCallback">ArrayStringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#GetDateNamesOptions">GetDateNamesOptions</a> options)
-                      raises();
-    void getDatePattern(<a href="#GetDatePatternSuccessCallback">GetDatePatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
-                        raises();
-    void getFirstDayOfWeek(<a href="#LongSuccessCallback">LongSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void getNumberPattern(<a href="#GetNumberPatternSuccessCallback">GetNumberPatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
-                          raises();
-    void isDayLightSavingsTime(Date date, <a href="#DSTSuccessCallback">DSTSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises();
-    void numberToString(double number, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
-                        raises();
-    void stringToDate(DOMString dateString, <a href="#GlobalizationDateSuccessCallback">GlobalizationDateSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
-                      optional <a href="#DateOptions">DateOptions</a> options) raises();
-    void stringToNumber(DOMString numberString, <a href="#DoubleSuccessCallback">DoubleSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
-                        optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options) raises();
-  };
   dictionary DateOptions {
     DOMString formatLength;
     DOMString selector;
@@ -2196,6 +2170,31 @@ The GlobalizationError interface
     long second;
     long millisecond;
   };
+  [NoInterfaceObject] interface GlobalizationManagerObject {
+    readonly attribute <a href="#GlobalizationManager">GlobalizationManager</a> globalization;
+  };
+  Navigator implements <a href="#GlobalizationManagerObject">GlobalizationManagerObject</a>;
+  [NoInterfaceObject] interface GlobalizationManager {
+    void getPreferredLanguage(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void getLocaleName(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void dateToString(Date date, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
+                      raises(TypeError);
+    void getCurrencyPattern(DOMString currencyCode, <a href="#PatternSuccessCallback">PatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void getDateNames(<a href="#ArrayStringSuccessCallback">ArrayStringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#GetDateNamesOptions">GetDateNamesOptions</a> options)
+                      raises(TypeError);
+    void getDatePattern(<a href="#GetDatePatternSuccessCallback">GetDatePatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#DateOptions">DateOptions</a> options)
+                        raises(TypeError);
+    void getFirstDayOfWeek(<a href="#LongSuccessCallback">LongSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void getNumberPattern(<a href="#GetNumberPatternSuccessCallback">GetNumberPatternSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
+                          raises(TypeError);
+    void isDayLightSavingsTime(Date date, <a href="#DSTSuccessCallback">DSTSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
+    void numberToString(double number, <a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror, optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options)
+                        raises(TypeError);
+    void stringToDate(DOMString dateString, <a href="#GlobalizationDateSuccessCallback">GlobalizationDateSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
+                      optional <a href="#DateOptions">DateOptions</a> options) raises(TypeError);
+    void stringToNumber(DOMString numberString, <a href="#DoubleSuccessCallback">DoubleSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror,
+                        optional <a href="#NumberPatternOptions">NumberPatternOptions</a> options) raises(TypeError);
+  };
   [Callback=FunctionOnly, NoInterfaceObject] interface DSTSuccessCallback {
     void onsuccess(object properties);
   };
@@ -2224,15 +2223,14 @@ The GlobalizationError interface
     void onsuccess(<a href="#NumberPattern">NumberPattern</a> pattern);
   };
   interface GlobalizationError {
-    attribute long code;
-    attribute DOMString message;
     const short UNKNOWN_ERROR = 0;
     const short FORMATTING_ERROR = 1;
     const short PARSING_ERROR = 2;
     const short PATTERN_ERROR = 3;
+    attribute long code;
+    attribute DOMString message;
   };
-  [Callback=FunctionOnly,NoInterfaceObject]
-  interface ErrorCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/globalization.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/globalization.html
@@ -2170,10 +2170,10 @@ The GlobalizationError interface
     long second;
     long millisecond;
   };
+  Navigator implements <a href="#GlobalizationManagerObject">GlobalizationManagerObject</a>;
   [NoInterfaceObject] interface GlobalizationManagerObject {
     readonly attribute <a href="#GlobalizationManager">GlobalizationManager</a> globalization;
   };
-  Navigator implements <a href="#GlobalizationManagerObject">GlobalizationManagerObject</a>;
   [NoInterfaceObject] interface GlobalizationManager {
     void getPreferredLanguage(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);
     void getLocaleName(<a href="#StringSuccessCallback">StringSuccessCallback</a> onsuccess, <a href="#ErrorCallback">ErrorCallback</a> onerror) raises(TypeError);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/media.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/media.html
@@ -149,7 +149,7 @@ Storage privileges are privacy-related privileges and there is a need of asking 
 <div class="brief">
  The Media interface provides interface and functions to manage audio objects.
               </div>
-<pre class="webidl prettyprint">Media(DOMString src, optional <a href="cordova.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="#MediaErrorCallback">MediaErrorCallback</a>? errorCallback, 
+<pre class="webidl prettyprint">Media(DOMString src, optional <a href="cordova.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="#MediaErrorCallback">MediaErrorCallback</a>? errorCallback,
       optional <a href="#StatusChangeCallback">StatusChangeCallback</a>? mediaStatus);</pre>
 <div class="description">
               <ul>
@@ -786,7 +786,7 @@ setTimeout(function()
 <div class="brief">
  Basic error callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly,NoInterfaceObject] interface MediaErrorCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface MediaErrorCallback {
     void onerror(<a href="#MediaError">MediaError</a> error);
   };</pre>
 <div class="methods">
@@ -933,15 +933,14 @@ If an application uses startRecord() or stopRecord(), declare the following feat
     void startRecord();
     void stopRecord();
     void stop();
-  };
-  interface MediaError {
+  };  interface MediaError {
     const short MEDIA_ERR_ABORTED = 1;
     const short MEDIA_ERR_NETWORK = 2;
     const short MEDIA_ERR_DECODE = 3;
     const short MEDIA_ERR_NONE_SUPPORTED = 4;
     readonly attribute short code;
   };
-  [Callback=FunctionOnly,NoInterfaceObject] interface MediaErrorCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface MediaErrorCallback {
     void onerror(<a href="#MediaError">MediaError</a> error);
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface StatusChangeCallback {

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/media.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/media.html
@@ -933,7 +933,8 @@ If an application uses startRecord() or stopRecord(), declare the following feat
     void startRecord();
     void stopRecord();
     void stop();
-  };  interface MediaError {
+  };
+  interface MediaError {
     const short MEDIA_ERR_ABORTED = 1;
     const short MEDIA_ERR_NETWORK = 2;
     const short MEDIA_ERR_DECODE = 3;

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/networkInformation.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/networkInformation.html
@@ -459,10 +459,10 @@ To guarantee that the NetworkInformation application runs on a device with the N
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module NetworkInformation {
+  Navigator implements <a href="#NetworkInformationManagerObject">NetworkInformationManagerObject</a>;
   [NoInterfaceObject] interface NetworkInformationManagerObject {
     readonly attribute <a href="#NetworkInformationManager">NetworkInformationManager</a> connection;
   };
-  Navigator implements <a href="#NetworkInformationManagerObject">NetworkInformationManagerObject</a>;
   [NoInterfaceObject] interface NetworkInformationManager {
     readonly attribute DOMString type;
   };

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/networkInformation.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/cordova/networkInformation.html
@@ -375,8 +375,7 @@ checkConnection();
 <div class="brief">
  Callback for the event when an application goes online, and the device becomes connected to the Internet.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface OnlineEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface OnlineEventCallback {
     void online();
   };</pre>
 <p><span class="version">Since: </span>
@@ -412,8 +411,7 @@ function onOnline()
 <div class="brief">
  Callback for the event when an application goes offline, and the device is not connected to the Internet.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly]
-  interface OfflineEventCallback {
+<pre class="webidl prettyprint">  [NoInterfaceObject, Callback=FunctionOnly] interface OfflineEventCallback {
     void offline();
   };</pre>
 <p><span class="version">Since: </span>
@@ -478,12 +476,10 @@ To guarantee that the NetworkInformation application runs on a device with the N
     readonly attribute DOMString CELL;
     readonly attribute DOMString NONE;
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface OnlineEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface OnlineEventCallback {
     void online();
   };
-  [NoInterfaceObject, Callback=FunctionOnly]
-  interface OfflineEventCallback {
+  [NoInterfaceObject, Callback=FunctionOnly] interface OfflineEventCallback {
     void offline();
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/datacontrol.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/datacontrol.html
@@ -267,8 +267,7 @@ Data Control API.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DataControlConsumerObject:
-                  </span>
+<span class="return">DataControlConsumerObject:</span>
  The local <em>DataControlConsumerObject</em>.
               </ul>
 </div>
@@ -422,8 +421,7 @@ The data sending implementation determines the actual change data returned to th
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  An identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -613,7 +611,7 @@ removeChangeListener was invoked
 <div class="brief">
  Inserts new rows into a table owned by an SQL-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void insert(unsigned long reqId, <a href="#RowData">RowData</a> insertionData, optional <a href="#DataControlInsertSuccessCallback">DataControlInsertSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void insert(unsigned long reqId, <a href="#RowData">RowData</a> insertionData, optional <a href="#DataControlInsertSuccessCallback">DataControlInsertSuccessCallback</a>? successCallback,
             optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3.2
@@ -698,7 +696,7 @@ catch (err)
 <div class="brief">
  Updates values of a table owned by an SQL-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void update(unsigned long reqId, <a href="#RowData">RowData</a> updateData, DOMString where, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void update(unsigned long reqId, <a href="#RowData">RowData</a> updateData, DOMString where, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback,
             optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3.2
@@ -787,7 +785,7 @@ catch (err)
 <div class="brief">
  Delete rows from a table that is owned by an SQL-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void remove(unsigned long reqId, DOMString where, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void remove(unsigned long reqId, DOMString where, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback,
             optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3.2
@@ -870,8 +868,8 @@ catch (err)
 <div class="brief">
  Selects the specified columns to be queried. The result set of the specified columns is retrieved from a table owned by an SQL-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void select(unsigned long reqId, DOMString[] columns, DOMString where, <a href="#DataControlSelectSuccessCallback">DataControlSelectSuccessCallback</a> successCallback, 
-            optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback, optional unsigned long? page, 
+<div class="synopsis"><pre class="signature prettyprint">void select(unsigned long reqId, DOMString[] columns, DOMString where, <a href="#DataControlSelectSuccessCallback">DataControlSelectSuccessCallback</a> successCallback,
+            optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback, optional unsigned long? page,
             optional unsigned long? maxNumberPerPage, optional DOMString? order);</pre></div>
 <p><span class="version">Since: </span>
  2.3.2
@@ -1022,7 +1020,7 @@ catch (err)
 <div class="brief">
  Adds the value associated with the specified key to a key-values map owned by a MAP-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void addValue(unsigned long reqId, DOMString key, DOMString value, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void addValue(unsigned long reqId, DOMString key, DOMString value, optional <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a>? successCallback,
               optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3.2
@@ -1109,7 +1107,7 @@ catch (err)
 <div class="brief">
  Removes the value associated with the specified key from a key-values map owned by a MAP-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void removeValue(unsigned long reqId, DOMString key, DOMString value, <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void removeValue(unsigned long reqId, DOMString key, DOMString value, <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a> successCallback,
                  optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3.2
@@ -1199,7 +1197,7 @@ catch (err)
 <div class="brief">
  Gets the value associated with the specified key, from a key-values map owned by a MAP-type data control provider.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getValue(unsigned long reqId, DOMString key, <a href="#DataControlGetValueSuccessCallback">DataControlGetValueSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getValue(unsigned long reqId, DOMString key, <a href="#DataControlGetValueSuccessCallback">DataControlGetValueSuccessCallback</a> successCallback,
               optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3.2
@@ -1285,7 +1283,7 @@ catch (err)
 <div class="brief">
  Sets the value associated with the specified key to a new value.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void updateValue(unsigned long reqId, DOMString key, DOMString oldValue, DOMString newValue, 
+<div class="synopsis"><pre class="signature prettyprint">void updateValue(unsigned long reqId, DOMString key, DOMString oldValue, DOMString newValue,
                  <a href="#DataControlSuccessCallback">DataControlSuccessCallback</a> successCallback, optional <a href="#DataControlErrorCallback">DataControlErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3.2
@@ -1664,6 +1662,10 @@ catch (err)
 <pre class="webidl prettyprint">module DataControl {
   enum DataType { "MAP", "SQL" };
   enum EventType { "SQL_UPDATE", "SQL_INSERT", "SQL_DELETE", "MAP_SET", "MAP_ADD", "MAP_REMOVE" };
+  dictionary RowData {
+    DOMString[] columns;
+    DOMString[] values;
+  };
   [NoInterfaceObject] interface DataControlManagerObject {
     readonly attribute <a href="#DataControlManager">DataControlManager</a> datacontrol;
   };
@@ -1718,10 +1720,6 @@ catch (err)
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface DataControlChangeCallback {
     void onsuccess(<a href="#EventType">EventType</a> type, <a href="#RowData">RowData</a> data);
-  };
-  dictionary RowData {
-    DOMString[] columns;
-    DOMString[] values;
   };
 };</pre>
 </div>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/datacontrol.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/datacontrol.html
@@ -1666,10 +1666,10 @@ catch (err)
     DOMString[] columns;
     DOMString[] values;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DataControlManagerObject">DataControlManagerObject</a>;
   [NoInterfaceObject] interface DataControlManagerObject {
     readonly attribute <a href="#DataControlManager">DataControlManager</a> datacontrol;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DataControlManagerObject">DataControlManagerObject</a>;
   [NoInterfaceObject] interface DataControlManager {
     <a href="#DataControlConsumerObject">DataControlConsumerObject</a> getDataControlConsumer(DOMString providerId, DOMString dataId, <a href="#DataType">DataType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/download.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/download.html
@@ -223,7 +223,7 @@ The <em>tizen.download </em>object allows access to the functionality of the Dow
           </p>
 <div class="constructors">
 <h4 id="DownloadRequest::constructor">Constructors</h4>
-<dl><pre class="webidl prettyprint">DownloadRequest(DOMString url, optional DOMString? destination, optional DOMString? fileName, 
+<dl><pre class="webidl prettyprint">DownloadRequest(DOMString url, optional DOMString? destination, optional DOMString? fileName,
                 optional <a href="#DownloadNetworkType">DownloadNetworkType</a>? networkType, optional <a href="#DownloadHTTPHeaderFields">DownloadHTTPHeaderFields</a>? httpHeader);</pre></dl>
 </div>
 <div class="attributes">
@@ -368,8 +368,7 @@ req.httpHeader["X-Agent"] = "Tizen Sample App";
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  An identifier for each download operation.
 If the network is not available for downloading, the return value is -1 since Tizen 2.3.
               </ul>
@@ -607,8 +606,7 @@ tizen.download.resume(downloadId);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DownloadState:
-                  </span>
+<span class="return">DownloadState:</span>
  The current download state of the specified ID.
               </ul>
 </div>
@@ -659,8 +657,7 @@ var state = tizen.download.getState(downloadId);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DownloadRequest:
-                  </span>
+<span class="return">DownloadRequest:</span>
  The download request information of the given ID.
               </ul>
 </div>
@@ -718,8 +715,7 @@ and successfully retrieves the file header.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The MIME type of the downloaded file.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/download.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/download.html
@@ -1010,10 +1010,10 @@ DownloadNetworkType <em>CELLULAR</em> can be available on a cellular-enabled dev
   typedef object DownloadHTTPHeaderFields;
   enum DownloadState { "QUEUED", "DOWNLOADING", "PAUSED", "CANCELED", "COMPLETED", "FAILED" };
   enum DownloadNetworkType { "CELLULAR", "WIFI", "ALL" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DownloadManagerObject">DownloadManagerObject</a>;
   [NoInterfaceObject] interface DownloadManagerObject {
     readonly attribute <a href="#DownloadManager">DownloadManager</a> download;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DownloadManagerObject">DownloadManagerObject</a>;
   [Constructor(DOMString url, optional DOMString? destination, optional DOMString? fileName,
                optional <a href="#DownloadNetworkType">DownloadNetworkType</a>? networkType, optional <a href="#DownloadHTTPHeaderFields">DownloadHTTPHeaderFields</a>? httpHeader)]
   interface DownloadRequest {

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/exif.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/exif.html
@@ -865,18 +865,6 @@ This callback interface specifies a success method with the URI for the thumbnai
   enum WhiteBalanceMode { "AUTO", "MANUAL" };
   enum ExposureProgram { "NOT_DEFINED", "MANUAL", "NORMAL", "APERTURE_PRIORITY", "SHUTTER_PRIORITY", "CREATIVE_PROGRAM",
     "ACTION_PROGRAM", "PORTRAIT_MODE", "LANDSCAPE_MODE" };
-  [NoInterfaceObject] interface ExifManagerObject {
-    readonly attribute <a href="#ExifManager">ExifManager</a> exif;
-  };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ExifManagerObject">ExifManagerObject</a>;
-  [NoInterfaceObject] interface ExifManager {
-    void getExifInfo(DOMString uri, <a href="#ExifInformationSuccessCallback">ExifInformationSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                     raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void saveExifInfo(<a href="#ExifInformation">ExifInformation</a> exifInfo, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getThumbnail(DOMString uri, <a href="#ExifThumbnailSuccessCallback">ExifThumbnailSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
   dictionary ExifInit {
     DOMString uri;
     unsigned long width;
@@ -897,6 +885,18 @@ This callback interface specifies a success method with the URI for the thumbnai
     DOMString gpsProcessingMethod;
     Date gpsTime;
     DOMString userComment;
+  };
+  [NoInterfaceObject] interface ExifManagerObject {
+    readonly attribute <a href="#ExifManager">ExifManager</a> exif;
+  };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ExifManagerObject">ExifManagerObject</a>;
+  [NoInterfaceObject] interface ExifManager {
+    void getExifInfo(DOMString uri, <a href="#ExifInformationSuccessCallback">ExifInformationSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                     raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void saveExifInfo(<a href="#ExifInformation">ExifInformation</a> exifInfo, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void getThumbnail(DOMString uri, <a href="#ExifThumbnailSuccessCallback">ExifThumbnailSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [Constructor(optional <a href="#ExifInit">ExifInit</a>? ExifInitDict)]
   interface ExifInformation {

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/exif.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/exif.html
@@ -886,10 +886,10 @@ This callback interface specifies a success method with the URI for the thumbnai
     Date gpsTime;
     DOMString userComment;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ExifManagerObject">ExifManagerObject</a>;
   [NoInterfaceObject] interface ExifManagerObject {
     readonly attribute <a href="#ExifManager">ExifManager</a> exif;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#ExifManagerObject">ExifManagerObject</a>;
   [NoInterfaceObject] interface ExifManager {
     void getExifInfo(DOMString uri, <a href="#ExifInformationSuccessCallback">ExifInformationSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/feedback.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/feedback.html
@@ -419,10 +419,10 @@ To guarantee the running of the application on a device which supports feedback 
   enum FeedbackPattern { "TAP", "SIP", "KEY0", "KEY1", "KEY2", "KEY3", "KEY4", "KEY5", "KEY6", "KEY7", "KEY8", "KEY9",
     "KEY_STAR", "KEY_SHARP", "KEY_BACK", "HOLD", "HW_TAP", "HW_HOLD", "MESSAGE", "EMAIL", "WAKEUP", "SCHEDULE", "TIMER",
     "GENERAL", "POWERON", "POWEROFF", "CHARGERCONN", "CHARGING_ERROR", "FULLCHARGED", "LOWBATT", "LOCK", "UNLOCK", "VIBRATION_ON", "SILENT_OFF", "BT_CONNECTED", "BT_DISCONNECTED", "LIST_REORDER", "LIST_SLIDER", "VOLUME_KEY" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#FeedbackManagerObject">FeedbackManagerObject</a>;
   [NoInterfaceObject] interface FeedbackManagerObject {
     readonly attribute <a href="#FeedbackManager">FeedbackManager</a> feedback;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#FeedbackManagerObject">FeedbackManagerObject</a>;
   [NoInterfaceObject] interface FeedbackManager {
     void play(<a href="#FeedbackPattern">FeedbackPattern</a> pattern, optional <a href="#FeedbackType">FeedbackType</a>? type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void stop() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/feedback.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/feedback.html
@@ -363,8 +363,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if the pattern is supported, <var>false</var> otherwise.
               </ul>
 </div>
@@ -417,10 +416,9 @@ To guarantee the running of the application on a device which supports feedback 
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Feedback {
   enum FeedbackType { "TYPE_SOUND", "TYPE_VIBRATION" };
-  enum FeedbackPattern { "TAP", "SIP", "KEY0", "KEY1", "KEY2", "KEY3", "KEY4", "KEY5", "KEY6", "KEY7", "KEY8", "KEY9", "KEY_STAR",
-    "KEY_SHARP", "KEY_BACK", "HOLD", "HW_TAP", "HW_HOLD", "MESSAGE", "EMAIL", "WAKEUP", "SCHEDULE", "TIMER", "GENERAL", "POWERON",
-    "POWEROFF", "CHARGERCONN", "CHARGING_ERROR", "FULLCHARGED", "LOWBATT", "LOCK", "UNLOCK", "VIBRATION_ON", "SILENT_OFF",
-    "BT_CONNECTED", "BT_DISCONNECTED", "LIST_REORDER", "LIST_SLIDER", "VOLUME_KEY" };
+  enum FeedbackPattern { "TAP", "SIP", "KEY0", "KEY1", "KEY2", "KEY3", "KEY4", "KEY5", "KEY6", "KEY7", "KEY8", "KEY9",
+    "KEY_STAR", "KEY_SHARP", "KEY_BACK", "HOLD", "HW_TAP", "HW_HOLD", "MESSAGE", "EMAIL", "WAKEUP", "SCHEDULE", "TIMER",
+    "GENERAL", "POWERON", "POWEROFF", "CHARGERCONN", "CHARGING_ERROR", "FULLCHARGED", "LOWBATT", "LOCK", "UNLOCK", "VIBRATION_ON", "SILENT_OFF", "BT_CONNECTED", "BT_DISCONNECTED", "LIST_REORDER", "LIST_SLIDER", "VOLUME_KEY" };
   [NoInterfaceObject] interface FeedbackManagerObject {
     readonly attribute <a href="#FeedbackManager">FeedbackManager</a> feedback;
   };

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/filesystem.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/filesystem.html
@@ -7026,10 +7026,10 @@ This callback interface specifies a success callback with a function taking an a
     Date startCreated;
     Date endCreated;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#FileSystemManagerObject">FileSystemManagerObject</a>;
   [NoInterfaceObject] interface FileSystemManagerObject {
     readonly attribute <a href="#FileSystemManager">FileSystemManager</a> filesystem;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#FileSystemManagerObject">FileSystemManagerObject</a>;
   [NoInterfaceObject] interface FileSystemManager {
     readonly attribute long maxNameLength;
     readonly attribute long maxPathLength;

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/filesystem.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/filesystem.html
@@ -476,7 +476,9 @@ There is a <em>tizen.filesystem </em>object that allows accessing the functional
     boolean isDirectory(<a href="#Path">Path</a> path) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     boolean pathExists(<a href="#Path">Path</a> path) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     DOMString getDirName(DOMString path);
-    void getStorage(DOMString label, <a href="#FileSystemStorageSuccessCallback">FileSystemStorageSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror)
+<span class="nocode deprecated">    void resolve(DOMString location, <a href="#FileSuccessCallback">FileSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, optional <a href="#FileMode">FileMode</a>? mode)
+                 raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void getStorage(DOMString label, <a href="#FileSystemStorageSuccessCallback">FileSystemStorageSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror)
                     raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void listStorages(<a href="#FileSystemStorageArraySuccessCallback">FileSystemStorageArraySuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addStorageStateChangeListener(<a href="#FileSystemStorageSuccessCallback">FileSystemStorageSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror)
@@ -600,8 +602,7 @@ By default, <em>makeParents</em> is equal to <var>true</var>. Its value is ignor
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">FileHandle:
-                  </span>
+<span class="return">FileHandle:</span>
  Object representing open file.
               </ul>
 </div>
@@ -656,7 +657,7 @@ File content: Lorem ipsum dolor sit amet...
 <div class="brief">
  Creates directory pointed by <em>path</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void createDirectory(<a href="#Path">Path</a> path, optional boolean makeParents, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void createDirectory(<a href="#Path">Path</a> path, optional boolean makeParents, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -844,7 +845,7 @@ catch (error)
 <div class="brief">
  Deletes directory or directory tree under the current directory pointed by <em>path</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void deleteDirectory(<a href="#Path">Path</a> path, optional boolean recursive, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void deleteDirectory(<a href="#Path">Path</a> path, optional boolean recursive, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -940,7 +941,7 @@ catch (error)
 <div class="brief">
  Copies file from location pointed by <em>sourcePath</em> to <em>destinationPath</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void copyFile(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void copyFile(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback,
               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1044,7 +1045,7 @@ catch (error)
 <div class="brief">
  Recursively copies directory pointed by <em>sourcePath</em> to <em>destinationPath</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void copyDirectory(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, 
+<div class="synopsis"><pre class="signature prettyprint">void copyDirectory(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite,
                    optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1213,7 +1214,7 @@ file
 <div class="brief">
  Moves file pointed by <em>sourcePath</em> to <em>destinationPath</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void moveFile(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void moveFile(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback,
               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1318,7 +1319,7 @@ catch (error)
 <div class="brief">
  Recursively moves directory pointed by <em>sourcePath</em> to <em>destinationPath</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void moveDirectory(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite, 
+<div class="synopsis"><pre class="signature prettyprint">void moveDirectory(<a href="#Path">Path</a> sourcePath, <a href="#Path">Path</a> destinationPath, optional boolean overwrite,
                    optional <a href="#PathSuccessCallback">PathSuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1519,7 +1520,7 @@ catch (error)
 <div class="brief">
  Lists directory content located in <em>path</em>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void listDirectory(<a href="#Path">Path</a> path, <a href="#ListDirectorySuccessCallback">ListDirectorySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void listDirectory(<a href="#Path">Path</a> path, <a href="#ListDirectorySuccessCallback">ListDirectorySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                    optional <a href="#FileFilter">FileFilter</a>? filter);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1649,8 +1650,7 @@ foo_dir_a
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  <a href="https://tools.ietf.org/html/rfc8089">File URI</a> for given path.
               </ul>
 </div>
@@ -1712,8 +1712,7 @@ file:///mnt/media/SDCardA1/Documents/directory/file.ext
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if <em>path</em> points to a file, <var>false</var> otherwise.
               </ul>
 </div>
@@ -1774,8 +1773,7 @@ file:///mnt/media/SDCardA1/Documents/directory/file.ext
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if <em>path</em> points to a directory, <var>false</var> otherwise.
               </ul>
 </div>
@@ -1836,8 +1834,7 @@ file:///mnt/media/SDCardA1/Documents/directory/file.ext
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if <em>path</em> points to a existing element, <var>false</var> otherwise.
               </ul>
 </div>
@@ -1897,8 +1894,7 @@ Strips trailing '/', then breaks <em>path</em> into two components by last <em>p
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  Path to directory for given path.
               </ul>
 </div>
@@ -2228,8 +2224,7 @@ The watch operation must continue until the removeStorageStateChangeListener() m
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Subscription identifier.
               </ul>
 </div>
@@ -2468,8 +2463,7 @@ Note, that current position indicator value, can be obtained by calling <var>see
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long long:
-                  </span>
+<span class="return">long long:</span>
  File position indicator.
               </ul>
 </div>
@@ -2524,7 +2518,7 @@ Bytes between: 44,55,66
 <div class="brief">
  Sets position indicator in file stream to <var>offset</var>.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void seekNonBlocking(long long offset, optional <a href="#SeekSuccessCallback">SeekSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">void seekNonBlocking(long long offset, optional <a href="#SeekSuccessCallback">SeekSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
                      optional <a href="#BaseSeekPosition">BaseSeekPosition</a> whence);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -2711,8 +2705,7 @@ Reads given number of characters.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  String with data read from file.
               </ul>
 </div>
@@ -2767,7 +2760,7 @@ File content: Lorem ipsum dolor sit amet...
 <div class="brief">
  Reads file content as string.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void readStringNonBlocking(optional <a href="#ReadStringSuccessCallback">ReadStringSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">void readStringNonBlocking(optional <a href="#ReadStringSuccessCallback">ReadStringSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
                            optional long long count, optional DOMString inputEncoding);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -2912,8 +2905,7 @@ Sets file handle position indicator at the end of written data.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long long:
-                  </span>
+<span class="return">long long:</span>
  Number of bytes written (can be more than <em>inputString</em> length for multibyte encodings and will never be less)
               </ul>
 </div>
@@ -2962,7 +2954,7 @@ File content: Lorem ipsum dolor sit amet...
 <div class="brief">
  Writes <var>inputString</var> content to a file.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void writeStringNonBlocking(DOMString inputString, optional <a href="#WriteStringSuccessCallback">WriteStringSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, 
+<div class="synopsis"><pre class="signature prettyprint">void writeStringNonBlocking(DOMString inputString, optional <a href="#WriteStringSuccessCallback">WriteStringSuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror,
                             optional DOMString outputEncoding);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -3098,8 +3090,7 @@ Sets file handle position indicator at the end of read data.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Blob:
-                  </span>
+<span class="return">Blob:</span>
  Blob object with file content.
               </ul>
 </div>
@@ -3482,8 +3473,7 @@ Sets file handle position indicator at the end of read data.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Uint8Array:
-                  </span>
+<span class="return">Uint8Array:</span>
  Read data as Uint8Array.
               </ul>
 </div>
@@ -4286,8 +4276,36 @@ File handle closed
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface File {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface File {
+<span class="nocode deprecated">    readonly attribute <a href="#File">File</a>? parent;
+</span><span class="nocode deprecated">    readonly attribute boolean readOnly;
+</span><span class="nocode deprecated">    readonly attribute boolean isFile;
+</span><span class="nocode deprecated">    readonly attribute boolean isDirectory;
+</span><span class="nocode deprecated">    readonly attribute Date? created;
+</span><span class="nocode deprecated">    readonly attribute Date? modified;
+</span><span class="nocode deprecated">    readonly attribute DOMString path;
+</span><span class="nocode deprecated">    readonly attribute DOMString name;
+</span><span class="nocode deprecated">    readonly attribute DOMString fullPath;
+</span><span class="nocode deprecated">    readonly attribute unsigned long long fileSize;
+</span><span class="nocode deprecated">    readonly attribute long length;
+</span><span class="nocode deprecated">    DOMString toURI() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void listFiles(<a href="#FileArraySuccessCallback">FileArraySuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, optional <a href="#FileFilter">FileFilter</a>? filter)
+                   raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void openStream(<a href="#FileMode">FileMode</a> mode, <a href="#FileStreamSuccessCallback">FileStreamSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, optional DOMString? encoding)
+                    raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void readAsText(<a href="#FileStringSuccessCallback">FileStringSuccessCallback</a> onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror, optional DOMString? encoding)
+                    raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void copyTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
+                optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void moveTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
+                optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    <a href="#File">File</a> createDirectory(DOMString dirPath) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    <a href="#File">File</a> createFile(DOMString relativeFilePath) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    <a href="#File">File</a> resolve(DOMString filePath) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void deleteDirectory(DOMString directoryPath, boolean recursive, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
+                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void deleteFile(DOMString filePath, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -4722,8 +4740,7 @@ These URIs must not be accessible to other widgets, apart from the one invoking 
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  URI that identifies the file or <var>null</var> if an error occurs.
               </ul>
 </div>
@@ -5078,7 +5095,7 @@ directory from a specified location to another specified location.
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
             </p>
-<div class="synopsis"><pre class="signature prettyprint">void copyTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, 
+<div class="synopsis"><pre class="signature prettyprint">void copyTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
             optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -5197,7 +5214,7 @@ This operation is different from instantiating copyTo() and then deleting the or
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
             </p>
-<div class="synopsis"><pre class="signature prettyprint">void moveTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, 
+<div class="synopsis"><pre class="signature prettyprint">void moveTo(DOMString originFilePath, DOMString destinationFilePath, boolean overwrite, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
             optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -5355,8 +5372,7 @@ In case the directory cannot be created, an error must be thrown with the approp
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">File:
-                  </span>
+<span class="return">File:</span>
  File handle of the new directory.
 The new <em>File </em>object has "rw" access rights, as it inherits this from the <em>File </em>object on which the createDirectory() method is called.
               </ul>
@@ -5432,8 +5448,7 @@ In case the file cannot be created, an error must be thrown with the appropriate
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">File:
-                  </span>
+<span class="return">File:</span>
  File handle for the new empty file.
 The new <em>File </em>object has "rw" access rights, as it inherits this from the <em>File </em>object on which the createFile() method is
 called.
@@ -5505,8 +5520,7 @@ The encoding of file paths is <a href="http://www.ietf.org/rfc/rfc2279.txt">UTF-
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">File:
-                  </span>
+<span class="return">File:</span>
  File handle of the file.
 The new <em>File </em>object inherits its access rights from the <em>File </em>object on which this resolve() method is called.
               </ul>
@@ -5562,7 +5576,7 @@ tizen.filesystem.resolve("documents",
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
             </p>
-<div class="synopsis"><pre class="signature prettyprint">void deleteDirectory(DOMString directoryPath, boolean recursive, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, 
+<div class="synopsis"><pre class="signature prettyprint">void deleteDirectory(DOMString directoryPath, boolean recursive, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -5926,8 +5940,18 @@ Read and write operations are performed relative to a position attribute, which 
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface FileStream {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface FileStream {
+<span class="nocode deprecated">    readonly attribute boolean eof;
+</span><span class="nocode deprecated">    attribute long position;
+</span><span class="nocode deprecated">    readonly attribute long bytesAvailable;
+</span><span class="nocode deprecated">    void close();
+</span><span class="nocode deprecated">    DOMString read(long charCount) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    octet[] readBytes(long byteCount) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    DOMString readBase64(long byteCount) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void write(DOMString stringData) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void writeBytes(octet[] byteData) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void writeBase64(DOMString base64Data) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -6089,8 +6113,7 @@ The resulting string length might be shorter than <em>charCount </em>if EOF is <
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  Array of read characters as a string.
               </ul>
 </div>
@@ -6150,8 +6173,7 @@ stream.close();
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">octet[]:
-                  </span>
+<span class="return">octet[]:</span>
  Result of read bytes as a byte (or number) array.
               </ul>
 </div>
@@ -6215,8 +6237,7 @@ for (var i = 0; i &lt; raw.length; i++)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  Array of read characters as base64 encoding string.
               </ul>
 </div>
@@ -6408,8 +6429,9 @@ output.writeBase64(base64);
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileSuccessCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback=FunctionOnly, NoInterfaceObject] interface FileSuccessCallback {
+<span class="nocode deprecated">    void onsuccess(<a href="#File">File</a> file);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -6800,8 +6822,9 @@ It is used in asynchronous operation FileHandle.readDataNonBlocking().
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileStringSuccessCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback=FunctionOnly, NoInterfaceObject] interface FileStringSuccessCallback {
+<span class="nocode deprecated">    void onsuccess(DOMString fileStr);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -6848,8 +6871,9 @@ It is used in asynchronous operation File.readAsText().
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileStreamSuccessCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback=FunctionOnly, NoInterfaceObject] interface FileStreamSuccessCallback {
+<span class="nocode deprecated">    void onsuccess(<a href="#FileStream">FileStream</a> filestream);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -6943,8 +6967,9 @@ This callback interface specifies a success callback with a function taking an a
 <p class="deprecated"><b>Deprecated.</b>
  Since 5.0
           </p>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileArraySuccessCallback {
-  };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Callback=FunctionOnly, NoInterfaceObject] interface FileArraySuccessCallback {
+<span class="nocode deprecated">    void onsuccess(<a href="#File">File</a>[] files);
+</span>  };</span></pre>
 <p><span class="version">Since: </span>
  1.0
           </p>
@@ -6987,11 +7012,20 @@ This callback interface specifies a success callback with a function taking an a
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Filesystem {
   typedef DOMString Path;
+  typedef <a href="#Blob">Blob</a> Blob;
   enum FileMode { "a", "r", "rw", "rwo", "w" };
   enum FileSystemStorageType { "INTERNAL", "EXTERNAL" };
   enum FileSystemStorageState { "MOUNTED", "REMOVED", "UNMOUNTABLE" };
-  typedef <a href="#Blob">Blob</a> Blob;
   enum BaseSeekPosition { "BEGIN", "CURRENT", "END" };
+  dictionary FileFilter {
+    DOMString name;
+    boolean isFile;
+    boolean isDirectory;
+    Date startModified;
+    Date endModified;
+    Date startCreated;
+    Date endCreated;
+  };
   [NoInterfaceObject] interface FileSystemManagerObject {
     readonly attribute <a href="#FileSystemManager">FileSystemManager</a> filesystem;
   };
@@ -7063,15 +7097,6 @@ This callback interface specifies a success callback with a function taking an a
     void syncNonBlocking(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void close() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void closeNonBlocking(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? onsuccess, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? onerror) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  dictionary FileFilter {
-    DOMString name;
-    boolean isFile;
-    boolean isDirectory;
-    Date startModified;
-    Date endModified;
-    Date startCreated;
-    Date endCreated;
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface FileSystemStorageArraySuccessCallback {
     void onsuccess(<a href="#FileSystemStorage">FileSystemStorage</a>[] storages);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/humanactivitymonitor.html
@@ -576,7 +576,7 @@ The <em>tizen.humanactivitymonitor</em> object allows access to the human activi
 <div class="brief">
  Gets the current human activity data for certain human activity types.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getHumanActivityData(<a href="#HumanActivityType">HumanActivityType</a> type, <a href="#HumanActivityMonitorSuccessCallback">HumanActivityMonitorSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getHumanActivityData(<a href="#HumanActivityType">HumanActivityType</a> type, <a href="#HumanActivityMonitorSuccessCallback">HumanActivityMonitorSuccessCallback</a> successCallback,
                           optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -679,7 +679,7 @@ Cumulative total step count: 100
 <div class="brief">
  Starts a sensor and registers a change listener to be called when new human activity data for a given human activity type is available.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void start(<a href="#HumanActivityType">HumanActivityType</a> type, optional <a href="#HumanActivityMonitorSuccessCallback">HumanActivityMonitorSuccessCallback</a>? changedCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void start(<a href="#HumanActivityType">HumanActivityType</a> type, optional <a href="#HumanActivityMonitorSuccessCallback">HumanActivityMonitorSuccessCallback</a>? changedCallback,
            optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="#HumanActivityMonitorOption">HumanActivityMonitorOption</a>? option);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -968,7 +968,7 @@ Calling this function has no effect if listener is not set.
 <div class="brief">
  Registers a listener that is to be called when the activity is recognized.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long addActivityRecognitionListener(<a href="#ActivityRecognitionType">ActivityRecognitionType</a> type, <a href="#HumanActivityMonitorSuccessCallback">HumanActivityMonitorSuccessCallback</a> listener, 
+<div class="synopsis"><pre class="signature prettyprint">long addActivityRecognitionListener(<a href="#ActivityRecognitionType">ActivityRecognitionType</a> type, <a href="#HumanActivityMonitorSuccessCallback">HumanActivityMonitorSuccessCallback</a> listener,
                                     optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3.2
@@ -1002,8 +1002,7 @@ The <em>ErrorCallback</em> method is launched with this error type:
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  ID of the listener that can be used to remove the listener later.
               </ul>
 </div>
@@ -1251,7 +1250,7 @@ catch (err)
 <div class="brief">
  Reads the recorded human activity data with some query.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void readRecorderData(<a href="#HumanActivityRecorderType">HumanActivityRecorderType</a> type, <a href="#HumanActivityRecorderQuery">HumanActivityRecorderQuery</a>? query, 
+<div class="synopsis"><pre class="signature prettyprint">void readRecorderData(<a href="#HumanActivityRecorderType">HumanActivityRecorderType</a> type, <a href="#HumanActivityRecorderQuery">HumanActivityRecorderQuery</a>? query,
                       <a href="#HumanActivityReadRecorderSuccessCallback">HumanActivityReadRecorderSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3.2
@@ -1382,8 +1381,7 @@ This function allows to check whether a gesture type is supported on the current
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if the given gesture type is supported.
               </ul>
 </div>
@@ -1423,7 +1421,7 @@ catch (error)
 <div class="brief">
  Adds a listener to be invoked when given gesture type is detected.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long addGestureRecognitionListener(<a href="#GestureType">GestureType</a> type, <a href="#GestureRecognitionCallback">GestureRecognitionCallback</a> listener, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, 
+<div class="synopsis"><pre class="signature prettyprint">long addGestureRecognitionListener(<a href="#GestureType">GestureType</a> type, <a href="#GestureRecognitionCallback">GestureRecognitionCallback</a> listener, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback,
                                    optional boolean? alwaysOn);</pre></div>
 <p><span class="version">Since: </span>
  4.0
@@ -1461,8 +1459,7 @@ The <em>ErrorCallback</em> method is launched with this error type:
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The watch ID used to remove the listener.
               </ul>
 </div>
@@ -1718,8 +1715,7 @@ Within the range 10-15                </td>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The watch ID used to remove the listener.
               </ul>
 </div>
@@ -3184,17 +3180,30 @@ To guarantee that the stress monitor vector sensor application runs on a device 
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module HumanActivityMonitor {
-  enum HumanActivityType { "PEDOMETER", "WRIST_UP", "HRM", "GPS", "SLEEP_MONITOR", "SLEEP_DETECTOR", "STRESS_MONITOR" };
+  enum HumanActivityType { "PEDOMETER", "HRM", "GPS", "SLEEP_MONITOR", "SLEEP_DETECTOR", "STRESS_MONITOR" };
   enum HumanActivityRecorderType { "PEDOMETER", "HRM", "SLEEP_MONITOR", "PRESSURE" };
   enum PedometerStepStatus { "NOT_MOVING", "WALKING", "RUNNING", "UNKNOWN" };
   enum ActivityRecognitionType { "STATIONARY", "WALKING", "RUNNING", "IN_VEHICLE" };
   enum ActivityAccuracy { "LOW", "MEDIUM", "HIGH" };
   enum SleepStatus { "ASLEEP", "AWAKE", "UNKNOWN" };
-  enum GestureType { "GESTURE_DOUBLE_TAP", "GESTURE_MOVE_TO_EAR", "GESTURE_NO_MOVE", "GESTURE_PICK_UP", "GESTURE_SHAKE", "GESTURE_SNAP",
-    "GESTURE_TILT", "GESTURE_TURN_FACE_DOWN", "GESTURE_WRIST_UP" };
+  enum GestureType { "GESTURE_DOUBLE_TAP", "GESTURE_MOVE_TO_EAR", "GESTURE_NO_MOVE", "GESTURE_PICK_UP", "GESTURE_SHAKE",
+    "GESTURE_SNAP", "GESTURE_TILT", "GESTURE_TURN_FACE_DOWN", "GESTURE_WRIST_UP" };
   enum GestureEvent { "GESTURE_EVENT_DETECTED", "GESTURE_SHAKE_DETECTED", "GESTURE_SHAKE_FINISHED", "GESTURE_SNAP_X_NEGATIVE",
-    "GESTURE_SNAP_X_POSITIVE", "GESTURE_SNAP_Y_NEGATIVE", "GESTURE_SNAP_Y_POSITIVE", "GESTURE_SNAP_Z_NEGATIVE",
-    "GESTURE_SNAP_Z_POSITIVE" };
+    "GESTURE_SNAP_X_POSITIVE", "GESTURE_SNAP_Y_NEGATIVE", "GESTURE_SNAP_Y_POSITIVE", "GESTURE_SNAP_Z_NEGATIVE", "GESTURE_SNAP_Z_POSITIVE" };
+  dictionary HumanActivityRecorderOption {
+    long interval;
+    long retentionPeriod;
+  };
+  dictionary HumanActivityRecorderQuery {
+    long startTime;
+    long endTime;
+    long anchorTime;
+    long interval;
+  };
+  dictionary HumanActivityMonitorOption {
+    long callbackInterval;
+    long sampleInterval;
+  };
   [NoInterfaceObject] interface HumanActivityMonitorManagerObject {
     readonly attribute <a href="#HumanActivityMonitorManager">HumanActivityMonitorManager</a> humanactivitymonitor;
   };
@@ -3225,16 +3234,6 @@ To guarantee that the stress monitor vector sensor application runs on a device 
   [NoInterfaceObject] interface StepDifference {
     readonly attribute long stepCountDifference;
     readonly attribute long timestamp;
-  };
-  dictionary HumanActivityRecorderOption {
-    long interval;
-    long retentionPeriod;
-  };
-  dictionary HumanActivityRecorderQuery {
-    long startTime;
-    long endTime;
-    long anchorTime;
-    long interval;
   };
   [NoInterfaceObject] interface HumanActivityData {
   };
@@ -3284,10 +3283,6 @@ To guarantee that the stress monitor vector sensor application runs on a device 
   };
   [NoInterfaceObject] interface HumanActivityStressMonitorData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute long stressScore;
-  };
-  dictionary HumanActivityMonitorOption {
-    long callbackInterval;
-    long sampleInterval;
   };
   [NoInterfaceObject] interface HumanActivityRecognitionData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#ActivityRecognitionType">ActivityRecognitionType</a> type;

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/humanactivitymonitor.html
@@ -3204,10 +3204,10 @@ To guarantee that the stress monitor vector sensor application runs on a device 
     long callbackInterval;
     long sampleInterval;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#HumanActivityMonitorManagerObject">HumanActivityMonitorManagerObject</a>;
   [NoInterfaceObject] interface HumanActivityMonitorManagerObject {
     readonly attribute <a href="#HumanActivityMonitorManager">HumanActivityMonitorManager</a> humanactivitymonitor;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#HumanActivityMonitorManagerObject">HumanActivityMonitorManagerObject</a>;
   [NoInterfaceObject] interface HumanActivityMonitorManager {
     void getHumanActivityData(<a href="#HumanActivityType">HumanActivityType</a> type, <a href="#HumanActivityMonitorSuccessCallback">HumanActivityMonitorSuccessCallback</a> successCallback,
                               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/inputdevice.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/inputdevice.html
@@ -539,10 +539,10 @@ tizen.inputdevice.unregisterKeyBatch(keys, successCB, errorCB);
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module InputDevice {
   typedef DOMString InputDeviceKeyName;
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#InputDeviceManagerObject">InputDeviceManagerObject</a>;
   [NoInterfaceObject] interface InputDeviceManagerObject {
     readonly attribute <a href="#InputDeviceManager">InputDeviceManager</a> inputdevice;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#InputDeviceManagerObject">InputDeviceManagerObject</a>;
   [NoInterfaceObject] interface InputDeviceKey {
     readonly attribute <a href="#InputDeviceKeyName">InputDeviceKeyName</a> name;
     readonly attribute long code;

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/inputdevice.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/inputdevice.html
@@ -218,8 +218,7 @@ Mandatory keys will not be retrieved by this method.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">InputDeviceKey[]:
-                  </span>
+<span class="return">InputDeviceKey[]:</span>
  List of supported keys.
               </ul>
 </div>
@@ -275,8 +274,7 @@ window.addEventListener("keydown", function(keyEvent)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">InputDeviceKey:
-                  </span>
+<span class="return">InputDeviceKey<span class="optional"> [nullable]</span>:</span>
  InputDeviceKey object for the given key name or <var>null</var> if the key is not supported.
               </ul>
 </div>
@@ -393,7 +391,7 @@ for (i = 0; i &lt; keys.length; i++)
 <div class="brief">
  Registers a batch of input device keys to receive DOM keyboard event when any of them is pressed or released
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void registerKeyBatch(<a href="#InputDeviceKeyName">InputDeviceKeyName</a>[] keyNames, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void registerKeyBatch(<a href="#InputDeviceKeyName">InputDeviceKeyName</a>[] keyNames, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -470,7 +468,7 @@ tizen.inputdevice.registerKeyBatch(keys, successCB, errorCB);
 <div class="brief">
  Unregisters a batch of input device keys
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void unregisterKeyBatch(<a href="#InputDeviceKeyName">InputDeviceKeyName</a>[] keyNames, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void unregisterKeyBatch(<a href="#InputDeviceKeyName">InputDeviceKeyName</a>[] keyNames, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/iotcon.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/iotcon.html
@@ -4812,10 +4812,10 @@ To guarantee this application will run on a device with a Iotcon, add the below 
     <a href="#ResourceInterface">ResourceInterface</a>? resourceInterface;
     object? filter;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#IotconObject">IotconObject</a>;
   [NoInterfaceObject] interface IotconObject {
     readonly attribute <a href="#Iotcon">Iotcon</a> iotcon;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#IotconObject">IotconObject</a>;
   [NoInterfaceObject] interface Iotcon {
     attribute DOMString deviceName;
     void initialize(DOMString filePath) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/iotcon.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/iotcon.html
@@ -634,8 +634,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Client:
-                  </span>
+<span class="return">Client:</span>
  The <em>Client</em> object.
               </ul>
 </div>
@@ -668,8 +667,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Server:
-                  </span>
+<span class="return">Server:</span>
  The <em>Server</em> object.
               </ul>
 </div>
@@ -708,8 +706,7 @@ Without a response after the specified time, the mentioned methods would trigger
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The timeout value in seconds.
               </ul>
 </div>
@@ -795,8 +792,7 @@ console.log("Timeout value is " + timeout);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The watchID which can be used to remove the listener.
               </ul>
 </div>
@@ -870,14 +866,14 @@ watchId = tizen.iotcon.addGeneratedPinListener(RandomPinSuccess);
  The Client provides API for client side.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface Client {
-    void findResource(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findResource(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                       <a href="#FoundResourceSuccessCallback">FoundResourceSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addPresenceEventListener(DOMString? hostAddress, <a href="#ResourceType">ResourceType</a>? resourceType, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                                   <a href="#PresenceEventCallback">PresenceEventCallback</a> successCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removePresenceEventListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                         <a href="#FoundDeviceInfoSuccessCallback">FoundDeviceInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                           <a href="#FoundPlatformInfoSuccessCallback">FoundPlatformInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                           raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
@@ -894,7 +890,7 @@ watchId = tizen.iotcon.addGeneratedPinListener(RandomPinSuccess);
 <div class="brief">
  Finds resources using host address and resource type.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void findResource(DOMString? hostAddress, <a href="#Query">Query</a>? query<a href="#ConnectivityType">ConnectivityType</a> connectivityType, 
+<div class="synopsis"><pre class="signature prettyprint">void findResource(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                   <a href="#FoundResourceSuccessCallback">FoundResourceSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1022,7 +1018,7 @@ Resource interfaces:
  Adds a listener to receive a presence events from the server.
 A server sends presence events when starts or stops presence.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">long addPresenceEventListener(DOMString? hostAddress, <a href="#ResourceType">ResourceType</a>? resourceType, <a href="#ConnectivityType">ConnectivityType</a> connectivityType, 
+<div class="synopsis"><pre class="signature prettyprint">long addPresenceEventListener(DOMString? hostAddress, <a href="#ResourceType">ResourceType</a>? resourceType, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                               <a href="#PresenceEventCallback">PresenceEventCallback</a> successCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1057,8 +1053,7 @@ A server sends presence events when starts or stops presence.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The watchID which can be used to remove the listener.
               </ul>
 </div>
@@ -1167,7 +1162,7 @@ Resource type: oic.wk.ad
 <div class="brief">
  Gets the device information of remote server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query<a href="#ConnectivityType">ConnectivityType</a> connectivityType, 
+<div class="synopsis"><pre class="signature prettyprint">void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                     <a href="#FoundDeviceInfoSuccessCallback">FoundDeviceInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1286,7 +1281,7 @@ Data model version: res.1.0.0
 <div class="brief">
  Gets the platform information of remote server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query<a href="#ConnectivityType">ConnectivityType</a> connectivityType, 
+<div class="synopsis"><pre class="signature prettyprint">void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                       <a href="#FoundPlatformInfoSuccessCallback">FoundPlatformInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1446,8 +1441,7 @@ There are different resource types, for example a temperature sensor, a light co
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Resource[]:
-                  </span>
+<span class="return">Resource[]:</span>
  Array of <em>Resource</em> objects registered on server.
               </ul>
 </div>
@@ -1471,7 +1465,7 @@ var resources = server.getResources();
 <div class="brief">
  Creates a resource and registers the resource on server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint"><a href="#Resource">Resource</a> createResource(DOMString uriPath, <a href="#ResourceType">ResourceType</a>[] resourceTypes, <a href="#ResourceInterface">ResourceInterface</a>[] resourceInterfaces, 
+<div class="synopsis"><pre class="signature prettyprint"><a href="#Resource">Resource</a> createResource(DOMString uriPath, <a href="#ResourceType">ResourceType</a>[] resourceTypes, <a href="#ResourceInterface">ResourceInterface</a>[] resourceInterfaces,
                         <a href="#RequestCallback">RequestCallback</a> listener, optional <a href="#ResourcePolicy">ResourcePolicy</a> policy);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -1510,8 +1504,7 @@ var resources = server.getResources();
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Resource:
-                  </span>
+<span class="return">Resource:</span>
  Instance of <em>Resource</em> object.
               </ul>
 </div>
@@ -2041,7 +2034,7 @@ key: openstate, value: open
 <div class="brief">
  Puts the representation of a resource for update.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void methodPut(<a href="#Representation">Representation</a> representation, <a href="#RemoteResourceResponseCallback">RemoteResourceResponseCallback</a> responseCallback, optional <a href="#Query">Query</a>? query, 
+<div class="synopsis"><pre class="signature prettyprint">void methodPut(<a href="#Representation">Representation</a> representation, <a href="#RemoteResourceResponseCallback">RemoteResourceResponseCallback</a> responseCallback, optional <a href="#Query">Query</a>? query,
                optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -2160,7 +2153,7 @@ key: openstate, value: closed
 <div class="brief">
  Posts the representation of a resource for create.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void methodPost(<a href="#Representation">Representation</a> representation, <a href="#RemoteResourceResponseCallback">RemoteResourceResponseCallback</a> responseCallback, optional <a href="#Query">Query</a>? query, 
+<div class="synopsis"><pre class="signature prettyprint">void methodPost(<a href="#Representation">Representation</a> representation, <a href="#RemoteResourceResponseCallback">RemoteResourceResponseCallback</a> responseCallback, optional <a href="#Query">Query</a>? query,
                 optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -3812,7 +3805,7 @@ query["filter"] = filter;
  The Request interface represents a details from client.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface Request {
-    readonly attribute DOMString  hostAddress;
+    readonly attribute DOMString hostAddress;
     readonly attribute <a href="#ConnectivityType">ConnectivityType</a> connectivityType;
     readonly attribute <a href="#Representation">Representation</a>? representation;
     readonly attribute <a href="#IotconOption">IotconOption</a>[] options;
@@ -4798,14 +4791,27 @@ To guarantee this application will run on a device with a Iotcon, add the below 
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Iotcon {
   typedef DOMString ResourceType;
+  typedef DOMString ResourceInterface;
   enum QosLevel { "HIGH", "LOW" };
   enum ResponseResult { "SUCCESS", "ERROR", "RESOURCE_CREATED", "RESOURCE_DELETED", "RESOURCE_CHANGED", "SLOW", "FORBIDDEN" };
   enum PresenceResponseResultType { "OK", "STOPPED", "TIMEOUT" };
   enum PresenceTriggerType { "CREATED", "UPDATED", "DESTROYED" };
   enum ConnectivityType { "IP", "PREFER_UDP", "PREFER_TCP", "IPV4_ONLY", "IPV6_ONLY", "ALL" };
-  typedef DOMString ResourceInterface;
   enum ObservePolicy { "IGNORE_OUT_OF_ORDER", "ACCEPT_OUT_OF_ORDER" };
   enum ObserveType { "NO_TYPE", "REGISTER", "DEREGISTER" };
+  dictionary ResourcePolicy {
+    boolean isObservable;
+    boolean isDiscoverable;
+    boolean isActive;
+    boolean isSlow;
+    boolean isSecure;
+    boolean isExplicitDiscoverable;
+  };
+  dictionary Query {
+    <a href="#ResourceType">ResourceType</a>? resourceType;
+    <a href="#ResourceInterface">ResourceInterface</a>? resourceInterface;
+    object? filter;
+  };
   [NoInterfaceObject] interface IotconObject {
     readonly attribute <a href="#Iotcon">Iotcon</a> iotcon;
   };
@@ -4821,14 +4827,14 @@ To guarantee this application will run on a device with a Iotcon, add the below 
     void removeGeneratedPinListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface Client {
-    void findResource(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findResource(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                       <a href="#FoundResourceSuccessCallback">FoundResourceSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addPresenceEventListener(DOMString? hostAddress, <a href="#ResourceType">ResourceType</a>? resourceType, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                                   <a href="#PresenceEventCallback">PresenceEventCallback</a> successCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removePresenceEventListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findDeviceInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                         <a href="#FoundDeviceInfoSuccessCallback">FoundDeviceInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>?  query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
+    void findPlatformInfo(DOMString? hostAddress, <a href="#Query">Query</a>? query, <a href="#ConnectivityType">ConnectivityType</a> connectivityType,
                           <a href="#FoundPlatformInfoSuccessCallback">FoundPlatformInfoSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                           raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
@@ -4872,14 +4878,6 @@ To guarantee this application will run on a device with a Iotcon, add the below 
     void setResourceStateChangeListener(<a href="#ResourceStateChangeCallback">ResourceStateChangeCallback</a> successCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unsetResourceStateChangeListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
-  dictionary ResourcePolicy {
-    boolean isObservable;
-    boolean isDiscoverable;
-    boolean isActive;
-    boolean isSlow;
-    boolean isSecure;
-    boolean isExplicitDiscoverable;
-  };
   [NoInterfaceObject] interface Resource {
     readonly attribute DOMString uriPath;
     readonly attribute <a href="#ResourceType">ResourceType</a>[] resourceTypes;
@@ -4916,18 +4914,13 @@ To guarantee this application will run on a device with a Iotcon, add the below 
     readonly attribute <a href="#PresenceResponseResultType">PresenceResponseResultType</a> resultType;
     readonly attribute <a href="#PresenceTriggerType">PresenceTriggerType</a>? triggerType;
   };
-  dictionary Query {
-    <a href="#ResourceType">ResourceType</a>? resourceType;
-    <a href="#ResourceInterface">ResourceInterface</a>? resourceInterface;
-    object? filter;
-  };
   [Constructor(unsigned long id, DOMString data)]
   interface IotconOption {
     attribute unsigned long id;
     attribute DOMString data;
   };
   [NoInterfaceObject] interface Request {
-    readonly attribute DOMString  hostAddress;
+    readonly attribute DOMString hostAddress;
     readonly attribute <a href="#ConnectivityType">ConnectivityType</a> connectivityType;
     readonly attribute <a href="#Representation">Representation</a>? representation;
     readonly attribute <a href="#IotconOption">IotconOption</a>[] options;

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/keymanager.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/keymanager.html
@@ -172,7 +172,7 @@ It provides access to the API functionalities through the <em>tizen.keymanager</
 <div class="brief">
  Saves and stores data as a <a href="#KeyManagerAlias">KeyManagerAlias</a> inside the KeyManager.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void saveData(DOMString name, <a href="#RawData">RawData</a> rawData, optional DOMString? password, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void saveData(DOMString name, <a href="#RawData">RawData</a> rawData, optional DOMString? password, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -338,8 +338,7 @@ If an application calls this method to retrieve raw data which it saved into the
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">RawData:
-                  </span>
+<span class="return">RawData:</span>
  Data.
               </ul>
 </div>
@@ -402,8 +401,7 @@ if (aliases.length != 0)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">KeyManagerAlias[]:
-                  </span>
+<span class="return">KeyManagerAlias[]:</span>
  Array of aliases.
               </ul>
 </div>
@@ -432,7 +430,7 @@ for (var i = 0; i &lt; aliases.length; i++)
 <div class="brief">
  Sets permissions that another application has for accessing an application's data.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void setPermission(<a href="#KeyManagerAlias">KeyManagerAlias</a> dataAlias, <a href="package.html#PackageId">PackageId</a> packageId, <a href="#PermissionType">PermissionType</a> permissionType, 
+<div class="synopsis"><pre class="signature prettyprint">void setPermission(<a href="#KeyManagerAlias">KeyManagerAlias</a> dataAlias, <a href="package.html#PackageId">PackageId</a> packageId, <a href="#PermissionType">PermissionType</a> permissionType,
                    optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -597,6 +595,11 @@ Possible values:
 <pre class="webidl prettyprint">module KeyManager {
   typedef DOMString RawData;
   enum PermissionType { "NONE", "READ", "REMOVE", "READ_REMOVE" };
+  dictionary KeyManagerAlias {
+    <a href="package.html#PackageId">PackageId</a> packageId;
+    DOMString name;
+    boolean isProtected;
+  };
   [NoInterfaceObject] interface KeyManagerObject {
     readonly attribute <a href="#KeyManager">KeyManager</a> keymanager;
   };
@@ -609,11 +612,6 @@ Possible values:
     <a href="#KeyManagerAlias">KeyManagerAlias</a>[] getDataAliasList() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void setPermission(<a href="#KeyManagerAlias">KeyManagerAlias</a> dataAlias, <a href="package.html#PackageId">PackageId</a> packageId, <a href="#PermissionType">PermissionType</a> permissionType,
                        optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  dictionary KeyManagerAlias {
-    <a href="package.html#PackageId">PackageId</a> packageId;
-    DOMString name;
-    boolean isProtected;
   };
 };</pre>
 </div>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/keymanager.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/keymanager.html
@@ -600,10 +600,10 @@ Possible values:
     DOMString name;
     boolean isProtected;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#KeyManagerObject">KeyManagerObject</a>;
   [NoInterfaceObject] interface KeyManagerObject {
     readonly attribute <a href="#KeyManager">KeyManager</a> keymanager;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#KeyManagerObject">KeyManagerObject</a>;
   [NoInterfaceObject] interface KeyManager {
     void saveData(DOMString name, <a href="#RawData">RawData</a> rawData, optional DOMString? password, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                   optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/mediacontroller.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/mediacontroller.html
@@ -414,8 +414,7 @@ There is a <em>tizen.mediacontroller</em> object that allows access to the Media
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">MediaControllerClient:
-                  </span>
+<span class="return">MediaControllerClient:</span>
  The <em>MediaController Client</em> object.
               </ul>
 </div>
@@ -467,8 +466,7 @@ and is controlled by Client.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">MediaControllerServer:
-                  </span>
+<span class="return">MediaControllerServer:</span>
  The <em>MediaController Server</em> object.
               </ul>
 </div>
@@ -516,7 +514,8 @@ catch (err)
     void updatePlaybackAgeRating(<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void updatePlaybackContentType(<a href="#MediaControllerContentType">MediaControllerContentType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void updateShuffleMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    void updateRepeatMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void updateMetadata(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addChangeRequestPlaybackInfoListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeChangeRequestPlaybackInfoListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -968,8 +967,7 @@ requests from client.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -1112,8 +1110,7 @@ See <em>MediaControllerServerInfo</em> to check how to send custom commands from
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -1228,8 +1225,7 @@ mcServer.removeCommandListener(watcherId);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">MediaControllerPlaylist:
-                  </span>
+<span class="return">MediaControllerPlaylist:</span>
  New empty <em>MediaControllerPlaylist</em> object with given name.
               </ul>
 </div>
@@ -1258,7 +1254,7 @@ var playlist = server.createPlaylist("testPlaylistName");
 <div class="brief">
  Saves playlist in local database.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                   optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1377,7 +1373,7 @@ The <em>errorCallback</em> may be triggered for one of the following errors:
 </li></ul>
         </div>
 <div class="example">
-<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var server = mediacontroller.createServer();
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var server = tizen.mediacontroller.createServer();
 var playlist = server.createPlaylist("testPlaylistName");
 function deleteSuccess()
 {
@@ -1436,7 +1432,7 @@ server.savePlaylist(playlist, saveSuccess);
 </li></ul>
         </div>
 <div class="example">
-<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var server = mediacontroller.createServer();
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var server = tizen.mediacontroller.createServer();
 var playlist = server.createPlaylist("testPlaylistName");
 var metadata =
 {
@@ -1453,10 +1449,12 @@ var metadata =
   picture: "testPicture"
 };
 playlist.addItem("index1", metadata);
-server.savePlaylist(playlist);
-server.updatePlaybackItem("testPlaylistName", "index1");
-console.log("Current playlist: " + server.playbackInfo.playlistName);
-console.log("Current index: " + server.playbackInfo.index);
+server.savePlaylist(playlist, function()
+{
+  server.updatePlaybackItem("testPlaylistName", "index1");
+  console.log("Current playlist: " + server.playbackInfo.playlistName);
+  console.log("Current index: " + server.playbackInfo.index);
+});
 </pre>
 </div>
 <div class="output">
@@ -1517,26 +1515,25 @@ var playlist = server.createPlaylist("testPlaylist");
 function saveSuccess()
 {
   console.log("savePlaylist successful");
+  function successCallback(playlists)
+  {
+    playlists.forEach(function(playlist)
+    {
+      console.log("Playlist name: " + playlist.name);
+    });
+  }
+  function errorCallback(error)
+  {
+    console.log("getAllPlaylists failed with error: " + error);
+  }
+  server.getAllPlaylists(successCallback, errorCallback);
 }
 function saveError(error)
 {
   console.log("savePlaylist failed with error: " + error);
 }
 
-server.savePlaylist(saveSuccess, saveError);
-
-function successCallback(playlists)
-{
-  playlists.forEach(function(playlist)
-  {
-    console.log("Playlist name: " + playlist.name);
-  });
-}
-function errorCallback(error)
-{
-  console.log("getAllPlaylists failed with error: " + error);
-}
-server.getAllPlaylists(successCallback, errorCallback);
+server.savePlaylist(playlist, saveSuccess, saveError);
 </pre>
 </div>
 <div class="output">
@@ -1651,8 +1648,7 @@ mcClient.findServers(successCallback, errorCallback);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">MediaControllerServerInfo:
-                  </span>
+<span class="return">MediaControllerServerInfo<span class="optional"> [nullable]</span>:</span>
  Server info or <var>null</var>.
               </ul>
 </div>
@@ -1692,7 +1688,9 @@ Provides methods to send commands to server and listen for server status change.
                               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void sendShuffleMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+<span class="nocode deprecated">    void sendRepeatMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                        raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                          optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void sendCommand(DOMString command, object data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -1788,7 +1786,7 @@ console.log(sinfo.iconURI);
 <div class="brief">
  Allows to change playback state of media controller server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                        optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1845,7 +1843,7 @@ mcServerInfo.sendPlaybackState("STOP",
 <div class="brief">
  Allows to change playback position of media controller server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                           optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -2020,7 +2018,7 @@ mcServerInfo.sendRepeatMode(false,
 <div class="brief">
  Allows to change repeat state of media controller server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -2081,7 +2079,7 @@ mcServerInfo.sendRepeatState("REPEAT_ALL",
 <div class="brief">
  Allows to send custom command to media controller server.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void sendCommand(DOMString command, object data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void sendCommand(DOMString command, object data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback,
                  optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -2163,8 +2161,7 @@ mcServerInfo.sendCommand("myPlaylistFilter", exampleCustomCommandData,
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -2264,8 +2261,7 @@ mcServerInfo.removeServerStatusChangeListener(watcherId);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -2434,26 +2430,26 @@ var playlist = server.createPlaylist("testPlaylist");
 function saveSuccess()
 {
   console.log("savePlaylist successful");
+  function successCallback(playlists)
+  {
+    playlists.forEach(function(playlist)
+    {
+      console.log("Playlist name: " + playlist.name);
+    });
+  }
+  function errorCallback(error)
+  {
+    console.log("getAllPlaylists failed with error: " + error);
+  }
+  serverInfo.getAllPlaylists(successCallback, errorCallback);
 }
+
 function saveError(error)
 {
   console.log("savePlaylist failed with error: " + error);
 }
 
-server.savePlaylist(saveSuccess, saveError);
-
-function successCallback(playlists)
-{
-  playlists.forEach(function(playlist)
-  {
-    console.log("Playlist name: " + playlist.name);
-  });
-}
-function errorCallback(error)
-{
-  console.log("getAllPlaylists failed with error: " + error);
-}
-serverInfo.getAllPlaylists(successCallback, errorCallback);
+server.savePlaylist(playlist, saveSuccess, saveError);
 </pre>
 </div>
 <div class="output">
@@ -2534,8 +2530,7 @@ serverInfo.sendPlaybackItem("testPlaylist", "1", "PLAY", 0);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -2559,7 +2554,7 @@ var listener =
 {
   onplaylistupdated: function(playlist)
   {
-    console.log("updated playlist " + playlist.name);
+    console.log("updated playlist " + playlist);
   },
   onplaylistdeleted: function(playlistName)
   {
@@ -2628,7 +2623,8 @@ serverInfo.removePlaylistUpdatedListener(listenerId);
     readonly attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating;
     readonly attribute <a href="#MediaControllerContentType">MediaControllerContentType</a> contentType;
     readonly attribute boolean shuffleMode;
-    readonly attribute <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> repeatState;
+<span class="nocode deprecated">    readonly attribute boolean repeatMode;
+</span>    readonly attribute <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> repeatState;
     readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
     readonly attribute DOMString? index;
     readonly attribute DOMString? playlistName;
@@ -3035,7 +3031,7 @@ function errorCallback(error)
 {
   console.log("savePlaylist failed with error: " + error);
 }
-server.savePlaylist(successCallback, errorCallback);
+server.savePlaylist(playlist, successCallback, errorCallback);
 </pre>
 </div>
 <div class="output">
@@ -3245,8 +3241,7 @@ See <em>MediaControllerSendCommandSuccessCallback</em> interface.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">object:
-                  </span>
+<span class="return">object<span class="optional"> [nullable]</span>:</span>
  Data object which should be send with reply to the client.
               </ul>
 </div>
@@ -3302,7 +3297,8 @@ object for receiving media controller playback info changes from server.
 <pre class="webidl prettyprint">  [Callback, NoInterfaceObject] interface MediaControllerPlaybackInfoChangeCallback {
     void onplaybackchanged(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position);
     void onshufflemodechanged(boolean mode);
-    void onrepeatstatechanged(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state);
+<span class="nocode deprecated">    void onrepeatmodechanged(boolean mode);
+</span>    void onrepeatstatechanged(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state);
     void onmetadatachanged(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata);
   };</pre>
 <p><span class="version">Since: </span>
@@ -3446,7 +3442,8 @@ object for receiving playback info change requests from client.
     void onplaybackstaterequest(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
     void onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
     void onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+<span class="nocode deprecated">    void onrepeatmoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+</span>    void onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
     void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state,
                                unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
   };</pre>
@@ -3613,7 +3610,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 <div class="brief">
  Called when client request change of playback item.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, 
+<div class="synopsis"><pre class="signature prettyprint">void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state,
                            unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -3798,8 +3795,21 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
   enum MediaControllerPlaybackState { "PLAY", "PAUSE", "STOP", "NEXT", "PREV", "FORWARD", "REWIND" };
   enum MediaControllerRepeatState { "REPEAT_OFF", "REPEAT_ONE", "REPEAT_ALL" };
   enum MediaControllerContentType { "IMAGE", "MUSIC", "VIDEO", "OTHER", "UNDECIDED" };
-  enum MediaControllerContentAgeRating { "ALL", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16",
-    "17", "18", "19" };
+  enum MediaControllerContentAgeRating { "ALL", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13",
+    "14", "15", "16", "17", "18", "19" };
+  dictionary MediaControllerMetadataInit {
+    DOMString title;
+    DOMString artist;
+    DOMString album;
+    DOMString author;
+    DOMString genre;
+    DOMString duration;
+    DOMString date;
+    DOMString copyright;
+    DOMString description;
+    DOMString trackNum;
+    DOMString picture;
+  };
   [NoInterfaceObject] interface MediaControllerObject {
     readonly attribute <a href="#MediaControllerManager">MediaControllerManager</a> mediacontroller;
   };
@@ -3890,19 +3900,6 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
   [NoInterfaceObject] interface MediaControllerPlaylistItem {
     readonly attribute DOMString index;
     readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
-  };
-  dictionary MediaControllerMetadataInit {
-    DOMString title;
-    DOMString artist;
-    DOMString album;
-    DOMString author;
-    DOMString genre;
-    DOMString duration;
-    DOMString date;
-    DOMString copyright;
-    DOMString description;
-    DOMString trackNum;
-    DOMString picture;
   };
   [NoInterfaceObject] interface MediaControllerPlaylist {
     readonly attribute DOMString name;

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/mediacontroller.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/mediacontroller.html
@@ -3810,10 +3810,10 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
     DOMString trackNum;
     DOMString picture;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MediaControllerObject">MediaControllerObject</a>;
   [NoInterfaceObject] interface MediaControllerObject {
     readonly attribute <a href="#MediaControllerManager">MediaControllerManager</a> mediacontroller;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MediaControllerObject">MediaControllerObject</a>;
   [NoInterfaceObject] interface MediaControllerManager {
     <a href="#MediaControllerClient">MediaControllerClient</a> getClient() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#MediaControllerServer">MediaControllerServer</a> createServer() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/mediakey.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/mediakey.html
@@ -306,8 +306,8 @@ To guarantee that the Media Key application runs on a device with Bluetooth feat
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module MediaKey {
-  enum MediaKeyType { "MEDIA_PLAY", "MEDIA_STOP", "MEDIA_PAUSE", "MEDIA_PREVIOUS", "MEDIA_NEXT", "MEDIA_FAST_FORWARD", "MEDIA_REWIND",
-    "MEDIA_PLAY_PAUSE" };
+  enum MediaKeyType { "MEDIA_PLAY", "MEDIA_STOP", "MEDIA_PAUSE", "MEDIA_PREVIOUS", "MEDIA_NEXT", "MEDIA_FAST_FORWARD",
+    "MEDIA_REWIND", "MEDIA_PLAY_PAUSE" };
   [NoInterfaceObject] interface MediaKeyManagerObject {
     readonly attribute <a href="#MediaKeyManager">MediaKeyManager</a> mediakey;
   };

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/mediakey.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/mediakey.html
@@ -308,10 +308,10 @@ To guarantee that the Media Key application runs on a device with Bluetooth feat
 <pre class="webidl prettyprint">module MediaKey {
   enum MediaKeyType { "MEDIA_PLAY", "MEDIA_STOP", "MEDIA_PAUSE", "MEDIA_PREVIOUS", "MEDIA_NEXT", "MEDIA_FAST_FORWARD",
     "MEDIA_REWIND", "MEDIA_PLAY_PAUSE" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MediaKeyManagerObject">MediaKeyManagerObject</a>;
   [NoInterfaceObject] interface MediaKeyManagerObject {
     readonly attribute <a href="#MediaKeyManager">MediaKeyManager</a> mediakey;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MediaKeyManagerObject">MediaKeyManagerObject</a>;
   [NoInterfaceObject] interface MediaKeyManager {
     void setMediaKeyEventListener(<a href="#MediaKeyEventCallback">MediaKeyEventCallback</a> callback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unsetMediaKeyEventListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/messageport.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/messageport.html
@@ -784,10 +784,10 @@ var watchId = localMsgPort.addMessagePortListener(onreceived);
     DOMString key;
     <a href="#ByteStreamDataItemValue">ByteStreamDataItemValue</a> value;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MessagePortManagerObject">MessagePortManagerObject</a>;
   [NoInterfaceObject] interface MessagePortManagerObject {
     readonly attribute <a href="#MessagePortManager">MessagePortManager</a> messageport;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#MessagePortManagerObject">MessagePortManagerObject</a>;
   [NoInterfaceObject] interface MessagePortManager {
     <a href="#LocalMessagePort">LocalMessagePort</a> requestLocalMessagePort(DOMString localMessagePortName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#LocalMessagePort">LocalMessagePort</a> requestTrustedLocalMessagePort(DOMString localMessagePortName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/messageport.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/messageport.html
@@ -222,8 +222,7 @@ The <em>tizen.messageport</em> object allows access to the functionality of the 
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">LocalMessagePort:
-                  </span>
+<span class="return">LocalMessagePort:</span>
  LocalMessagePort instance.
               </ul>
 </div>
@@ -276,8 +275,7 @@ Trusted local message port can communicate with applications that are signed wit
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">LocalMessagePort:
-                  </span>
+<span class="return">LocalMessagePort:</span>
  Trusted LocalMessagePort instance.
               </ul>
 </div>
@@ -334,8 +332,7 @@ If the message port name and application ID are the same, the platform returns t
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">RemoteMessagePort:
-                  </span>
+<span class="return">RemoteMessagePort:</span>
  RemoteMessagePort instance.
               </ul>
 </div>
@@ -390,8 +387,7 @@ Trusted remote message port can communicate with applications that are signed wi
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">RemoteMessagePort:
-                  </span>
+<span class="return">RemoteMessagePort:</span>
  Trusted RemoteMessagePort instance.
               </ul>
 </div>
@@ -483,8 +479,7 @@ var remoteMsgPort =
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  ID of the listener that is later used to remove the listener.
               </ul>
 </div>
@@ -781,6 +776,14 @@ var watchId = localMsgPort.addMessagePortListener(onreceived);
   typedef (DOMString or DOMString[]) StringDataItemValue;
   typedef (<a href="#ByteStream">ByteStream</a> or <a href="#ByteStream">ByteStream</a>[]) ByteStreamDataItemValue;
   typedef (<a href="#MessagePortStringDataItem">MessagePortStringDataItem</a> or <a href="#MessagePortByteStreamDataItem">MessagePortByteStreamDataItem</a>) MessagePortDataItem;
+  dictionary MessagePortStringDataItem {
+    DOMString key;
+    <a href="#StringDataItemValue">StringDataItemValue</a> value;
+  };
+  dictionary MessagePortByteStreamDataItem {
+    DOMString key;
+    <a href="#ByteStreamDataItemValue">ByteStreamDataItemValue</a> value;
+  };
   [NoInterfaceObject] interface MessagePortManagerObject {
     readonly attribute <a href="#MessagePortManager">MessagePortManager</a> messageport;
   };
@@ -802,14 +805,6 @@ var watchId = localMsgPort.addMessagePortListener(onreceived);
     readonly attribute <a href="application.html#ApplicationId">ApplicationId</a> appId;
     readonly attribute boolean isTrusted;
     void sendMessage(<a href="#MessagePortDataItem">MessagePortDataItem</a>[] data, optional <a href="#LocalMessagePort">LocalMessagePort</a>? localMessagePort) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  dictionary MessagePortStringDataItem {
-    DOMString key;
-    <a href="#StringDataItemValue">StringDataItemValue</a> value;
-  };
-  dictionary MessagePortByteStreamDataItem {
-    DOMString key;
-    <a href="#ByteStreamDataItemValue">ByteStreamDataItemValue</a> value;
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface MessagePortCallback {
     void onreceived(<a href="#MessagePortDataItem">MessagePortDataItem</a>[] data, <a href="#RemoteMessagePort">RemoteMessagePort</a>? remoteMessagePort);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/nfc.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/nfc.html
@@ -561,8 +561,7 @@ It provides access to the API functionalities through the tizen.nfc interface.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">NFCAdapter:
-                  </span>
+<span class="return">NFCAdapter:</span>
  The default NFCAdapter object.
               </ul>
 </div>
@@ -1132,8 +1131,7 @@ adapter.setPeerListener(onSuccessCB);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Subscription identifier.
               </ul>
 </div>
@@ -1263,8 +1261,7 @@ Such an event may indicate initiating a financial transaction using the device.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Subscription identifier.
               </ul>
 </div>
@@ -1388,8 +1385,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Subscription identifier.
               </ul>
 </div>
@@ -1511,8 +1507,7 @@ should be returned.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">NDEFMessage:
-                  </span>
+<span class="return">NDEFMessage<span class="optional"> [nullable]</span>:</span>
  The NDEF Message that was last read.
               </ul>
 </div>
@@ -1641,8 +1636,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Subscription identifier.
               </ul>
 </div>
@@ -1874,8 +1868,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if current application is activated handler for the AID.
               </ul>
 </div>
@@ -1951,8 +1944,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if current application is activated handler for the category.
               </ul>
 </div>
@@ -2135,7 +2127,7 @@ catch (err)
 <div class="brief">
  Retrieves AIDs that were previously registered for a specific card emulation category and secure element type. An application can only retrieve the AIDs which it registered.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getAIDsForCategory(<a href="#SecureElementType">SecureElementType</a> type, <a href="#CardEmulationCategoryType">CardEmulationCategoryType</a> category, <a href="#AIDArraySuccessCallback">AIDArraySuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getAIDsForCategory(<a href="#SecureElementType">SecureElementType</a> type, <a href="#CardEmulationCategoryType">CardEmulationCategoryType</a> category, <a href="#AIDArraySuccessCallback">AIDArraySuccessCallback</a> successCallback,
                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
@@ -3069,8 +3061,7 @@ If the operation completes successfully, it returns the serial byte array of the
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">byte[]:
-                  </span>
+<span class="return">byte[]:</span>
  The raw data in the NDEFMessage.
               </ul>
 </div>
@@ -3375,7 +3366,7 @@ var newRecord = new tizen.NDEFRecordMedia("text/plain", myData);
 <div class="brief">
  The HCEEventData interface represents HCE event data.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface  HCEEventData {
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface HCEEventData {
     readonly attribute <a href="#HCEEventType">HCEEventType</a> eventType;
     readonly attribute byte[] apdu;
     readonly attribute long length;
@@ -3425,10 +3416,10 @@ var newRecord = new tizen.NDEFRecordMedia("text/plain", myData);
 <div class="brief">
  The AID data interface represents registered AID data
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface  AIDData{
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface AIDData {
     readonly attribute <a href="#SecureElementType">SecureElementType</a> type;
     readonly attribute <a href="#AID">AID</a> aid;
-    readonly attribute boolean  readOnly;
+    readonly attribute boolean readOnly;
   };</pre>
 <p><span class="version">Since: </span>
  2.3.1
@@ -4148,14 +4139,15 @@ To guarantee that the NFC host-based card emulation application runs on a device
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module NFC {
+  typedef DOMString AID;
   enum NDEFRecordTextEncoding { "UTF8", "UTF16" };
   enum NFCTagType { "GENERIC_TARGET", "ISO14443_A", "ISO14443_4A", "ISO14443_3A", "MIFARE_MINI", "MIFARE_1K", "MIFARE_4K",
-    "MIFARE_ULTRA", "MIFARE_DESFIRE", "ISO14443_B", "ISO14443_4B", "ISO14443_BPRIME", "FELICA", "JEWEL", "ISO15693", "UNKNOWN_TARGET" };
+    "MIFARE_ULTRA", "MIFARE_DESFIRE", "ISO14443_B", "ISO14443_4B", "ISO14443_BPRIME", "FELICA", "JEWEL", "ISO15693",
+    "UNKNOWN_TARGET" };
   enum CardEmulationMode { "ALWAYS_ON", "OFF" };
   enum SecureElementType { "ESE", "UICC", "HCE" };
   enum CardEmulationCategoryType { "PAYMENT", "OTHER" };
   enum HCEEventType { "DEACTIVATED", "ACTIVATED", "APDU_RECEIVED" };
-  typedef DOMString AID;
   [NoInterfaceObject] interface NFCManagerObject {
     readonly attribute <a href="#NFCManager">NFCManager</a> nfc;
   };
@@ -4248,15 +4240,15 @@ To guarantee that the NFC host-based card emulation application runs on a device
   interface NDEFRecordMedia : <a href="#NDEFRecord">NDEFRecord</a> {
     readonly attribute DOMString mimeType;
   };
-  [NoInterfaceObject] interface  HCEEventData {
+  [NoInterfaceObject] interface HCEEventData {
     readonly attribute <a href="#HCEEventType">HCEEventType</a> eventType;
     readonly attribute byte[] apdu;
     readonly attribute long length;
   };
-  [NoInterfaceObject] interface  AIDData{
+  [NoInterfaceObject] interface AIDData {
     readonly attribute <a href="#SecureElementType">SecureElementType</a> type;
     readonly attribute <a href="#AID">AID</a> aid;
-    readonly attribute boolean  readOnly;
+    readonly attribute boolean readOnly;
   };
   [Callback, NoInterfaceObject] interface NFCTagDetectCallback {
     void onattach(<a href="#NFCTag">NFCTag</a> nfcTag);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/nfc.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/nfc.html
@@ -4148,10 +4148,10 @@ To guarantee that the NFC host-based card emulation application runs on a device
   enum SecureElementType { "ESE", "UICC", "HCE" };
   enum CardEmulationCategoryType { "PAYMENT", "OTHER" };
   enum HCEEventType { "DEACTIVATED", "ACTIVATED", "APDU_RECEIVED" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#NFCManagerObject">NFCManagerObject</a>;
   [NoInterfaceObject] interface NFCManagerObject {
     readonly attribute <a href="#NFCManager">NFCManager</a> nfc;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#NFCManagerObject">NFCManagerObject</a>;
   [NoInterfaceObject] interface NFCManager {
     const short NFC_RECORD_TNF_EMPTY = 0;
     const short NFC_RECORD_TNF_WELL_KNOWN = 1;

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/notification.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/notification.html
@@ -2242,10 +2242,10 @@ If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare t
     unsigned long ledOnPeriod;
     unsigned long ledOffPeriod;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#NotificationObject">NotificationObject</a>;
   [NoInterfaceObject] interface NotificationObject {
     readonly attribute <a href="#NotificationManager">NotificationManager</a> notification;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#NotificationObject">NotificationObject</a>;
   [NoInterfaceObject] interface NotificationManager {
     void post(<a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void update(<a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/notification.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/notification.html
@@ -200,7 +200,7 @@ The status notification consists of an icon, title, content, and time. The statu
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 4.0. Use <a href="#UserNotificationType">UserNotificationType</a> instead.
           </p>
-<pre class="webidl prettyprint">  enum StatusNotificationType { "SIMPLE", "THUMBNAIL", "ONGOING", "PROGRESS" };</pre>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  enum StatusNotificationType { "SIMPLE", "THUMBNAIL", "ONGOING", "PROGRESS" };</span></pre>
 <p><span class="version">Since: </span>
  2.3.1
           </p>
@@ -314,8 +314,10 @@ Notification API.
     void update(<a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void remove(<a href="#NotificationId">NotificationId</a> id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeAll() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    <a href="#Notification">Notification</a> getNotification(<a href="#NotificationId">NotificationId</a> id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    <a href="#Notification">Notification</a>[] getAllNotifications() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    <a href="#Notification">Notification</a> get(<a href="#NotificationId">NotificationId</a> id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    <a href="#Notification">Notification</a> getNotification(<a href="#NotificationId">NotificationId</a> id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    <a href="#Notification">Notification</a>[] getAll() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    <a href="#Notification">Notification</a>[] getAllNotifications() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void saveNotificationAsTemplate(DOMString name, <a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#UserNotification">UserNotification</a> createNotificationFromTemplate(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
@@ -645,8 +647,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Notification:
-                  </span>
+<span class="return">Notification:</span>
  Notification posted previously by the current application.
               </ul>
 </div>
@@ -707,8 +708,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Notification:
-                  </span>
+<span class="return">Notification:</span>
  Notification previously been posted by the current application.
               </ul>
 </div>
@@ -762,8 +762,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Notification[]:
-                  </span>
+<span class="return">Notification[]:</span>
  All notifications previously been posted by the current application.
               </ul>
 </div>
@@ -822,8 +821,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Notification[]:
-                  </span>
+<span class="return">Notification[]:</span>
  All notifications posted previously by the current application.
               </ul>
 </div>
@@ -986,8 +984,7 @@ An application can load only templates that it has saved.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">UserNotification:
-                  </span>
+<span class="return">UserNotification:</span>
  Created notification.
               </ul>
 </div>
@@ -1095,7 +1092,7 @@ catch (err)
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 4.0. Use <a href="#UserNotificationInit">UserNotificationInit</a> instead.
           </p>
-<pre class="webidl prettyprint">  dictionary StatusNotificationInit {
+<pre class="webidl prettyprint"><span class="nocode deprecated">  dictionary StatusNotificationInit {
     DOMString? content;
     DOMString? iconPath;
     DOMString? soundPath;
@@ -1112,7 +1109,7 @@ catch (err)
     unsigned long ledOffPeriod;
     DOMString? backgroundImagePath;
     DOMString[]? thumbnails;
-  };</pre>
+  };</span></pre>
 <p><span class="version">Since: </span>
  2.3.1
           </p>
@@ -1586,7 +1583,7 @@ By default, this attribute is set to 0.
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 4.0. Use <a href="#UserNotification">UserNotification</a> instead.
           </p>
-<pre class="webidl prettyprint">  [Constructor(<a href="#StatusNotificationType">StatusNotificationType</a> statusType, DOMString title, optional <a href="#StatusNotificationInit">StatusNotificationInit</a>? notificationInitDict)]
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [Constructor(<a href="#StatusNotificationType">StatusNotificationType</a> statusType, DOMString title, optional <a href="#StatusNotificationInit">StatusNotificationInit</a>? notificationInitDict)]
   interface StatusNotification : <a href="#Notification">Notification</a> {
     readonly attribute <a href="#StatusNotificationType">StatusNotificationType</a> statusType;
     attribute DOMString? iconPath;
@@ -1604,7 +1601,7 @@ By default, this attribute is set to 0.
     attribute <a href="application.html#ApplicationId">ApplicationId</a>? appId;
     attribute <a href="#NotificationProgressType">NotificationProgressType</a> progressType;
     attribute unsigned long? progressValue;
-  };</pre>
+  };</span></pre>
 <p><span class="version">Since: </span>
  2.3.1
           </p>
@@ -1619,7 +1616,7 @@ All notifications must have a title attribute.
         
       <div class="constructors">
 <h4 id="StatusNotification::constructor">Constructors</h4>
-<dl><pre class="webidl prettyprint">StatusNotification(<a href="#StatusNotificationType">StatusNotificationType</a> statusType, DOMString title, optional <a href="#StatusNotificationInit">StatusNotificationInit</a>? notificationInitDict);</pre></dl>
+<dl><pre class="webidl prettyprint"><span class="nocode deprecated">StatusNotification(<a href="#StatusNotificationType">StatusNotificationType</a> statusType, DOMString title, optional <a href="#StatusNotificationInit">StatusNotificationInit</a>? notificationInitDict);</span></pre></dl>
 </div>
 <div class="attributes">
 <h4>Attributes</h4>
@@ -2199,27 +2196,6 @@ If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare t
   enum NotificationType { "STATUS" };
   enum UserNotificationType { "SIMPLE", "THUMBNAIL", "ONGOING", "PROGRESS" };
   enum NotificationProgressType { "PERCENTAGE", "BYTE" };
-  [NoInterfaceObject] interface NotificationObject {
-    readonly attribute <a href="#NotificationManager">NotificationManager</a> notification;
-  };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#NotificationObject">NotificationObject</a>;
-  [NoInterfaceObject] interface NotificationManager {
-    void post(<a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void update(<a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void remove(<a href="#NotificationId">NotificationId</a> id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removeAll() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    <a href="#Notification">Notification</a> getNotification(<a href="#NotificationId">NotificationId</a> id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    <a href="#Notification">Notification</a>[] getAllNotifications() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void saveNotificationAsTemplate(DOMString name, <a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    <a href="#UserNotification">UserNotification</a> createNotificationFromTemplate(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  [NoInterfaceObject] interface Notification {
-    readonly attribute <a href="#NotificationId">NotificationId</a> id;
-    readonly attribute <a href="#NotificationType">NotificationType</a> type;
-    readonly attribute Date postedTime;
-    attribute DOMString title;
-    attribute DOMString? content;
-  };
   dictionary UserNotificationInit {
     DOMString? content;
     <a href="#NotificationTextContentInfo">NotificationTextContentInfo</a>? textContents;
@@ -2266,24 +2242,26 @@ If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare t
     unsigned long ledOnPeriod;
     unsigned long ledOffPeriod;
   };
-  [Constructor(<a href="#StatusNotificationType">StatusNotificationType</a> statusType, DOMString title, optional <a href="#StatusNotificationInit">StatusNotificationInit</a>? notificationInitDict)]
-  interface StatusNotification : <a href="#Notification">Notification</a> {
-    readonly attribute <a href="#StatusNotificationType">StatusNotificationType</a> statusType;
-    attribute DOMString? iconPath;
-    attribute DOMString? subIconPath;
-    attribute long? number;
-    attribute <a href="#NotificationDetailInfo">NotificationDetailInfo</a>[]? detailInfo;
-    attribute DOMString? ledColor;
-    attribute unsigned long ledOnPeriod;
-    attribute unsigned long ledOffPeriod;
-    attribute DOMString? backgroundImagePath;
-    attribute DOMString[]? thumbnails;
-    attribute DOMString? soundPath;
-    attribute boolean vibration;
-    attribute <a href="application.html#ApplicationControl">ApplicationControl</a>? appControl;
-    attribute <a href="application.html#ApplicationId">ApplicationId</a>? appId;
-    attribute <a href="#NotificationProgressType">NotificationProgressType</a> progressType;
-    attribute unsigned long? progressValue;
+  [NoInterfaceObject] interface NotificationObject {
+    readonly attribute <a href="#NotificationManager">NotificationManager</a> notification;
+  };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#NotificationObject">NotificationObject</a>;
+  [NoInterfaceObject] interface NotificationManager {
+    void post(<a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void update(<a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void remove(<a href="#NotificationId">NotificationId</a> id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removeAll() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#Notification">Notification</a> getNotification(<a href="#NotificationId">NotificationId</a> id) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#Notification">Notification</a>[] getAllNotifications() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void saveNotificationAsTemplate(DOMString name, <a href="#Notification">Notification</a> notification) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#UserNotification">UserNotification</a> createNotificationFromTemplate(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };
+  [NoInterfaceObject] interface Notification {
+    readonly attribute <a href="#NotificationId">NotificationId</a> id;
+    readonly attribute <a href="#NotificationType">NotificationType</a> type;
+    readonly attribute Date postedTime;
+    attribute DOMString title;
+    attribute DOMString? content;
   };
   [Constructor(<a href="#UserNotificationType">UserNotificationType</a> userType, DOMString title, optional <a href="#UserNotificationInit">UserNotificationInit</a>? notificationGroupedInitDict)]
   interface UserNotification : <a href="#Notification">Notification</a> {

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/package.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/package.html
@@ -460,8 +460,7 @@ The list of installed packages and their package IDs is obtained using <em>getPa
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">PackageInformation:
-                  </span>
+<span class="return">PackageInformation:</span>
  The information of a package.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/package.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/package.html
@@ -923,10 +923,10 @@ It is used in <em>tizen.package.getPackagesInfo()</em>.
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Package {
   typedef DOMString PackageId;
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PackageManagerObject">PackageManagerObject</a>;
   [NoInterfaceObject] interface PackageManagerObject {
     readonly attribute <a href="#PackageManager">PackageManager</a> package;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PackageManagerObject">PackageManagerObject</a>;
   [NoInterfaceObject] interface PackageManager {
     void install(DOMString packageFileURI, <a href="#PackageProgressCallback">PackageProgressCallback</a> progressCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                  raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/playerutil.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/playerutil.html
@@ -213,10 +213,10 @@ Changed latency mode is: HIGH
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module PlayerUtil {
   enum LatencyMode { "LOW", "MID", "HIGH" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PlayerUtilManagerObject">PlayerUtilManagerObject</a>;
   [NoInterfaceObject] interface PlayerUtilManagerObject {
     readonly attribute <a href="#PlayerUtilManager">PlayerUtilManager</a> playerutil;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PlayerUtilManagerObject">PlayerUtilManagerObject</a>;
   [NoInterfaceObject] interface PlayerUtilManager {
     <a href="#LatencyMode">LatencyMode</a> getLatencyMode() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void setLatencyMode(<a href="#LatencyMode">LatencyMode</a> mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/playerutil.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/playerutil.html
@@ -141,8 +141,7 @@ The <em>tizen.playerutil </em>object allows access to the functionality of the P
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">LatencyMode:
-                  </span>
+<span class="return">LatencyMode:</span>
  Latency mode, which is currently set on device.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/power.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/power.html
@@ -740,10 +740,10 @@ To guarantee that the application runs on a device which allows screen state cha
   enum PowerResource { "SCREEN", "CPU" };
   enum PowerScreenState { "SCREEN_OFF", "SCREEN_DIM", "SCREEN_NORMAL" };
   enum PowerCpuState { "CPU_AWAKE" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PowerManagerObject">PowerManagerObject</a>;
   [NoInterfaceObject] interface PowerManagerObject {
     readonly attribute <a href="#PowerManager">PowerManager</a> power;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PowerManagerObject">PowerManagerObject</a>;
   [NoInterfaceObject] interface PowerManager {
     void request(<a href="#PowerResource">PowerResource</a> resource, <a href="#PowerState">PowerState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void release(<a href="#PowerResource">PowerResource</a> resource) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/power.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/power.html
@@ -217,7 +217,9 @@ There will be a <em>tizen.power </em>object that allows accessing of a functiona
     void setScreenBrightness(double brightness) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     boolean isScreenOn() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void restoreScreenBrightness() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };</pre>
+<span class="nocode deprecated">    void turnScreenOn() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void turnScreenOff() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</pre>
 <p><span class="version">Since: </span>
  2.0
           </p>
@@ -432,8 +434,7 @@ tizen.power.unsetScreenStateChangeListener();
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">double:
-                  </span>
+<span class="return">double:</span>
  Current screen brightness value.
               </ul>
 </div>
@@ -529,8 +530,7 @@ tizen.power.setScreenBrightness(1);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if screen is on, otherwise <var>false</var> if the screen is off.
               </ul>
 </div>
@@ -736,10 +736,10 @@ To guarantee that the application runs on a device which allows screen state cha
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Power {
-  enum PowerResource { "SCREEN", "CPU" };
-  enum PowerScreenState { "SCREEN_OFF", "SCREEN_DIM", "SCREEN_NORMAL", "SCREEN_BRIGHT" };
-  enum PowerCpuState { "CPU_AWAKE" };
   typedef (<a href="#PowerScreenState">PowerScreenState</a> or <a href="#PowerCpuState">PowerCpuState</a>) PowerState;
+  enum PowerResource { "SCREEN", "CPU" };
+  enum PowerScreenState { "SCREEN_OFF", "SCREEN_DIM", "SCREEN_NORMAL" };
+  enum PowerCpuState { "CPU_AWAKE" };
   [NoInterfaceObject] interface PowerManagerObject {
     readonly attribute <a href="#PowerManager">PowerManager</a> power;
   };

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/ppm.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/ppm.html
@@ -223,8 +223,7 @@ For privileges not listed in application's <em>config.xml</em> file (or not priv
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">PermissionType:
-                  </span>
+<span class="return">PermissionType:</span>
  State of user's permission for using specified privilege.
               </ul>
 </div>
@@ -279,8 +278,7 @@ Maximum number of privileges that can be passed to array is 100.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">PrivilegeStatus[]:
-                  </span>
+<span class="return">PrivilegeStatus[]:</span>
  The array of status of user's permission for using specified privileges.
               </ul>
 </div>
@@ -400,7 +398,7 @@ tizen.ppm.requestPermission(
 <div class="brief">
  This method allows launching pop-up for asking user to directly grant permission for given privileges.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void requestPermissions(DOMString[] privileges, <a href="#PermissionRequestSuccessCallback">PermissionRequestSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void requestPermissions(DOMString[] privileges, <a href="#PermissionRequestSuccessCallback">PermissionRequestSuccessCallback</a> successCallback,
                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -566,8 +564,7 @@ User's action for privilege http://tizen.org/privilege/contact.write was to: PPM
 <div class="brief">
  The PermissionSuccessCallback interface that implements the success callback used in the asynchronous operation for requesting permission for using privilege.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PermissionSuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PermissionSuccessCallback {
     void onsuccess(<a href="#PermissionRequestResult">PermissionRequestResult</a> result, DOMString privilege);
   };</pre>
 <p><span class="version">Since: </span>
@@ -622,8 +619,7 @@ tizen.ppm.requestPermission("http://tizen.org/privilege/callhistory.read", permi
 <div class="brief">
  The PermissionRequestSuccessCallback interface implements the success callback used in the asynchronous operation of requesting permissions for using privilege.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PermissionRequestSuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PermissionRequestSuccessCallback {
     void onsuccess(<a href="#RequestStatus">RequestStatus</a>[] result);
   };</pre>
 <p><span class="version">Since: </span>
@@ -708,12 +704,10 @@ User's action for privilege http://tizen.org/privilege/contact.write was to: PPM
     readonly attribute DOMString privilege;
     readonly attribute <a href="#PermissionRequestResult">PermissionRequestResult</a> result;
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PermissionSuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface PermissionSuccessCallback {
     void onsuccess(<a href="#PermissionRequestResult">PermissionRequestResult</a> result, DOMString privilege);
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PermissionRequestSuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface PermissionRequestSuccessCallback {
     void onsuccess(<a href="#RequestStatus">RequestStatus</a>[] result);
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/ppm.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/ppm.html
@@ -684,10 +684,10 @@ User's action for privilege http://tizen.org/privilege/contact.write was to: PPM
 <pre class="webidl prettyprint">module PrivacyPrivilege {
   enum PermissionType { "PPM_ALLOW", "PPM_DENY", "PPM_ASK" };
   enum PermissionRequestResult { "PPM_ALLOW_FOREVER", "PPM_DENY_FOREVER", "PPM_DENY_ONCE" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PrivacyPrivilegeManagerObject">PrivacyPrivilegeManagerObject</a>;
   [NoInterfaceObject] interface PrivacyPrivilegeManagerObject {
     readonly attribute <a href="#PrivacyPrivilegeManager">PrivacyPrivilegeManager</a> ppm;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PrivacyPrivilegeManagerObject">PrivacyPrivilegeManagerObject</a>;
   [NoInterfaceObject] interface PrivacyPrivilegeManager {
     <a href="#PermissionType">PermissionType</a> checkPermission(DOMString privilege) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#PrivilegeStatus">PrivilegeStatus</a>[] checkPermissions(DOMString[] privileges) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/preference.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/preference.html
@@ -659,10 +659,10 @@ tizen.preference.getAll(successCB);
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Preference {
   typedef (DOMString or long or double or boolean) PreferenceValueType;
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PreferenceManagerObject">PreferenceManagerObject</a>;
   [NoInterfaceObject] interface PreferenceManagerObject {
     readonly attribute <a href="#PreferenceManager">PreferenceManager</a> preference;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PreferenceManagerObject">PreferenceManagerObject</a>;
   [NoInterfaceObject] interface PreferenceData {
     readonly attribute DOMString key;
     readonly attribute <a href="#PreferenceValueType">PreferenceValueType</a> value;

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/preference.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/preference.html
@@ -297,8 +297,7 @@ tizen.preference.getAll(successCB);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">PreferenceValueType:
-                  </span>
+<span class="return">PreferenceValueType:</span>
  The value associated with the given key.
               </ul>
 </div>
@@ -418,8 +417,7 @@ console.log("The current value of the preference key1 is: " + currentValue);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  If <var>true</var> the key exists in the  application preference, otherwise <var>false</var>.
               </ul>
 </div>
@@ -660,11 +658,11 @@ tizen.preference.getAll(successCB);
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Preference {
+  typedef (DOMString or long or double or boolean) PreferenceValueType;
   [NoInterfaceObject] interface PreferenceManagerObject {
     readonly attribute <a href="#PreferenceManager">PreferenceManager</a> preference;
   };
   <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PreferenceManagerObject">PreferenceManagerObject</a>;
-  typedef (DOMString or long or double or boolean) PreferenceValueType;
   [NoInterfaceObject] interface PreferenceData {
     readonly attribute DOMString key;
     readonly attribute <a href="#PreferenceValueType">PreferenceValueType</a> value;

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/push.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/push.html
@@ -1297,10 +1297,10 @@ To guarantee that the push application runs on a device with the push feature, d
 <pre class="webidl prettyprint">module Push {
   typedef DOMString PushRegistrationId;
   enum PushRegistrationState { "REGISTERED", "UNREGISTERED" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PushManagerObject">PushManagerObject</a>;
   [NoInterfaceObject] interface PushManagerObject {
     readonly attribute <a href="#PushManager">PushManager</a> push;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#PushManagerObject">PushManagerObject</a>;
   [NoInterfaceObject] interface PushManager {
     void register(<a href="#PushRegisterSuccessCallback">PushRegisterSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unregister(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/push.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/push.html
@@ -190,11 +190,16 @@ The <em>tizen.push </em>object allows access to the functionality of the Push AP
  The PushManager interface provides methods to manage push registration and notification.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface PushManager {
-    void register(<a href="#PushRegisterSuccessCallback">PushRegisterSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void unregister(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void connect(<a href="#PushRegistrationStateChangeCallback">PushRegistrationStateChangeCallback</a> stateChangeCallback, <a href="#PushNotificationCallback">PushNotificationCallback</a> notificationCallback,
+<span class="nocode deprecated">    void registerService(<a href="application.html#ApplicationControl">ApplicationControl</a> appControl, <a href="#PushRegisterSuccessCallback">PushRegisterSuccessCallback</a> successCallback,
+                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void register(<a href="#PushRegisterSuccessCallback">PushRegisterSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    void unregisterService(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void unregister(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    void connectService(<a href="#PushNotificationCallback">PushNotificationCallback</a> notificationCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void connect(<a href="#PushRegistrationStateChangeCallback">PushRegistrationStateChangeCallback</a> stateChangeCallback, <a href="#PushNotificationCallback">PushNotificationCallback</a> notificationCallback,
                  optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void disconnect() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    void disconnectService() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void disconnect() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#PushRegistrationId">PushRegistrationId</a> getRegistrationId() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void getUnreadNotifications() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#PushMessage">PushMessage</a>? getPushMessage() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -215,7 +220,7 @@ The <em>tizen.push </em>object allows access to the functionality of the Push AP
 <p class="deprecated"><b>Deprecated.</b>
  This function has been deprecated since 3.0. Use the <a href="push.html#PushManager::register">register()</a> function instead.
             </p>
-<div class="synopsis"><pre class="signature prettyprint">void registerService(<a href="application.html#ApplicationControl">ApplicationControl</a> appControl, <a href="#PushRegisterSuccessCallback">PushRegisterSuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void registerService(<a href="application.html#ApplicationControl">ApplicationControl</a> appControl, <a href="#PushRegisterSuccessCallback">PushRegisterSuccessCallback</a> successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3.1
@@ -655,7 +660,7 @@ tizen.push.registerService(service, registerSuccessCallback, errorCallback);
 <div class="brief">
  Connects to the push service and gets state change events and push notifications.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void connect(<a href="#PushRegistrationStateChangeCallback">PushRegistrationStateChangeCallback</a> stateChangeCallback, <a href="#PushNotificationCallback">PushNotificationCallback</a> notificationCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void connect(<a href="#PushRegistrationStateChangeCallback">PushRegistrationStateChangeCallback</a> stateChangeCallback, <a href="#PushNotificationCallback">PushNotificationCallback</a> notificationCallback,
              optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  3.0
@@ -829,8 +834,7 @@ tizen.push.disconnect();
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">PushRegistrationId:
-                  </span>
+<span class="return">PushRegistrationId:</span>
  ID assigned by push service.
               </ul>
 </div>
@@ -983,8 +987,7 @@ If the application was not launched by the push service, this method returns <va
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">PushMessage:
-                  </span>
+<span class="return">PushMessage<span class="optional"> [nullable]</span>:</span>
  The last message delivered from the push service or <var>null</var>.
               </ul>
 </div>
@@ -1150,8 +1153,7 @@ Details:
 <div class="brief">
  The PushRegisterSuccessCallback interface specifies the success callback for a push service registration request.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushRegisterSuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PushRegisterSuccessCallback {
     void onsuccess(<a href="#PushRegistrationId">PushRegistrationId</a> id);
   };</pre>
 <p><span class="version">Since: </span>
@@ -1194,8 +1196,7 @@ This success callback is invoked when a push service registration request is suc
 <div class="brief">
  The PushRegistrationStateChangeCallback interface specifies the state change callback for the state change event.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushRegistrationStateChangeCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PushRegistrationStateChangeCallback {
     void onsuccess(<a href="#PushRegistrationState">PushRegistrationState</a> state);
   };</pre>
 <p><span class="version">Since: </span>
@@ -1239,8 +1240,7 @@ Moreover PushRegistrationStateChangeCallback would be called at least once, just
 <div class="brief">
  The PushNotificationCallback interface specifies the notification callback for the received push notification message.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushNotificationCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PushNotificationCallback {
     void onsuccess(<a href="#PushMessage">PushMessage</a> message);
   };</pre>
 <p><span class="version">Since: </span>
@@ -1320,16 +1320,13 @@ To guarantee that the push application runs on a device with the push feature, d
     readonly attribute DOMString sessionInfo;
     readonly attribute DOMString requestId;
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushRegisterSuccessCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface PushRegisterSuccessCallback {
     void onsuccess(<a href="#PushRegistrationId">PushRegistrationId</a> id);
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushRegistrationStateChangeCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface PushRegistrationStateChangeCallback {
     void onsuccess(<a href="#PushRegistrationState">PushRegistrationState</a> state);
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface PushNotificationCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface PushNotificationCallback {
     void onsuccess(<a href="#PushMessage">PushMessage</a> message);
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/se.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/se.html
@@ -284,8 +284,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">unsigned long:
-                  </span>
+<span class="return">unsigned long:</span>
  An identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -486,8 +485,7 @@ This interface offers methods to control sessions on the reader.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The name of the reader.
               </ul>
 </div>
@@ -917,8 +915,7 @@ catch (err)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">byte[]:
-                  </span>
+<span class="return">byte[]:</span>
  The ATR of a Secure Element.
               </ul>
 </div>
@@ -1221,8 +1218,7 @@ the selection response can not be retrieved by the reader implementation.       
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">byte[]:
-                  </span>
+<span class="return">byte[]:</span>
  The data as returned by the application select command including the status words.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/se.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/se.html
@@ -1516,10 +1516,10 @@ To guarantee this application will run on a device with a Secure Element, add th
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module SecureElement {
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SEServiceManagerObject">SEServiceManagerObject</a>;
   [NoInterfaceObject] interface SEServiceManagerObject {
     readonly attribute <a href="#SEService">SEService</a> seService;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SEServiceManagerObject">SEServiceManagerObject</a>;
   [NoInterfaceObject] interface SEService {
     void getReaders(<a href="#ReaderArraySuccessCallback">ReaderArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     unsigned long registerSEListener(<a href="#SEChangeListener">SEChangeListener</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/sensor.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/sensor.html
@@ -473,8 +473,7 @@ The supported sensor types are hardware-dependent. <br><br>To check if the given
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Sensor:
-                  </span>
+<span class="return">Sensor:</span>
  Default sensor object.
               </ul>
 </div>
@@ -527,8 +526,7 @@ else
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">SensorType[]:
-                  </span>
+<span class="return">SensorType[]:</span>
  All available sensor types.
               </ul>
 </div>
@@ -2979,7 +2977,7 @@ For more information about sensor, see <a href="https://developer.tizen.org/deve
 <div class="brief">
  The SensorHardwareInfoSuccessCallback callback interface specifies a success callback with SensorHardwareInfo object as an input argument.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface SensorHardwareInfoSuccessCallback{
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface SensorHardwareInfoSuccessCallback {
     void onsuccess(<a href="#SensorHardwareInfo">SensorHardwareInfo</a> hardwareInfo);
   };</pre>
 <p><span class="version">Since: </span>
@@ -3127,8 +3125,8 @@ To guarantee that the UV sensor application runs on a device with a UV sensor, d
 <pre class="webidl prettyprint">module Sensor {
   enum MagneticSensorAccuracy { "ACCURACY_UNDEFINED", "ACCURACY_BAD", "ACCURACY_NORMAL", "ACCURACY_GOOD", "ACCURACY_VERYGOOD" };
   enum ProximityState { "FAR", "NEAR" };
-  enum SensorType { "ACCELERATION", "GRAVITY", "GYROSCOPE", "GYROSCOPE_ROTATION_VECTOR", "GYROSCOPE_UNCALIBRATED", "HRM_RAW", "LIGHT",
-    "LINEAR_ACCELERATION", "MAGNETIC", "MAGNETIC_UNCALIBRATED", "PRESSURE", "PROXIMITY", "ULTRAVIOLET" };
+  enum SensorType { "ACCELERATION", "GRAVITY", "GYROSCOPE", "GYROSCOPE_ROTATION_VECTOR", "GYROSCOPE_UNCALIBRATED",
+    "HRM_RAW", "LIGHT", "LINEAR_ACCELERATION", "MAGNETIC", "MAGNETIC_UNCALIBRATED", "PRESSURE", "PROXIMITY", "ULTRAVIOLET" };
   [NoInterfaceObject] interface SensorServiceManagerObject {
     readonly attribute <a href="#SensorService">SensorService</a> sensorservice;
   };
@@ -3276,7 +3274,7 @@ To guarantee that the UV sensor application runs on a device with a UV sensor, d
   [Callback=FunctionOnly, NoInterfaceObject] interface SensorDataSuccessCallback {
     void onsuccess(optional <a href="#SensorData">SensorData</a>? sensorData);
   };
-  [Callback=FunctionOnly, NoInterfaceObject] interface SensorHardwareInfoSuccessCallback{
+  [Callback=FunctionOnly, NoInterfaceObject] interface SensorHardwareInfoSuccessCallback {
     void onsuccess(<a href="#SensorHardwareInfo">SensorHardwareInfo</a> hardwareInfo);
   };
 };</pre>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/sensor.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/sensor.html
@@ -3127,10 +3127,10 @@ To guarantee that the UV sensor application runs on a device with a UV sensor, d
   enum ProximityState { "FAR", "NEAR" };
   enum SensorType { "ACCELERATION", "GRAVITY", "GYROSCOPE", "GYROSCOPE_ROTATION_VECTOR", "GYROSCOPE_UNCALIBRATED",
     "HRM_RAW", "LIGHT", "LINEAR_ACCELERATION", "MAGNETIC", "MAGNETIC_UNCALIBRATED", "PRESSURE", "PROXIMITY", "ULTRAVIOLET" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SensorServiceManagerObject">SensorServiceManagerObject</a>;
   [NoInterfaceObject] interface SensorServiceManagerObject {
     readonly attribute <a href="#SensorService">SensorService</a> sensorservice;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SensorServiceManagerObject">SensorServiceManagerObject</a>;
   [NoInterfaceObject] interface SensorService {
     <a href="#Sensor">Sensor</a> getDefaultSensor(<a href="#SensorType">SensorType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#SensorType">SensorType</a>[] getAvailableSensors() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/sound.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/sound.html
@@ -286,8 +286,7 @@ There is a tizen.sound object that allows accessing the functionality of the Sou
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">SoundModeType:
-                  </span>
+<span class="return">SoundModeType:</span>
  The current sound mode.
               </ul>
 </div>
@@ -374,8 +373,7 @@ There is a tizen.sound object that allows accessing the functionality of the Sou
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">double:
-                  </span>
+<span class="return">double:</span>
  The current volume level.
               </ul>
 </div>
@@ -526,8 +524,7 @@ Calling this function has no effect if listener is not set.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">SoundDeviceInfo[]:
-                  </span>
+<span class="return">SoundDeviceInfo[]:</span>
  List of connected sound devices.
               </ul>
 </div>
@@ -562,8 +559,7 @@ for (var i = 0; i &lt; infoArr.length; i++)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">SoundDeviceInfo[]:
-                  </span>
+<span class="return">SoundDeviceInfo[]:</span>
  List of activated sound devices.
               </ul>
 </div>
@@ -618,8 +614,7 @@ Activation: When a device changes from being activated to being deactivated or f
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  ID of the listener that can be used to remove the listener later.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/sound.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/sound.html
@@ -898,10 +898,10 @@ tizen.sound.removeDeviceStateChangeListener(id);
   enum SoundModeType { "SOUND", "VIBRATE", "MUTE" };
   enum SoundDeviceType { "SPEAKER", "RECEIVER", "AUDIO_JACK", "BLUETOOTH", "HDMI", "MIRRORING", "USB_AUDIO", "MIC" };
   enum SoundIOType { "IN", "OUT", "BOTH" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SoundManagerObject">SoundManagerObject</a>;
   [NoInterfaceObject] interface SoundManagerObject {
     readonly attribute <a href="#SoundManager">SoundManager</a> sound;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SoundManagerObject">SoundManagerObject</a>;
   [NoInterfaceObject] interface SoundManager {
     <a href="#SoundModeType">SoundModeType</a> getSoundMode() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void setVolume(<a href="#SoundType">SoundType</a> type, double volume) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/systeminfo.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/systeminfo.html
@@ -3505,10 +3505,10 @@ To guarantee the running of the application on a device which supports Wi-Fi, de
     double highThreshold;
     double lowThreshold;
   };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SystemInfoObject">SystemInfoObject</a>;
   [NoInterfaceObject] interface SystemInfoObject {
     readonly attribute <a href="#SystemInfo">SystemInfo</a> systeminfo;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SystemInfoObject">SystemInfoObject</a>;
   [NoInterfaceObject] interface SystemInfo {
     long long getTotalMemory() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long long getAvailableMemory() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/systeminfo.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/systeminfo.html
@@ -469,7 +469,8 @@ functionality of the System Information API.
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface SystemInfo {
     long long getTotalMemory() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long long getAvailableMemory() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    any getCapability(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    <a href="#SystemInfoDeviceCapability">SystemInfoDeviceCapability</a> getCapabilities() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    any getCapability(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long getCount(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void getPropertyValue(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertySuccessCallback">SystemInfoPropertySuccessCallback</a> successCallback,
                           optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -507,8 +508,7 @@ and for subscribing notifications of system information changes.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long long:
-                  </span>
+<span class="return">long long:</span>
  Total system memory.
               </ul>
 </div>
@@ -539,8 +539,7 @@ console.log("The total memory size is " + tizen.systeminfo.getTotalMemory() + " 
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long long:
-                  </span>
+<span class="return">long long:</span>
  Not used memory in bytes.
               </ul>
 </div>
@@ -579,8 +578,7 @@ The function must synchronously acquire the capabilities of the device.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">SystemInfoDeviceCapability:
-                  </span>
+<span class="return">SystemInfoDeviceCapability:</span>
  Capabilities of the device.
               </ul>
 </div>
@@ -630,8 +628,7 @@ The additional keys for the custom device capability are specified by OEMs and v
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">any:
-                  </span>
+<span class="return">any:</span>
  The value of the specified device capability.
               </ul>
 </div>
@@ -684,8 +681,7 @@ That is the length of array retrieved by the <a href="#SystemInfo::getPropertyVa
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The number of property values for the given property. If the property is not supported, 0 is returned.
               </ul>
 </div>
@@ -716,7 +712,7 @@ else
 <div class="brief">
  Gets the current value of a specified system property.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getPropertyValue(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertySuccessCallback">SystemInfoPropertySuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getPropertyValue(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertySuccessCallback">SystemInfoPropertySuccessCallback</a> successCallback,
                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -826,7 +822,7 @@ else
 <div class="brief">
  Gets the current values of a specified system property.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void getPropertyValueArray(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertyArraySuccessCallback">SystemInfoPropertyArraySuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">void getPropertyValueArray(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertyArraySuccessCallback">SystemInfoPropertyArraySuccessCallback</a> successCallback,
                            optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -920,7 +916,7 @@ else
 <div class="brief">
  Adds a listener to allow tracking changes in one or more system properties.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">unsigned long addPropertyValueChangeListener(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertySuccessCallback">SystemInfoPropertySuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">unsigned long addPropertyValueChangeListener(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, <a href="#SystemInfoPropertySuccessCallback">SystemInfoPropertySuccessCallback</a> successCallback,
                                              optional <a href="#SystemInfoOptions">SystemInfoOptions</a>? options, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  1.0
@@ -984,8 +980,7 @@ NotSupportedError - If the given <var>property</var> is not supported (since Tiz
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">unsigned long:
-                  </span>
+<span class="return">unsigned long:</span>
  An identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -1024,8 +1019,8 @@ tizen.systeminfo.addPropertyValueChangeListener("CPU", onSuccessCallback, {lowTh
 <div class="brief">
  Adds a listener to allow tracking of changes in one or more values of a system property.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">unsigned long addPropertyValueArrayChangeListener(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property, 
-                                                  <a href="#SystemInfoPropertyArraySuccessCallback">SystemInfoPropertyArraySuccessCallback</a> successCallback, 
+<div class="synopsis"><pre class="signature prettyprint">unsigned long addPropertyValueArrayChangeListener(<a href="#SystemInfoPropertyId">SystemInfoPropertyId</a> property,
+                                                  <a href="#SystemInfoPropertyArraySuccessCallback">SystemInfoPropertyArraySuccessCallback</a> successCallback,
                                                   optional <a href="#SystemInfoOptions">SystemInfoOptions</a>? options, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.3
@@ -1073,8 +1068,7 @@ any identifier of these properties, but the listener added for them will not be 
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">unsigned long:
-                  </span>
+<span class="return">unsigned long:</span>
  An identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -1167,7 +1161,7 @@ id = tizen.systeminfo.addPropertyValueChangeListener("CPU", onSuccessCallback);
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated since 2.3. Instead, use <a href="#SystemInfo::getCapability">getCapability()</a> to query device capabilities.
           </p>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface SystemInfoDeviceCapability {
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface SystemInfoDeviceCapability {
     readonly attribute boolean bluetooth;
     readonly attribute boolean nfc;
     readonly attribute boolean nfcReservedPush;
@@ -1236,7 +1230,7 @@ id = tizen.systeminfo.addPropertyValueChangeListener("CPU", onSuccessCallback);
     readonly attribute boolean secureElement;
     readonly attribute boolean nativeOspCompatible;
     readonly attribute <a href="#SystemInfoProfile">SystemInfoProfile</a> profile;
-  };</pre>
+  };</span></pre>
 <p><span class="version">Since: </span>
  2.0
           </p>
@@ -2281,7 +2275,8 @@ Any threshold parameter used in a watch function to monitor this property applie
     readonly attribute unsigned long long capacity;
     readonly attribute unsigned long long availableCapacity;
     readonly attribute boolean isRemovable;
-  };</pre>
+<span class="nocode deprecated">    readonly attribute boolean isRemoveable;
+</span>  };</pre>
         
       <div class="attributes">
 <h4>Attributes</h4>
@@ -3496,13 +3491,20 @@ To guarantee the running of the application on a device which supports Wi-Fi, de
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module SystemInfo {
-  enum SystemInfoPropertyId { "BATTERY", "CPU", "STORAGE", "DISPLAY", "DEVICE_ORIENTATION", "BUILD", "LOCALE", "NETWORK", "WIFI_NETWORK",
-    "ETHERNET_NETWORK", "CELLULAR_NETWORK", "NET_PROXY_NETWORK", "SIM", "PERIPHERAL", "MEMORY", "CAMERA_FLASH", "ADS" };
+  enum SystemInfoPropertyId { "BATTERY", "CPU", "STORAGE", "DISPLAY", "DEVICE_ORIENTATION", "BUILD", "LOCALE", "NETWORK",
+    "WIFI_NETWORK", "ETHERNET_NETWORK", "CELLULAR_NETWORK", "NET_PROXY_NETWORK", "SIM", "PERIPHERAL", "MEMORY", "CAMERA_FLASH",
+    "ADS" };
   enum SystemInfoNetworkType { "NONE", "2G", "2.5G", "3G", "4G", "WIFI", "ETHERNET", "NET_PROXY", "UNKNOWN" };
   enum SystemInfoDeviceOrientationStatus { "PORTRAIT_PRIMARY", "PORTRAIT_SECONDARY", "LANDSCAPE_PRIMARY", "LANDSCAPE_SECONDARY" };
-  enum SystemInfoSimState { "ABSENT", "INITIALIZING", "READY", "PIN_REQUIRED", "PUK_REQUIRED", "NETWORK_LOCKED", "SIM_LOCKED", "UNKNOWN" };
-  enum SystemInfoProfile { "MOBILE_FULL", "MOBILE_WEB", "MOBILE", "WEARABLE", "TV" };
+  enum SystemInfoSimState { "ABSENT", "INITIALIZING", "READY", "PIN_REQUIRED", "PUK_REQUIRED", "NETWORK_LOCKED",
+    "SIM_LOCKED", "UNKNOWN" };
+  enum SystemInfoProfile { "MOBILE", "WEARABLE", "TV" };
   enum SystemInfoLowMemoryStatus { "NORMAL", "WARNING" };
+  dictionary SystemInfoOptions {
+    unsigned long timeout;
+    double highThreshold;
+    double lowThreshold;
+  };
   [NoInterfaceObject] interface SystemInfoObject {
     readonly attribute <a href="#SystemInfo">SystemInfo</a> systeminfo;
   };
@@ -3524,11 +3526,6 @@ To guarantee the running of the application on a device which supports Wi-Fi, de
                                                       optional <a href="#SystemInfoOptions">SystemInfoOptions</a>? options, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                                                       raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removePropertyValueChangeListener(unsigned long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };
-  dictionary SystemInfoOptions {
-    unsigned long timeout;
-    double highThreshold;
-    double lowThreshold;
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface SystemInfoPropertySuccessCallback {
     void onsuccess(<a href="#SystemInfoProperty">SystemInfoProperty</a> property);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/systemsetting.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/systemsetting.html
@@ -428,10 +428,10 @@ tizen.systemsetting.getProperty("HOME_SCREEN", getPropertySuccessCallback, error
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module SystemSetting {
   enum SystemSettingType { "HOME_SCREEN", "LOCK_SCREEN", "INCOMING_CALL", "NOTIFICATION_EMAIL" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SystemSettingObject">SystemSettingObject</a>;
   [NoInterfaceObject] interface SystemSettingObject {
     readonly attribute <a href="#SystemSettingManager">SystemSettingManager</a> systemsetting;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SystemSettingObject">SystemSettingObject</a>;
   [NoInterfaceObject] interface SystemSettingManager {
     void setProperty(<a href="#SystemSettingType">SystemSettingType</a> type, DOMString value, <a href="tizen.html#SuccessCallback">SuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/systemsetting.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/systemsetting.html
@@ -427,11 +427,11 @@ tizen.systemsetting.getProperty("HOME_SCREEN", getPropertySuccessCallback, error
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module SystemSetting {
+  enum SystemSettingType { "HOME_SCREEN", "LOCK_SCREEN", "INCOMING_CALL", "NOTIFICATION_EMAIL" };
   [NoInterfaceObject] interface SystemSettingObject {
     readonly attribute <a href="#SystemSettingManager">SystemSettingManager</a> systemsetting;
   };
   <a href="tizen.html#Tizen">Tizen</a> implements <a href="#SystemSettingObject">SystemSettingObject</a>;
-  enum SystemSettingType { "HOME_SCREEN", "LOCK_SCREEN", "INCOMING_CALL", "NOTIFICATION_EMAIL" };
   [NoInterfaceObject] interface SystemSettingManager {
     void setProperty(<a href="#SystemSettingType">SystemSettingType</a> type, DOMString value, <a href="tizen.html#SuccessCallback">SuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/time.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/time.html
@@ -273,8 +273,7 @@ Get timezones using getLocalTimezone() and getAvailableTimezones().            <
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate:</span>
  The current TZDate object.
               </ul>
 </div>
@@ -305,8 +304,7 @@ console.log("current date/time is " + current_dt.toLocaleString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The local timezone.
               </ul>
 </div>
@@ -353,8 +351,7 @@ with the most general descriptor first and the most specific one last. For examp
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString[]:
-                  </span>
+<span class="return">DOMString[]:</span>
  Array of time zone identifiers.
               </ul>
 </div>
@@ -430,8 +427,7 @@ date format (23/10/2011) instead of a long date format ("Monday, October 23 2011
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The date format according to the system's locale settings.
               </ul>
 </div>
@@ -485,8 +481,7 @@ Examples of string formats include: "h:m:s ap", "h:m:s".
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The time format according to the system's locale settings.
               </ul>
 </div>
@@ -528,8 +523,7 @@ console.log(timeFormat);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var>, if the year is a leap year.
               </ul>
 </div>
@@ -813,7 +807,8 @@ If its date/time exceeds the platform limit, TZDate will be invalid.
     DOMString toDateString();
     DOMString toTimeString();
     DOMString toString();
-    long secondsFromUTC() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    DOMString getTimezoneAbbreviation() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    long secondsFromUTC() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     boolean isDST() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#TZDate">TZDate</a>? getPreviousDSTTransition() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#TZDate">TZDate</a>? getNextDSTTransition() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -849,7 +844,7 @@ var myDate = new tizen.TZDate(1999, 11, 31, 23, 59, 59, 999, "Europe/Berlin");
           </ul>
 </div>
 <pre class="webidl prettyprint">TZDate(optional Date? datetime, optional DOMString? timezone);</pre>
-<pre class="webidl prettyprint">TZDate(long year, long month, long day, optional long? hours, optional long? minutes, optional long? seconds, 
+<pre class="webidl prettyprint">TZDate(long year, long month, long day, optional long? hours, optional long? minutes, optional long? seconds,
        optional long? milliseconds, optional DOMString? timezone);</pre>
 </dl>
 </div>
@@ -870,8 +865,7 @@ var myDate = new tizen.TZDate(1999, 11, 31, 23, 59, 59, 999, "Europe/Berlin");
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The day of the month.
               </ul>
 </div>
@@ -928,8 +922,7 @@ console.log(someDate.getDate());  /* Outputs 1. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The day of the week.
               </ul>
 </div>
@@ -959,8 +952,7 @@ For example, 1 = AD 1, 0 = BC 1, -1 = BC 2.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The year.
               </ul>
 </div>
@@ -1011,8 +1003,7 @@ console.log(someDate.getFullYear());  /* Outputs 2099. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The hour.
               </ul>
 </div>
@@ -1069,8 +1060,7 @@ console.log(someDate.getHours());  /* Outputs 15. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The milliseconds.
               </ul>
 </div>
@@ -1127,8 +1117,7 @@ console.log(someDate.getMilliseconds());  /* Outputs 42. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The minutes.
               </ul>
 </div>
@@ -1185,8 +1174,7 @@ console.log(someDate.getMinutes());  /* Outputs 58. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The month.
               </ul>
 </div>
@@ -1243,8 +1231,7 @@ console.log(someDate.getMonth());  /* Outputs 2. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The seconds.
               </ul>
 </div>
@@ -1301,8 +1288,7 @@ console.log(someDate.getSeconds());  /* Outputs 23. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The day of the month, according to universal time.
               </ul>
 </div>
@@ -1359,8 +1345,7 @@ console.log(someDate.getUTCDate());  /* Outputs 5. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The day of the week, according to universal time.
               </ul>
 </div>
@@ -1390,8 +1375,7 @@ For example, 1 = AD 1, 0 = BC 1, -1 = BC 2.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The year, according to universal time.
               </ul>
 </div>
@@ -1442,8 +1426,7 @@ console.log(someDate.getUTCFullYear());  /* Outputs 2099. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The hour, according to universal time.
               </ul>
 </div>
@@ -1500,8 +1483,7 @@ console.log(someDate.getUTCHours());  /* Outputs 15. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The milliseconds, according to universal time.
               </ul>
 </div>
@@ -1558,8 +1540,7 @@ console.log(someDate.getUTCMilliseconds());  /* Outputs 42. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The minutes, according to universal time.
               </ul>
 </div>
@@ -1616,8 +1597,7 @@ console.log(someDate.getUTCMinutes());  /* Outputs 58. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The month, according to universal time.
               </ul>
 </div>
@@ -1674,8 +1654,7 @@ console.log(someDate.getUTCMonth());  /* Outputs 2. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The seconds, according to universal time.
               </ul>
 </div>
@@ -1742,8 +1721,7 @@ This attribute uniquely identifies the timezone.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The string timezone identifier. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -1780,8 +1758,7 @@ console.log(someDate.getTimezone());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate:</span>
  The new TZDate in given Timezone.
               </ul>
 </div>
@@ -1827,8 +1804,7 @@ console.log(someDate.toString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate:</span>
  The new TZDate in local Timezone.
               </ul>
 </div>
@@ -1866,8 +1842,7 @@ console.log(localDate.toString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate:</span>
  The Date/Time in UTC.
               </ul>
 </div>
@@ -1931,8 +1906,7 @@ Positive, if other is in the past              </li>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TimeDuration:
-                  </span>
+<span class="return">TimeDuration:</span>
  The duration in milliseconds between the two date/time objects
 (or in days for comparison between dates with no time component).
               </ul>
@@ -2008,8 +1982,7 @@ the two TZDate objects represent the same instant in different timezones.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if the 2 date/times are the same.
               </ul>
 </div>
@@ -2089,8 +2062,7 @@ This method takes the timezones into consideration.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var>, if the Date/Time is earlier than the one passed in argument.
               </ul>
 </div>
@@ -2150,8 +2122,7 @@ This method takes the timezones into consideration.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var>, if the Date/Time is later than the one passed in argument.
               </ul>
 </div>
@@ -2215,8 +2186,7 @@ Note that calling this method does not alter the current object.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate:</span>
  The new TZDate by adding a duration.
               </ul>
 </div>
@@ -2253,8 +2223,7 @@ var in_one_week = now.addDuration(new tizen.TimeDuration(7, "DAYS"));
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The date portion of the TZDate object as a string, using locale conventions. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2282,8 +2251,7 @@ console.log(someDate.toLocaleDateString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The time portion of the TZDate object as a string, using locale conventions. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2311,8 +2279,7 @@ console.log(someDate.toLocaleTimeString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The string representation of the TZDate object, using locale conventions. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2340,8 +2307,7 @@ console.log(someDate.toLocaleString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The date portion of the TZDate object as a string. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2367,8 +2333,7 @@ console.log(someDate.toDateString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The time portion of the TZDate object as a string. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2394,8 +2359,7 @@ console.log(someDate.toTimeString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The string representation of the TZDate object. If TZDate is invalid, it will return "Invalid Date".
               </ul>
 </div>
@@ -2430,8 +2394,7 @@ summer months when daylight savings time is in effect.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  DOMString The abbreviation of the time zone (such as "EST") <br>If TZDate is invalid, it will return 'Invalid Date'.
               </ul>
 </div>
@@ -2474,8 +2437,7 @@ savings if it is in the timezone. For example, if time zone is GMT+8, it will re
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The offset from UTC in seconds.
               </ul>
 </div>
@@ -2514,8 +2476,7 @@ identified by the TZDate object.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  The flag indicating whether the daylight saving are in effect.
               </ul>
 </div>
@@ -2549,8 +2510,7 @@ var isDstActiveInWinter = wintertime.isDST();  /* false. */
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate<span class="optional"> [nullable]</span>:</span>
  The date of the previous daylight saving transition (before the instant identified by the TZDate).
               </ul>
 </div>
@@ -2587,8 +2547,7 @@ console.log(previousDstTransition.toString());
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TZDate:
-                  </span>
+<span class="return">TZDate<span class="optional"> [nullable]</span>:</span>
  The date of the next daylight saving transition (after the instant identified by the TZDate).
               </ul>
 </div>
@@ -2722,8 +2681,7 @@ The returned TimeDuration is the biggest possible unit without losing the precis
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">TimeDuration:
-                  </span>
+<span class="return">TimeDuration:</span>
  New TimeDuration object corresponding to the result of <em>this</em> - <em>other</em>.
               </ul>
 </div>
@@ -2782,8 +2740,7 @@ if the two TimeDuration objects represent the same duration in different units.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if the two TimeDuration object represent the same duration.
               </ul>
 </div>
@@ -2835,8 +2792,7 @@ This method takes the units into consideration when doing the comparison.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if the TimeDuration is less than <em>other</em>.
               </ul>
 </div>
@@ -2887,8 +2843,7 @@ This method takes the units into consideration when doing the comparison.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">boolean:
-                  </span>
+<span class="return">boolean:</span>
  <var>true</var> if the TimeDuration is greater than <em>other</em>.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/time.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/time.html
@@ -2874,10 +2874,10 @@ var ret = d1.greaterThan(d2);                  /* Returns true. */
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Time {
   enum TimeDurationUnit { "MSECS", "SECS", "MINS", "HOURS", "DAYS" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#TimeManagerObject">TimeManagerObject</a>;
   [NoInterfaceObject] interface TimeManagerObject {
     readonly attribute <a href="#TimeUtil">TimeUtil</a> time;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#TimeManagerObject">TimeManagerObject</a>;
   [NoInterfaceObject] interface TimeUtil {
     <a href="#TZDate">TZDate</a> getCurrentDateTime() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     DOMString getLocalTimezone() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/tizen.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/tizen.html
@@ -1703,10 +1703,10 @@ type: STRING
   enum SortModeOrder { "ASC", "DESC" };
   enum CompositeFilterType { "UNION", "INTERSECTION" };
   enum BundleValueType { "STRING", "STRING_ARRAY", "BYTES", "BYTES_ARRAY" };
+  Window implements <a href="#TizenObject">TizenObject</a>;
   [NoInterfaceObject] interface TizenObject {
     readonly attribute <a href="#Tizen">Tizen</a> tizen;
   };
-  Window implements <a href="#TizenObject">TizenObject</a>;
   [NoInterfaceObject] interface Tizen {
   };
   [Constructor(optional object? json)]

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/tizen.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/tizen.html
@@ -331,9 +331,9 @@ It is a property of the ECMAScript global object, as specified by the <em>TizenO
           </div>
 <pre class="webidl prettyprint">  [Constructor(optional object? json)]
   interface Bundle {
-    any get(DOMString key) raises(<a href="#WebAPIException">WebAPIException</a>);
+    any get(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void set(DOMString key, any value);
-    <a href="#BundleValueType">BundleValueType</a> typeOf(DOMString key) raises(<a href="#WebAPIException">WebAPIException</a>);
+    <a href="#BundleValueType">BundleValueType</a> typeOf(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void forEach(<a href="#BundleItemCallback">BundleItemCallback</a> callback);
     object toJSON();
     DOMString toString();
@@ -377,8 +377,7 @@ All supported value types are specified in the BundleValueType enum.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">any:
-                  </span>
+<span class="return">any:</span>
  Bundle entry value for a given key.
               </ul>
 </div>
@@ -482,8 +481,7 @@ console.log(bundle.get("empty"));
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">BundleValueType:
-                  </span>
+<span class="return">BundleValueType:</span>
  Entry value type.
               </ul>
 </div>
@@ -588,8 +586,7 @@ type: STRING
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">object:
-                  </span>
+<span class="return">object:</span>
  JSON-compatible object.
               </ul>
 </div>
@@ -618,8 +615,7 @@ console.log(JSON.stringify(json));
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  JSON string representation of the bundle's data.
               </ul>
 </div>
@@ -1101,27 +1097,23 @@ catch (err)
 <div class="brief">
  Generic exception interface.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject]
-  interface WebAPIException {
-    readonly attribute unsigned short code;
-    readonly attribute DOMString name;
-    readonly attribute DOMString message;
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface WebAPIException {
     const unsigned short INDEX_SIZE_ERR = 1;
-    const unsigned short DOMSTRING_SIZE_ERR = 2; 
+    const unsigned short DOMSTRING_SIZE_ERR = 2;
     const unsigned short HIERARCHY_REQUEST_ERR = 3;
     const unsigned short WRONG_DOCUMENT_ERR = 4;
     const unsigned short INVALID_CHARACTER_ERR = 5;
-    const unsigned short NO_DATA_ALLOWED_ERR = 6; 
+    const unsigned short NO_DATA_ALLOWED_ERR = 6;
     const unsigned short NO_MODIFICATION_ALLOWED_ERR = 7;
     const unsigned short NOT_FOUND_ERR = 8;
     const unsigned short NOT_SUPPORTED_ERR = 9;
-    const unsigned short INUSE_ATTRIBUTE_ERR = 10; 
+    const unsigned short INUSE_ATTRIBUTE_ERR = 10;
     const unsigned short INVALID_STATE_ERR = 11;
     const unsigned short SYNTAX_ERR = 12;
     const unsigned short INVALID_MODIFICATION_ERR = 13;
     const unsigned short NAMESPACE_ERR = 14;
     const unsigned short INVALID_ACCESS_ERR = 15;
-    const unsigned short VALIDATION_ERR = 16; 
+    const unsigned short VALIDATION_ERR = 16;
     const unsigned short TYPE_MISMATCH_ERR = 17;
     const unsigned short SECURITY_ERR = 18;
     const unsigned short NETWORK_ERR = 19;
@@ -1131,6 +1123,9 @@ catch (err)
     const unsigned short TIMEOUT_ERR = 23;
     const unsigned short INVALID_NODE_TYPE_ERR = 24;
     const unsigned short DATA_CLONE_ERR = 25;
+    readonly attribute unsigned short code;
+    readonly attribute DOMString name;
+    readonly attribute DOMString message;
   };</pre>
 <p><span class="version">Since: </span>
  2.0
@@ -1440,8 +1435,7 @@ This attribute is mainly intended to be used for developers rather than end user
 <div class="brief">
  Generic error interface.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject]
-  interface WebAPIError {
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface WebAPIError {
     readonly attribute unsigned short code;
     readonly attribute DOMString name;
     readonly attribute DOMString message;
@@ -1522,8 +1516,7 @@ as it is mainly intended to be useful for developers rather than end users.
 <div class="brief">
  This interface is used in methods that do not require any return value in the success callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface SuccessCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {
     void onsuccess();
   };</pre>
 <p><span class="version">Since: </span>
@@ -1572,8 +1565,7 @@ tizen.application.launch(otherAppID, onSuccess);
 <div class="brief">
  This interface is used in methods that require only an error as an input parameter in the error callback.
           </div>
-<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject]
-  interface ErrorCallback {
+<pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="#WebAPIError">WebAPIError</a> error);
   };</pre>
 <p><span class="version">Since: </span>
@@ -1719,9 +1711,9 @@ type: STRING
   };
   [Constructor(optional object? json)]
   interface Bundle {
-    any get(DOMString key) raises(<a href="#WebAPIException">WebAPIException</a>);
+    any get(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void set(DOMString key, any value);
-    <a href="#BundleValueType">BundleValueType</a> typeOf(DOMString key) raises(<a href="#WebAPIException">WebAPIException</a>);
+    <a href="#BundleValueType">BundleValueType</a> typeOf(DOMString key) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void forEach(<a href="#BundleItemCallback">BundleItemCallback</a> callback);
     object toJSON();
     DOMString toString();
@@ -1755,27 +1747,23 @@ type: STRING
     attribute double latitude;
     attribute double longitude;
   };
-  [NoInterfaceObject]
-  interface WebAPIException {
-    readonly attribute unsigned short code;
-    readonly attribute DOMString name;
-    readonly attribute DOMString message;
+  [NoInterfaceObject] interface WebAPIException {
     const unsigned short INDEX_SIZE_ERR = 1;
-    const unsigned short DOMSTRING_SIZE_ERR = 2; 
+    const unsigned short DOMSTRING_SIZE_ERR = 2;
     const unsigned short HIERARCHY_REQUEST_ERR = 3;
     const unsigned short WRONG_DOCUMENT_ERR = 4;
     const unsigned short INVALID_CHARACTER_ERR = 5;
-    const unsigned short NO_DATA_ALLOWED_ERR = 6; 
+    const unsigned short NO_DATA_ALLOWED_ERR = 6;
     const unsigned short NO_MODIFICATION_ALLOWED_ERR = 7;
     const unsigned short NOT_FOUND_ERR = 8;
     const unsigned short NOT_SUPPORTED_ERR = 9;
-    const unsigned short INUSE_ATTRIBUTE_ERR = 10; 
+    const unsigned short INUSE_ATTRIBUTE_ERR = 10;
     const unsigned short INVALID_STATE_ERR = 11;
     const unsigned short SYNTAX_ERR = 12;
     const unsigned short INVALID_MODIFICATION_ERR = 13;
     const unsigned short NAMESPACE_ERR = 14;
     const unsigned short INVALID_ACCESS_ERR = 15;
-    const unsigned short VALIDATION_ERR = 16; 
+    const unsigned short VALIDATION_ERR = 16;
     const unsigned short TYPE_MISMATCH_ERR = 17;
     const unsigned short SECURITY_ERR = 18;
     const unsigned short NETWORK_ERR = 19;
@@ -1785,19 +1773,19 @@ type: STRING
     const unsigned short TIMEOUT_ERR = 23;
     const unsigned short INVALID_NODE_TYPE_ERR = 24;
     const unsigned short DATA_CLONE_ERR = 25;
-  };
-  [NoInterfaceObject]
-  interface WebAPIError {
     readonly attribute unsigned short code;
     readonly attribute DOMString name;
     readonly attribute DOMString message;
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface SuccessCallback {
+  [NoInterfaceObject] interface WebAPIError {
+    readonly attribute unsigned short code;
+    readonly attribute DOMString name;
+    readonly attribute DOMString message;
+  };
+  [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {
     void onsuccess();
   };
-  [Callback=FunctionOnly, NoInterfaceObject]
-  interface ErrorCallback {
+  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="#WebAPIError">WebAPIError</a> error);
   };
   [Callback=FunctionOnly] interface BundleItemCallback {

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/voicecontrol.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/voicecontrol.html
@@ -208,8 +208,7 @@ using one of voice control client objects, it affects other objects.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">VoiceControlClient:
-                  </span>
+<span class="return">VoiceControlClient:</span>
  The object to manage voice control.
               </ul>
 </div>
@@ -279,8 +278,7 @@ For example, "ko_KR" for Korean, "en_US" for American English.
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  Currently set language.
               </ul>
 </div>
@@ -451,8 +449,7 @@ client.unsetCommandList("FOREGROUND");
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Identifier used to clear the watch subscription.
               </ul>
 </div>
@@ -580,8 +577,7 @@ client.removeResultListener(id);
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  Identifier used to clear the watch subscription.
               </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/voicecontrol.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/voicecontrol.html
@@ -887,10 +887,10 @@ To guarantee that the voice control application runs on a device with microphone
 <pre class="webidl prettyprint">module VoiceControl {
   enum VoiceControlResultEvent { "SUCCESS", "FAILURE" };
   enum VoiceControlCommandType { "FOREGROUND" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#VoiceControlClientManagerObject">VoiceControlClientManagerObject</a>;
   [NoInterfaceObject] interface VoiceControlClientManagerObject {
     readonly attribute <a href="#VoiceControlClientManager">VoiceControlClientManager</a> voicecontrol;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#VoiceControlClientManagerObject">VoiceControlClientManagerObject</a>;
   [NoInterfaceObject] interface VoiceControlClientManager {
     <a href="#VoiceControlClient">VoiceControlClient</a> getVoiceControlClient() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/widgetservice.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/widgetservice.html
@@ -1720,10 +1720,10 @@ To guarantee that the widget application runs on a system which supports Widgets
   enum WidgetSizeType { "1x1", "2x1", "2x2", "4x1", "4x2", "4x3", "4x4", "4x5", "4x6", "EASY_1x1", "EASY_3x1", "EASY_3x3",
     "FULL" };
   enum WidgetStateType { "CREATE", "DESTROY", "PAUSE", "RESUME" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#WidgetServiceManagerObject">WidgetServiceManagerObject</a>;
   [NoInterfaceObject] interface WidgetServiceManagerObject {
     readonly attribute <a href="#WidgetServiceManager">WidgetServiceManager</a> widgetservice;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#WidgetServiceManagerObject">WidgetServiceManagerObject</a>;
   [NoInterfaceObject] interface WidgetServiceManager {
     <a href="#Widget">Widget</a> getWidget(<a href="#WidgetId">WidgetId</a> widgetId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void getWidgets(<a href="#WidgetArraySuccessCallback">WidgetArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="package.html#PackageId">PackageId</a>? packageId)

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/widgetservice.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/widgetservice.html
@@ -91,7 +91,7 @@ Do not use "widget" as name for one of your global variables, as it is a global 
 <a href="#Widget">Widget</a> <a href="#WidgetServiceManager::getWidget">getWidget</a> (<a href="#WidgetId">WidgetId</a> widgetId)</div>
 <div>void <a href="#WidgetServiceManager::getWidgets">getWidgets</a> (<a href="#WidgetArraySuccessCallback">WidgetArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="package.html#PackageId">PackageId</a>? packageId)</div>
 <div>
-<a href="#WidgetId">WidgetId</a> <a href="#WidgetServiceManager::getPrimaryWidgetId">getPrimaryWidgetId</a> ((PackageId or ApplicationId) id)</div>
+<a href="#WidgetId">WidgetId</a> <a href="#WidgetServiceManager::getPrimaryWidgetId">getPrimaryWidgetId</a> ((<a href="package.html#PackageId">PackageId</a> or <a href="application.html#ApplicationId">ApplicationId</a>) id)</div>
 <div>
 <a href="#WidgetSize">WidgetSize</a> <a href="#WidgetServiceManager::getSize">getSize</a> (<a href="#WidgetSizeType">WidgetSizeType</a> sizeType)</div>
 </td>
@@ -403,8 +403,7 @@ The <em>tizen.widgetservice</em> object provides access to the Widget Service AP
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">Widget:
-                  </span>
+<span class="return">Widget:</span>
  The Widget object.
               </ul>
 </div>
@@ -536,7 +535,7 @@ NotFoundError - If the device has no widgets or if a widget with the given id do
 <div class="brief">
  Returns the primary widget ID of the specified package or application.
             </div>
-<div class="synopsis"><pre class="signature prettyprint"><a href="#WidgetId">WidgetId</a> getPrimaryWidgetId((PackageId or ApplicationId) id);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#WidgetId">WidgetId</a> getPrimaryWidgetId((<a href="package.html#PackageId">PackageId</a> or <a href="application.html#ApplicationId">ApplicationId</a>) id);</pre></div>
 <p><span class="version">Since: </span>
  2.3.2
             </p>
@@ -558,8 +557,7 @@ NotFoundError - If the device has no widgets or if a widget with the given id do
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">WidgetId:
-                  </span>
+<span class="return">WidgetId:</span>
  The ID of the widget.
               </ul>
 </div>
@@ -623,8 +621,7 @@ catch (error)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">WidgetSize:
-                  </span>
+<span class="return">WidgetSize:</span>
  An object which contains width and height.
               </ul>
 </div>
@@ -759,8 +756,7 @@ Precondition: Widget tag in the config.xml file includes the "nodisplay" attribu
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">DOMString:
-                  </span>
+<span class="return">DOMString:</span>
  The name of the widget.
               </ul>
 </div>
@@ -892,8 +888,7 @@ catch (error)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">WidgetVariant:
-                  </span>
+<span class="return">WidgetVariant:</span>
  Size variant info.
               </ul>
 </div>
@@ -1026,8 +1021,7 @@ catch (error)
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
 <ul>
-<span class="return">long:
-                  </span>
+<span class="return">long:</span>
  The watch ID used to unregister the callback.
               </ul>
 </div>
@@ -1723,7 +1717,8 @@ To guarantee that the widget application runs on a system which supports Widgets
 <pre class="webidl prettyprint">module WidgetService {
   typedef DOMString WidgetId;
   typedef DOMString WidgetInstanceId;
-  enum WidgetSizeType { "1x1", "2x1", "2x2", "4x1", "4x2", "4x3", "4x4", "4x5", "4x6", "EASY_1x1", "EASY_3x1", "EASY_3x3", "FULL" };
+  enum WidgetSizeType { "1x1", "2x1", "2x2", "4x1", "4x2", "4x3", "4x4", "4x5", "4x6", "EASY_1x1", "EASY_3x1", "EASY_3x3",
+    "FULL" };
   enum WidgetStateType { "CREATE", "DESTROY", "PAUSE", "RESUME" };
   [NoInterfaceObject] interface WidgetServiceManagerObject {
     readonly attribute <a href="#WidgetServiceManager">WidgetServiceManager</a> widgetservice;


### PR DESCRIPTION
This is the same change set as in #787, but for 5.5 branch

* Added the description about shared directory structure in application module (requested by security team)
* Fixed raised errors in cordova modules
* Removed unnecessary trailing whitespaces (cleaned files) and added missing optional/nullable tags
* Fixed structure of full web idl sections (elements grouped by its type: typedef, dictionary, interfaces, callbacks)
* Fixed printing of deprecated enumerators (related to comment #731 (comment))
* Fixed links in few modules (added in few modules instead of just text)
