### PR TITLE
[IoT] Remove 'the' from unique nouns

### DIFF
--- a/docs/iot/get-started/overview.md
+++ b/docs/iot/get-started/overview.md
@@ -1,6 +1,6 @@
 # Tizen IoT
 
-Tizen is commercialized for smart TV, smart phone, smart watch, and smart home appliances with three profiles: TV, mobile, and wearable. Tizen IoT Headed and Headless binary support any type of special-purpose IoT devices based on the Linux kernel. Tizen IoT Extension SDK supports for the developers to develop an application running on the Tizen IoT Headed and Headless binary. Also, using Tizen IoT extension SDK, the developers can develop the IoT devices which are connected easily and securely with legacy IoT ecosystems such as SmartThings&trade;. 
+Tizen is commercialized for smart TVs, smartphones, smartwatches, and smart home appliances with three profiles: TV, Mobile, and Wearable. Tizen IoT Headed and Headless binaries support any type of special-purpose IoT devices based on the Linux kernel. Tizen IoT Extension SDK supports for the developers to develop an application running on the Tizen IoT Headed and Headless binaries. Also, using Tizen IoT extension SDK, the developers can develop the IoT devices which are connected easily and securely with legacy IoT ecosystems such as SmartThings&trade;. 
 
 Tizen IoT Extension SDK version 1.0 is released from Tizen Studio 3.0 for Tizen 5.0. The following features are supported:
 
@@ -14,7 +14,7 @@ Tizen IoT Extension SDK version 1.0 is released from Tizen Studio 3.0 for Tizen 
 
     -   IoT Setup Manager: The IoT Setup Manager is a computer application for easily setting up Tizen IoT on hardware targets. Both Linux and Windows computer environments are supported. 
 
-    -   Tizen Studio 3.0 (or higher) is used as the IDE for developing IoT applications with the Tizen IoT Platform on Raspberry Pi 3.
+    -   Tizen Studio 3.0 (or higher) is used as the IDE for developing IoT applications with the Tizen IoT platform on Raspberry Pi 3.
 
     -   [IoT API](../guides/iot-api.md)
         -   Things SDK for SmartThings&trade;: Using Things SDK API for [SmartThings&trade;](https://smartthings.developer.samsung.com/), you can create your IoT devices with the SmartThings Cloud. The Things SDK API enables you to integrate, control, and monitor your IoT devices through the SmartThings Cloud with the SmartThings application. 

--- a/docs/iot/guides/zigbee.md
+++ b/docs/iot/guides/zigbee.md
@@ -15,13 +15,13 @@ Following is the list of supported hardware and chipset combinations:
 - CEL's MeshConnect™ EM357 (external USB stick)
 
 > **Note**
-> - This feature is supported in the Tizen IoT.
+> - This feature is supported in Tizen IoT.
 > - You can test the Zigbee functionality only on a target device. The [Emulator](../../application/tizen-studio/common-tools/emulator.md) does not support this feature.
 > - All callbacks in this module are called in the main loop context.
 
 ## Prerequisites
 
-1. To make your application visible in the Tizen Store only for devices that support the Zigbee feature, the application must specify the following feature in the `tizen-manifest.xml` file:
+1. To make your application visible in Tizen Store only for devices that support the Zigbee feature, the application must specify the following feature in the `tizen-manifest.xml` file:
 
    ```
     <feature name="http://tizen.org/feature/network.zigbee">true</feature>


### PR DESCRIPTION
### Change Description ###
Removed 'the' from unique nouns.
e.g.
- Tizen, Tizen 3.x, 4.x, 5.x
- Tizen Mobile, Tizen Mobile 3.x, 4.x, 5.x
- Tizen TV
- Tizen Wearable
- Tizen IoT
- Tizen IVI
- Tizen .NET
- Tizen SDK
- Tizen Store
- Tizen Studio, Tizen Studio 2.x, 3.x
