### PR TITLE
Forbid "Use example" for non Chrome Browser

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Button.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Button.htm
@@ -16,7 +16,13 @@
 
 <img src="../../images/mobile_button.png" width="15%">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fbutton%2Findex.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fbutton%2Findex.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Checkbox.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Checkbox.htm
@@ -27,7 +27,13 @@
 
 <img src="../../images/mobile_checkbox.png" width="15%">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fcheckbox.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fcheckbox.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_ColoredListview.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_ColoredListview.htm
@@ -15,8 +15,13 @@
 
 <img src="../../images/mobile_coloredlistview.png" width="15%">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Flist%2Fnormallist.html', '_blank')">Use example</button>
-
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Flist%2Fnormallist.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_DropdownMenu.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_DropdownMenu.htm
@@ -15,7 +15,13 @@
 
 <img src="../../images/mobile_dropdownMenu.png" width="15%">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fdropdownmenu.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fdropdownmenu.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Expandable.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Expandable.htm
@@ -29,7 +29,13 @@
 </table>
 
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Flist%2Fexpandable%2Fexpandable.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Flist%2Fexpandable%2Fexpandable.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_FloatingActions.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_FloatingActions.htm
@@ -14,9 +14,14 @@
 <p>You can move the floating button from left end to right end.</p>
 
 <img src="../../images/mobile_floatingActions.png" width="15%">
-
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Ffloatingactions%2Fon-listview.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Ffloatingactions%2Fon-listview.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_GridView.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_GridView.htm
@@ -16,7 +16,13 @@
 
 <img src="../../images/mobile_gridView.png" width="15%">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Flist%2Fgridview%2Fgridview.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Flist%2Fgridview%2Fgridview.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_IndexScrollBar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_IndexScrollBar.htm
@@ -17,7 +17,13 @@
 
 <img src="../../images/mobile_indexScrollBar.png" width="15%">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fnavigationelements%2Findexscrollbar.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fnavigationelements%2Findexscrollbar.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Navigation.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Navigation.htm
@@ -26,8 +26,13 @@
 
 <img src="../../images/mobile_navigationBar.png" width="15%">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fnavigationelements%2Fpanel%2Findex.html', '_blank')">Use example</button>
-
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fnavigationelements%2Fpanel%2Findex.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_PageIndicator.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_PageIndicator.htm
@@ -28,7 +28,13 @@ The highlighted dots represent the corresponing active pages.</p>
 
 <img src="../../images/mobile_pageIndicator.png" width="15%">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fnavigationelements%2Fpageindicator.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fnavigationelements%2Fpageindicator.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_PanelChanger.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_PanelChanger.htm
@@ -15,7 +15,13 @@
 It works even if the panel components is in other HTML files.<br>
 Panel changer component controls lifecycle of the panels.</p>
 
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fnavigationelements%2Fpanel%2Findex.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fnavigationelements%2Fpanel%2Findex.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Popup.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Popup.htm
@@ -16,7 +16,13 @@
 
 <img src="../../images/mobile_popUp.png" width="15%">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fpopup%2Fpopup.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fpopup%2Fpopup.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Progress.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Progress.htm
@@ -30,7 +30,13 @@
 
 <img src="../../images/mobile_progressCircle.png" width="15%">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fprogress%2Factivitycircle.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fprogress%2Factivitycircle.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Radio.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Radio.htm
@@ -27,7 +27,13 @@
 
 <img src="../../images/mobile_radioButton.png" width="15%">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fradio.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fradio.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_SearchInput.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_SearchInput.htm
@@ -29,7 +29,13 @@
 
 <img src="../../images/mobile_searchInput.png" width="15%">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fsearchinput%2Findex.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fsearchinput%2Findex.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_SectionChanger.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_SectionChanger.htm
@@ -26,7 +26,13 @@ With Section changer on one page, you can scroll the <span style="font-family: C
 </table>
 
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fgallery%2Fgallery.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fgallery%2Fgallery.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Slider.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Slider.htm
@@ -16,7 +16,13 @@
 
 <img src="../../images/mobile_slider.png" width="15%">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fslider.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fslider.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Tabs.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_Tabs.htm
@@ -25,7 +25,13 @@ The Tabs component is a controller component for operate closely with tabbar and
 
 <img src="../../images/mobile_tabs.png" width="15%">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fnavigationelements%2Ftabs%2Ftabs_text_only_4.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fnavigationelements%2Ftabs%2Ftabs_text_only_4.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_TextEnveloper.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_TextEnveloper.htm
@@ -35,7 +35,13 @@ If you want to delete word block, you should press the backspace key. If you foc
 
 <img src="../../images/mobile_textEnveloper.png" width="15%">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Ftextenveloper%2Ftextenveloper.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Ftextenveloper%2Ftextenveloper.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_TextInput.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_TextInput.htm
@@ -15,7 +15,13 @@
 
 <img src="../../images/mobile_textInput.png" width="15%">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Ftextinput.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Ftextinput.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_ToggleSwitch.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Mobile_UIComponents/mobile_ToggleSwitch.htm
@@ -16,7 +16,13 @@
 
 <img src="../../images/mobile_toggleSwitch.png" width="15%">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Ftoggleswitch.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Ftoggleswitch.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_button.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_button.htm
@@ -15,7 +15,13 @@
 
 <img src="../../images/button.png" alt="photo of button element in Tizen">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fbutton%2Ficon-button.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fbutton%2Ficon-button.html', '_blank')"
+>Use example</button>
 
 <p>The following table describes the supported button classes.</p>
 <table>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_checkbox.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_checkbox.htm
@@ -15,7 +15,13 @@
 
 <img src="../../images/checkboxRadio.png" alt="photo of checkboxRadio in Tizen">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fcheckbox.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fcheckbox.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circleprogressbar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circleprogressbar.htm
@@ -16,7 +16,13 @@
 
 <img src="../../images/CircleProgressBar.png" alt="photo of CircleProgressBar in Tizen">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fprogress%2Fprogress_medium.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fprogress%2Fprogress_medium.html', '_blank')"
+>Use example</button>
 
 <table class="note">
 	<tbody>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_circularindexscrollbar.htm
@@ -14,7 +14,13 @@
 <p>If you spin the rotary quickly, an indicator will be displayed and you can move in an index unit.</p>
 <p>The indicator will disappear if no rotary action is detected for a second.</p>
 <p>This component fires a select event when the index characters are selected.</p>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fnavcontrols%2Findexscrollbar%2Findex.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fnavcontrols%2Findexscrollbar%2Findex.html', '_blank')"
+>Use example</button>
 
 <table class="note">
 	<tbody>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_datepicker.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_datepicker.htm
@@ -13,7 +13,13 @@
 
 <img src="../../images/DatePicker.png" alt="photo of date picker element in Tizen">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fdate-picker.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fdate-picker.html', '_blank')"
+>Use example</button>
 
 <p>To add a date picker component to the application, use the following code:</p>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_list.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_list.htm
@@ -15,7 +15,13 @@
 
 <img src="../../images/List.png" alt="photo of List element in Tizen">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Flist%2Flist_normal.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Flist%2Flist_normal.html', '_blank')"
+>Use example</button>
 
 <table>
 <caption>Table: List classes</caption>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_marquee.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_marquee.htm
@@ -16,7 +16,13 @@ It makes &lt;div&gt; element (has some child nodes such as text and img) move ho
 	<source src="https://developer.tizen.org/sites/default/files/documentation/marquee.mp4">
 </video>
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fmarquee%2Findex.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fmarquee%2Findex.html', '_blank')"
+>Use example</button>
 
 <table class="note">
 	<tbody>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_numberpicker.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_numberpicker.htm
@@ -13,7 +13,14 @@
 
 <img src="../../images/NumberPicker.png" alt="photo of number picker element in Tizen">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fnumberpicker%2Fsimple.html', '_blank')">Use example</button>
+<div>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fnumberpicker%2Fsimple.html', '_blank')"
+>Use example</button>
 
 <p>To add a number picker component to the application, use the following code:</p>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_pageindicator.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_pageindicator.htm
@@ -17,7 +17,13 @@
 
 <img src="../../images/PageIndicator.png" alt="photo of Page Indicator element in TIZEN">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Findicator%2Fpageindicator_circle.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Findicator%2Fpageindicator_circle.html', '_blank')"
+>Use example</button>
 
 <table class="note">
 	<tbody>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_popup.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_popup.htm
@@ -14,7 +14,14 @@
 <p>The popup component shows in the middle of the screen a list of items in a pop-up window. It automatically optimizes the pop-up window size within the screen.  The following table describes the supported popup classes.</p>
 <img src="../../images/Popup.png" alt="image of Popup element in TIZEN">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fpopup%2Fpopup.html', '_blank')">Use example</button>
+<div>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fpopup%2Fpopup.html', '_blank')"
+>Use example</button>
 
 <table>
    <caption>Table: Popup classes</caption>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_processing.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_processing.htm
@@ -18,7 +18,13 @@
 	<source src="https://developer.tizen.org/sites/default/files/documentation/processing.mp4">
 </video>
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fprocessing%2Ffull_processing.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fprocessing%2Ffull_processing.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_sectionchanger.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_sectionchanger.htm
@@ -19,7 +19,13 @@ It gets to have a virtue of needlessness of changing page and the existance of s
 	<source src="https://developer.tizen.org/sites/default/files/documentation/sectionchanger.mp4">
 </video>
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fnavcontrols%2Fsectionchanger%2Fhsection.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fnavcontrols%2Fsectionchanger%2Fhsection.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_selector.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_selector.htm
@@ -22,7 +22,13 @@ Indicator arrow is special indicator style that has the arrow. It is used for pr
 	<source src="https://developer.tizen.org/sites/default/files/documentation/selector.mp4">
 </video>
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fselector%2Fselector.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fselector%2Fselector.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_slider.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_slider.htm
@@ -18,7 +18,13 @@
        <source src="https://developer.tizen.org/sites/default/files/documentation/slider.mp4">
 </video>
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fslider%2Fslider.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fslider%2Fslider.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_snaplistview.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_snaplistview.htm
@@ -19,7 +19,13 @@ When scroll ended, it triggers &quot;selected&quot; event and attach class to de
 	<source src="https://developer.tizen.org/sites/default/files/documentation/snaplistview.mp4">
 </video>
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Flist%2Fsnaplistview.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Flist%2Fsnaplistview.html', '_blank')"
+>Use example</button>
 
 <table class="note">
         <tbody>

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_timepicker.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_timepicker.htm
@@ -13,7 +13,13 @@
 
 <img src="../../images/TimePicker.png" alt="photo of time picker element in Tizen">
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Ftime-picker.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Ftime-picker.html', '_blank')"
+>Use example</button>
 
 <p>To add a time picker component to the application, use the following code:</p>
 

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_toggleswitch.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_toggleswitch.htm
@@ -17,7 +17,13 @@
 	<source src="https://developer.tizen.org/sites/default/files/documentation/toggleswitch.mp4">
 </video>
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Ftoggle.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Ftoggle.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">

--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_virtuallist.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_virtuallist.htm
@@ -20,7 +20,13 @@
 	<source src="https://developer.tizen.org/sites/default/files/documentation/virtuallist.mp4">
 </video>
 <br>
-<button onclick="window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Flist%2Fvirtual%2Fnormal.html', '_blank')">Use example</button>
+<button
+	onclick="
+		if (navigator.userAgent.toLowerCase().indexOf('chrome') == -1) {
+			alert('Chrome Browser required')
+		} else
+			window.open('https://code.tizen.org/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Flist%2Fvirtual%2Fnormal.html', '_blank')"
+>Use example</button>
 
 <h2>Table of Contents</h2>
 <ol class="toc">


### PR DESCRIPTION
Examples can be opened in Chrome Browser only.
Show "Chrome Browser required" popup if "Use example" button
is clicked using different Browser than Chrome.
    
Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>
