### PR TITLE
Add naming rules for Tizen terms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ The document covers the process for contributing to the articles and code sample
 1.  [Process for contributing](#process-for-contributing)
     1. [Repository structure](#repository-structure)
     1. [File Name](#file-name)
+    1. [**Naming Rules for Tizen Terms**](./styleguide/naming-rules.md)
 1.  [DOs and DON'Ts](#dos-and-donts)
 1.  [Content license](#content-license)
 1.  [Contributor License Agreement](#contributor-license-agreement)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repo contains Tizen documents for platform and application developers. To contribute, see the [Contributing Guide](CONTRIBUTING.md) and the [issues list](https://github.com/Samsung/tizen-docs/issues).
 
+[**Naming Rules for Tizen Terms**](./styleguide/naming-rules.md) was added. 
+
 All files under ./docs/ are hosted on the [Tizen Docs site](https://docs.tizen.org). 
 
 The Tizen documents in this project are licensed under the [Creative Commons Attribution 3.0](http://creativecommons.org/licenses/by/3.0/) License and the Code Examples are under the [BSD-3-Clause License](https://www.tizen.org/bsd-3-clause-license). See [Content License](content-license.md) for more details.
+
+

--- a/styleguide/naming-rules.md
+++ b/styleguide/naming-rules.md
@@ -1,0 +1,100 @@
+# Tizen Naming Rules
+
+The document covers the naming rules and how to use the name on Tizen guides.
+
+## Components
+
+The compound nouns consist of Brand + Feature + Type + Suffix.
+
+- **Brand**: Brand is a service or platform brand.
+- **Feature**: Main feature or technology
+- **Type**: SDK, API, Guide, Studio
+- **Suffix**: etc.
+
+### Brand
+
+1. Service/platform brand directly related to a service or platform  
+     The name of service or platform comes for the 1st layer.  
+
+     e.g. Tizen, Tizen Studio, Tizen Store
+
+2. Profile name or device brand related to the function of a hardware device  
+     A brand name of the device comes for the 1st layer.  
+
+     e.g. Tizen TV, Tizen Wearable, Tizen IoT, Tizen IVI
+
+3. Application type
+
+     e.g. Tizen Native, Tizen Web, Tizen .NET
+ 
+### Feature
+
+Short-, simple- and intuitive words that imply the main features provided by the platform are to be used. 
+
+1. Main feature  
+   e.g. Alarm, Connectivity, Location, Multimedia, Notification
+
+2. Technology  
+   e.g. Wi-Fi, NFC, Network, Sensor
+
+### Type
+
+Each product is to use the exact service/product type name.
+
+1. SDK
+
+2. API for an API only  
+    ‘API’ comes for the 3rd layer.
+
+3. Guide for a technical document  
+    ‘Guide’ comes for the 3rd layer.
+
+4. Studio for design and technical development tools  
+    ‘Studio’ comes for the 3rd layer.
+
+## Unique nouns 
+
+The following nouns are unique nouns:
+- Tizen
+- Tizen Mobile
+- Tizen TV
+- Tizen Wearable
+- Tizen IoT
+- Tizen IVI
+- Tizen .NET
+- Tizen Native
+- Tizen Web
+- Tizen Store
+- Tizen Studio
+- All API module names  
+  e.g. Tizen Alarm API, Tizen Notification API, Tizen Device API
+- All API module names  
+  e.g. Tizen Alaram API, Tizen Notification API, Tizen Device API
+
+### How to use unique nouns
+
+1. Do use without 'the' when you use the following nouns alone:
+      - Tizen, Tizen 3.x, 4.x, 5.x
+      - Tizen Mobile, Tizen Mobile 3.x, 4.x, 5.x
+      - Tizen TV
+      - Tizen Wearable
+      - Tizen IoT
+      - Tizen IVI
+      - Tizen .NET
+      - Tizen Store
+      - Tizen Studio, Tizen Studio 2.x, 3.x
+
+2. Do follow the common compound nouns usage for the following nouns:
+
+      - Tizen SDK
+      - Tizen IDE
+      - Tizen API
+      - Tizen Native API
+      - TIzen Web API
+      - TizenFX API
+
+3. Do use 'the' when the unique nouns are used with common nouns.
+
+      - The Tizen Studio menu,
+      - The Tizen Mobile profile
+      - etc.


### PR DESCRIPTION
### Change Description ###

I added naming rules for Tizen terms because Tizen brand and Tizen terms are used in various formats.

