### PR TITLE
Remove Dynamic Analyzer from Tizen Studio > Web Tools.

### DIFF
--- a/docs/application/tizen-studio/web-tools/debugging.md
+++ b/docs/application/tizen-studio/web-tools/debugging.md
@@ -6,10 +6,6 @@ The Tizen Studio provides the following set of tools to help you debug your Web 
 
    The **Log** view allows you to check the logs of your application based on the logging methods you have inserted to your code. It helps to debug your application by capturing all the events logged by the platform and your application.
 
-- [Dynamic Analyzer](../common-tools/dynamic-analyzer/overview.md) **(Monitoring Performance with Dynamic Analyzer)**
-
-   The Dynamic Analyzer tool monitors the performance of your application on a target device or emulator. It analyzes your application for potential performance issues, such as high usage of CPU, memory, file or network operations.
-
 - [Web Inspector](web-inspector.md) **(Debugging with Web Inspector)**
 
   The Web Inspector tool allows you to debug your Web applications. It supports various features, such as viewing the Web page components, inspecting local and downloaded resources and the JavaScript source page, and performing advanced timing and speed analysis.

--- a/docs/application/toc_all.md
+++ b/docs/application/toc_all.md
@@ -1081,16 +1081,6 @@
 
 ### Debug Your App
 #### [Log View](/application/tizen-studio/common-tools/log-view.md)
-#### Dynamic Analyzer
-##### [Overview](/application/tizen-studio/common-tools/dynamic-analyzer/overview.md)
-##### [Common Tasks](/application/tizen-studio/common-tools/dynamic-analyzer/common-tasks.md)
-##### [Advanced Tasks](/application/tizen-studio/common-tools/dynamic-analyzer/advanced-tasks.md)
-##### [Memory Analysis](/application/tizen-studio/common-tools/dynamic-analyzer/memory-analysis.md)
-##### [Thread Analysis](/application/tizen-studio/common-tools/dynamic-analyzer/thread-analysis.md)
-##### [File Analysis](/application/tizen-studio/common-tools/dynamic-analyzer/file-analysis.md)
-##### [Network Analysis](/application/tizen-studio/common-tools/dynamic-analyzer/network-analysis.md)
-##### [OpenGL Analysis](/application/tizen-studio/common-tools/dynamic-analyzer/opengl-analysis.md)
-##### [UI Hierarchy Analysis](/application/tizen-studio/common-tools/dynamic-analyzer/ui-hierarchy-analysis.md)
 
 ### Run and Test Your App
 #### [SDB](/application/tizen-studio/common-tools/smart-development-bridge.md)


### PR DESCRIPTION
### Change Description ###

Remove Dynamic Analyzer from Tizen Studio > Web Tools.

Requested by dongkyun.s@samsung.com

### Reference ###
 
SWAP part> 
 - WSP (web startup profiling):
   - swap-modules:
     - wsp: remove module https://review.tizen.org/gerrit/#/c/platform/kernel/swap-modules/+/191136/
   - swap-manager:
     - Remove web startup profiling (WSP) feature https://review.tizen.org/gerrit/#/c/platform/core/system/swap-manager/+/191135/

 - Web Profilling:
   - swap-modules:
      - wsi: remove feature https://review.tizen.org/gerrit/#/c/platform/kernel/swap-modules/+/153910/
   - swap-manager:
     - wsi: remove feature https://review.tizen.org/gerrit/#/c/platform/core/system/swap-manager/+/153909/
