### PR TITLE
Remove old link to Visual Studio Marketplace for Tizen

### DIFF
--- a/docs/application/dotnet/index.md
+++ b/docs/application/dotnet/index.md
@@ -66,6 +66,6 @@ Visual Studio Tools for Tizen provides Tizen-specific tools to improve your prod
 
 You can create a Tizen .NET application project with the Project Wizard in Visual Studio Tools for Tizen. When you create a new project with a specific template, the Project Wizard uses it to automatically create basic functionalities and default project files and folders for the application.
 
-[![Download](media/ic_docs_download.png)](https://marketplace.visualstudio.com/items?itemName=tizen.VisualStudioToolsforTizen){:target="_blank"} The Visual Studio Tools for Tizen extension is registered in the Visual Studio Marketplace. You can [install the extension](../vstools/install.md) from the Visual Studio Marketplace in the Visual Studio IDE.
+[![Download](media/ic_docs_download.png)](https://marketplace.visualstudio.com/items?itemName=tizen.VSToolsforTizen){:target="_blank"} The Visual Studio Tools for Tizen extension is registered in the Visual Studio Marketplace. You can [install the extension](../vstools/install.md) from the Visual Studio Marketplace in the Visual Studio IDE. To download the latest Visual Studio Tools for Tizen click the button. To use Visual Studio 2017, download [Visual Studio Tools for Tizen for Visual Studio 2017](https://marketplace.visualstudio.com/items?itemName=tizen.VisualStudioToolsforTizen).
 
 For more information, see [the guides of Visual Studio Tools for Tizen](../vstools/index.md)

--- a/docs/application/vstools/install.md
+++ b/docs/application/vstools/install.md
@@ -71,7 +71,6 @@ The Visual Studio Tools for Tizen extension is registered in the Visual Studio M
 
    The installation starts.
 
-Alternatively, you can download the Visual Studio Tools for Tizen extension from the [Visual Studio Marketplace Web site](https://marketplace.visualstudio.com/items?itemName=tizen.VisualStudioToolsforTizen).
 
 ### Installing the Tizen Baseline SDK
 


### PR DESCRIPTION
Signed-off-by: Mijin, Cho <mijin85.cho@samsung.com>

### Change Description ###

We have links to Visual Studio Tools for Tizen, but it is based on old version, Visual Studio **2017**.
For now, the latest version is Visual Studio 2019, and it has different link.

Visual Studio **2017** : https://marketplace.visualstudio.com/items?itemName=tizen.VisualStudioToolsforTizen
&nbsp;&nbsp;=> This link is guided in the document.
Visual Studio **2019** : https://marketplace.visualstudio.com/items?itemName=tizen.VSToolsforTizen

Asking @winstone77's opinion, 
I got the suggestion that it'd be better to remove the links to Visual Studio Marketplace 
as the tool itself guide the user to proper version link (2017 or 2019).
So the links are removed in this PR.