### PR TITLE
Remove JDK9 from prerequisites

### DIFF
--- a/docs/application/tizen-studio/setup/prerequisites.md
+++ b/docs/application/tizen-studio/setup/prerequisites.md
@@ -4,7 +4,7 @@ Check the following prerequisites before attempting to install the Tizen Studio.
 
 ## Java Development Kit (JDK) Requirements
 
-You must install Oracle Java Development Kit (JDK) 8, JDK 9, or OpenJDK 10 to use the Tizen Studio.
+You must install Oracle Java Development Kit (JDK) 8, or OpenJDK 10 to use the Tizen Studio.
 
 Follow these instructions to install the appropriate JDK version for your system:
 
@@ -20,7 +20,7 @@ Follow these instructions to install the appropriate JDK version for your system
 
 - Ubuntu
 
-  Go to the [Ubuntu Web site](https://help.ubuntu.com/community/Java) for detailed instructions for installing the Oracle&reg; JDK version 8 or 9. The raw binaries can be downloaded directly from Oracle ([Oracle Java download page](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+  Go to the [Ubuntu Web site](https://help.ubuntu.com/community/Java) for detailed instructions for installing the Oracle&reg; JDK version 8. The raw binaries can be downloaded directly from Oracle ([Oracle Java download page](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
 
 You can also use Oracle's OpenJDK. For more installation details, see [OpenJDK 10 and OpenJFX Installation Guide](openjdk.md).
 


### PR DESCRIPTION
JDK9 is no longer supported on oracle website.

### Change Description ###

Describe your changes here.

For instance,
 - Remove JDK9 from prerequisite list.


