### PR TITLE
Restore TAU documentation changes - links

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Button.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Button.htm
@@ -15,6 +15,8 @@
 <p>The button component changes the default browser buttons to special buttons with additional configuration options, such as an icon, corners, and a shadow.</p>
 
 <img src="../../images/mobile_button.png" width="15%">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fbutton%2Findex.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Checkbox.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Checkbox.htm
@@ -26,6 +26,8 @@
 </table>
 
 <img src="../../images/mobile_checkbox.png" width="15%">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fcheckbox.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_ColoredListview.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_ColoredListview.htm
@@ -14,6 +14,9 @@
 <p>You should check if your brower support WebGL since colored list view uses the WebGL technology.</p>
 
 <img src="../../images/mobile_coloredlistview.png" width="15%">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Flist%2Fnormallist.html', '_blank')">Use example</button>
+
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_DropdownMenu.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_DropdownMenu.htm
@@ -14,6 +14,8 @@
 <p>DropdownMenu component allows you to create the component in the form of a drop-down list and manage its operation.</p>
 
 <img src="../../images/mobile_dropdownMenu.png" width="15%">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fdropdownmenu.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Expandable.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Expandable.htm
@@ -28,6 +28,8 @@
     </tbody>
 </table>
 
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Flist%2Fexpandable%2Fexpandable.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_FloatingActions.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_FloatingActions.htm
@@ -15,6 +15,9 @@
 
 <img src="../../images/mobile_floatingActions.png" width="15%">
 
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Ffloatingactions%2Fon-listview.html', '_blank')">Use example</button>
+
 <h2>Table of Contents</h2>
 <ol class="toc">
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_GridView.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_GridView.htm
@@ -15,6 +15,8 @@
 <p>Grid view can have labels and set type of the labels.</p>
 
 <img src="../../images/mobile_gridView.png" width="15%">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Flist%2Fgridview%2Fgridview.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_IndexScrollBar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_IndexScrollBar.htm
@@ -16,6 +16,8 @@
 <p>If you move the mouse over the shortcut column, then a pop-up containing the text is also displayed. The scroll view can be moved to the list divider matching the text currently under the mouse cursor.</p>
 
 <img src="../../images/mobile_indexScrollBar.png" width="15%">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fnavigationelements%2Findexscrollbar.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Navigation.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Navigation.htm
@@ -25,6 +25,9 @@
 </table>
 
 <img src="../../images/mobile_navigationBar.png" width="15%">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fnavigationelements%2Fpanel%2Findex.html', '_blank')">Use example</button>
+
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_PageIndicator.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_PageIndicator.htm
@@ -27,6 +27,8 @@ The highlighted dots represent the corresponing active pages.</p>
 </table>
 
 <img src="../../images/mobile_pageIndicator.png" width="15%">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fnavigationelements%2Fpageindicator.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_PanelChanger.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_PanelChanger.htm
@@ -15,6 +15,7 @@
 It works even if the panel components is in other HTML files.<br>
 Panel changer component controls lifecycle of the panels.</p>
 
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fnavigationelements%2Fpanel%2Findex.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Popup.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Popup.htm
@@ -15,6 +15,8 @@
 <p>The popup component handles creating and managing pop-up windows.</p>
 
 <img src="../../images/mobile_popUp.png" width="15%">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fpopup%2Fpopup.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Progress.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Progress.htm
@@ -29,6 +29,8 @@
 </table>
 
 <img src="../../images/mobile_progressCircle.png" width="15%">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fprogress%2Factivitycircle.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Radio.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Radio.htm
@@ -26,6 +26,8 @@
 </table>
 
 <img src="../../images/mobile_radioButton.png" width="15%">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fradio.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_SearchInput.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_SearchInput.htm
@@ -28,6 +28,8 @@
 </table>
 
 <img src="../../images/mobile_searchInput.png" width="15%">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fsearchinput%2Findex.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_SectionChanger.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_SectionChanger.htm
@@ -25,6 +25,8 @@ With Section changer on one page, you can scroll the <span style="font-family: C
 	</tbody>
 </table>
 
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fgallery%2Fgallery.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Slider.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Slider.htm
@@ -15,6 +15,8 @@
 <p>The slider component changes the range-type browser input to sliders.</p>
 
 <img src="../../images/mobile_slider.png" width="15%">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fslider.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Tabs.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Tabs.htm
@@ -24,6 +24,8 @@ The Tabs component is a controller component for operate closely with tabbar and
 </table>
 
 <img src="../../images/mobile_tabs.png" width="15%">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fnavigationelements%2Ftabs%2Ftabs_text_only_4.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_TextEnveloper.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_TextEnveloper.htm
@@ -34,6 +34,8 @@ If you want to delete word block, you should press the backspace key. If you foc
 </table>
 
 <img src="../../images/mobile_textEnveloper.png" width="15%">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Ftextenveloper%2Ftextenveloper.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_TextInput.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_TextInput.htm
@@ -14,6 +14,8 @@
 <p>TextInput component is decorator for input elements.</p>
 
 <img src="../../images/mobile_textInput.png" width="15%">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Ftextinput.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_ToggleSwitch.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_ToggleSwitch.htm
@@ -15,6 +15,8 @@
 <p>The ToggleSwitch component is used as 2-state switch for on/off or true/false data input.</p>
 
 <img src="../../images/mobile_toggleSwitch.png" width="15%">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Ftoggleswitch.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_button.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_button.htm
@@ -12,8 +12,12 @@
 <h1>Button</h1>
 
 <p>The button component shows on the screen a control that you can use to generate an action event when it is pressed and released.<br> The component is coded with standard HTML anchor and input elements.</p>
-<p>The following table describes the supported button classes.</p>
+
 <img src="../../images/button.png" alt="photo of button element in Tizen">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fbutton%2Ficon-button.html', '_blank')">Use example</button>
+
+<p>The following table describes the supported button classes.</p>
 <table>
 <caption>Table: Button type classes</caption>
 <tbody>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_checkbox.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_checkbox.htm
@@ -14,6 +14,8 @@
 <p>Checkbox and Radio Button components shows selectable items:</p>
 
 <img src="../../images/checkboxRadio.png" alt="photo of checkboxRadio in Tizen">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fcheckbox.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circleprogressbar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circleprogressbar.htm
@@ -15,6 +15,8 @@
 <p>The circle progress component shows a control that indicates the progress percentage of an on-going operation.<br>This component can be scaled to be fit inside a parent container.</p>
 
 <img src="../../images/CircleProgressBar.png" alt="photo of CircleProgressBar in Tizen">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fprogress%2Fprogress_medium.html', '_blank')">Use example</button>
 
 <table class="note">
 	<tbody>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
@@ -14,6 +14,7 @@
 <p>If you spin the rotary quickly, an indicator will be displayed and you can move in an index unit.</p>
 <p>The indicator will disappear if no rotary action is detected for a second.</p>
 <p>This component fires a select event when the index characters are selected.</p>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fnavcontrols%2Findexscrollbar%2Findex.html', '_blank')">Use example</button>
 
 <table class="note">
 	<tbody>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_datepicker.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_datepicker.htm
@@ -12,6 +12,8 @@
 <h1>Date Picker</h1>
 
 <img src="../../images/DatePicker.png" alt="photo of date picker element in Tizen">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fdate-picker.html', '_blank')">Use example</button>
 
 <p>To add a date picker component to the application, use the following code:</p>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_list.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_list.htm
@@ -14,6 +14,8 @@
 <p>The list component is used to display, for example, navigation data, results, and data entries. The following table describes the supported list classes.</p>
 
 <img src="../../images/List.png" alt="photo of List element in Tizen">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Flist%2Flist_normal.html', '_blank')">Use example</button>
 
 <table>
 <caption>Table: List classes</caption>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_marquee.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_marquee.htm
@@ -15,6 +15,8 @@ It makes &lt;div&gt; element (has some child nodes such as text and img) move ho
 <video autoplay muted loop controls>
 	<source src="https://developer.tizen.org/sites/default/files/documentation/marquee.mp4">
 </video>
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fmarquee%2Findex.html', '_blank')">Use example</button>
 
 <table class="note">
 	<tbody>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_numberpicker.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_numberpicker.htm
@@ -12,6 +12,8 @@
 <h1>Number Picker</h1>
 
 <img src="../../images/NumberPicker.png" alt="photo of number picker element in Tizen">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fnumberpicker%2Fsimple.html', '_blank')">Use example</button>
 
 <p>To add a number picker component to the application, use the following code:</p>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_pageindicator.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_pageindicator.htm
@@ -16,6 +16,9 @@
 <p>If the number of linked pages is more than dots which can be displayed, a central dot is assigned to multiple pages.</p>
 
 <img src="../../images/PageIndicator.png" alt="photo of Page Indicator element in TIZEN">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Findicator%2Fpageindicator_circle.html', '_blank')">Use example</button>
+
 <table class="note">
 	<tbody>
 	<tr>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_popup.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_popup.htm
@@ -13,6 +13,9 @@
 
 <p>The popup component shows in the middle of the screen a list of items in a pop-up window. It automatically optimizes the pop-up window size within the screen.  The following table describes the supported popup classes.</p>
 <img src="../../images/Popup.png" alt="image of Popup element in TIZEN">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fpopup%2Fpopup.html', '_blank')">Use example</button>
+
 <table>
 <caption>Table: Popup classes</caption>
 <tbody>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_processing.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_processing.htm
@@ -17,6 +17,8 @@
 <video autoplay muted loop controls>
 	<source src="https://developer.tizen.org/sites/default/files/documentation/processing.mp4">
 </video>
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fprocessing%2Ffull_processing.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_sectionchanger.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_sectionchanger.htm
@@ -18,6 +18,8 @@ It gets to have a virtue of needlessness of changing page and the existance of s
 <video autoplay muted loop controls>
 	<source src="https://developer.tizen.org/sites/default/files/documentation/sectionchanger.mp4">
 </video>
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fnavcontrols%2Fsectionchanger%2Fhsection.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_selector.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_selector.htm
@@ -21,6 +21,8 @@ Indicator arrow is special indicator style that has the arrow. It is used for pr
 <video autoplay muted loop controls>
 	<source src="https://developer.tizen.org/sites/default/files/documentation/selector.mp4">
 </video>
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fselector%2Fselector.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_slider.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_slider.htm
@@ -17,7 +17,8 @@
 <video autoplay muted loop controls>
        <source src="https://developer.tizen.org/sites/default/files/documentation/slider.mp4">
 </video>
-
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fslider%2Fslider.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_snaplistview.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_snaplistview.htm
@@ -18,6 +18,8 @@ When scroll ended, it triggers &quot;selected&quot; event and attach class to de
 <video autoplay muted loop controls>
 	<source src="https://developer.tizen.org/sites/default/files/documentation/snaplistview.mp4">
 </video>
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Flist%2Fsnaplistview.html', '_blank')">Use example</button>
 
 <table class="note">
         <tbody>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_timepicker.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_timepicker.htm
@@ -12,6 +12,8 @@
 <h1>Time Picker</h1>
 
 <img src="../../images/TimePicker.png" alt="photo of time picker element in Tizen">
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Ftime-picker.html', '_blank')">Use example</button>
 
 <p>To add a time picker component to the application, use the following code:</p>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_toggleswitch.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_toggleswitch.htm
@@ -16,6 +16,8 @@
 <video autoplay muted loop controls>
 	<source src="https://developer.tizen.org/sites/default/files/documentation/toggleswitch.mp4">
 </video>
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Ftoggle.html', '_blank')">Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_virtuallist.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_virtuallist.htm
@@ -19,7 +19,10 @@
 <video autoplay muted loop controls>
 	<source src="https://developer.tizen.org/sites/default/files/documentation/virtuallist.mp4">
 </video>
+<br>
+<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Flist%2Fvirtual%2Fnormal.html', '_blank')">Use example</button>
 
+<h2>Table of Contents</h2>
 <ol class="toc">
 
 		<li><a href="#manual-constructor">How to Create Virtual List</a>


### PR DESCRIPTION
### Restore TAU documentation changes - links  ###
Restore reverted commits for TAU components documentation.
Links to code.tizen.org examples were restored.

Restore is done to prepare for proper testing.
