### PR TITLE
Remove JDK9 from rt-ide prerequisites

### DIFF
--- a/docs/application/tizen-studio/rt-ide/get-started/overview.md
+++ b/docs/application/tizen-studio/rt-ide/get-started/overview.md
@@ -15,9 +15,9 @@ Check the following prerequisites before installing the Tizen Studio for RT:
 
 - Java Development Kit (JDK) requirements
 
-  You must install a JDK 8 or 9 to use the Tizen Studio. Do not install OpenJDK.
+  You must install a JDK 8 to use the Tizen Studio. Do not install OpenJDK.
 
-  To install the appropriate JDK version for your Ubuntu system, go to the Ubuntu Web site and follow the detailed instructions for installing the Oracle&reg; JDK version 8 or 9.
+  To install the appropriate JDK version for your Ubuntu system, go to the Ubuntu Web site and follow the detailed instructions for installing the Oracle&reg; JDK version 8.
 
 
 - Operating system and hardware requirements


### PR DESCRIPTION
### Change Description ###

Remove JDK9 from rt-ide prerequisites because oracle doesn't support the JDK9.

