### PR TITLE
[Download] Download module exception correction

### DIFF
--- a/docs/application/web/api/5.5/device_api/mobile/tizen/download.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/download.html
@@ -85,6 +85,7 @@ For more information on the Download features, see <a href="https://developer.ti
 <div>long <a href="#DownloadManager::start">start</a> (<a href="#DownloadRequest">DownloadRequest</a> downloadRequest, optional <a href="#DownloadCallback">DownloadCallback</a>? downloadCallback)</div>
 <div>void <a href="#DownloadManager::cancel">cancel</a> (long downloadId)</div>
 <div>void <a href="#DownloadManager::pause">pause</a> (long downloadId)</div>
+<div>void <a href="#DownloadManager::abandon">abandon</a> (long downloadId)</div>
 <div>void <a href="#DownloadManager::resume">resume</a> (long downloadId)</div>
 <div>
 <a href="#DownloadState">DownloadState</a> <a href="#DownloadManager::getState">getState</a> (long downloadId)</div>
@@ -128,7 +129,7 @@ The key / value type of each HTTP header field should be DOMString.
 <div class="brief">
  An enumerator to indicate the state of a download operation.
           </div>
-<pre class="webidl prettyprint">  enum DownloadState { "QUEUED", "DOWNLOADING", "PAUSED", "CANCELED", "COMPLETED", "FAILED" };</pre>
+<pre class="webidl prettyprint">  enum DownloadState { "QUEUED", "DOWNLOADING", "PAUSED", "CANCELED", "COMPLETED", "FAILED", "ABANDONED" };</pre>
 <p><span class="version">Since: </span>
  2.0
           </p>
@@ -149,6 +150,8 @@ CANCELED - Indicates that the download operation is canceled by user request.   
 COMPLETED - Indicates that the download operation is in a completed state.            </li>
             <li>
 FAILED - Indicates that the download operation has failed due to some reasons.            </li>
+            <li>
+ABANDONED - Indicates that the download operation has been abandoned.            </li>
           </ul>
          </div>
 </div>
@@ -319,6 +322,7 @@ req.httpHeader["X-Agent"] = "Tizen Sample App";
     long start(<a href="#DownloadRequest">DownloadRequest</a> downloadRequest, optional <a href="#DownloadCallback">DownloadCallback</a>? downloadCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void cancel(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void pause(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void abandon(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void resume(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#DownloadState">DownloadState</a> getState(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#DownloadRequest">DownloadRequest</a> getDownloadRequest(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -457,6 +461,7 @@ else
 <dd>
 <div class="brief">
  Cancels an ongoing download operation that is specified by the <em>downloadId</em> parameter.
+The abandoned download operation cannot be canceled and trying to do so will result in InvalidValuesError exception.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void cancel(long downloadId);</pre></div>
 <p><span class="version">Since: </span>
@@ -474,12 +479,6 @@ else
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
-<li class="list"><p>
- with error type NotFoundError, if the identifier does not match any download operation in progress.
-                </p></li>
-<li class="list"><p>
- with error type TypeMismatchError, if the input parameter is not compatible with the expected type for that parameter.
-                </p></li>
 <li class="list"><p>
  with error type InvalidValuesError, if any of the input parameters contain an invalid value.
                 </p></li>
@@ -507,6 +506,11 @@ The paused download operation can be resumed later by the <em>resume()</em> meth
 <p><span class="version">Since: </span>
  2.0
             </p>
+<div class="description">
+            <p>
+The abandoned download operation cannot be paused and trying to do so will result in InvalidValuesError exception.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -519,12 +523,6 @@ The paused download operation can be resumed later by the <em>resume()</em> meth
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
-<li class="list"><p>
- with error type NotFoundError, if the identifier does not match any download operation in progress.
-                </p></li>
-<li class="list"><p>
- with error type TypeMismatchError, if the input parameter is not compatible with the expected type for that parameter.
-                </p></li>
 <li class="list"><p>
  with error type InvalidValuesError, if any of the input parameters contain an invalid value.
                 </p></li>
@@ -540,6 +538,48 @@ tizen.download.pause(downloadId);
 </pre>
 </div>
 </dd>
+<dt class="method" id="DownloadManager::abandon">
+<a class="backward-compatibility-anchor" name="::Download::DownloadManager::abandon"></a><code><b><span class="methodName">abandon</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Abandons a download operation that is specified by the <em>downloadId</em> parameter.
+The abandoned download operation cannot be resumed later with the <em>resume()</em> method.
+Trying to resume this download operation will result in <em>InvalidValuesError</em> exception.
+Calling the <em>pause()</em> method or the <em>cancel()</em> method with this <em>downloadId</em> will also result in <em>InvalidValuesError</em> exception.
+All resources needed by download operation are freed.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void abandon(long downloadId);</pre></div>
+<p><span class="version">Since: </span>
+ 5.5
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">downloadId</span>:
+ The ID of the ongoing download operation to abandon.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type InvalidValuesError, if any of the input parameters contain an invalid value.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">/* Abandons the ongoing download operation with the specified ID. */
+tizen.download.abandon(downloadId);
+</pre>
+</div>
+</dd>
 <dt class="method" id="DownloadManager::resume">
 <a class="backward-compatibility-anchor" name="::Download::DownloadManager::resume"></a><code><b><span class="methodName">resume</span></b></code>
 </dt>
@@ -551,6 +591,12 @@ tizen.download.pause(downloadId);
 <p><span class="version">Since: </span>
  2.0
             </p>
+<div class="description">
+            <p>
+The abandoned download operation cannot be resumed and trying to do so will result in InvalidValuesError exception.
+Resuming operation that is queued, completed or currently in progress will have no effect.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -564,13 +610,7 @@ tizen.download.pause(downloadId);
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
- with error type NotFoundError, if the identifier does not match any download operation in progress.
-                </p></li>
-<li class="list"><p>
- with error type TypeMismatchError, if the input parameter is not compatible with the expected type for that parameter.
-                </p></li>
-<li class="list"><p>
- with error type InvalidValuesError, if any of the input parameters contain an invalid value.
+ with error type InvalidValuesError, if any of the input parameters contain an invalid value or in case of an attempt to resume abandoned download operation.
                 </p></li>
 <li class="list"><p>
  with error type UnknownError, if any other error occurs.
@@ -1004,12 +1044,12 @@ DownloadNetworkType <em>CELLULAR</em> can be available on a cellular-enabled dev
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Download {
   typedef object DownloadHTTPHeaderFields;
-  enum DownloadState { "QUEUED", "DOWNLOADING", "PAUSED", "CANCELED", "COMPLETED", "FAILED" };
+  enum DownloadState { "QUEUED", "DOWNLOADING", "PAUSED", "CANCELED", "COMPLETED", "FAILED", "ABANDONED" };
   enum DownloadNetworkType { "CELLULAR", "WIFI", "ALL" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DownloadManagerObject">DownloadManagerObject</a>;
   [NoInterfaceObject] interface DownloadManagerObject {
     readonly attribute <a href="#DownloadManager">DownloadManager</a> download;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DownloadManagerObject">DownloadManagerObject</a>;
   [Constructor(DOMString url, optional DOMString? destination, optional DOMString? fileName,
                optional <a href="#DownloadNetworkType">DownloadNetworkType</a>? networkType, optional <a href="#DownloadHTTPHeaderFields">DownloadHTTPHeaderFields</a>? httpHeader)]
   interface DownloadRequest {
@@ -1023,6 +1063,7 @@ DownloadNetworkType <em>CELLULAR</em> can be available on a cellular-enabled dev
     long start(<a href="#DownloadRequest">DownloadRequest</a> downloadRequest, optional <a href="#DownloadCallback">DownloadCallback</a>? downloadCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void cancel(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void pause(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void abandon(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void resume(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#DownloadState">DownloadState</a> getState(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#DownloadRequest">DownloadRequest</a> getDownloadRequest(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/tv/tizen/download.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/download.html
@@ -83,6 +83,7 @@ For more information on the Download features, see <a href="https://developer.ti
 <div>long <a href="#DownloadManager::start">start</a> (<a href="#DownloadRequest">DownloadRequest</a> downloadRequest, optional <a href="#DownloadCallback">DownloadCallback</a>? downloadCallback)</div>
 <div>void <a href="#DownloadManager::cancel">cancel</a> (long downloadId)</div>
 <div>void <a href="#DownloadManager::pause">pause</a> (long downloadId)</div>
+<div>void <a href="#DownloadManager::abandon">abandon</a> (long downloadId)</div>
 <div>void <a href="#DownloadManager::resume">resume</a> (long downloadId)</div>
 <div>
 <a href="#DownloadState">DownloadState</a> <a href="#DownloadManager::getState">getState</a> (long downloadId)</div>
@@ -126,7 +127,7 @@ The key / value type of each HTTP header field should be DOMString.
 <div class="brief">
  An enumerator to indicate the state of a download operation.
           </div>
-<pre class="webidl prettyprint">  enum DownloadState { "QUEUED", "DOWNLOADING", "PAUSED", "CANCELED", "COMPLETED", "FAILED" };</pre>
+<pre class="webidl prettyprint">  enum DownloadState { "QUEUED", "DOWNLOADING", "PAUSED", "CANCELED", "COMPLETED", "FAILED", "ABANDONED" };</pre>
 <p><span class="version">Since: </span>
  2.0
           </p>
@@ -147,6 +148,8 @@ CANCELED - Indicates that the download operation is canceled by user request.   
 COMPLETED - Indicates that the download operation is in a completed state.            </li>
             <li>
 FAILED - Indicates that the download operation has failed due to some reasons.            </li>
+            <li>
+ABANDONED - Indicates that the download operation has been abandoned.            </li>
           </ul>
          </div>
 </div>
@@ -317,6 +320,7 @@ req.httpHeader["X-Agent"] = "Tizen Sample App";
     long start(<a href="#DownloadRequest">DownloadRequest</a> downloadRequest, optional <a href="#DownloadCallback">DownloadCallback</a>? downloadCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void cancel(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void pause(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void abandon(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void resume(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#DownloadState">DownloadState</a> getState(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#DownloadRequest">DownloadRequest</a> getDownloadRequest(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -455,6 +459,7 @@ else
 <dd>
 <div class="brief">
  Cancels an ongoing download operation that is specified by the <em>downloadId</em> parameter.
+The abandoned download operation cannot be canceled and trying to do so will result in InvalidValuesError exception.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void cancel(long downloadId);</pre></div>
 <p><span class="version">Since: </span>
@@ -472,12 +477,6 @@ else
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
-<li class="list"><p>
- with error type NotFoundError, if the identifier does not match any download operation in progress.
-                </p></li>
-<li class="list"><p>
- with error type TypeMismatchError, if the input parameter is not compatible with the expected type for that parameter.
-                </p></li>
 <li class="list"><p>
  with error type InvalidValuesError, if any of the input parameters contain an invalid value.
                 </p></li>
@@ -505,6 +504,11 @@ The paused download operation can be resumed later by the <em>resume()</em> meth
 <p><span class="version">Since: </span>
  2.0
             </p>
+<div class="description">
+            <p>
+The abandoned download operation cannot be paused and trying to do so will result in InvalidValuesError exception.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -517,12 +521,6 @@ The paused download operation can be resumed later by the <em>resume()</em> meth
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
-<li class="list"><p>
- with error type NotFoundError, if the identifier does not match any download operation in progress.
-                </p></li>
-<li class="list"><p>
- with error type TypeMismatchError, if the input parameter is not compatible with the expected type for that parameter.
-                </p></li>
 <li class="list"><p>
  with error type InvalidValuesError, if any of the input parameters contain an invalid value.
                 </p></li>
@@ -538,6 +536,48 @@ tizen.download.pause(downloadId);
 </pre>
 </div>
 </dd>
+<dt class="method" id="DownloadManager::abandon">
+<a class="backward-compatibility-anchor" name="::Download::DownloadManager::abandon"></a><code><b><span class="methodName">abandon</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Abandons a download operation that is specified by the <em>downloadId</em> parameter.
+The abandoned download operation cannot be resumed later with the <em>resume()</em> method.
+Trying to resume this download operation will result in <em>InvalidValuesError</em> exception.
+Calling the <em>pause()</em> method or the <em>cancel()</em> method with this <em>downloadId</em> will also result in <em>InvalidValuesError</em> exception.
+All resources needed by download operation are freed.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void abandon(long downloadId);</pre></div>
+<p><span class="version">Since: </span>
+ 5.5
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">downloadId</span>:
+ The ID of the ongoing download operation to abandon.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type InvalidValuesError, if any of the input parameters contain an invalid value.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">/* Abandons the ongoing download operation with the specified ID. */
+tizen.download.abandon(downloadId);
+</pre>
+</div>
+</dd>
 <dt class="method" id="DownloadManager::resume">
 <a class="backward-compatibility-anchor" name="::Download::DownloadManager::resume"></a><code><b><span class="methodName">resume</span></b></code>
 </dt>
@@ -549,6 +589,12 @@ tizen.download.pause(downloadId);
 <p><span class="version">Since: </span>
  2.0
             </p>
+<div class="description">
+            <p>
+The abandoned download operation cannot be resumed and trying to do so will result in InvalidValuesError exception.
+Resuming operation that is queued, completed or currently in progress will have no effect.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -562,13 +608,7 @@ tizen.download.pause(downloadId);
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
- with error type NotFoundError, if the identifier does not match any download operation in progress.
-                </p></li>
-<li class="list"><p>
- with error type TypeMismatchError, if the input parameter is not compatible with the expected type for that parameter.
-                </p></li>
-<li class="list"><p>
- with error type InvalidValuesError, if any of the input parameters contain an invalid value.
+ with error type InvalidValuesError, if any of the input parameters contain an invalid value or in case of an attempt to resume abandoned download operation.
                 </p></li>
 <li class="list"><p>
  with error type UnknownError, if any other error occurs.
@@ -1010,12 +1050,12 @@ DownloadNetworkType <em>ALL</em> can be available on a ethernet-enabled device. 
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Download {
   typedef object DownloadHTTPHeaderFields;
-  enum DownloadState { "QUEUED", "DOWNLOADING", "PAUSED", "CANCELED", "COMPLETED", "FAILED" };
+  enum DownloadState { "QUEUED", "DOWNLOADING", "PAUSED", "CANCELED", "COMPLETED", "FAILED", "ABANDONED" };
   enum DownloadNetworkType { "CELLULAR", "WIFI", "ALL" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DownloadManagerObject">DownloadManagerObject</a>;
   [NoInterfaceObject] interface DownloadManagerObject {
     readonly attribute <a href="#DownloadManager">DownloadManager</a> download;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DownloadManagerObject">DownloadManagerObject</a>;
   [Constructor(DOMString url, optional DOMString? destination, optional DOMString? fileName,
                optional <a href="#DownloadNetworkType">DownloadNetworkType</a>? networkType, optional <a href="#DownloadHTTPHeaderFields">DownloadHTTPHeaderFields</a>? httpHeader)]
   interface DownloadRequest {
@@ -1029,6 +1069,7 @@ DownloadNetworkType <em>ALL</em> can be available on a ethernet-enabled device. 
     long start(<a href="#DownloadRequest">DownloadRequest</a> downloadRequest, optional <a href="#DownloadCallback">DownloadCallback</a>? downloadCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void cancel(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void pause(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void abandon(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void resume(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#DownloadState">DownloadState</a> getState(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#DownloadRequest">DownloadRequest</a> getDownloadRequest(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/download.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/download.html
@@ -85,6 +85,7 @@ For more information on the Download features, see <a href="https://developer.ti
 <div>long <a href="#DownloadManager::start">start</a> (<a href="#DownloadRequest">DownloadRequest</a> downloadRequest, optional <a href="#DownloadCallback">DownloadCallback</a>? downloadCallback)</div>
 <div>void <a href="#DownloadManager::cancel">cancel</a> (long downloadId)</div>
 <div>void <a href="#DownloadManager::pause">pause</a> (long downloadId)</div>
+<div>void <a href="#DownloadManager::abandon">abandon</a> (long downloadId)</div>
 <div>void <a href="#DownloadManager::resume">resume</a> (long downloadId)</div>
 <div>
 <a href="#DownloadState">DownloadState</a> <a href="#DownloadManager::getState">getState</a> (long downloadId)</div>
@@ -128,7 +129,7 @@ The key / value type of each HTTP header field should be DOMString.
 <div class="brief">
  An enumerator to indicate the state of a download operation.
           </div>
-<pre class="webidl prettyprint">  enum DownloadState { "QUEUED", "DOWNLOADING", "PAUSED", "CANCELED", "COMPLETED", "FAILED" };</pre>
+<pre class="webidl prettyprint">  enum DownloadState { "QUEUED", "DOWNLOADING", "PAUSED", "CANCELED", "COMPLETED", "FAILED", "ABANDONED" };</pre>
 <p><span class="version">Since: </span>
  2.0
           </p>
@@ -149,6 +150,8 @@ CANCELED - Indicates that the download operation is canceled by user request.   
 COMPLETED - Indicates that the download operation is in a completed state.            </li>
             <li>
 FAILED - Indicates that the download operation has failed due to some reasons.            </li>
+            <li>
+ABANDONED - Indicates that the download operation has been abandoned.            </li>
           </ul>
          </div>
 </div>
@@ -223,7 +226,7 @@ The <em>tizen.download </em>object allows access to the functionality of the Dow
           </p>
 <div class="constructors">
 <h4 id="DownloadRequest::constructor">Constructors</h4>
-<dl><pre class="webidl prettyprint">DownloadRequest(DOMString url, optional DOMString? destination, optional DOMString? fileName, 
+<dl><pre class="webidl prettyprint">DownloadRequest(DOMString url, optional DOMString? destination, optional DOMString? fileName,
                 optional <a href="#DownloadNetworkType">DownloadNetworkType</a>? networkType, optional <a href="#DownloadHTTPHeaderFields">DownloadHTTPHeaderFields</a>? httpHeader);</pre></dl>
 </div>
 <div class="attributes">
@@ -319,6 +322,7 @@ req.httpHeader["X-Agent"] = "Tizen Sample App";
     long start(<a href="#DownloadRequest">DownloadRequest</a> downloadRequest, optional <a href="#DownloadCallback">DownloadCallback</a>? downloadCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void cancel(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void pause(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void abandon(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void resume(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#DownloadState">DownloadState</a> getState(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#DownloadRequest">DownloadRequest</a> getDownloadRequest(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -457,6 +461,7 @@ else
 <dd>
 <div class="brief">
  Cancels an ongoing download operation that is specified by the <em>downloadId</em> parameter.
+The abandoned download operation cannot be canceled and trying to do so will result in InvalidValuesError exception.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void cancel(long downloadId);</pre></div>
 <p><span class="version">Since: </span>
@@ -474,12 +479,6 @@ else
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
-<li class="list"><p>
- with error type NotFoundError, if the identifier does not match any download operation in progress.
-                </p></li>
-<li class="list"><p>
- with error type TypeMismatchError, if the input parameter is not compatible with the expected type for that parameter.
-                </p></li>
 <li class="list"><p>
  with error type InvalidValuesError, if any of the input parameters contain an invalid value.
                 </p></li>
@@ -507,6 +506,11 @@ The paused download operation can be resumed later by the <em>resume()</em> meth
 <p><span class="version">Since: </span>
  2.0
             </p>
+<div class="description">
+            <p>
+The abandoned download operation cannot be paused and trying to do so will result in InvalidValuesError exception.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -519,12 +523,6 @@ The paused download operation can be resumed later by the <em>resume()</em> meth
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
-<li class="list"><p>
- with error type NotFoundError, if the identifier does not match any download operation in progress.
-                </p></li>
-<li class="list"><p>
- with error type TypeMismatchError, if the input parameter is not compatible with the expected type for that parameter.
-                </p></li>
 <li class="list"><p>
  with error type InvalidValuesError, if any of the input parameters contain an invalid value.
                 </p></li>
@@ -540,6 +538,48 @@ tizen.download.pause(downloadId);
 </pre>
 </div>
 </dd>
+<dt class="method" id="DownloadManager::abandon">
+<a class="backward-compatibility-anchor" name="::Download::DownloadManager::abandon"></a><code><b><span class="methodName">abandon</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Abandons a download operation that is specified by the <em>downloadId</em> parameter.
+The abandoned download operation cannot be resumed later with the <em>resume()</em> method.
+Trying to resume this download operation will result in <em>InvalidValuesError</em> exception.
+Calling the <em>pause()</em> method or the <em>cancel()</em> method with this <em>downloadId</em> will also result in <em>InvalidValuesError</em> exception.
+All resources needed by download operation are freed.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void abandon(long downloadId);</pre></div>
+<p><span class="version">Since: </span>
+ 5.5
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">downloadId</span>:
+ The ID of the ongoing download operation to abandon.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type InvalidValuesError, if any of the input parameters contain an invalid value.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">/* Abandons the ongoing download operation with the specified ID. */
+tizen.download.abandon(downloadId);
+</pre>
+</div>
+</dd>
 <dt class="method" id="DownloadManager::resume">
 <a class="backward-compatibility-anchor" name="::Download::DownloadManager::resume"></a><code><b><span class="methodName">resume</span></b></code>
 </dt>
@@ -551,6 +591,12 @@ tizen.download.pause(downloadId);
 <p><span class="version">Since: </span>
  2.0
             </p>
+<div class="description">
+            <p>
+The abandoned download operation cannot be resumed and trying to do so will result in InvalidValuesError exception.
+Resuming operation that is queued, completed or currently in progress will have no effect.
+            </p>
+           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -564,13 +610,7 @@ tizen.download.pause(downloadId);
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
- with error type NotFoundError, if the identifier does not match any download operation in progress.
-                </p></li>
-<li class="list"><p>
- with error type TypeMismatchError, if the input parameter is not compatible with the expected type for that parameter.
-                </p></li>
-<li class="list"><p>
- with error type InvalidValuesError, if any of the input parameters contain an invalid value.
+ with error type InvalidValuesError, if any of the input parameters contain an invalid value or in case of an attempt to resume abandoned download operation.
                 </p></li>
 <li class="list"><p>
  with error type UnknownError, if any other error occurs.
@@ -1012,12 +1052,12 @@ DownloadNetworkType <em>CELLULAR</em> can be available on a cellular-enabled dev
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Download {
   typedef object DownloadHTTPHeaderFields;
-  enum DownloadState { "QUEUED", "DOWNLOADING", "PAUSED", "CANCELED", "COMPLETED", "FAILED" };
+  enum DownloadState { "QUEUED", "DOWNLOADING", "PAUSED", "CANCELED", "COMPLETED", "FAILED", "ABANDONED" };
   enum DownloadNetworkType { "CELLULAR", "WIFI", "ALL" };
+  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DownloadManagerObject">DownloadManagerObject</a>;
   [NoInterfaceObject] interface DownloadManagerObject {
     readonly attribute <a href="#DownloadManager">DownloadManager</a> download;
   };
-  <a href="tizen.html#Tizen">Tizen</a> implements <a href="#DownloadManagerObject">DownloadManagerObject</a>;
   [Constructor(DOMString url, optional DOMString? destination, optional DOMString? fileName,
                optional <a href="#DownloadNetworkType">DownloadNetworkType</a>? networkType, optional <a href="#DownloadHTTPHeaderFields">DownloadHTTPHeaderFields</a>? httpHeader)]
   interface DownloadRequest {
@@ -1031,6 +1071,7 @@ DownloadNetworkType <em>CELLULAR</em> can be available on a cellular-enabled dev
     long start(<a href="#DownloadRequest">DownloadRequest</a> downloadRequest, optional <a href="#DownloadCallback">DownloadCallback</a>? downloadCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void cancel(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void pause(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void abandon(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void resume(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#DownloadState">DownloadState</a> getState(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     <a href="#DownloadRequest">DownloadRequest</a> getDownloadRequest(long downloadId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);

--- a/docs/application/web/guides/connectivity/download.md
+++ b/docs/application/web/guides/connectivity/download.md
@@ -8,7 +8,7 @@ The main features of the Download API include:
 
 - Managing downloads
 
-  You can [start, pause, resume, and cancel a download](#managing-downloads) of content using the `DownloadManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/download.html#DownloadManager), [wearable](../../api/latest/device_api/wearable/tizen/download.html#DownloadManager), and [TV](../../api/latest/device_api/tv/tizen/download.html#DownloadManager) applications).
+  You can [start, pause, resume, cancel, and abandon a download](#managing-downloads) of content using the `DownloadManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/download.html#DownloadManager), [wearable](../../api/latest/device_api/wearable/tizen/download.html#DownloadManager), and [TV](../../api/latest/device_api/tv/tizen/download.html#DownloadManager) applications).
 
 - Checking the download state and information
 
@@ -85,25 +85,45 @@ To provide the user access to Internet resources, you must learn how to manage d
 
    The `start()` method returns a unique identifier for the download operation.
 
-5. During the download:
+   You can check the status of the download operation by calling the `getState()` method with the download ID:
+
+      ```
+      tizen.download.getState(downloadId);
+      ```
+
+5. During the download operation, you can modify the download state.
+
+    >**Note**
+    >
+    >For downloading small file with using high speed connection, the download operation completes almost instantly.
 
    1. To pause the download, use the `pause()` method with the download ID:
 
       ```
       tizen.download.pause(downloadId);
       ```
+        If the current state is DOWNLOADING or QUEUED, calling the `pause()` method changes the download state to PAUSED.
 
    2. To resume the download, use the `resume()` method with the download ID:
 
       ```
       tizen.download.resume(downloadId);
       ```
+        If the current state is PAUSED, CANCELED, or FAILED, calling the `resume()` method changes the download state to DOWNLOADING or QUEUED.
 
    3. To cancel the download, use the `cancel()` method with the download ID:
 
       ```
       tizen.download.cancel(downloadId);
       ```
+        If the current state is DOWNLOADING or QUEUED, calling the `cancel()` method changes the download state to CANCELED.
+
+   4. To abandon the download, use the `abandon()` method with the download ID:
+
+      ```
+      tizen.download.abandon(downloadId);
+      ```
+        For any abandoned download operation, the resources are already released. Thus the download operation cannot be resumed.
 
 ## Checking the Download State and Information
 
@@ -138,7 +158,7 @@ To provide the user access to Internet resources, you must learn how to check th
    ```
 
 ## Related Information
-* Dependencies   
+- Dependencies
    - Tizen 2.4 and Higher for Mobile
    - Tizen 2.3.1 and Higher for Wearable
    - Tizen 3.0 and Higher for TV


### PR DESCRIPTION
Correcting exceptions for cancel, pause and resume methods.
NotFoundError and TypeMismatchError exceptions are removed from above functions.

Abandon method added.
ABANDONED value added to DownaloadState enum.

[ACR] http://suprem.sec.samsung.net/jira/browse/TWDAPI-222

Signed-off-by: Arkadiusz Pietraszek <a.pietraszek@partner.samsung.com>