### PR TITLE
[HumanActivityMonitor][3.0] Changed type of timestamp

### DIFF
--- a/docs/application/web/api/3.0/device_api/mobile/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/3.0/device_api/mobile/tizen/humanactivitymonitor.html
@@ -1834,7 +1834,7 @@ When a user takes off the watch device, the heartRate is set to -3. When a user 
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface HumanActivitySleepMonitorData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#SleepStatus">SleepStatus</a> status;
-    readonly attribute long timestamp;
+    readonly attribute long long timestamp;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -1857,7 +1857,7 @@ When a user takes off the watch device, the heartRate is set to -3. When a user 
 </li>
 <li class="attribute" id="HumanActivitySleepMonitorData::timestamp">
 <span class="attrName"><span class="readonly">                readonly
-</span><span class="type">long </span><span class="name">timestamp</span></span><div class="brief">
+</span><span class="type">long long </span><span class="name">timestamp</span></span><div class="brief">
  The time when the sleep status is recognized. Epoch time in milliseconds.
             </div>
 <p><span class="version">Since: </span>
@@ -2388,7 +2388,7 @@ To guarantee that the barometer (pressure) sensor application runs on a device w
   };
   [NoInterfaceObject] interface HumanActivitySleepMonitorData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#SleepStatus">SleepStatus</a> status;
-    readonly attribute long timestamp;
+    readonly attribute long long timestamp;
   };
   [NoInterfaceObject] interface HumanActivityRecognitionData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#ActivityRecognitionType">ActivityRecognitionType</a> type;

--- a/docs/application/web/api/3.0/device_api/wearable/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/3.0/device_api/wearable/tizen/humanactivitymonitor.html
@@ -1837,7 +1837,7 @@ When a user takes off the watch device, the heartRate is set to -3. When a user 
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface HumanActivitySleepMonitorData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#SleepStatus">SleepStatus</a> status;
-    readonly attribute long timestamp;
+    readonly attribute long long timestamp;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -1860,7 +1860,7 @@ When a user takes off the watch device, the heartRate is set to -3. When a user 
 </li>
 <li class="attribute" id="HumanActivitySleepMonitorData::timestamp">
 <span class="attrName"><span class="readonly">                readonly
-</span><span class="type">long </span><span class="name">timestamp</span></span><div class="brief">
+</span><span class="type">long long </span><span class="name">timestamp</span></span><div class="brief">
  The time when the sleep status is recognized. Epoch time in milliseconds.
             </div>
 <p><span class="version">Since: </span>
@@ -2391,7 +2391,7 @@ To guarantee that the barometer (pressure) sensor application runs on a device w
   };
   [NoInterfaceObject] interface HumanActivitySleepMonitorData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#SleepStatus">SleepStatus</a> status;
-    readonly attribute long timestamp;
+    readonly attribute long long timestamp;
   };
   [NoInterfaceObject] interface HumanActivityRecognitionData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#ActivityRecognitionType">ActivityRecognitionType</a> type;

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/humanactivitymonitor.html
@@ -2157,7 +2157,7 @@ When a user takes off the watch device, the heartRate is set to -3. When a user 
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface HumanActivitySleepMonitorData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#SleepStatus">SleepStatus</a> status;
-    readonly attribute long timestamp;
+    readonly attribute long long timestamp;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -2180,7 +2180,7 @@ When a user takes off the watch device, the heartRate is set to -3. When a user 
 </li>
 <li class="attribute" id="HumanActivitySleepMonitorData::timestamp">
 <span class="attrName"><span class="readonly">                readonly
-</span><span class="type">long </span><span class="name">timestamp</span></span><div class="brief">
+</span><span class="type">long long </span><span class="name">timestamp</span></span><div class="brief">
  The time when the sleep status is recognized. Epoch time in milliseconds.
             </div>
 <p><span class="version">Since: </span>
@@ -2831,7 +2831,7 @@ To guarantee that the barometer (pressure) sensor application runs on a device w
   };
   [NoInterfaceObject] interface HumanActivitySleepMonitorData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#SleepStatus">SleepStatus</a> status;
-    readonly attribute long timestamp;
+    readonly attribute long long timestamp;
   };
   [NoInterfaceObject] interface HumanActivityRecognitionData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#ActivityRecognitionType">ActivityRecognitionType</a> type;

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/humanactivitymonitor.html
@@ -2157,7 +2157,7 @@ When a user takes off the watch device, the heartRate is set to -3. When a user 
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface HumanActivitySleepMonitorData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#SleepStatus">SleepStatus</a> status;
-    readonly attribute long timestamp;
+    readonly attribute long long timestamp;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -2180,7 +2180,7 @@ When a user takes off the watch device, the heartRate is set to -3. When a user 
 </li>
 <li class="attribute" id="HumanActivitySleepMonitorData::timestamp">
 <span class="attrName"><span class="readonly">                readonly
-</span><span class="type">long </span><span class="name">timestamp</span></span><div class="brief">
+</span><span class="type">long long </span><span class="name">timestamp</span></span><div class="brief">
  The time when the sleep status is recognized. Epoch time in milliseconds.
             </div>
 <p><span class="version">Since: </span>
@@ -2831,7 +2831,7 @@ To guarantee that the barometer (pressure) sensor application runs on a device w
   };
   [NoInterfaceObject] interface HumanActivitySleepMonitorData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#SleepStatus">SleepStatus</a> status;
-    readonly attribute long timestamp;
+    readonly attribute long long timestamp;
   };
   [NoInterfaceObject] interface HumanActivityRecognitionData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#ActivityRecognitionType">ActivityRecognitionType</a> type;

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/humanactivitymonitor.html
@@ -2455,7 +2455,7 @@ When a user takes off the watch device, the heartRate is set to -3. When a user 
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface HumanActivitySleepMonitorData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#SleepStatus">SleepStatus</a> status;
-    readonly attribute long timestamp;
+    readonly attribute long long timestamp;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -2478,7 +2478,7 @@ When a user takes off the watch device, the heartRate is set to -3. When a user 
 </li>
 <li class="attribute" id="HumanActivitySleepMonitorData::timestamp">
 <span class="attrName"><span class="readonly">                readonly
-</span><span class="type">long </span><span class="name">timestamp</span></span><div class="brief">
+</span><span class="type">long long </span><span class="name">timestamp</span></span><div class="brief">
  The time when the sleep status is recognized. Epoch time in milliseconds.
             </div>
 <p><span class="version">Since: </span>
@@ -3276,7 +3276,7 @@ To guarantee that the stress monitor vector sensor application runs on a device 
   };
   [NoInterfaceObject] interface HumanActivitySleepMonitorData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#SleepStatus">SleepStatus</a> status;
-    readonly attribute long timestamp;
+    readonly attribute long long timestamp;
   };
   [NoInterfaceObject] interface HumanActivitySleepDetectorData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#SleepStatus">SleepStatus</a> status;

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/humanactivitymonitor.html
@@ -2455,7 +2455,7 @@ When a user takes off the watch device, the heartRate is set to -3. When a user 
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface HumanActivitySleepMonitorData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#SleepStatus">SleepStatus</a> status;
-    readonly attribute long timestamp;
+    readonly attribute long long timestamp;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -2478,7 +2478,7 @@ When a user takes off the watch device, the heartRate is set to -3. When a user 
 </li>
 <li class="attribute" id="HumanActivitySleepMonitorData::timestamp">
 <span class="attrName"><span class="readonly">                readonly
-</span><span class="type">long </span><span class="name">timestamp</span></span><div class="brief">
+</span><span class="type">long long </span><span class="name">timestamp</span></span><div class="brief">
  The time when the sleep status is recognized. Epoch time in milliseconds.
             </div>
 <p><span class="version">Since: </span>
@@ -3276,7 +3276,7 @@ To guarantee that the stress monitor vector sensor application runs on a device 
   };
   [NoInterfaceObject] interface HumanActivitySleepMonitorData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#SleepStatus">SleepStatus</a> status;
-    readonly attribute long timestamp;
+    readonly attribute long long timestamp;
   };
   [NoInterfaceObject] interface HumanActivitySleepDetectorData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#SleepStatus">SleepStatus</a> status;


### PR DESCRIPTION
Changed type of timestamp of HumanActivitySleepMonitorData

[Bug] There was an issue with type of timestamp member of HumanActivitySleepMonitorData
  timestamp was described as long value, but also in milliseconds. 'long' type is not wide
  enough to keep the current timestamp in milliseconds, so it need to be extended.

  Backward compatibility is kept, only the range of values was extended.

[ACR] http://suprem.sec.samsung.net/jira/browse/TWDAPI-228
