### PR TITLE
Change prerequisite for TS and VS.

### DIFF
--- a/docs/application/tizen-studio/setup/prerequisites.md
+++ b/docs/application/tizen-studio/setup/prerequisites.md
@@ -70,7 +70,7 @@ The following table lists the supported operating systems and hardware requireme
 <th>Architecture</th>
 <td>x64 (64 bit)</td>
 <td>x64 only</td>
-<td>x64 / x86</td>
+<td>x64 (64 bit)</td>
 </tr>
 <tr>
 <th>Memory</th>

--- a/docs/application/vstools/install.md
+++ b/docs/application/vstools/install.md
@@ -16,7 +16,8 @@ You need the following components on top of Visual Studio to make Visual Studio 
 To work with Visual Studio Tools for Tizen, your computer must have:
 
 - At least 1.5 GB of available disk space
-- Visual Studio 2017 for Tizen-4.0 and Tizen-5.0 or Visual Studio 2019 for Tizen-4.0 and higher
+- Visual Studio 2017 to use Tizen 4.0 and 5.0
+- Visual Studio 2019 to use Tizen 4.0 and higher
 
   Visual Studio Tools for Tizen works with all Visual Studio variations, including Community. Installing or re-installing Visual Studio with .NET desktop development and .NET Core cross-platform development toolsets is recommended.
 

--- a/docs/application/vstools/install.md
+++ b/docs/application/vstools/install.md
@@ -16,7 +16,7 @@ You need the following components on top of Visual Studio to make Visual Studio 
 To work with Visual Studio Tools for Tizen, your computer must have:
 
 - At least 1.5 GB of available disk space
-- Visual Studio 2017
+- Visual Studio 2017 for Tizen-4.0 and Tizen-5.0 or Visual Studio 2019 for Tizen-4.0 and higher
 
   Visual Studio Tools for Tizen works with all Visual Studio variations, including Community. Installing or re-installing Visual Studio with .NET desktop development and .NET Core cross-platform development toolsets is recommended.
 


### PR DESCRIPTION
Signed-off-by: seok.oh <seok.oh@samsung.com>

### Change Description ###

- Change prerequisite of TS (Ubuntu x86 arch supporting is removed.)
- Change prerequisite of VS (Tizen-5.5 is suppoted by only VS2019)


