### PR TITLE
Mark ViewSwitcher component as deprecated

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_viewSwitcher.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_viewSwitcher.htm
@@ -13,13 +13,16 @@
 
 ViewSwitcher component controls each view elements which are changing position.This component managed to animation, views position, events and get/set active view index.If you want to change the view as various animating, you should wrap views as the ViewSwitcher element thenViewSwitcher would set views position and start to manage to gesture event.
 
-<table class="note">
+<table class="note deprecated">
 	<tbody>
 	<tr>
-		<th class="note">Note</th>
+		<th class="note deprecated">Note</th>
 	</tr>
 	<tr>
-		<td class="note">This component is supported since <strong>2.3</strong>.</td>
+		<td class="note deprecated">This component has been <span class="deprecated">DEPRECATED since <b>Tizen 4.0</b></span> and will be <i>deleted in future releases.</i></td>
+	</tr>
+	<tr>
+		<td class="note deprecated">Since Tizen 4.0, please use <a href="./wearable_sectionchanger.htm">Section Changer</a> component instead.</td>
 	</tr>
 
 	</tbody>


### PR DESCRIPTION
- Add missing information about deprecation of ViewSwitcher component
- Component has been replaced with SectionChanger since Tizen 5.0

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>

