### PR TITLE
[humanactivitymonitor] Add accumulative data to HumanActivityPedometerData

### DIFF
--- a/docs/application/web/api/6.0/device_api/mobile/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/humanactivitymonitor.html
@@ -648,6 +648,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
 {
   console.log("Step status: " + pedometerInfo.stepStatus);
   console.log("Cumulative total step count: " + pedometerInfo.cumulativeTotalStepCount);
+  console.log("Accumulative total step count: " + pedometerInfo.accumulativeTotalStepCount);
 }
 
 function onerrorCB(error)
@@ -2096,6 +2097,11 @@ The <em>interval</em> should be greater than or equal to zero.<br>For the PEDOME
     readonly attribute double cumulativeTotalStepCount;
     readonly attribute double cumulativeWalkStepCount;
     readonly attribute double cumulativeRunStepCount;
+    readonly attribute double accumulativeDistance;
+    readonly attribute double accumulativeCalorie;
+    readonly attribute double accumulativeTotalStepCount;
+    readonly attribute double accumulativeWalkStepCount;
+    readonly attribute double accumulativeRunStepCount;
     readonly attribute <a href="#StepDifference">StepDifference</a>[] stepCountDifferences;
   };</pre>
 <p><span class="version">Since: </span>
@@ -2144,7 +2150,7 @@ The <em>interval</em> should be greater than or equal to zero.<br>For the PEDOME
 <li class="attribute" id="HumanActivityPedometerData::cumulativeCalorie">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">cumulativeCalorie</span></span><div class="brief">
- Cumulative calories burned since the last <a href="#HumanActivityMonitorManager::start">start()</a> method call in kcal.
+ Cumulative calories burnt since the last <a href="#HumanActivityMonitorManager::start">start()</a> method call in kcal.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2182,6 +2188,51 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
  2.3
             </p>
 </li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeDistance">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeDistance</span></span><div class="brief">
+ Accumulative distance traveled since the device boot in meters.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeCalorie">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeCalorie</span></span><div class="brief">
+ Accumulative calories burnt since the device boot in kcal.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeTotalStepCount">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeTotalStepCount</span></span><div class="brief">
+ Accumulative walking and running step count since the device boot.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeWalkStepCount">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeWalkStepCount</span></span><div class="brief">
+ Accumulative walking step count since the device boot.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeRunStepCount">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeRunStepCount</span></span><div class="brief">
+ Accumulative running step count since the device boot.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
 <li class="attribute" id="HumanActivityPedometerData::stepCountDifferences">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">StepDifference[]
@@ -2198,7 +2249,7 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
 <div class="interface" id="HumanActivityAccumulativePedometerData">
 <a class="backward-compatibility-anchor" name="::HumanActivityMonitor::HumanActivityAccumulativePedometerData"></a><h3>2.8. HumanActivityAccumulativePedometerData</h3>
 <div class="brief">
- The HumanActivityAccumulativePedometerData interface represents pedometer motion data since the device is booted.
+ The HumanActivityAccumulativePedometerData interface represents pedometer motion data since the device boot.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface HumanActivityAccumulativePedometerData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#PedometerStepStatus">PedometerStepStatus</a> stepStatus;
@@ -2248,7 +2299,7 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeDistance">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeDistance</span></span><div class="brief">
- Accumulative distance traveled since the device is booted in meters.
+ Accumulative distance traveled since the device boot in meters.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2257,7 +2308,7 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeCalorie">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeCalorie</span></span><div class="brief">
- Accumulative calories burnt since the device is booted in kcal.
+ Accumulative calories burnt since the device boot in kcal.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2266,7 +2317,7 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeTotalStepCount">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeTotalStepCount</span></span><div class="brief">
- Accumulative walking and running step count since the device is booted.
+ Accumulative walking and running step count since the device boot.
             </div>
 <div class="description">
             <p>
@@ -2280,7 +2331,7 @@ The value is the sum of <em>accumulativeWalkStepCount</em> and <em>accumulativeR
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeWalkStepCount">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeWalkStepCount</span></span><div class="brief">
- Accumulative walking step count since the device is booted.
+ Accumulative walking step count since the device boot.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2289,7 +2340,7 @@ The value is the sum of <em>accumulativeWalkStepCount</em> and <em>accumulativeR
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeRunStepCount">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeRunStepCount</span></span><div class="brief">
- Accumulative running step count since the device is booted.
+ Accumulative running step count since the device boot.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2692,7 +2743,7 @@ It's a <a href="https://www.researchgate.net/publication/313837778_Microcontroll
 <li class="attribute" id="HumanActivityRecorderPedometerData::calorie">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">calorie</span></span><div class="brief">
- Calories burned from <em>startTime</em> to <em>endTime</em> in kcal.
+ Calories burnt from <em>startTime</em> to <em>endTime</em> in kcal.
             </div>
 <p><span class="version">Since: </span>
  3.0
@@ -3253,6 +3304,11 @@ To guarantee that the stress monitor vector sensor application runs on a device 
     readonly attribute double cumulativeTotalStepCount;
     readonly attribute double cumulativeWalkStepCount;
     readonly attribute double cumulativeRunStepCount;
+    readonly attribute double accumulativeDistance;
+    readonly attribute double accumulativeCalorie;
+    readonly attribute double accumulativeTotalStepCount;
+    readonly attribute double accumulativeWalkStepCount;
+    readonly attribute double accumulativeRunStepCount;
     readonly attribute <a href="#StepDifference">StepDifference</a>[] stepCountDifferences;
   };
   [NoInterfaceObject] interface HumanActivityAccumulativePedometerData : <a href="#HumanActivityData">HumanActivityData</a> {

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/humanactivitymonitor.html
@@ -648,6 +648,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
 {
   console.log("Step status: " + pedometerInfo.stepStatus);
   console.log("Cumulative total step count: " + pedometerInfo.cumulativeTotalStepCount);
+  console.log("Accumulative total step count: " + pedometerInfo.accumulativeTotalStepCount);
 }
 
 function onerrorCB(error)
@@ -2096,6 +2097,11 @@ The <em>interval</em> should be greater than or equal to zero.<br>For the PEDOME
     readonly attribute double cumulativeTotalStepCount;
     readonly attribute double cumulativeWalkStepCount;
     readonly attribute double cumulativeRunStepCount;
+    readonly attribute double accumulativeDistance;
+    readonly attribute double accumulativeCalorie;
+    readonly attribute double accumulativeTotalStepCount;
+    readonly attribute double accumulativeWalkStepCount;
+    readonly attribute double accumulativeRunStepCount;
     readonly attribute <a href="#StepDifference">StepDifference</a>[] stepCountDifferences;
   };</pre>
 <p><span class="version">Since: </span>
@@ -2144,7 +2150,7 @@ The <em>interval</em> should be greater than or equal to zero.<br>For the PEDOME
 <li class="attribute" id="HumanActivityPedometerData::cumulativeCalorie">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">cumulativeCalorie</span></span><div class="brief">
- Cumulative calories burned since the last <a href="#HumanActivityMonitorManager::start">start()</a> method call in kcal.
+ Cumulative calories burnt since the last <a href="#HumanActivityMonitorManager::start">start()</a> method call in kcal.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2182,6 +2188,51 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
  2.3
             </p>
 </li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeDistance">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeDistance</span></span><div class="brief">
+ Accumulative distance traveled since the device boot in meters.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeCalorie">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeCalorie</span></span><div class="brief">
+ Accumulative calories burnt since the device boot in kcal.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeTotalStepCount">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeTotalStepCount</span></span><div class="brief">
+ Accumulative walking and running step count since the device boot.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeWalkStepCount">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeWalkStepCount</span></span><div class="brief">
+ Accumulative walking step count since the device boot.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeRunStepCount">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeRunStepCount</span></span><div class="brief">
+ Accumulative running step count since the device boot.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
 <li class="attribute" id="HumanActivityPedometerData::stepCountDifferences">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">StepDifference[]
@@ -2198,7 +2249,7 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
 <div class="interface" id="HumanActivityAccumulativePedometerData">
 <a class="backward-compatibility-anchor" name="::HumanActivityMonitor::HumanActivityAccumulativePedometerData"></a><h3>2.8. HumanActivityAccumulativePedometerData</h3>
 <div class="brief">
- The HumanActivityAccumulativePedometerData interface represents pedometer motion data since the device is booted.
+ The HumanActivityAccumulativePedometerData interface represents pedometer motion data since the device boot.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface HumanActivityAccumulativePedometerData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#PedometerStepStatus">PedometerStepStatus</a> stepStatus;
@@ -2248,7 +2299,7 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeDistance">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeDistance</span></span><div class="brief">
- Accumulative distance traveled since the device is booted in meters.
+ Accumulative distance traveled since the device boot in meters.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2257,7 +2308,7 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeCalorie">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeCalorie</span></span><div class="brief">
- Accumulative calories burnt since the device is booted in kcal.
+ Accumulative calories burnt since the device boot in kcal.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2266,7 +2317,7 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeTotalStepCount">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeTotalStepCount</span></span><div class="brief">
- Accumulative walking and running step count since the device is booted.
+ Accumulative walking and running step count since the device boot.
             </div>
 <div class="description">
             <p>
@@ -2280,7 +2331,7 @@ The value is the sum of <em>accumulativeWalkStepCount</em> and <em>accumulativeR
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeWalkStepCount">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeWalkStepCount</span></span><div class="brief">
- Accumulative walking step count since the device is booted.
+ Accumulative walking step count since the device boot.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2289,7 +2340,7 @@ The value is the sum of <em>accumulativeWalkStepCount</em> and <em>accumulativeR
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeRunStepCount">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeRunStepCount</span></span><div class="brief">
- Accumulative running step count since the device is booted.
+ Accumulative running step count since the device boot.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2692,7 +2743,7 @@ It's a <a href="https://www.researchgate.net/publication/313837778_Microcontroll
 <li class="attribute" id="HumanActivityRecorderPedometerData::calorie">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">calorie</span></span><div class="brief">
- Calories burned from <em>startTime</em> to <em>endTime</em> in kcal.
+ Calories burnt from <em>startTime</em> to <em>endTime</em> in kcal.
             </div>
 <p><span class="version">Since: </span>
  2.3.2
@@ -3253,6 +3304,11 @@ To guarantee that the stress monitor vector sensor application runs on a device 
     readonly attribute double cumulativeTotalStepCount;
     readonly attribute double cumulativeWalkStepCount;
     readonly attribute double cumulativeRunStepCount;
+    readonly attribute double accumulativeDistance;
+    readonly attribute double accumulativeCalorie;
+    readonly attribute double accumulativeTotalStepCount;
+    readonly attribute double accumulativeWalkStepCount;
+    readonly attribute double accumulativeRunStepCount;
     readonly attribute <a href="#StepDifference">StepDifference</a>[] stepCountDifferences;
   };
   [NoInterfaceObject] interface HumanActivityAccumulativePedometerData : <a href="#HumanActivityData">HumanActivityData</a> {

--- a/docs/application/web/guides/sensors/ham.md
+++ b/docs/application/web/guides/sensors/ham.md
@@ -85,7 +85,7 @@ Enabling the monitor and retrieving data is a basic Human Activity Monitor (HAM)
    tizen.humanactivitymonitor.getHumanActivityData('HRM', onsuccessCB, onerrorCB);
    ```
 
-4. If requested `HumanActivityType` type is `PEDOMETER`, then `getHumanActivityData()` provides `HumanActivityPedometerData` object data gathered since the call of the `start()` method, but also data, which is gathered since the device boot.
+4. If the requested `HumanActivityType` type is `PEDOMETER` then `getHumanActivityData()` provides the `HumanActivityPedometerData` object. This object not only includes data gathered since the call of the `start()` method, but also the data gathered since the device boot:
 
     ```
     function onsuccessCB(pedometerData) {

--- a/docs/application/web/guides/sensors/ham.md
+++ b/docs/application/web/guides/sensors/ham.md
@@ -85,7 +85,22 @@ Enabling the monitor and retrieving data is a basic Human Activity Monitor (HAM)
    tizen.humanactivitymonitor.getHumanActivityData('HRM', onsuccessCB, onerrorCB);
    ```
 
-4. To disable HAM when it is no longer required, use the `stop()` method of the `HumanActivityMonitorManager` interface:
+4. If requested `HumanActivityType` type is `PEDOMETER`, then `getHumanActivityData()` provides `HumanActivityPedometerData` object data gathered since the call of the `start()` method, but also data, which is gathered since the device boot.
+
+    ```
+    function onsuccessCB(pedometerData) {
+        console.log('Steps made since start: ' + pedometerData.cumulativeTotalStepCount);
+        console.log('Steps made since device boot: ' + pedometerData.accumulativeTotalStepCount);
+    }
+
+    function onerrorCB(error) {
+        console.log('Error occurred: ' + error.message);
+    }
+
+    tizen.humanactivitymonitor.getHumanActivityData('PEDOMETER', onsuccessCB, onerrorCB);
+    ```
+
+5. To disable HAM when it is no longer required, use the `stop()` method of the `HumanActivityMonitorManager` interface:
 
    ```
    tizen.humanactivitymonitor.stop('HRM');


### PR DESCRIPTION
Adding accumulative pedometer data to HumanActivityPedometerData to enable getting data gathered from device boot by getHumanActivityData function

[ACR]
http://suprem.sec.samsung.net/jira/browse/TWDAPI-251