### PR TITLE
[WebAPI] Fix missing version information

### DIFF
--- a/docs/application/web/api/6.0/device_api/mobile/tizen/calendar.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/calendar.html
@@ -2376,8 +2376,6 @@ The default value for this attribute is <var>null</var>.
             <p>
 <em>startDate</em> must be specified in the same time zone as <em>endDate / dueDate</em> if provided.
             </p>
-           </div>
-<div class="description">
             <p>
 This attribute is precise to the second. Milliseconds are ignored.
             </p>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/cordova.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/cordova.html
@@ -102,6 +102,9 @@
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {
     void onsuccess();
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -128,6 +131,9 @@
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="#DOMException">DOMException</a> error);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -165,6 +171,9 @@
     readonly attribute DOMString name;
     readonly attribute DOMString message;
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="attributes">
 <h4>Attributes</h4>
 <ul>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/device-motion.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/device-motion.html
@@ -361,6 +361,9 @@ Acceleration values include the effect of gravity (9.81 m/s^2), so that when a d
     readonly attribute double z;
     readonly attribute long timestamp;
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <p><span class="privilegelevel">Privilege level: </span>
  public
           </p>
@@ -441,6 +444,9 @@ Acceleration values include the effect of gravity (9.81 m/s^2), so that when a d
 <pre class="webidl prettyprint">  dictionary AccelerationOptions {
     long frequency;
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="attributes">
 <h4>Dictionary members</h4>
 <dl>
@@ -464,6 +470,9 @@ Acceleration values include the effect of gravity (9.81 m/s^2), so that when a d
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface AccelerometerSuccessCallback {
     void onsuccess(<a href="#Acceleration">Acceleration</a> acceleration);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -496,6 +505,9 @@ Acceleration values include the effect of gravity (9.81 m/s^2), so that when a d
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/dialogs.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/dialogs.html
@@ -397,6 +397,9 @@ the index uses one-based indexing, so the values could be 1, 2, 3, etc.
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ConfirmCallback {
     void onsuccess(long buttonIndex);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <p><span class="remark">Remark: </span>
  Example usage is described on method <a href="#DialogsManager::confirm">confirm</a>.
           </p>
@@ -436,6 +439,9 @@ the index uses one-based indexing, so the values could be 1, 2, 3, etc.
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PromptCallback {
     void onsuccess(<a href="#PromptData">PromptData</a> data);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <p><span class="remark">Remark: </span>
  Example usage is described on method <a href="#DialogsManager::prompt">prompt</a>.
           </p>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/file.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/file.html
@@ -255,6 +255,9 @@ Storage privileges are privacy-related privileges and there is a need of asking 
 See <a href="https://www.w3.org/TR/FileAPI/#blob-section">The Blob Interface and Binary Data</a>.
           </div>
 <pre class="webidl prettyprint">  typedef <a href="#Blob">Blob</a> Blob;</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 </div>
 <div class="typedef" id="WriteData">
 <a class="backward-compatibility-anchor" name="::File::WriteData"></a><h3>1.2. WriteData</h3>
@@ -2014,6 +2017,9 @@ Otherwise, if no other error occurs, getFile must return a FileEntry correspondi
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface DirectoryReader {
     void readEntries(<a href="#EntriesCallback">EntriesCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <p><span class="privilegelevel">Privilege level: </span>
  public
           </p>
@@ -2088,6 +2094,9 @@ Otherwise, if no other error occurs, getFile must return a FileEntry correspondi
     void createWriter(<a href="#FileWriterCallback">FileWriterCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror);
     void file(<a href="#FileCallback">FileCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a> onerror);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <p><span class="privilegelevel">Privilege level: </span>
  public
           </p>
@@ -2718,6 +2727,9 @@ ByteLength: 3
 <a class="backward-compatibility-anchor" name="::File::FileWriter::DONE"></a><span class="name">DONE</span><div class="brief">
  Above constants describe current state of FileWriter object.
             </div>
+<p><span class="version">Since: </span>
+ 3.0
+            </p>
 <br><br>
 </li>
 </dl>
@@ -3111,6 +3123,9 @@ entry.createWriter(successCallback, errorCallback);
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ProgressCallback {
     void onsuccess(<a href="#ProgressEvent">ProgressEvent</a> event);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -3368,6 +3383,9 @@ entry.createWriter(successCallback, errorCallback);
  Used to supply a File as a response to a user query.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void handleEvent(<a href="#File">File</a> file);</pre></div>
+<p><span class="version">Since: </span>
+ 3.0
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/filetransfer.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/filetransfer.html
@@ -944,6 +944,9 @@ Upload error target http://some.server.com/file.txt
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileDownloadSuccessCallback {
     void onsuccess(<a href="file.html#FileEntry">FileEntry</a> file);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -982,6 +985,9 @@ Upload error target http://some.server.com/file.txt
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileTransferErrorCallback {
     void onerror(<a href="#FileTransferError">FileTransferError</a> error);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/globalization.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/globalization.html
@@ -1196,6 +1196,9 @@ Valid values are:
 "full"              </li>
             </ul>
            </div>
+<p><span class="version">Since: </span>
+ 3.0
+            </p>
 </dd>
 <dt class="member" id="DateOptions::selector"><span class="attrName">DOMString selector</span></dt>
 <dd>
@@ -1215,6 +1218,9 @@ Valid values are:
 "date and time"              </li>
             </ul>
            </div>
+<p><span class="version">Since: </span>
+ 3.0
+            </p>
 </dd>
 </dl>
 </div>
@@ -1232,6 +1238,9 @@ Valid values are:
     DOMString decimal;
     DOMString grouping;
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="attributes">
 <h4>Dictionary members</h4>
 <dl>
@@ -2096,6 +2105,9 @@ The GlobalizationError interface
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/media.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/media.html
@@ -774,6 +774,9 @@ setTimeout(function()
     const short MEDIA_ERR_NONE_SUPPORTED = 4;
     readonly attribute short code;
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="attributes">
 <h4>Attributes</h4>
 <ul><li class="attribute" id="MediaError::code">
@@ -795,6 +798,9 @@ setTimeout(function()
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface MediaErrorCallback {
     void onerror(<a href="#MediaError">MediaError</a> error);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -830,6 +836,9 @@ setTimeout(function()
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface StatusChangeCallback {
     void onchanged(short status);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -865,6 +874,9 @@ setTimeout(function()
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PositionSuccessCallback {
     void onsuccess(double position);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/filesystem.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/filesystem.html
@@ -2534,8 +2534,6 @@ The <em>ErrorCallback</em> is launched with these error types:
               <li>
 IOError, if any error related to file handle occurs.               </li>
             </ul>
-           </div>
-<div class="description">
             <p>
 Note, that current position indicator value, can be obtained in SeekSuccessCallback by calling <var>seekNonBlocking(0, "CURRENT")</var>.
 seekNonBlocking is executed in background and does not block further instructions.
@@ -3874,8 +3872,6 @@ The <em>ErrorCallback</em> is launched with these error types:
               <li>
 IOError, if flush fails or any error related to file handle occurs.              </li>
             </ul>
-           </div>
-<div class="description">
             <p>
 This method is asynchronous. Its execution will occur in background and after all previously commissioned background jobs will finish.
             </p>
@@ -4036,8 +4032,6 @@ The <em>ErrorCallback</em> is launched with these error types:
               <li>
 IOError, if sync fails or any error related to file handle occurs.              </li>
             </ul>
-           </div>
-<div class="description">
             <p>
 This method is asynchronous. Its execution will occur in background and after all previously commissioned background jobs will finish.
             </p>
@@ -4184,8 +4178,6 @@ The <em>ErrorCallback</em> is launched with these error types:
               <li>
 IOError, if close fails or any error related to file handle occurs.              </li>
             </ul>
-           </div>
-<div class="description">
             <p>
 This method is asynchronous. Its execution will occur in background and after all previously commissioned background jobs will finish.
             </p>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/fmradio.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/fmradio.html
@@ -236,6 +236,9 @@ The tizen.fmradio object provides access to the functionality of the FM Radio AP
     void setAntennaChangeListener(<a href="#AntennaChangeCallback">AntennaChangeCallback</a> changeCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unsetAntennaChangeListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
+<p><span class="version">Since: </span>
+ 2.3
+          </p>
 <div class="attributes">
 <h4>Attributes</h4>
 <ul>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/humanactivitymonitor.html
@@ -648,6 +648,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
 {
   console.log("Step status: " + pedometerInfo.stepStatus);
   console.log("Cumulative total step count: " + pedometerInfo.cumulativeTotalStepCount);
+  console.log("Accumulative total step count: " + pedometerInfo.accumulativeTotalStepCount);
 }
 
 function onerrorCB(error)
@@ -2096,6 +2097,11 @@ The <em>interval</em> should be greater than or equal to zero.<br>For the PEDOME
     readonly attribute double cumulativeTotalStepCount;
     readonly attribute double cumulativeWalkStepCount;
     readonly attribute double cumulativeRunStepCount;
+    readonly attribute double accumulativeDistance;
+    readonly attribute double accumulativeCalorie;
+    readonly attribute double accumulativeTotalStepCount;
+    readonly attribute double accumulativeWalkStepCount;
+    readonly attribute double accumulativeRunStepCount;
     readonly attribute <a href="#StepDifference">StepDifference</a>[] stepCountDifferences;
   };</pre>
 <p><span class="version">Since: </span>
@@ -2144,7 +2150,7 @@ The <em>interval</em> should be greater than or equal to zero.<br>For the PEDOME
 <li class="attribute" id="HumanActivityPedometerData::cumulativeCalorie">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">cumulativeCalorie</span></span><div class="brief">
- Cumulative calories burned since the last <a href="#HumanActivityMonitorManager::start">start()</a> method call in kcal.
+ Cumulative calories burnt since the last <a href="#HumanActivityMonitorManager::start">start()</a> method call in kcal.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2182,6 +2188,51 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
  2.3
             </p>
 </li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeDistance">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeDistance</span></span><div class="brief">
+ Accumulative distance traveled since the device boot in meters.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeCalorie">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeCalorie</span></span><div class="brief">
+ Accumulative calories burnt since the device boot in kcal.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeTotalStepCount">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeTotalStepCount</span></span><div class="brief">
+ Accumulative walking and running step count since the device boot.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeWalkStepCount">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeWalkStepCount</span></span><div class="brief">
+ Accumulative walking step count since the device boot.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeRunStepCount">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeRunStepCount</span></span><div class="brief">
+ Accumulative running step count since the device boot.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
 <li class="attribute" id="HumanActivityPedometerData::stepCountDifferences">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">StepDifference[]
@@ -2198,7 +2249,7 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
 <div class="interface" id="HumanActivityAccumulativePedometerData">
 <a class="backward-compatibility-anchor" name="::HumanActivityMonitor::HumanActivityAccumulativePedometerData"></a><h3>2.8. HumanActivityAccumulativePedometerData</h3>
 <div class="brief">
- The HumanActivityAccumulativePedometerData interface represents pedometer motion data since the device is booted.
+ The HumanActivityAccumulativePedometerData interface represents pedometer motion data since the device boot.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface HumanActivityAccumulativePedometerData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#PedometerStepStatus">PedometerStepStatus</a> stepStatus;
@@ -2248,7 +2299,7 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeDistance">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeDistance</span></span><div class="brief">
- Accumulative distance traveled since the device is booted in meters.
+ Accumulative distance traveled since the device boot in meters.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2257,7 +2308,7 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeCalorie">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeCalorie</span></span><div class="brief">
- Accumulative calories burnt since the device is booted in kcal.
+ Accumulative calories burnt since the device boot in kcal.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2266,7 +2317,7 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeTotalStepCount">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeTotalStepCount</span></span><div class="brief">
- Accumulative walking and running step count since the device is booted.
+ Accumulative walking and running step count since the device boot.
             </div>
 <div class="description">
             <p>
@@ -2280,7 +2331,7 @@ The value is the sum of <em>accumulativeWalkStepCount</em> and <em>accumulativeR
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeWalkStepCount">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeWalkStepCount</span></span><div class="brief">
- Accumulative walking step count since the device is booted.
+ Accumulative walking step count since the device boot.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2289,7 +2340,7 @@ The value is the sum of <em>accumulativeWalkStepCount</em> and <em>accumulativeR
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeRunStepCount">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeRunStepCount</span></span><div class="brief">
- Accumulative running step count since the device is booted.
+ Accumulative running step count since the device boot.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2692,7 +2743,7 @@ It's a <a href="https://www.researchgate.net/publication/313837778_Microcontroll
 <li class="attribute" id="HumanActivityRecorderPedometerData::calorie">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">calorie</span></span><div class="brief">
- Calories burned from <em>startTime</em> to <em>endTime</em> in kcal.
+ Calories burnt from <em>startTime</em> to <em>endTime</em> in kcal.
             </div>
 <p><span class="version">Since: </span>
  3.0
@@ -3253,6 +3304,11 @@ To guarantee that the stress monitor vector sensor application runs on a device 
     readonly attribute double cumulativeTotalStepCount;
     readonly attribute double cumulativeWalkStepCount;
     readonly attribute double cumulativeRunStepCount;
+    readonly attribute double accumulativeDistance;
+    readonly attribute double accumulativeCalorie;
+    readonly attribute double accumulativeTotalStepCount;
+    readonly attribute double accumulativeWalkStepCount;
+    readonly attribute double accumulativeRunStepCount;
     readonly attribute <a href="#StepDifference">StepDifference</a>[] stepCountDifferences;
   };
   [NoInterfaceObject] interface HumanActivityAccumulativePedometerData : <a href="#HumanActivityData">HumanActivityData</a> {

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/inputdevice.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/inputdevice.html
@@ -81,6 +81,9 @@ For more information on the Input Device features, see <a href="/application/web
  Name which identifies the key
           </div>
 <pre class="webidl prettyprint">  typedef DOMString InputDeviceKeyName;</pre>
+<p><span class="version">Since: </span>
+ 2.4
+          </p>
 <div class="description">
           <p>
 Name of the key may be, for example:

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/mediacontroller.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/mediacontroller.html
@@ -39,25 +39,28 @@ For more information on the Media Controller features, see <a href="/application
                     1.3. <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a>
 </li>
 <li>
-                    1.4. <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a>
+                    1.4. <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a>
 </li>
 <li>
-                    1.5. <a href="#MediaControllerContentType">MediaControllerContentType</a>
+                    1.5. <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a>
 </li>
 <li>
-                    1.6. <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a>
+                    1.6. <a href="#MediaControllerContentType">MediaControllerContentType</a>
 </li>
 <li>
-                    1.7. <a href="#MediaControllerAbilitySupport">MediaControllerAbilitySupport</a>
+                    1.7. <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a>
 </li>
 <li>
-                    1.8. <a href="#MediaControllerSimpleAbility">MediaControllerSimpleAbility</a>
+                    1.8. <a href="#MediaControllerAbilitySupport">MediaControllerAbilitySupport</a>
 </li>
 <li>
-                    1.9. <a href="#MediaControllerDisplayModeType">MediaControllerDisplayModeType</a>
+                    1.9. <a href="#MediaControllerSimpleAbility">MediaControllerSimpleAbility</a>
 </li>
 <li>
-                    1.10. <a href="#MediaControllerDisplayRotationType">MediaControllerDisplayRotationType</a>
+                    1.10. <a href="#MediaControllerDisplayModeType">MediaControllerDisplayModeType</a>
+</li>
+<li>
+                    1.11. <a href="#MediaControllerDisplayRotationType">MediaControllerDisplayRotationType</a>
 </li>
 </ul>
 </li>
@@ -72,89 +75,97 @@ For more information on the Media Controller features, see <a href="/application
 </li>
 <li>2.5. <a href="#MediaControllerServerInfo">MediaControllerServerInfo</a>
 </li>
-<li>2.6. <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a>
+<li class="deprecated">2.6. <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a>
 </li>
-<li>2.7. <a href="#MediaControllerAbilities">MediaControllerAbilities</a>
+<li>2.7. <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>
 </li>
-<li>2.8. <a href="#MediaControllerPlaybackAbilities">MediaControllerPlaybackAbilities</a>
+<li>2.8. <a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a>
 </li>
-<li>2.9. <a href="#MediaControllerDisplayModeAbilities">MediaControllerDisplayModeAbilities</a>
+<li>2.9. <a href="#MediaControllerPlaylists">MediaControllerPlaylists</a>
 </li>
-<li>2.10. <a href="#MediaControllerDisplayRotationAbilities">MediaControllerDisplayRotationAbilities</a>
+<li>2.10. <a href="#MediaControllerPlaylistsInfo">MediaControllerPlaylistsInfo</a>
 </li>
-<li>2.11. <a href="#MediaControllerAbilitiesInfo">MediaControllerAbilitiesInfo</a>
+<li>2.11. <a href="#MediaControllerAbilities">MediaControllerAbilities</a>
 </li>
-<li>2.12. <a href="#MediaControllerPlaybackAbilitiesInfo">MediaControllerPlaybackAbilitiesInfo</a>
+<li>2.12. <a href="#MediaControllerPlaybackAbilities">MediaControllerPlaybackAbilities</a>
 </li>
-<li>2.13. <a href="#MediaControllerDisplayModeAbilitiesInfo">MediaControllerDisplayModeAbilitiesInfo</a>
+<li>2.13. <a href="#MediaControllerDisplayModeAbilities">MediaControllerDisplayModeAbilities</a>
 </li>
-<li>2.14. <a href="#MediaControllerDisplayRotationAbilitiesInfo">MediaControllerDisplayRotationAbilitiesInfo</a>
+<li>2.14. <a href="#MediaControllerDisplayRotationAbilities">MediaControllerDisplayRotationAbilities</a>
 </li>
-<li>2.15. <a href="#MediaControllerSubtitles">MediaControllerSubtitles</a>
+<li>2.15. <a href="#MediaControllerAbilitiesInfo">MediaControllerAbilitiesInfo</a>
 </li>
-<li>2.16. <a href="#MediaControllerSubtitlesInfo">MediaControllerSubtitlesInfo</a>
+<li>2.16. <a href="#MediaControllerPlaybackAbilitiesInfo">MediaControllerPlaybackAbilitiesInfo</a>
 </li>
-<li>2.17. <a href="#MediaControllerMode360">MediaControllerMode360</a>
+<li>2.17. <a href="#MediaControllerDisplayModeAbilitiesInfo">MediaControllerDisplayModeAbilitiesInfo</a>
 </li>
-<li>2.18. <a href="#MediaControllerMode360Info">MediaControllerMode360Info</a>
+<li>2.18. <a href="#MediaControllerDisplayRotationAbilitiesInfo">MediaControllerDisplayRotationAbilitiesInfo</a>
 </li>
-<li>2.19. <a href="#MediaControllerDisplayMode">MediaControllerDisplayMode</a>
+<li>2.19. <a href="#MediaControllerSubtitles">MediaControllerSubtitles</a>
 </li>
-<li>2.20. <a href="#MediaControllerDisplayModeInfo">MediaControllerDisplayModeInfo</a>
+<li>2.20. <a href="#MediaControllerSubtitlesInfo">MediaControllerSubtitlesInfo</a>
 </li>
-<li>2.21. <a href="#MediaControllerDisplayRotation">MediaControllerDisplayRotation</a>
+<li>2.21. <a href="#MediaControllerMode360">MediaControllerMode360</a>
 </li>
-<li>2.22. <a href="#MediaControllerClientInfo">MediaControllerClientInfo</a>
+<li>2.22. <a href="#MediaControllerMode360Info">MediaControllerMode360Info</a>
 </li>
-<li>2.23. <a href="#MediaControllerDisplayRotationInfo">MediaControllerDisplayRotationInfo</a>
+<li>2.23. <a href="#MediaControllerDisplayMode">MediaControllerDisplayMode</a>
 </li>
-<li>2.24. <a href="#MediaControllerMetadata">MediaControllerMetadata</a>
+<li>2.24. <a href="#MediaControllerDisplayModeInfo">MediaControllerDisplayModeInfo</a>
 </li>
-<li>2.25. <a href="#MediaControllerPlaylistItem">MediaControllerPlaylistItem</a>
+<li>2.25. <a href="#MediaControllerDisplayRotation">MediaControllerDisplayRotation</a>
 </li>
-<li>2.26. <a href="#MediaControllerMetadataInit">MediaControllerMetadataInit</a>
+<li>2.26. <a href="#MediaControllerClientInfo">MediaControllerClientInfo</a>
 </li>
-<li>2.27. <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a>
+<li>2.27. <a href="#MediaControllerDisplayRotationInfo">MediaControllerDisplayRotationInfo</a>
 </li>
-<li>2.28. <a href="#SearchFilter">SearchFilter</a>
+<li>2.28. <a href="#MediaControllerMetadata">MediaControllerMetadata</a>
 </li>
-<li>2.29. <a href="#MediaControllerServerInfoArraySuccessCallback">MediaControllerServerInfoArraySuccessCallback</a>
+<li>2.29. <a href="#MediaControllerPlaylistItem">MediaControllerPlaylistItem</a>
 </li>
-<li>2.30. <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>
+<li>2.30. <a href="#MediaControllerMetadataInit">MediaControllerMetadataInit</a>
 </li>
-<li>2.31. <a href="#RequestReply">RequestReply</a>
+<li>2.31. <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a>
 </li>
-<li>2.32. <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a>
+<li>2.32. <a href="#SearchFilter">SearchFilter</a>
 </li>
-<li>2.33. <a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a>
+<li>2.33. <a href="#MediaControllerServerInfoArraySuccessCallback">MediaControllerServerInfoArraySuccessCallback</a>
 </li>
-<li>2.34. <a href="#MediaControllerReceiveCommandCallback">MediaControllerReceiveCommandCallback</a>
+<li>2.34. <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>
 </li>
-<li>2.35. <a href="#MediaControllerEnabledChangeRequestCallback">MediaControllerEnabledChangeRequestCallback</a>
+<li>2.35. <a href="#RequestReply">RequestReply</a>
 </li>
-<li>2.36. <a href="#MediaControllerEnabledChangeCallback">MediaControllerEnabledChangeCallback</a>
+<li>2.36. <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a>
 </li>
-<li>2.37. <a href="#MediaControllerDisplayModeChangeRequestCallback">MediaControllerDisplayModeChangeRequestCallback</a>
+<li>2.37. <a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a>
 </li>
-<li>2.38. <a href="#MediaControllerDisplayModeChangeCallback">MediaControllerDisplayModeChangeCallback</a>
+<li>2.38. <a href="#MediaControllerReceiveCommandCallback">MediaControllerReceiveCommandCallback</a>
 </li>
-<li>2.39. <a href="#MediaControllerDisplayRotationChangeRequestCallback">MediaControllerDisplayRotationChangeRequestCallback</a>
+<li>2.39. <a href="#MediaControllerEnabledChangeRequestCallback">MediaControllerEnabledChangeRequestCallback</a>
 </li>
-<li>2.40. <a href="#MediaControllerDisplayRotationChangeCallback">MediaControllerDisplayRotationChangeCallback</a>
+<li>2.40. <a href="#MediaControllerEnabledChangeCallback">MediaControllerEnabledChangeCallback</a>
 </li>
-<li>2.41. <a href="#MediaControllerServerStatusChangeCallback">MediaControllerServerStatusChangeCallback</a>
+<li>2.41. <a href="#MediaControllerDisplayModeChangeRequestCallback">MediaControllerDisplayModeChangeRequestCallback</a>
 </li>
-<li>2.42. <a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a>
+<li>2.42. <a href="#MediaControllerDisplayModeChangeCallback">MediaControllerDisplayModeChangeCallback</a>
 </li>
-<li>2.43. <a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a>
+<li>2.43. <a href="#MediaControllerDisplayRotationChangeRequestCallback">MediaControllerDisplayRotationChangeRequestCallback</a>
 </li>
-<li>2.44. <a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a>
+<li>2.44. <a href="#MediaControllerDisplayRotationChangeCallback">MediaControllerDisplayRotationChangeCallback</a>
 </li>
-<li>2.45. <a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a>
+<li>2.45. <a href="#MediaControllerServerStatusChangeCallback">MediaControllerServerStatusChangeCallback</a>
 </li>
-<li>2.46. <a href="#MediaControllerGetItemsSuccessCallback">MediaControllerGetItemsSuccessCallback</a>
+<li>2.46. <a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a>
 </li>
-<li>2.47. <a href="#MediaControllerAbilityChangeCallback">MediaControllerAbilityChangeCallback</a>
+<li>2.47. <a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a>
+</li>
+<li>2.48. <a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a>
+</li>
+<li>2.49. <a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a>
+</li>
+<li>2.50. <a href="#MediaControllerGetItemsSuccessCallback">MediaControllerGetItemsSuccessCallback</a>
+</li>
+<li>2.51. <a href="#MediaControllerAbilityChangeCallback">MediaControllerAbilityChangeCallback</a>
 </li>
 </ul>
 </li>
@@ -187,26 +198,10 @@ For more information on the Media Controller features, see <a href="/application
 <td>
 <div>
 <a href="#MediaControllerClientInfo">MediaControllerClientInfo</a>[] <a href="#MediaControllerServer::getAllClientsInfo">getAllClientsInfo</a> ()</div>
-<div>void <a href="#MediaControllerServer::updatePlaybackState">updatePlaybackState</a> (<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state)</div>
-<div>void <a href="#MediaControllerServer::updateIconURI">updateIconURI</a> (DOMString? iconURI)</div>
-<div>void <a href="#MediaControllerServer::updatePlaybackPosition">updatePlaybackPosition</a> (unsigned long long position)</div>
-<div>void <a href="#MediaControllerServer::updatePlaybackAgeRating">updatePlaybackAgeRating</a> (<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating)</div>
-<div>void <a href="#MediaControllerServer::updatePlaybackContentType">updatePlaybackContentType</a> (<a href="#MediaControllerContentType">MediaControllerContentType</a> type)</div>
-<div>void <a href="#MediaControllerServer::updateShuffleMode">updateShuffleMode</a> (boolean mode)</div>
-<div>void <a href="#MediaControllerServer::updateRepeatState">updateRepeatState</a> (<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state)</div>
-<div>void <a href="#MediaControllerServer::updateMetadata">updateMetadata</a> (<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata)</div>
-<div>long <a href="#MediaControllerServer::addChangeRequestPlaybackInfoListener">addChangeRequestPlaybackInfoListener</a> (<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener)</div>
-<div>void <a href="#MediaControllerServer::removeChangeRequestPlaybackInfoListener">removeChangeRequestPlaybackInfoListener</a> (long watchId)</div>
 <div>void <a href="#MediaControllerServer::setSearchRequestListener">setSearchRequestListener</a> (<a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a> listener)</div>
 <div>void <a href="#MediaControllerServer::unsetSearchRequestListener">unsetSearchRequestListener</a> ()</div>
 <div>long <a href="#MediaControllerServer::addCommandListener">addCommandListener</a> (<a href="#MediaControllerReceiveCommandCallback">MediaControllerReceiveCommandCallback</a> listener)</div>
 <div>void <a href="#MediaControllerServer::removeCommandListener">removeCommandListener</a> (long watchId)</div>
-<div>
-<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> <a href="#MediaControllerServer::createPlaylist">createPlaylist</a> (DOMString name)</div>
-<div>void <a href="#MediaControllerServer::savePlaylist">savePlaylist</a> (<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServer::deletePlaylist">deletePlaylist</a> (DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServer::updatePlaybackItem">updatePlaybackItem</a> (DOMString playlistName, DOMString index)</div>
-<div>void <a href="#MediaControllerServer::getAllPlaylists">getAllPlaylists</a> (<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
 </td>
 </tr>
 <tr>
@@ -225,25 +220,53 @@ For more information on the Media Controller features, see <a href="/application
 <tr>
 <td><a href="#MediaControllerServerInfo">MediaControllerServerInfo</a></td>
 <td>
-<div>void <a href="#MediaControllerServerInfo::sendPlaybackState">sendPlaybackState</a> (<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServerInfo::sendPlaybackPosition">sendPlaybackPosition</a> (unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServerInfo::sendShuffleMode">sendShuffleMode</a> (boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServerInfo::sendRepeatState">sendRepeatState</a> (<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
 <div>void <a href="#MediaControllerServerInfo::sendSearchRequest">sendSearchRequest</a> (<a href="#SearchFilter">SearchFilter</a>[] request, <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a> replyCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
 <div>void <a href="#MediaControllerServerInfo::sendCommand">sendCommand</a> (DOMString command, <a href="tizen.html#Bundle">Bundle</a>? data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
 <div>long <a href="#MediaControllerServerInfo::addServerStatusChangeListener">addServerStatusChangeListener</a> (<a href="#MediaControllerServerStatusChangeCallback">MediaControllerServerStatusChangeCallback</a> listener)</div>
 <div>void <a href="#MediaControllerServerInfo::removeServerStatusChangeListener">removeServerStatusChangeListener</a> (long watchId)</div>
-<div>long <a href="#MediaControllerServerInfo::addPlaybackInfoChangeListener">addPlaybackInfoChangeListener</a> (<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener)</div>
-<div>void <a href="#MediaControllerServerInfo::removePlaybackInfoChangeListener">removePlaybackInfoChangeListener</a> (long watchId)</div>
-<div>void <a href="#MediaControllerServerInfo::getAllPlaylists">getAllPlaylists</a> (<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServerInfo::sendPlaybackItem">sendPlaybackItem</a> (DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position)</div>
-<div>long <a href="#MediaControllerServerInfo::addPlaylistUpdatedListener">addPlaylistUpdatedListener</a> (<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener)</div>
-<div>void <a href="#MediaControllerServerInfo::removePlaylistUpdatedListener">removePlaylistUpdatedListener</a> (long listenerId)</div>
 </td>
 </tr>
 <tr>
-<td><a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a></td>
-<td></td>
+<td><a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a></td>
+<td>
+<div>void <a href="#MediaControllerServerPlaybackInfo::updatePlaybackItem">updatePlaybackItem</a> (DOMString playlistName, DOMString index)</div>
+<div>long <a href="#MediaControllerServerPlaybackInfo::addChangeRequestListener">addChangeRequestListener</a> (<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener)</div>
+<div>void <a href="#MediaControllerServerPlaybackInfo::removeChangeRequestListener">removeChangeRequestListener</a> (long watchId)</div>
+</td>
+</tr>
+<tr>
+<td><a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a></td>
+<td>
+<div>void <a href="#MediaControllerServerInfoPlaybackInfo::sendPlaybackAction">sendPlaybackAction</a> (<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)</div>
+<div>void <a href="#MediaControllerServerInfoPlaybackInfo::sendPlaybackPosition">sendPlaybackPosition</a> (unsigned long long position, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)</div>
+<div>void <a href="#MediaControllerServerInfoPlaybackInfo::sendShuffleMode">sendShuffleMode</a> (boolean mode, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)</div>
+<div>void <a href="#MediaControllerServerInfoPlaybackInfo::sendRepeatState">sendRepeatState</a> (<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)</div>
+<div>long <a href="#MediaControllerServerInfoPlaybackInfo::addPlaybackInfoChangeListener">addPlaybackInfoChangeListener</a> (<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener)</div>
+<div>void <a href="#MediaControllerServerInfoPlaybackInfo::removePlaybackInfoChangeListener">removePlaybackInfoChangeListener</a> (long watchId)</div>
+</td>
+</tr>
+<tr>
+<td><a href="#MediaControllerPlaylists">MediaControllerPlaylists</a></td>
+<td>
+<div>
+<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> <a href="#MediaControllerPlaylists::createPlaylist">createPlaylist</a> (DOMString name)</div>
+<div>void <a href="#MediaControllerPlaylists::savePlaylist">savePlaylist</a> (<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
+<div>void <a href="#MediaControllerPlaylists::deletePlaylist">deletePlaylist</a> (DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
+<div>void <a href="#MediaControllerPlaylists::getAllPlaylists">getAllPlaylists</a> (<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
+<div>
+<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> <a href="#MediaControllerPlaylists::getPlaylist">getPlaylist</a> (DOMString playlistName)</div>
+</td>
+</tr>
+<tr>
+<td><a href="#MediaControllerPlaylistsInfo">MediaControllerPlaylistsInfo</a></td>
+<td>
+<div>void <a href="#MediaControllerPlaylistsInfo::getAllPlaylists">getAllPlaylists</a> (<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
+<div>void <a href="#MediaControllerPlaylistsInfo::sendPlaybackItem">sendPlaybackItem</a> (DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, unsigned long long position, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)</div>
+<div>long <a href="#MediaControllerPlaylistsInfo::addPlaylistUpdatedListener">addPlaylistUpdatedListener</a> (<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener)</div>
+<div>void <a href="#MediaControllerPlaylistsInfo::removePlaylistUpdatedListener">removePlaylistUpdatedListener</a> (long listenerId)</div>
+<div>
+<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> <a href="#MediaControllerPlaylistsInfo::getPlaylist">getPlaylist</a> (DOMString playlistName)</div>
+</td>
 </tr>
 <tr>
 <td><a href="#MediaControllerAbilities">MediaControllerAbilities</a></td>
@@ -346,7 +369,7 @@ For more information on the Media Controller features, see <a href="/application
 </tr>
 <tr>
 <td><a href="#MediaControllerMetadata">MediaControllerMetadata</a></td>
-<td></td>
+<td><div>void <a href="#MediaControllerMetadata::save">save</a> ()</div></td>
 </tr>
 <tr>
 <td><a href="#MediaControllerPlaylistItem">MediaControllerPlaylistItem</a></td>
@@ -436,11 +459,16 @@ For more information on the Media Controller features, see <a href="/application
 <tr>
 <td><a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a></td>
 <td>
-<div>void <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackstaterequest">onplaybackstaterequest</a> (<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
-<div>void <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackpositionrequest">onplaybackpositionrequest</a> (unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
-<div>void <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onshufflemoderequest">onshufflemoderequest</a> (boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
-<div>void <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onrepeatstaterequest">onrepeatstaterequest</a> (<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
-<div>void <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackitemrequest">onplaybackitemrequest</a> (DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
+<div>
+<a href="#RequestReply">RequestReply</a>? <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackactionrequest">onplaybackactionrequest</a> (<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
+<div>
+<a href="#RequestReply">RequestReply</a>? <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackpositionrequest">onplaybackpositionrequest</a> (unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
+<div>
+<a href="#RequestReply">RequestReply</a>? <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onshufflemoderequest">onshufflemoderequest</a> (boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
+<div>
+<a href="#RequestReply">RequestReply</a>? <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onrepeatstaterequest">onrepeatstaterequest</a> (<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
+<div>
+<a href="#RequestReply">RequestReply</a>? <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackitemrequest">onplaybackitemrequest</a> (DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
 </td>
 </tr>
 <tr>
@@ -527,24 +555,54 @@ TPO - Search by Time Place Occasion.            </li>
 <div class="description">
           <ul>
             <li>
-PLAY - Corresponds to play media controller playback state.            </li>
+PLAY - Corresponds to the "playing" media controller playback state.            </li>
             <li>
-PAUSE - Corresponds to pause media controller playback state.            </li>
+PAUSE - Corresponds to the "paused" media controller playback state.            </li>
             <li>
-STOP - Corresponds to stop media controller playback state.            </li>
+STOP - Corresponds to the "stopped" media controller playback state.            </li>
             <li>
-NEXT - Corresponds to next media controller playback state.            </li>
+NEXT - Corresponds to the "moving to next" media controller playback state.            </li>
             <li>
-PREV - Corresponds to previous media controller playback state.            </li>
+PREV - Corresponds to the "moving to previous" media controller playback state.            </li>
             <li>
-FORWARD - Corresponds to forward media controller playback state.            </li>
+FORWARD - Corresponds to the "forwarding" media controller playback state.            </li>
             <li>
-REWIND - Corresponds to rewind media controller playback state.            </li>
+REWIND - Corresponds to the "rewinding" media controller playback state.            </li>
+          </ul>
+         </div>
+</div>
+<div class="enum" id="MediaControllerPlaybackAction">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackAction"></a><h3>1.4. MediaControllerPlaybackAction</h3>
+<div class="brief">
+ Defines media playback actions.
+          </div>
+<pre class="webidl prettyprint">  enum MediaControllerPlaybackAction { "PLAY", "PAUSE", "STOP", "NEXT", "PREV", "FORWARD", "REWIND", "TOGGLE_PLAY_PAUSE" };</pre>
+<p><span class="version">Since: </span>
+ 6.0
+          </p>
+<div class="description">
+          <ul>
+            <li>
+PLAY - Corresponds to the "play" media controller playback action.            </li>
+            <li>
+PAUSE - Corresponds to "pause" media controller playback action.            </li>
+            <li>
+STOP - Corresponds to the "stop" media controller playback action.            </li>
+            <li>
+NEXT - Corresponds to the "next" media controller playback action.            </li>
+            <li>
+PREV - Corresponds to the "previous" media controller playback action.            </li>
+            <li>
+FORWARD - Corresponds to the "forward" media controller playback action.            </li>
+            <li>
+REWIND - Corresponds to the "rewind" media controller playback action.            </li>
+            <li>
+TOGGLE_PLAY_PAUSE - Corresponds to the "toggle play/pause" media controller playback action.            </li>
           </ul>
          </div>
 </div>
 <div class="enum" id="MediaControllerRepeatState">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerRepeatState"></a><h3>1.4. MediaControllerRepeatState</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerRepeatState"></a><h3>1.5. MediaControllerRepeatState</h3>
 <div class="brief">
  Defines states for repeating media.
           </div>
@@ -567,7 +625,7 @@ REPEAT_ALL - repeating all media.            </li>
          </div>
 </div>
 <div class="enum" id="MediaControllerContentType">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerContentType"></a><h3>1.5. MediaControllerContentType</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerContentType"></a><h3>1.6. MediaControllerContentType</h3>
 <div class="brief">
  Content type.
           </div>
@@ -591,7 +649,7 @@ UNDECIDED - content type for unspecified media types.            </li>
          </div>
 </div>
 <div class="enum" id="MediaControllerContentAgeRating">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerContentAgeRating"></a><h3>1.6. MediaControllerContentAgeRating</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerContentAgeRating"></a><h3>1.7. MediaControllerContentAgeRating</h3>
 <div class="brief">
  Media Controller content age rating.
           </div>
@@ -607,7 +665,7 @@ Each value represents the minimum age restriction for the media.
          </div>
 </div>
 <div class="enum" id="MediaControllerAbilitySupport">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilitySupport"></a><h3>1.7. MediaControllerAbilitySupport</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilitySupport"></a><h3>1.8. MediaControllerAbilitySupport</h3>
 <div class="brief">
  The media controller ability support values.
           </div>
@@ -627,7 +685,7 @@ UNDECIDED - The support of ability is not set.            </li>
          </div>
 </div>
 <div class="enum" id="MediaControllerSimpleAbility">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSimpleAbility"></a><h3>1.8. MediaControllerSimpleAbility</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSimpleAbility"></a><h3>1.9. MediaControllerSimpleAbility</h3>
 <div class="brief">
  The media controller simple ability types. Simple means, that each ability is described by a single <a href="#MediaControllerAbilitySupport">MediaControllerAbilitySupport</a> value and is not a part of a complex ability structure.
           </div>
@@ -658,7 +716,7 @@ MODE_360 - Ability to receive requests for spherical (360°) mode change from me
          </div>
 </div>
 <div class="enum" id="MediaControllerDisplayModeType">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeType"></a><h3>1.9. MediaControllerDisplayModeType</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeType"></a><h3>1.10. MediaControllerDisplayModeType</h3>
 <div class="brief">
  Types of supported media controller display modes.
           </div>
@@ -680,7 +738,7 @@ CROPPED_FULL - Cropped full screen display mode type.            </li>
          </div>
 </div>
 <div class="enum" id="MediaControllerDisplayRotationType">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationType"></a><h3>1.10. MediaControllerDisplayRotationType</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationType"></a><h3>1.11. MediaControllerDisplayRotationType</h3>
 <div class="brief">
  The media controller rotation values.
           </div>
@@ -861,38 +919,40 @@ catch (err)
  Provides functions for sending the server information to the client.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerServer {
-    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo;
-    readonly attribute DOMString? iconURI;
+<span class="nocode deprecated">    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo;
+</span>    readonly attribute <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a> playback;
+    readonly attribute <a href="#MediaControllerPlaylists">MediaControllerPlaylists</a> playlists;
+    attribute DOMString? iconURI raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute <a href="#MediaControllerAbilities">MediaControllerAbilities</a> abilities;
     readonly attribute <a href="#MediaControllerSubtitles">MediaControllerSubtitles</a> subtitles;
     readonly attribute <a href="#MediaControllerMode360">MediaControllerMode360</a> mode360;
     readonly attribute <a href="#MediaControllerDisplayMode">MediaControllerDisplayMode</a> displayMode;
     readonly attribute <a href="#MediaControllerDisplayRotation">MediaControllerDisplayRotation</a> displayRotation;
     <a href="#MediaControllerClientInfo">MediaControllerClientInfo</a>[] getAllClientsInfo() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateIconURI(DOMString? iconURI) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackPosition(unsigned long long position) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackAgeRating(<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackContentType(<a href="#MediaControllerContentType">MediaControllerContentType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateShuffleMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-<span class="nocode deprecated">    void updateRepeatMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-</span>    void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateMetadata(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addChangeRequestPlaybackInfoListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removeChangeRequestPlaybackInfoListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void setSearchRequestListener(<a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    void updatePlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updateIconURI(DOMString? iconURI) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updatePlaybackPosition(unsigned long long position) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updatePlaybackAgeRating(<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updatePlaybackContentType(<a href="#MediaControllerContentType">MediaControllerContentType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updateShuffleMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updateRepeatMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updateMetadata(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    long addChangeRequestPlaybackInfoListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void removeChangeRequestPlaybackInfoListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void setSearchRequestListener(<a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unsetSearchRequestListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addCommandListener(<a href="#MediaControllerReceiveCommandCallback">MediaControllerReceiveCommandCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeCommandListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+<span class="nocode deprecated">    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+</span><span class="nocode deprecated">    void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackItem(DOMString playlistName, DOMString index) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+</span><span class="nocode deprecated">    void updatePlaybackItem(DOMString playlistName, DOMString index) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };</pre>
+</span>  };</pre>
 <p><span class="version">Since: </span>
  2.4
           </p>
@@ -905,11 +965,14 @@ and be controlled by other application(client) remotely.
 <div class="attributes">
 <h4>Attributes</h4>
 <ul>
-<li class="attribute" id="MediaControllerServer::playbackInfo">
+<li class="attribute deprecated" id="MediaControllerServer::playbackInfo">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">MediaControllerPlaybackInfo </span><span class="name">playbackInfo</span></span><div class="brief">
  Current playback info.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a> <var>playback</var> attribute.
+            </p>
 <p><span class="version">Since: </span>
  2.4
             </p>
@@ -917,14 +980,41 @@ and be controlled by other application(client) remotely.
  Object holds state which is automatically updated by update methods.
             </p>
 </li>
-<li class="attribute" id="MediaControllerServer::iconURI">
+<li class="attribute" id="MediaControllerServer::playback">
 <span class="attrName"><span class="readonly">                readonly
-</span><span class="type">DOMString </span><span class="name">iconURI</span><span class="optional"> [nullable]</span></span><div class="brief">
+</span><span class="type">MediaControllerServerPlaybackInfo </span><span class="name">playback</span></span><div class="brief">
+ Current playback info.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServer::playlists">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerPlaylists </span><span class="name">playlists</span></span><div class="brief">
+ Object representing features related to playlists of a media controller server.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServer::iconURI">
+<span class="attrName"><span class="type">DOMString </span><span class="name">iconURI</span><span class="optional"> [nullable]</span></span><div class="brief">
  Server icon URI.
             </div>
 <p><span class="version">Since: </span>
  5.5
             </p>
+<p><span class="remark">Remark: </span>
+ The readonly modifier is removed since 6.0 version.
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
 </li>
 <li class="attribute" id="MediaControllerServer::abilities">
 <span class="attrName"><span class="readonly">                readonly
@@ -1005,15 +1095,18 @@ and be controlled by other application(client) remotely.
 </li></ul>
         </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updatePlaybackState">
+<dt class="deprecated method" id="MediaControllerServer::updatePlaybackState">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updatePlaybackState"></a><code><b><span class="methodName">updatePlaybackState</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates playback state and send notification to the listening clients.
 See <em>MediaControllerServerInfo.addPlaybackInfoChangeListener</em> to check
 how to receive playback info changes from server on client side.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>state</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updatePlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1051,13 +1144,16 @@ console.log("Current playback state is: " + mcServer.playbackInfo.state);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updateIconURI">
+<dt class="deprecated method" id="MediaControllerServer::updateIconURI">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updateIconURI"></a><code><b><span class="methodName">updateIconURI</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates server icon URI.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>iconURI</var> attribute in <a href="#MediaControllerServer">MediaControllerServer</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updateIconURI(DOMString? iconURI);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1092,13 +1188,16 @@ console.log(mcServerInfo.iconURI);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updatePlaybackPosition">
+<dt class="deprecated method" id="MediaControllerServer::updatePlaybackPosition">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updatePlaybackPosition"></a><code><b><span class="methodName">updatePlaybackPosition</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates playback position and send notification to the listening clients.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>position</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updatePlaybackPosition(unsigned long long position);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1136,13 +1235,16 @@ console.log("Current playback position is: " + mcServer.playbackInfo.position);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updatePlaybackAgeRating">
+<dt class="deprecated method" id="MediaControllerServer::updatePlaybackAgeRating">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updatePlaybackAgeRating"></a><code><b><span class="methodName">updatePlaybackAgeRating</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Sets content age rating for current playback item.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>ageRating</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updatePlaybackAgeRating(<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1182,13 +1284,16 @@ console.log("Only viewers older than " + mcServerInfo.playbackInfo.ageRating +
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updatePlaybackContentType">
+<dt class="deprecated method" id="MediaControllerServer::updatePlaybackContentType">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updatePlaybackContentType"></a><code><b><span class="methodName">updatePlaybackContentType</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Sets content type for the current playback item.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>contentType</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updatePlaybackContentType(<a href="#MediaControllerContentType">MediaControllerContentType</a> type);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1227,13 +1332,16 @@ console.log("Content type of current item is " + mcServerInfo.playbackInfo.conte
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updateShuffleMode">
+<dt class="deprecated method" id="MediaControllerServer::updateShuffleMode">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updateShuffleMode"></a><code><b><span class="methodName">updateShuffleMode</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates shuffle mode and send notification to the listening clients.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>shuffleMode</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updateShuffleMode(boolean mode);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1304,13 +1412,16 @@ console.log("Current repeat mode is: " + mcServer.playbackInfo.repeatMode);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updateRepeatState">
+<dt class="deprecated method" id="MediaControllerServer::updateRepeatState">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updateRepeatState"></a><code><b><span class="methodName">updateRepeatState</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates repeat state and sends notification to the listening clients.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>repeatState</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1348,13 +1459,16 @@ console.log("Current repeat state is: " + mcServer.playbackInfo.repeatState);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updateMetadata">
+<dt class="deprecated method" id="MediaControllerServer::updateMetadata">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updateMetadata"></a><code><b><span class="methodName">updateMetadata</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates metadata and send notification to the listening clients.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerMetadata::save">save()</a> on metadata object.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updateMetadata(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1397,15 +1511,18 @@ console.log("Current metadata is: " + JSON.stringify(mcServer.playbackInfo.metad
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::addChangeRequestPlaybackInfoListener">
+<dt class="deprecated method" id="MediaControllerServer::addChangeRequestPlaybackInfoListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::addChangeRequestPlaybackInfoListener"></a><code><b><span class="methodName">addChangeRequestPlaybackInfoListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Adds the listener for a media playback info requests from client.
 See <em>MediaControllerServerInfo</em> to check how to send playback info change
 requests from client.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerPlaybackInfo::addChangeRequestListener">addChangeRequestListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">long addChangeRequestPlaybackInfoListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1472,13 +1589,16 @@ watcherId = mcServer.addChangeRequestPlaybackInfoListener(playbackRequestListene
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::removeChangeRequestPlaybackInfoListener">
+<dt class="deprecated method" id="MediaControllerServer::removeChangeRequestPlaybackInfoListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::removeChangeRequestPlaybackInfoListener"></a><code><b><span class="methodName">removeChangeRequestPlaybackInfoListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Removes the listener, so stop receiving playback state requests from clients.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerPlaybackInfo::removeChangeRequestListener">removeChangeRequestListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void removeChangeRequestPlaybackInfoListener(long watchId);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1731,13 +1851,16 @@ mcServer.removeCommandListener(watcherId);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::createPlaylist">
+<dt class="deprecated method" id="MediaControllerServer::createPlaylist">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::createPlaylist"></a><code><b><span class="methodName">createPlaylist</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Creates <em>MediaControllerPlaylist</em> object.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylists::createPlaylist">createPlaylist()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint"><a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1779,13 +1902,16 @@ var playlist = mcServer.createPlaylist("testPlaylistName");
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::savePlaylist">
+<dt class="deprecated method" id="MediaControllerServer::savePlaylist">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::savePlaylist"></a><code><b><span class="methodName">savePlaylist</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
- Saves playlist in local database.
+ Saves the playlist in a local database.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylists::savePlaylist">savePlaylist()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                   optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
@@ -1797,13 +1923,13 @@ The <em>errorCallback</em> may be triggered for one of the following errors:
             </p>
             <ul>
               <li>
-<em>InvalidValuesError</em>: if playlist with given name does not exists.              </li>
+<em>InvalidValuesError</em>: if playlist with given name does not exist.              </li>
               <li>
-<em>UnknownError</em>: if any other error prevents function from successful completion.              </li>
+<em>UnknownError</em>: if any other error prevents the function from successful completion.              </li>
             </ul>
            </div>
 <p><span class="remark">Remark: </span>
- All playlists will be deleted after application is closed.
+ All playlists will be deleted after the application is closed.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -1853,13 +1979,16 @@ mcServer.savePlaylist(playlist, successCallback, errorCallback);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::deletePlaylist">
+<dt class="deprecated method" id="MediaControllerServer::deletePlaylist">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::deletePlaylist"></a><code><b><span class="methodName">deletePlaylist</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Deletes playlist from local database.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylists::deletePlaylist">deletePlaylist()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1870,9 +1999,9 @@ The <em>errorCallback</em> may be triggered for one of the following errors:
             </p>
             <ul>
               <li>
-<em>InvalidValuesError</em>: if playlist with given name does not exists.              </li>
+<em>InvalidValuesError</em>: if playlist with given name does not exist.              </li>
               <li>
-<em>UnknownError</em>: if any other error prevents function from successful completion.              </li>
+<em>UnknownError</em>: if any other error prevents the function from successful completion.              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1927,13 +2056,16 @@ mcServer.savePlaylist(playlist, saveSuccess);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updatePlaybackItem">
+<dt class="deprecated method" id="MediaControllerServer::updatePlaybackItem">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updatePlaybackItem"></a><code><b><span class="methodName">updatePlaybackItem</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Sets index and playlist name properties of playback info object.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerPlaybackInfo::updatePlaybackItem">updatePlaybackItem()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updatePlaybackItem(DOMString playlistName, DOMString index);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1990,13 +2122,16 @@ Current index: index1
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::getAllPlaylists">
+<dt class="deprecated method" id="MediaControllerServer::getAllPlaylists">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::getAllPlaylists"></a><code><b><span class="methodName">getAllPlaylists</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
- Retrieves all playlists from local database.
+ Retrieves all playlists from a local database.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylists::getAllPlaylists">getAllPlaylists()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -2553,38 +2688,40 @@ Provides methods to send commands to server and listen for server status change.
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerServerInfo {
     readonly attribute <a href="application.html#ApplicationId">ApplicationId</a> name;
     readonly attribute <a href="#MediaControllerServerState">MediaControllerServerState</a> state;
-    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    readonly attribute <a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a> playback raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    readonly attribute <a href="#MediaControllerPlaylistsInfo">MediaControllerPlaylistsInfo</a> playlists;
     readonly attribute DOMString? iconURI raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute <a href="#MediaControllerAbilitiesInfo">MediaControllerAbilitiesInfo</a> abilities;
     readonly attribute <a href="#MediaControllerSubtitlesInfo">MediaControllerSubtitlesInfo</a> subtitles;
     readonly attribute <a href="#MediaControllerMode360Info">MediaControllerMode360Info</a> mode360;
     readonly attribute <a href="#MediaControllerDisplayModeInfo">MediaControllerDisplayModeInfo</a> displayMode;
     readonly attribute <a href="#MediaControllerDisplayRotationInfo">MediaControllerDisplayRotationInfo</a> displayRotation;
-    void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+<span class="nocode deprecated">    void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                            optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+</span><span class="nocode deprecated">    void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendShuffleMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+</span><span class="nocode deprecated">    void sendShuffleMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-<span class="nocode deprecated">    void sendRepeatMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+</span><span class="nocode deprecated">    void sendRepeatMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-</span>    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+</span><span class="nocode deprecated">    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                          optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendSearchRequest(<a href="#SearchFilter">SearchFilter</a>[] request, <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a> replyCallback,
+</span>    void sendSearchRequest(<a href="#SearchFilter">SearchFilter</a>[] request, <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a> replyCallback,
                            optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void sendCommand(DOMString command, <a href="tizen.html#Bundle">Bundle</a>? data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addServerStatusChangeListener(<a href="#MediaControllerServerStatusChangeCallback">MediaControllerServerStatusChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeServerStatusChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removePlaybackInfoChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+<span class="nocode deprecated">    long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void removePlaybackInfoChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position)
+</span><span class="nocode deprecated">    void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position)
                           raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removePlaylistUpdatedListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };</pre>
+</span><span class="nocode deprecated">    long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void removePlaylistUpdatedListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</pre>
 <p><span class="version">Since: </span>
  2.4
           </p>
@@ -2609,11 +2746,14 @@ Provides methods to send commands to server and listen for server status change.
  2.4
             </p>
 </li>
-<li class="attribute" id="MediaControllerServerInfo::playbackInfo">
+<li class="attribute deprecated" id="MediaControllerServerInfo::playbackInfo">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">MediaControllerPlaybackInfo </span><span class="name">playbackInfo</span></span><div class="brief">
  Current playback info.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a> <var>playback</var> attribute.
+            </p>
 <p><span class="version">Since: </span>
  2.4
             </p>
@@ -2624,6 +2764,31 @@ Provides methods to send commands to server and listen for server status change.
                 </p></li></ul>
 </li></ul>
         </div>
+</li>
+<li class="attribute" id="MediaControllerServerInfo::playback">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerServerInfoPlaybackInfo </span><span class="name">playback</span></span><div class="brief">
+ Playback info of current server info.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerInfo::playlists">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerPlaylistsInfo </span><span class="name">playlists</span></span><div class="brief">
+ An attribute providing access to the playlist information from the server.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
 </li>
 <li class="attribute" id="MediaControllerServerInfo::iconURI">
 <span class="attrName"><span class="readonly">                readonly
@@ -2691,13 +2856,16 @@ Provides methods to send commands to server and listen for server status change.
 <div class="methods">
 <h4>Methods</h4>
 <dl>
-<dt class="method" id="MediaControllerServerInfo::sendPlaybackState">
+<dt class="deprecated method" id="MediaControllerServerInfo::sendPlaybackState">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::sendPlaybackState"></a><code><b><span class="methodName">sendPlaybackState</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Allows to change playback state of media controller server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::sendPlaybackAction">sendPlaybackAction()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                        optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
@@ -2752,13 +2920,16 @@ mcServerInfo.sendPlaybackState("STOP",
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::sendPlaybackPosition">
+<dt class="deprecated method" id="MediaControllerServerInfo::sendPlaybackPosition">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::sendPlaybackPosition"></a><code><b><span class="methodName">sendPlaybackPosition</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Allows to change playback position of media controller server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::sendPlaybackPosition">sendPlaybackPosition()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                           optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
@@ -2816,13 +2987,16 @@ mcServerInfo.sendPlaybackPosition(164,
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::sendShuffleMode">
+<dt class="deprecated method" id="MediaControllerServerInfo::sendShuffleMode">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::sendShuffleMode"></a><code><b><span class="methodName">sendShuffleMode</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Allows to change shuffle mode of media controller server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::sendShuffleMode">sendShuffleMode()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void sendShuffleMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -2935,13 +3109,16 @@ mcServerInfo.sendRepeatMode(false,
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::sendRepeatState">
+<dt class="deprecated method" id="MediaControllerServerInfo::sendRepeatState">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::sendRepeatState"></a><code><b><span class="methodName">sendRepeatState</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Allows to change repeat state of media controller server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::sendRepeatState">sendRepeatState()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
@@ -3255,13 +3432,16 @@ mcServerInfo.removeServerStatusChangeListener(watcherId);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::addPlaybackInfoChangeListener">
+<dt class="deprecated method" id="MediaControllerServerInfo::addPlaybackInfoChangeListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::addPlaybackInfoChangeListener"></a><code><b><span class="methodName">addPlaybackInfoChangeListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Adds the listener for a media playback info changes.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::addPlaybackInfoChangeListener">addPlaybackInfoChangeListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -3325,13 +3505,16 @@ watcherId = mcServerInfo.addPlaybackInfoChangeListener(playbackListener);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::removePlaybackInfoChangeListener">
+<dt class="deprecated method" id="MediaControllerServerInfo::removePlaybackInfoChangeListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::removePlaybackInfoChangeListener"></a><code><b><span class="methodName">removePlaybackInfoChangeListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Removes the listener, so stop receiving notifications about media playback info changes.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::removePlaybackInfoChangeListener">removePlaybackInfoChangeListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void removePlaybackInfoChangeListener(long watchId);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -3392,13 +3575,16 @@ mcServerInfo.removePlaybackInfoChangeListener(watcherId);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::getAllPlaylists">
+<dt class="deprecated method" id="MediaControllerServerInfo::getAllPlaylists">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::getAllPlaylists"></a><code><b><span class="methodName">getAllPlaylists</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Retrieves all playlists saved in local database.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylistsInfo::getAllPlaylists">getAllPlaylists()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -3474,13 +3660,16 @@ Playlist name: testPlaylist
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::sendPlaybackItem">
+<dt class="deprecated method" id="MediaControllerServerInfo::sendPlaybackItem">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::sendPlaybackItem"></a><code><b><span class="methodName">sendPlaybackItem</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Requests setting new playback item to server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylistsInfo::sendPlaybackItem">sendPlaybackItem()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -3523,13 +3712,16 @@ mcServerInfo.sendPlaybackItem("testPlaylist", "1", "PLAY", 0);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::addPlaylistUpdatedListener">
+<dt class="deprecated method" id="MediaControllerServerInfo::addPlaylistUpdatedListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::addPlaylistUpdatedListener"></a><code><b><span class="methodName">addPlaylistUpdatedListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Adds listener to be invoked when playlist is updated by server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylistsInfo::addPlaylistUpdatedListener">addPlaylistUpdatedListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -3581,13 +3773,16 @@ var listenerId = mcServerInfo.addPlaylistUpdatedListener(listener);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::removePlaylistUpdatedListener">
+<dt class="deprecated method" id="MediaControllerServerInfo::removePlaylistUpdatedListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::removePlaylistUpdatedListener"></a><code><b><span class="methodName">removePlaylistUpdatedListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Stops listening for playlist updates and removals.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylistsInfo::removePlaylistUpdatedListener">removePlaylistUpdatedListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void removePlaylistUpdatedListener(long listenerId);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -3628,12 +3823,17 @@ mcServerInfo.removePlaylistUpdatedListener(listenerId);
 </dl>
 </div>
 </div>
-<div class="interface" id="MediaControllerPlaybackInfo">
+<div class="interface deprecated" id="MediaControllerPlaybackInfo">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackInfo"></a><h3>2.6. MediaControllerPlaybackInfo</h3>
 <div class="brief">
  Current playback info.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerPlaybackInfo {
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a> for
+server-side object of playback info and <a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a> for
+client-side object of playback info.
+          </p>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface MediaControllerPlaybackInfo {
     readonly attribute <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state;
     readonly attribute unsigned long long position;
     readonly attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating;
@@ -3644,7 +3844,7 @@ mcServerInfo.removePlaylistUpdatedListener(listenerId);
     readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
     readonly attribute DOMString? index;
     readonly attribute DOMString? playlistName;
-  };</pre>
+  };</span></pre>
 <p><span class="version">Since: </span>
  2.4
           </p>
@@ -3780,8 +3980,1445 @@ Default value is <var>REPEAT_ALL</var>.
 </ul>
 </div>
 </div>
+<div class="interface" id="MediaControllerServerPlaybackInfo">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerPlaybackInfo"></a><h3>2.7. MediaControllerServerPlaybackInfo</h3>
+<div class="brief">
+ Server-side object representing current playback info.
+          </div>
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerServerPlaybackInfo {
+    attribute <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute unsigned long long position raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerContentType">MediaControllerContentType</a> contentType raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute boolean shuffleMode raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> repeatState raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
+    readonly attribute DOMString? index;
+    readonly attribute DOMString? playlistName;
+    void updatePlaybackItem(DOMString playlistName, DOMString index) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addChangeRequestListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removeChangeRequestListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };</pre>
+<p><span class="version">Since: </span>
+ 6.0
+          </p>
+<div class="attributes">
+<h4>Attributes</h4>
+<ul>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::state">
+<span class="attrName"><span class="type">MediaControllerPlaybackState </span><span class="name">state</span></span><div class="brief">
+ Current playback state.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if the set value will not be compatible with <var>MediaControllerPlaybackState</var> enum.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::position">
+<span class="attrName"><span class="type">unsigned long long </span><span class="name">position</span></span><div class="brief">
+ Current playback position.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type InvalidValuesError, if the set value is less than 0.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::ageRating">
+<span class="attrName"><span class="type">MediaControllerContentAgeRating </span><span class="name">ageRating</span></span><div class="brief">
+ Current playback age rating.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if the set value will not be compatible with <var>MediaControllerContentAgeRating</var> enum.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::contentType">
+<span class="attrName"><span class="type">MediaControllerContentType </span><span class="name">contentType</span></span><div class="brief">
+ Current playback content type.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if the set value will not be compatible with <var>MediaControllerContentType</var> enum.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::shuffleMode">
+<span class="attrName"><span class="type">boolean </span><span class="name">shuffleMode</span></span><div class="brief">
+ Current shuffle mode.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::repeatState">
+<span class="attrName"><span class="type">MediaControllerRepeatState </span><span class="name">repeatState</span></span><div class="brief">
+ Current repeat state.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if the set value will not be compatible with <var>MediaControllerRepeatState</var> enum.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::metadata">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerMetadata </span><span class="name">metadata</span></span><div class="brief">
+ Current playback metadata.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::index">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">DOMString </span><span class="name">index</span><span class="optional"> [nullable]</span></span><div class="brief">
+ Current item index.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::playlistName">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">DOMString </span><span class="name">playlistName</span><span class="optional"> [nullable]</span></span><div class="brief">
+ Current playlist name.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+</ul>
+</div>
+<div class="methods">
+<h4>Methods</h4>
+<dl>
+<dt class="method" id="MediaControllerServerPlaybackInfo::updatePlaybackItem">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerPlaybackInfo::updatePlaybackItem"></a><code><b><span class="methodName">updatePlaybackItem</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Sets index and playlist name properties of playback info object.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void updatePlaybackItem(DOMString playlistName, DOMString index);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlistName</span>:
+ Name of playlist to be set.
+                </li>
+          <li class="param">
+<span class="name">index</span>:
+ Index of item on playlist <em>playlistName</em> to be set.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+
+mcServer.playback.updatePlaybackItem("testPlaylistName", "index1");
+console.log("Current playlist: " + mcServer.playback.playlistName);
+console.log("Current index: " + mcServer.playback.index);
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>Current playlist: testPlaylistName
+Current index: index1
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerPlaybackInfo::addChangeRequestListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerPlaybackInfo::addChangeRequestListener"></a><code><b><span class="methodName">addChangeRequestListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Adds the listener for change requests of a media controller playback info.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">long addChangeRequestListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">listener</span>:
+ Change request listener to add.
+                </li>
+        </ul>
+</div>
+<div class="returntype">
+<p><span class="return">Return value:</span></p>
+<ul>
+<span class="return">long:</span>
+ The identifier used to remove the listener.
+              </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var watcherId = 0;  /* Watcher identifier. */
+var mcServer = tizen.mediacontroller.createServer();
+
+var playbackRequestListener =
+{
+  onplaybackactionrequest: function(action, clientName)
+  {
+    console.log("Playback action requested to: " + action + " by " + clientName);
+  },
+  onplaybackpositionrequest: function(position, clientName)
+  {
+    console.log("Playback position requested to: " + position + " by " + clientName);
+  },
+  onshufflemoderequest: function(mode, clientName)
+  {
+    console.log("Shuffle mode requested to: " + mode + " by " + clientName);
+  },
+  onrepeatstaterequest: function(state, clientName)
+  {
+    console.log("Repeat state requested to: " + state + " by " + clientName);
+  },
+  onplaybackitemrequest: function(playlistName, index, state, position, clientName)
+  {
+    console.log("Playlist: " + playlistName + " index: " + index + " state: " + state +
+                " position " + position + " requested by " + clientName);
+  }
+};
+
+/* Registers to receive playback info change requests from client. */
+watcherId = mcServer.playback.addChangeRequestListener(playbackRequestListener);
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerPlaybackInfo::removeChangeRequestListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerPlaybackInfo::removeChangeRequestListener"></a><code><b><span class="methodName">removeChangeRequestListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Removes the listener and stops receiving change requests of media controller playback info.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void removeChangeRequestListener(long watchId);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">watchId</span>:
+ Watcher identifier.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var watcherId = 0;  /* Watcher identifier. */
+var mcServer = tizen.mediacontroller.createServer();
+
+var playbackRequestListener =
+{
+  onplaybackactionrequest: function(action, clientName) {},
+  onplaybackpositionrequest: function(position, clientName) {},
+  onshufflemoderequest: function(mode, clientName) {},
+  onrepeatstaterequest: function(state, clientName) {},
+  onplaybackitemrequest: function(playlistName, index, state, position, clientName) {}
+};
+
+/* Registers to receive playback info change requests from client. */
+watcherId = mcServer.playback.addChangeRequestListener(playbackRequestListener);
+
+/* Cancels the watch operation. */
+mcServer.playback.removeChangeRequestListener(watcherId);
+</pre>
+</div>
+</dd>
+</dl>
+</div>
+</div>
+<div class="interface" id="MediaControllerServerInfoPlaybackInfo">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo"></a><h3>2.8. MediaControllerServerInfoPlaybackInfo</h3>
+<div class="brief">
+ Client-side object representing current playback info.
+          </div>
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerServerInfoPlaybackInfo {
+    readonly attribute <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state;
+    readonly attribute unsigned long long position;
+    readonly attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating;
+    readonly attribute <a href="#MediaControllerContentType">MediaControllerContentType</a> contentType;
+    readonly attribute boolean shuffleMode;
+    readonly attribute <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> repeatState;
+    readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
+    readonly attribute DOMString? index;
+    readonly attribute DOMString? playlistName;
+    void sendPlaybackAction(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                            raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendPlaybackPosition(unsigned long long position, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                              raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendShuffleMode(boolean mode, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removePlaybackInfoChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };</pre>
+<p><span class="version">Since: </span>
+ 6.0
+          </p>
+<div class="attributes">
+<h4>Attributes</h4>
+<ul>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::state">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerPlaybackState </span><span class="name">state</span></span><div class="brief">
+ Current playback state.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::position">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">unsigned long long </span><span class="name">position</span></span><div class="brief">
+ Current playback position.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::ageRating">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerContentAgeRating </span><span class="name">ageRating</span></span><div class="brief">
+ Current playback age rating.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::contentType">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerContentType </span><span class="name">contentType</span></span><div class="brief">
+ Current playback content type.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::shuffleMode">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">boolean </span><span class="name">shuffleMode</span></span><div class="brief">
+ Current shuffle mode.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::repeatState">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerRepeatState </span><span class="name">repeatState</span></span><div class="brief">
+ Current repeat state.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::metadata">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerMetadata </span><span class="name">metadata</span></span><div class="brief">
+ Current playback metadata.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::index">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">DOMString </span><span class="name">index</span><span class="optional"> [nullable]</span></span><div class="brief">
+ Current item index. Value set to <var>null</var> means no playlist set in playback
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::playlistName">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">DOMString </span><span class="name">playlistName</span><span class="optional"> [nullable]</span></span><div class="brief">
+ Current playlist name. Value set to <var>null</var> means no playlist set in playback
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+</ul>
+</div>
+<div class="methods">
+<h4>Methods</h4>
+<dl>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::sendPlaybackAction">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::sendPlaybackAction"></a><code><b><span class="methodName">sendPlaybackAction</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Sends request to change the playback state of a media controller server.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackAction(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">action</span>:
+ Playback action.
+                </li>
+          <li class="param">
+<span class="name">replyCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method to invoke when server responded to change request.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+mcServerInfo.playback.sendPlaybackAction("STOP", function(data, code)
+{
+  console.log("Server replied with return data: " + JSON.stringify(data) + " and code: " + code);
+});
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::sendPlaybackPosition">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::sendPlaybackPosition"></a><code><b><span class="methodName">sendPlaybackPosition</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Sends request to change the playback position of a media controller server.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackPosition(unsigned long long position, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">position</span>:
+ Playback position.
+                </li>
+          <li class="param">
+<span class="name">replyCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method to invoke when server responded to change request.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type InvalidValuesError, if any of the input parameters contain an invalid value.
+                </p></li>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+mcServerInfo.playback.sendPlaybackPosition(164, function(data, code)
+{
+  console.log("Server replied with return data: " + JSON.stringify(data) + " and code: " + code);
+});
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::sendShuffleMode">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::sendShuffleMode"></a><code><b><span class="methodName">sendShuffleMode</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Sends request to change the shuffle mode of a media controller server.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void sendShuffleMode(boolean mode, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">mode</span>:
+ Shuffle mode.
+                </li>
+          <li class="param">
+<span class="name">replyCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method to invoke when server responded to change request.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+mcServerInfo.playback.sendShuffleMode(true, function(data, code)
+{
+  console.log("Server replied with return data: " + JSON.stringify(data) + " and code: " + code);
+});
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::sendRepeatState">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::sendRepeatState"></a><code><b><span class="methodName">sendRepeatState</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Sends request to change the repeat state of a media controller server.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 5.5
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">state</span>:
+ Repeat state to be set.
+                </li>
+          <li class="param">
+<span class="name">replyCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method to invoke when server responded to change request.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+mcServerInfo.playback.sendRepeatState("REPEAT_ALL", function(data, code)
+{
+  console.log("Server replied with return data: " + JSON.stringify(data) + " and code: " + code);
+});
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::addPlaybackInfoChangeListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::addPlaybackInfoChangeListener"></a><code><b><span class="methodName">addPlaybackInfoChangeListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Adds the listener for a media playback info changes.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">listener</span>:
+ Status change listener to add.
+                </li>
+        </ul>
+</div>
+<div class="returntype">
+<p><span class="return">Return value:</span></p>
+<ul>
+<span class="return">long:</span>
+ The identifier used to clear the watch subscription.
+              </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var watcherId = 0;  /* Watcher identifier. */
+var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+/* receives playback state changes. */
+var playbackListener =
+{
+  onplaybackchanged: function(state, position)
+  {
+    console.log("Current playback state: " + state);
+    console.log("Current playback position: " + position);
+  },
+  onshufflemodechanged: function(mode)
+  {
+    console.log("Shuffle mode changed to: " + mode);
+  },
+  onrepeatstatechanged: function(state)
+  {
+    console.log("Repeat state changed to: " + state);
+  },
+  onmetadatachanged: function(metadata)
+  {
+    console.log("Playback metadata changed: " + JSON.stringify(metadata));
+  }
+};
+
+/* Registers to be notified when playback state changes. */
+watcherId = mcServerInfo.playback.addPlaybackInfoChangeListener(playbackListener);
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::removePlaybackInfoChangeListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::removePlaybackInfoChangeListener"></a><code><b><span class="methodName">removePlaybackInfoChangeListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Removes the listener, so stop receiving notifications about media playback info changes.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void removePlaybackInfoChangeListener(long watchId);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">watchId</span>:
+ Subscription identifier.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var watcherId = 0;  /* Watcher identifier. */
+var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+/* receives playback state changes. */
+var playbackListener =
+{
+  onplaybackchanged: function(state, position) {},
+  onshufflemodechanged: function(mode) {},
+  onrepeatstatechanged: function(state) {},
+  onmetadatachanged: function(metadata) {}
+};
+
+/* Registers to be notified when playback state changes. */
+watcherId = mcServerInfo.playback.addPlaybackInfoChangeListener(playbackListener);
+
+/* Cancels the watch operation. */
+mcServerInfo.playback.removePlaybackInfoChangeListener(watcherId);
+</pre>
+</div>
+</dd>
+</dl>
+</div>
+</div>
+<div class="interface" id="MediaControllerPlaylists">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists"></a><h3>2.9. MediaControllerPlaylists</h3>
+<div class="brief">
+ Server-side object representing methods for playlists of a media controller server.
+          </div>
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerPlaylists {
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                        raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };</pre>
+<p><span class="version">Since: </span>
+ 6.0
+          </p>
+<div class="methods">
+<h4>Methods</h4>
+<dl>
+<dt class="method" id="MediaControllerPlaylists::createPlaylist">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists::createPlaylist"></a><code><b><span class="methodName">createPlaylist</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Creates <em>MediaControllerPlaylist</em> object.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<p><span class="remark">Remark: </span>
+ Please note that there is a need to use <a href="#MediaControllerPlaylists::savePlaylist">savePlaylist()</a>, otherwise playlist creation will have no effect on a device. All playlists will be deleted after application is closed.
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">name</span>:
+ Name of the new playlist.
+                </li>
+        </ul>
+</div>
+<div class="returntype">
+<p><span class="return">Return value:</span></p>
+<ul>
+<span class="return">MediaControllerPlaylist:</span>
+ New empty <em>MediaControllerPlaylist</em> object with given name.
+              </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type InvalidValuesError, if playlist with given name already exists.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var playlist = mcServer.playlists.createPlaylist("testPlaylistName");
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylists::savePlaylist">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists::savePlaylist"></a><code><b><span class="methodName">savePlaylist</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Saves the playlist in a local database.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+                  optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+The <em>errorCallback</em> may be triggered for one of the following errors:
+            </p>
+            <ul>
+              <li>
+<em>InvalidValuesError</em>: if playlist with given name does not exist.              </li>
+              <li>
+<em>UnknownError</em>: if any other error prevents the function from successful completion.              </li>
+            </ul>
+           </div>
+<p><span class="remark">Remark: </span>
+ All playlists will be deleted after the application is closed.
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlist</span>:
+ <em>MediaControllerPlaylist</em> object to save.
+                </li>
+          <li class="param">
+<span class="name">successCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called when <em>savePlaylist</em> is finished without error.
+                </li>
+          <li class="param">
+<span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called when <em>savePlaylist</em> fails.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var playlist = mcServer.playlists.createPlaylist("testPlaylistName");
+function successCallback()
+{
+  console.log("savePlaylist successful.");
+}
+function errorCallback(error)
+{
+  console.log("savePlaylist failed with error: " + error);
+}
+mcServer.playlists.savePlaylist(playlist, successCallback, errorCallback);
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>savePlaylist successful.
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylists::deletePlaylist">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists::deletePlaylist"></a><code><b><span class="methodName">deletePlaylist</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Deletes the playlist from a local database.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+The <em>errorCallback</em> may be triggered for one of the following errors:
+            </p>
+            <ul>
+              <li>
+<em>InvalidValuesError</em>: if playlist with given name does not exist.              </li>
+              <li>
+<em>UnknownError</em>: if any other error prevents the function from successful completion.              </li>
+            </ul>
+           </div>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlistName</span>:
+ Name of the playlist to remove.
+                </li>
+          <li class="param">
+<span class="name">successCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called when <em>deletePlaylist</em> is finished without error.
+                </li>
+          <li class="param">
+<span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called when <em>deletePlaylist</em> fails.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var playlist = mcServer.playlists.createPlaylist("testPlaylistName");
+function deleteSuccess()
+{
+  console.log("deletePlaylist successful.");
+}
+function deleteFailure(error)
+{
+  console.log("deletePlaylist failed with error: " + error);
+}
+function saveSuccess()
+{
+  mcServer.playlists.deletePlaylist(playlist.name, deleteSuccess, deleteFailure);
+}
+mcServer.playlists.savePlaylist(playlist, saveSuccess);
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>deletePlaylist successful.
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylists::getAllPlaylists">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists::getAllPlaylists"></a><code><b><span class="methodName">getAllPlaylists</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Retrieves all playlists from a local database.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+The <em>errorCallback</em> may be triggered for one of the following errors:
+            </p>
+            <ul>
+              <li>
+<em>UnknownError</em>: if any error prevents function from successful completion.              </li>
+            </ul>
+           </div>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">successCallback</span>:
+ Function to be called on <em>getAllPlaylists</em> success.
+                </li>
+          <li class="param">
+<span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called when <em>getAllPlaylists</em> fails.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any parameter has invalid type.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var playlist = mcServer.playlists.createPlaylist("testPlaylist");
+
+function saveSuccess()
+{
+  console.log("savePlaylist successful");
+  function successCallback(playlists)
+  {
+    playlists.forEach(function(playlist)
+    {
+      console.log("Playlist name: " + playlist.name);
+    });
+  }
+  function errorCallback(error)
+  {
+    console.log("getAllPlaylists failed with error: " + error);
+  }
+  mcServer.playlists.getAllPlaylists(successCallback, errorCallback);
+}
+function saveError(error)
+{
+  console.log("savePlaylist failed with error: " + error);
+}
+
+mcServer.playlists.savePlaylist(playlist, saveSuccess, saveError);
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>savePlaylist successful
+Playlist name: testPlaylistName
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylists::getPlaylist">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists::getPlaylist"></a><code><b><span class="methodName">getPlaylist</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Returns the playlist with the given name.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlistName</span>:
+ The name of playlist to get.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type NotFoundError, if the playlist with the given name does not exist.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">/* assuming that the playlist was previously created */
+var mcServer = tizen.mediacontroller.createServer();
+var playlist = null;
+try
+{
+  playlist = mcServer.playlists.getPlaylist("testPlaylist");
+}
+catch (err)
+{
+  console.log(err.name + ": " + err.message);
+}
+</pre>
+</div>
+</dd>
+</dl>
+</div>
+</div>
+<div class="interface" id="MediaControllerPlaylistsInfo">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo"></a><h3>2.10. MediaControllerPlaylistsInfo</h3>
+<div class="brief">
+ Client-side object representing methods for playlists of a media controller server.
+          </div>
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerPlaylistsInfo {
+    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, unsigned long long position,
+                          optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removePlaylistUpdatedListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };</pre>
+<p><span class="version">Since: </span>
+ 6.0
+          </p>
+<div class="methods">
+<h4>Methods</h4>
+<dl>
+<dt class="method" id="MediaControllerPlaylistsInfo::getAllPlaylists">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo::getAllPlaylists"></a><code><b><span class="methodName">getAllPlaylists</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Retrieves all playlists saved in local database.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+The <em>errorCallback</em> may be triggered for one of the following errors:
+            </p>
+            <ul>
+              <li>
+<em>UnknownError</em>: if any error prevents function from successful completion.              </li>
+            </ul>
+           </div>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">successCallback</span>:
+ Function to be called upon success.
+                </li>
+          <li class="param">
+<span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called upon failure.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any parameter has invalid type.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+var playlist = mcServer.playlists.createPlaylist("testPlaylist");
+
+function saveSuccess()
+{
+  console.log("savePlaylist successful");
+  function successCallback(playlists)
+  {
+    playlists.forEach(function(playlist)
+    {
+      console.log("Playlist name: " + playlist.name);
+    });
+  }
+  function errorCallback(error)
+  {
+    console.log("getAllPlaylists failed with error: " + error);
+  }
+  mcServerInfo.playlists.getAllPlaylists(successCallback, errorCallback);
+}
+
+function saveError(error)
+{
+  console.log("savePlaylist failed with error: " + error);
+}
+
+mcServer.playlists.savePlaylist(playlist, saveSuccess, saveError);
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>savePlaylist successful
+Playlist name: testPlaylist
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylistsInfo::sendPlaybackItem">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo::sendPlaybackItem"></a><code><b><span class="methodName">sendPlaybackItem</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Asks the server to set a new playback item.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, unsigned long long position,
+                      optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<p><span class="remark">Remark: </span>
+ <em>PlaybackInfoChangeListener</em> should be invoked, if registered.
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlistName</span>:
+ Name of playlist to be set.
+                </li>
+          <li class="param">
+<span class="name">index</span>:
+ Index of item on playlist to be set.
+                </li>
+          <li class="param">
+<span class="name">action</span>:
+ Playback action.
+                </li>
+          <li class="param">
+<span class="name">position</span>:
+ Playback position.
+                </li>
+          <li class="param">
+<span class="name">replyCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method to invoke when server responded to change request.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var serverInfo = mcClient.getLatestServerInfo();
+serverInfo.playlists.sendPlaybackItem("testPlaylist", "1", "PLAY", 0);
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylistsInfo::addPlaylistUpdatedListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo::addPlaylistUpdatedListener"></a><code><b><span class="methodName">addPlaylistUpdatedListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Adds listener to be invoked when playlist is updated by server.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">listener</span>:
+ Listener for adding, updating or deleting of any playlist.
+                </li>
+        </ul>
+</div>
+<div class="returntype">
+<p><span class="return">Return value:</span></p>
+<ul>
+<span class="return">long:</span>
+ The identifier used to clear the watch subscription.
+              </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+var listener =
+{
+  onplaylistupdated: function(serverName, playlist)
+  {
+    console.log("updated playlist " + playlist);
+  },
+  onplaylistdeleted: function(serverName, playlistName)
+  {
+    console.log("deleted playlist " + playlistName);
+  }
+};
+var listenerId = mcServerInfo.playlists.addPlaylistUpdatedListener(listener);
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylistsInfo::removePlaylistUpdatedListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo::removePlaylistUpdatedListener"></a><code><b><span class="methodName">removePlaylistUpdatedListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Stops listening for playlist updates.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void removePlaylistUpdatedListener(long listenerId);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<p><span class="remark">Remark: </span>
+ This function has no effect, if there is no listener for given id.
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">listenerId</span>:
+ Listener ID returned by <em>addPlaylistUpdatedListener</em>.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+var listener =
+{
+  onplaylistupdated: function(serverName, playlist) {},
+  onplaylistdeleted: function(serverName, playlistName) {}
+};
+var listenerId = mcServerInfo.playlists.addPlaylistUpdatedListener(listener);
+mcServerInfo.playlists.removePlaylistUpdatedListener(listenerId);
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylistsInfo::getPlaylist">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo::getPlaylist"></a><code><b><span class="methodName">getPlaylist</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Returns the playlist with the given name.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlistName</span>:
+ The name of the playlist to get.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type NotFoundError, if the playlist with the given name does not exist.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">/* assuming that the playlist was previously created */
+var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+var playlist = null;
+try
+{
+  playlist = mcServerInfo.playlists.getPlaylist("testPlaylist");
+}
+catch (err)
+{
+  console.log(err.name + ": " + err.message);
+}
+</pre>
+</div>
+</dd>
+</dl>
+</div>
+</div>
 <div class="interface" id="MediaControllerAbilities">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilities"></a><h3>2.7. MediaControllerAbilities</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilities"></a><h3>2.11. MediaControllerAbilities</h3>
 <div class="brief">
  Server-side object representing abilities of the media controller server.
           </div>
@@ -4059,7 +5696,7 @@ Default value is NO.
 </div>
 </div>
 <div class="interface" id="MediaControllerPlaybackAbilities">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackAbilities"></a><h3>2.8. MediaControllerPlaybackAbilities</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackAbilities"></a><h3>2.12. MediaControllerPlaybackAbilities</h3>
 <div class="brief">
  Server-side object representing playback abilities of the media controller server.
           </div>
@@ -4384,7 +6021,7 @@ ability FORWARD: NO
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayModeAbilities">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeAbilities"></a><h3>2.9. MediaControllerDisplayModeAbilities</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeAbilities"></a><h3>2.13. MediaControllerDisplayModeAbilities</h3>
 <div class="brief">
  Server-side object representing display mode abilities of the media controller server.
           </div>
@@ -4516,7 +6153,7 @@ Default value is NO.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotationAbilities">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationAbilities"></a><h3>2.10. MediaControllerDisplayRotationAbilities</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationAbilities"></a><h3>2.14. MediaControllerDisplayRotationAbilities</h3>
 <div class="brief">
  The server-side object representing display rotation abilities
 of the media controller server.
@@ -4649,7 +6286,7 @@ Default value is NO.
 </div>
 </div>
 <div class="interface" id="MediaControllerAbilitiesInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilitiesInfo"></a><h3>2.11. MediaControllerAbilitiesInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilitiesInfo"></a><h3>2.15. MediaControllerAbilitiesInfo</h3>
 <div class="brief">
  Client-side object representing abilities of the media controller server.
           </div>
@@ -4940,7 +6577,7 @@ REPEAT ability changed, server name: GC8qUW5iQf.SecondMCServer, ability: "NO"
 </div>
 </div>
 <div class="interface" id="MediaControllerPlaybackAbilitiesInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackAbilitiesInfo"></a><h3>2.12. MediaControllerPlaybackAbilitiesInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackAbilitiesInfo"></a><h3>2.16. MediaControllerPlaybackAbilitiesInfo</h3>
 <div class="brief">
  Client-side object representing playback abilities of the media controller server.
           </div>
@@ -5092,7 +6729,7 @@ REPEAT ability changed, server name: GC8qUW5iQf.SecondMCServer, ability: "NO"
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayModeAbilitiesInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeAbilitiesInfo"></a><h3>2.13. MediaControllerDisplayModeAbilitiesInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeAbilitiesInfo"></a><h3>2.17. MediaControllerDisplayModeAbilitiesInfo</h3>
 <div class="brief">
  Client-side object representing display mode abilities of the media controller server.
           </div>
@@ -5196,7 +6833,7 @@ Default value is NO.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotationAbilitiesInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationAbilitiesInfo"></a><h3>2.14. MediaControllerDisplayRotationAbilitiesInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationAbilitiesInfo"></a><h3>2.18. MediaControllerDisplayRotationAbilitiesInfo</h3>
 <div class="brief">
  The client-side object representing display rotation abilities
 of the media controller server.
@@ -5281,7 +6918,7 @@ of the media controller server.
 </div>
 </div>
 <div class="interface" id="MediaControllerSubtitles">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSubtitles"></a><h3>2.15. MediaControllerSubtitles</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSubtitles"></a><h3>2.19. MediaControllerSubtitles</h3>
 <div class="brief">
  Server-side object representing subtitles mode of a media controller server.
           </div>
@@ -5433,7 +7070,7 @@ mcServer.subtitles.removeChangeRequestListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerSubtitlesInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSubtitlesInfo"></a><h3>2.16. MediaControllerSubtitlesInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSubtitlesInfo"></a><h3>2.20. MediaControllerSubtitlesInfo</h3>
 <div class="brief">
  Client-side object representing subtitles mode of a media controller server.
           </div>
@@ -5627,7 +7264,7 @@ mcServerInfo.subtitles.removeModeChangeListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerMode360">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMode360"></a><h3>2.17. MediaControllerMode360</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMode360"></a><h3>2.21. MediaControllerMode360</h3>
 <div class="brief">
  Server-side object representing spherical (360°) mode of a media controller server.
           </div>
@@ -5779,7 +7416,7 @@ mcServer.mode360.removeChangeRequestListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerMode360Info">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMode360Info"></a><h3>2.18. MediaControllerMode360Info</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMode360Info"></a><h3>2.22. MediaControllerMode360Info</h3>
 <div class="brief">
  Client-side object representing spherical (360°) mode of a media controller server.
           </div>
@@ -5973,7 +7610,7 @@ mcServerInfo.mode360.removeModeChangeListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayMode">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayMode"></a><h3>2.19. MediaControllerDisplayMode</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayMode"></a><h3>2.23. MediaControllerDisplayMode</h3>
 <div class="brief">
  Server-side object representing display mode of a media controller server.
           </div>
@@ -6129,7 +7766,7 @@ mcServer.displayMode.removeChangeRequestListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayModeInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeInfo"></a><h3>2.20. MediaControllerDisplayModeInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeInfo"></a><h3>2.24. MediaControllerDisplayModeInfo</h3>
 <div class="brief">
  Client-side object representing display mode of a media controller server.
           </div>
@@ -6324,7 +7961,7 @@ mcServerInfo.displayMode.removeModeChangeListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotation">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotation"></a><h3>2.21. MediaControllerDisplayRotation</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotation"></a><h3>2.25. MediaControllerDisplayRotation</h3>
 <div class="brief">
  Server-side object representing display rotation of a media controller server.
           </div>
@@ -6481,7 +8118,7 @@ mcServer.displayRotation.removeChangeRequestListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerClientInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerClientInfo"></a><h3>2.22. MediaControllerClientInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerClientInfo"></a><h3>2.26. MediaControllerClientInfo</h3>
 <div class="brief">
  This interface provides communication methods from the server to the client.
           </div>
@@ -6593,7 +8230,7 @@ Media controller server received a reply to the event:
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotationInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationInfo"></a><h3>2.23. MediaControllerDisplayRotationInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationInfo"></a><h3>2.27. MediaControllerDisplayRotationInfo</h3>
 <div class="brief">
  Client-side object representing display rotation of a media controller server.
           </div>
@@ -6788,7 +8425,7 @@ mcServerInfo.displayRotation.removeDisplayRotationChangeListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerMetadata">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMetadata"></a><h3>2.24. MediaControllerMetadata</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMetadata"></a><h3>2.28. MediaControllerMetadata</h3>
 <div class="brief">
  Playback metadata.
           </div>
@@ -6810,6 +8447,7 @@ mcServerInfo.displayRotation.removeDisplayRotationChangeListener(watcherId);
     attribute DOMString? episodeTitle;
     attribute long resolutionWidth;
     attribute long resolutionHeight;
+    void save() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
 <p><span class="version">Since: </span>
  2.4
@@ -6955,9 +8593,54 @@ mcServerInfo.displayRotation.removeDisplayRotationChangeListener(watcherId);
 </li>
 </ul>
 </div>
+<div class="methods">
+<h4>Methods</h4>
+<dl>
+<dt class="method" id="MediaControllerMetadata::save">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMetadata::save"></a><code><b><span class="methodName">save</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Saves current state of metadata to the database and sends notification to the listening clients.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void save();</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+mcServer.playback.metadata.artist = "Artist Name";
+
+console.log("Before save metadata is: " + JSON.stringify(mcServerInfo.playback.metadata));
+
+mcServer.playback.metadata.save();
+console.log("After save metadata is: " + JSON.stringify(mcServerInfo.playback.metadata));
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>Before save metadata is: {"title":"","artist":"","album":"","author":"","genre":"","duration":"","date":"",
+"copyright":"","description":"","trackNum":"","picture":"","seasonNumber":0,"seasonTitle":null,
+"episodeNumber":0,"episodeTitle":null,"resolutionWidth":0,"resolutionHeight":0}
+After save metadata is: {"title":"","artist":"ArtistName","album":"","author":"","genre":"","duration":"","date":"",
+"copyright":"","description":"","trackNum":"","picture":"","seasonNumber":0,"seasonTitle":null,
+"episodeNumber":0,"episodeTitle":null,"resolutionWidth":0,"resolutionHeight":0}
+</pre>
+</div>
+</dd>
+</dl>
+</div>
 </div>
 <div class="interface" id="MediaControllerPlaylistItem">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistItem"></a><h3>2.25. MediaControllerPlaylistItem</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistItem"></a><h3>2.29. MediaControllerPlaylistItem</h3>
 <div class="brief">
  Object represents single playlist item.
           </div>
@@ -6993,7 +8676,7 @@ mcServerInfo.displayRotation.removeDisplayRotationChangeListener(watcherId);
 </div>
 </div>
 <div class="dictionary" id="MediaControllerMetadataInit">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMetadataInit"></a><h3>2.26. MediaControllerMetadataInit</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMetadataInit"></a><h3>2.30. MediaControllerMetadataInit</h3>
 <div class="brief">
  The MediaControllerMetadataInit dictionary defines the properties of a MediaControllerMetadata to add in addItem method.
           </div>
@@ -7026,7 +8709,7 @@ See <a href="#MediaControllerMetadata">MediaControllerMetadata</a> interface for
          </div>
 </div>
 <div class="interface" id="MediaControllerPlaylist">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylist"></a><h3>2.27. MediaControllerPlaylist</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylist"></a><h3>2.31. MediaControllerPlaylist</h3>
 <div class="brief">
  Object represents single playlist (collection of items).
           </div>
@@ -7207,7 +8890,7 @@ playlist.getItems(successCallback, errorCallback);
 </div>
 </div>
 <div class="interface" id="SearchFilter">
-<a class="backward-compatibility-anchor" name="::MediaController::SearchFilter"></a><h3>2.28. SearchFilter</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::SearchFilter"></a><h3>2.32. SearchFilter</h3>
 <div class="brief">
  Search filter representation.
           </div>
@@ -7304,7 +8987,7 @@ playlist.getItems(successCallback, errorCallback);
 </div>
 </div>
 <div class="interface" id="MediaControllerServerInfoArraySuccessCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoArraySuccessCallback"></a><h3>2.29. MediaControllerServerInfoArraySuccessCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoArraySuccessCallback"></a><h3>2.33. MediaControllerServerInfoArraySuccessCallback</h3>
 <div class="brief">
  The MediaControllerServerInfoArraySuccessCallback interface that defines the success method
 for <em>MediaControllerClient.findServers()</em>.
@@ -7343,7 +9026,7 @@ for <em>MediaControllerClient.findServers()</em>.
 </div>
 </div>
 <div class="interface" id="MediaControllerSendCommandSuccessCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSendCommandSuccessCallback"></a><h3>2.30. MediaControllerSendCommandSuccessCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSendCommandSuccessCallback"></a><h3>2.34. MediaControllerSendCommandSuccessCallback</h3>
 <div class="brief">
  The MediaControllerSendCommandSuccessCallback interface that defines the success method which is triggered, when the server responds to a command.
           </div>
@@ -7404,7 +9087,7 @@ Interface is used as a success method for:
 </div>
 </div>
 <div class="interface" id="RequestReply">
-<a class="backward-compatibility-anchor" name="::MediaController::RequestReply"></a><h3>2.31. RequestReply</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::RequestReply"></a><h3>2.35. RequestReply</h3>
 <div class="brief">
  Representation of server's response to a request.
           </div>
@@ -7448,7 +9131,7 @@ Interface is used as a success method for:
 </div>
 </div>
 <div class="interface" id="MediaControllerSearchRequestReplyCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSearchRequestReplyCallback"></a><h3>2.32. MediaControllerSearchRequestReplyCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSearchRequestReplyCallback"></a><h3>2.36. MediaControllerSearchRequestReplyCallback</h3>
 <div class="brief">
  The MediaControllerSearchRequestReplyCallback interface defines reply callback for
 <em>MediaControllerServerInfo.sendSearchRequest()</em>.
@@ -7492,7 +9175,7 @@ Interpretation of status and data parameters depends on the server implementatio
 </div>
 </div>
 <div class="interface" id="MediaControllerSearchRequestCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSearchRequestCallback"></a><h3>2.33. MediaControllerSearchRequestCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSearchRequestCallback"></a><h3>2.37. MediaControllerSearchRequestCallback</h3>
 <div class="brief">
  Server search request listener interface.
           </div>
@@ -7542,7 +9225,7 @@ It will be passed to the replyCallback of <a href="#MediaControllerServerInfo::s
 </div>
 </div>
 <div class="interface" id="MediaControllerReceiveCommandCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerReceiveCommandCallback"></a><h3>2.34. MediaControllerReceiveCommandCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerReceiveCommandCallback"></a><h3>2.38. MediaControllerReceiveCommandCallback</h3>
 <div class="brief">
  The MediaControllerReceiveCommandCallback interface that defines the listener
 for custom communication between server and client.
@@ -7611,7 +9294,7 @@ Related functions:
 </div>
 </div>
 <div class="interface" id="MediaControllerEnabledChangeRequestCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerEnabledChangeRequestCallback"></a><h3>2.35. MediaControllerEnabledChangeRequestCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerEnabledChangeRequestCallback"></a><h3>2.39. MediaControllerEnabledChangeRequestCallback</h3>
 <div class="brief">
  The MediaControllerEnabledChangeRequestCallback interface that defines the listener
 for change requests for spherical mode in <em>MediaControllerMode360.addChangeRequestListener()</em> and
@@ -7668,7 +9351,7 @@ to check how to handle and respond to commands.
 </div>
 </div>
 <div class="interface" id="MediaControllerEnabledChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerEnabledChangeCallback"></a><h3>2.36. MediaControllerEnabledChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerEnabledChangeCallback"></a><h3>2.40. MediaControllerEnabledChangeCallback</h3>
 <div class="brief">
  The MediaControllerEnabledChangeCallback interface that defines the listener
 for a media controller server's attribute changes.
@@ -7707,7 +9390,7 @@ for a media controller server's attribute changes.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayModeChangeRequestCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeChangeRequestCallback"></a><h3>2.37. MediaControllerDisplayModeChangeRequestCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeChangeRequestCallback"></a><h3>2.41. MediaControllerDisplayModeChangeRequestCallback</h3>
 <div class="brief">
  The MediaControllerDisplayModeChangeRequestCallback interface that defines the listener
 for change requests for display mode in <em>MediaControllerDisplayMode.addChangeRequestListener()</em>.
@@ -7762,7 +9445,7 @@ to check how to handle and respond to commands.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayModeChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeChangeCallback"></a><h3>2.38. MediaControllerDisplayModeChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeChangeCallback"></a><h3>2.42. MediaControllerDisplayModeChangeCallback</h3>
 <div class="brief">
  The MediaControllerDisplayModeChangeCallback interface that defines the listener
 for display mode changes of the media controller server.
@@ -7801,7 +9484,7 @@ for display mode changes of the media controller server.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotationChangeRequestCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationChangeRequestCallback"></a><h3>2.39. MediaControllerDisplayRotationChangeRequestCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationChangeRequestCallback"></a><h3>2.43. MediaControllerDisplayRotationChangeRequestCallback</h3>
 <div class="brief">
  The MediaControllerDisplayRotationChangeRequestCallback interface that defines the listener
 for change requests for display rotation in <em>MediaControllerDisplayRotation.addChangeRequestListener().
@@ -7856,7 +9539,7 @@ to check how to handle and respond to commands.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotationChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationChangeCallback"></a><h3>2.40. MediaControllerDisplayRotationChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationChangeCallback"></a><h3>2.44. MediaControllerDisplayRotationChangeCallback</h3>
 <div class="brief">
  The MediaControllerDisplayModeChangeCallback interface that defines the listener
 for changes of a media controller server's display rotation.
@@ -7895,7 +9578,7 @@ for changes of a media controller server's display rotation.
 </div>
 </div>
 <div class="interface" id="MediaControllerServerStatusChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerStatusChangeCallback"></a><h3>2.41. MediaControllerServerStatusChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerStatusChangeCallback"></a><h3>2.45. MediaControllerServerStatusChangeCallback</h3>
 <div class="brief">
  The MediaControllerServerStatusChangeCallback interface that defines the listener
 for media controller server status changes.
@@ -7934,7 +9617,7 @@ for media controller server status changes.
 </div>
 </div>
 <div class="interface" id="MediaControllerPlaybackInfoChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackInfoChangeCallback"></a><h3>2.42. MediaControllerPlaybackInfoChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackInfoChangeCallback"></a><h3>2.46. MediaControllerPlaybackInfoChangeCallback</h3>
 <div class="brief">
  The MediaControllerPlaybackInfoChangeCallback interface that defines the listeners
 object for receiving media controller playback info changes from server.
@@ -8078,19 +9761,20 @@ will be invoked after the <a href="#MediaControllerPlaybackInfoChangeCallback::o
 </div>
 </div>
 <div class="interface" id="MediaControllerChangeRequestPlaybackInfoCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerChangeRequestPlaybackInfoCallback"></a><h3>2.43. MediaControllerChangeRequestPlaybackInfoCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerChangeRequestPlaybackInfoCallback"></a><h3>2.47. MediaControllerChangeRequestPlaybackInfoCallback</h3>
 <div class="brief">
  The MediaControllerChangeRequestPlaybackInfoCallback interface that defines the listeners
 object for receiving playback info change requests from client.
           </div>
 <pre class="webidl prettyprint">  [Callback, NoInterfaceObject] interface MediaControllerChangeRequestPlaybackInfoCallback {
-    void onplaybackstaterequest(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+<span class="nocode deprecated">    void onplaybackstaterequest(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+</span>    <a href="#RequestReply">RequestReply</a>? onplaybackactionrequest(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
 <span class="nocode deprecated">    void onrepeatmoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-</span>    void onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state,
-                               unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+</span>    <a href="#RequestReply">RequestReply</a>? onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action,
+                                        unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
   };</pre>
 <p><span class="version">Since: </span>
  2.4
@@ -8098,13 +9782,16 @@ object for receiving playback info change requests from client.
 <div class="methods">
 <h4>Methods</h4>
 <dl>
-<dt class="method" id="MediaControllerChangeRequestPlaybackInfoCallback::onplaybackstaterequest">
+<dt class="deprecated method" id="MediaControllerChangeRequestPlaybackInfoCallback::onplaybackstaterequest">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerChangeRequestPlaybackInfoCallback::onplaybackstaterequest"></a><code><b><span class="methodName">onplaybackstaterequest</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Called when client requested playback state changes.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackactionrequest">onplaybackactionrequest()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void onplaybackstaterequest(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -8126,6 +9813,31 @@ object for receiving playback info change requests from client.
         </ul>
 </div>
 </dd>
+<dt class="method" id="MediaControllerChangeRequestPlaybackInfoCallback::onplaybackactionrequest">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerChangeRequestPlaybackInfoCallback::onplaybackactionrequest"></a><code><b><span class="methodName">onplaybackactionrequest</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Called when a client requested the playback state changes by sending the playback action.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#RequestReply">RequestReply</a>? onplaybackactionrequest(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">action</span>:
+ Playback action sent by the client.
+                </li>
+          <li class="param">
+<span class="name">clientName</span>:
+ Id of client application, which sent a command.
+                </li>
+        </ul>
+</div>
+</dd>
 <dt class="method" id="MediaControllerChangeRequestPlaybackInfoCallback::onplaybackpositionrequest">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerChangeRequestPlaybackInfoCallback::onplaybackpositionrequest"></a><code><b><span class="methodName">onplaybackpositionrequest</span></b></code>
 </dt>
@@ -8133,7 +9845,7 @@ object for receiving playback info change requests from client.
 <div class="brief">
  Called when client requested playback position changes.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#RequestReply">RequestReply</a>? onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  2.4
             </p>
@@ -8161,7 +9873,7 @@ object for receiving playback info change requests from client.
 <div class="brief">
  Called when client requested shuffle mode changes.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#RequestReply">RequestReply</a>? onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  2.4
             </p>
@@ -8224,7 +9936,7 @@ will not be invoked, if the <a href="#MediaControllerPlaybackInfo::repeatState">
 <div class="brief">
  Called when client requested change of repeat state.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#RequestReply">RequestReply</a>? onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  5.5
             </p>
@@ -8255,8 +9967,8 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 <div class="brief">
  Called when client request change of playback item.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state,
-                           unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#RequestReply">RequestReply</a>? onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action,
+                                    unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  5.5
             </p>
@@ -8265,19 +9977,19 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 <ul>
           <li class="param">
 <span class="name">playlistName</span>:
- Name of a requested playlist.
+ Name of playlist.
                 </li>
           <li class="param">
 <span class="name">index</span>:
- Requested index.
+ Index of the item to be changed.
                 </li>
           <li class="param">
-<span class="name">state</span>:
- Requested playback state.
+<span class="name">action</span>:
+ Playback action.
                 </li>
           <li class="param">
 <span class="name">position</span>:
- Requested playback position.
+ Playback position.
                 </li>
           <li class="param">
 <span class="name">clientName</span>:
@@ -8290,7 +10002,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 </div>
 </div>
 <div class="interface" id="MediaControllerGetAllPlaylistsSuccessCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerGetAllPlaylistsSuccessCallback"></a><h3>2.44. MediaControllerGetAllPlaylistsSuccessCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerGetAllPlaylistsSuccessCallback"></a><h3>2.48. MediaControllerGetAllPlaylistsSuccessCallback</h3>
 <div class="brief">
  Interface for success callback for <em>getAllPlaylists</em> function.
           </div>
@@ -8328,7 +10040,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 </div>
 </div>
 <div class="interface" id="MediaControllerPlaylistUpdatedCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistUpdatedCallback"></a><h3>2.45. MediaControllerPlaylistUpdatedCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistUpdatedCallback"></a><h3>2.49. MediaControllerPlaylistUpdatedCallback</h3>
 <div class="brief">
  Interface for specific playlist update events (including deletion).
           </div>
@@ -8396,7 +10108,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 </div>
 </div>
 <div class="interface" id="MediaControllerGetItemsSuccessCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerGetItemsSuccessCallback"></a><h3>2.46. MediaControllerGetItemsSuccessCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerGetItemsSuccessCallback"></a><h3>2.50. MediaControllerGetItemsSuccessCallback</h3>
 <div class="brief">
  Interface for success callback for <em>getItems</em> function.
           </div>
@@ -8434,7 +10146,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 </div>
 </div>
 <div class="interface" id="MediaControllerAbilityChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilityChangeCallback"></a><h3>2.47. MediaControllerAbilityChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilityChangeCallback"></a><h3>2.51. MediaControllerAbilityChangeCallback</h3>
 <div class="brief">
  Interface for handling ability events.
           </div>
@@ -8565,6 +10277,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
   enum MediaControllerServerState { "ACTIVE", "INACTIVE" };
   enum MediaControllerSearchCategory { "NO_CATEGORY", "TITLE", "ARTIST", "ALBUM", "GENRE", "TPO" };
   enum MediaControllerPlaybackState { "PLAY", "PAUSE", "STOP", "NEXT", "PREV", "FORWARD", "REWIND" };
+  enum MediaControllerPlaybackAction { "PLAY", "PAUSE", "STOP", "NEXT", "PREV", "FORWARD", "REWIND", "TOGGLE_PLAY_PAUSE" };
   enum MediaControllerRepeatState { "REPEAT_OFF", "REPEAT_ONE", "REPEAT_ALL" };
   enum MediaControllerContentType { "IMAGE", "MUSIC", "VIDEO", "OTHER", "UNDECIDED" };
   enum MediaControllerContentAgeRating { "ALL", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13",
@@ -8602,36 +10315,19 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
     <a href="#MediaControllerServer">MediaControllerServer</a> createServer() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface MediaControllerServer {
-    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo;
-    readonly attribute DOMString? iconURI;
+    readonly attribute <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a> playback;
+    readonly attribute <a href="#MediaControllerPlaylists">MediaControllerPlaylists</a> playlists;
+    attribute DOMString? iconURI raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute <a href="#MediaControllerAbilities">MediaControllerAbilities</a> abilities;
     readonly attribute <a href="#MediaControllerSubtitles">MediaControllerSubtitles</a> subtitles;
     readonly attribute <a href="#MediaControllerMode360">MediaControllerMode360</a> mode360;
     readonly attribute <a href="#MediaControllerDisplayMode">MediaControllerDisplayMode</a> displayMode;
     readonly attribute <a href="#MediaControllerDisplayRotation">MediaControllerDisplayRotation</a> displayRotation;
     <a href="#MediaControllerClientInfo">MediaControllerClientInfo</a>[] getAllClientsInfo() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateIconURI(DOMString? iconURI) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackPosition(unsigned long long position) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackAgeRating(<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackContentType(<a href="#MediaControllerContentType">MediaControllerContentType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateShuffleMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateMetadata(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addChangeRequestPlaybackInfoListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removeChangeRequestPlaybackInfoListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void setSearchRequestListener(<a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unsetSearchRequestListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addCommandListener(<a href="#MediaControllerReceiveCommandCallback">MediaControllerReceiveCommandCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeCommandListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
-                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                        raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackItem(DOMString playlistName, DOMString index) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface MediaControllerClient {
     void findServers(<a href="#MediaControllerServerInfoArraySuccessCallback">MediaControllerServerInfoArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
@@ -8647,37 +10343,36 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
   [NoInterfaceObject] interface MediaControllerServerInfo {
     readonly attribute <a href="application.html#ApplicationId">ApplicationId</a> name;
     readonly attribute <a href="#MediaControllerServerState">MediaControllerServerState</a> state;
-    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    readonly attribute <a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a> playback raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    readonly attribute <a href="#MediaControllerPlaylistsInfo">MediaControllerPlaylistsInfo</a> playlists;
     readonly attribute DOMString? iconURI raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute <a href="#MediaControllerAbilitiesInfo">MediaControllerAbilitiesInfo</a> abilities;
     readonly attribute <a href="#MediaControllerSubtitlesInfo">MediaControllerSubtitlesInfo</a> subtitles;
     readonly attribute <a href="#MediaControllerMode360Info">MediaControllerMode360Info</a> mode360;
     readonly attribute <a href="#MediaControllerDisplayModeInfo">MediaControllerDisplayModeInfo</a> displayMode;
     readonly attribute <a href="#MediaControllerDisplayRotationInfo">MediaControllerDisplayRotationInfo</a> displayRotation;
-    void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
-                           optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
-                              optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendShuffleMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
-                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void sendSearchRequest(<a href="#SearchFilter">SearchFilter</a>[] request, <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a> replyCallback,
                            optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void sendCommand(DOMString command, <a href="tizen.html#Bundle">Bundle</a>? data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addServerStatusChangeListener(<a href="#MediaControllerServerStatusChangeCallback">MediaControllerServerStatusChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeServerStatusChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removePlaybackInfoChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position)
-                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removePlaylistUpdatedListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
-  [NoInterfaceObject] interface MediaControllerPlaybackInfo {
+  [NoInterfaceObject] interface MediaControllerServerPlaybackInfo {
+    attribute <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute unsigned long long position raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerContentType">MediaControllerContentType</a> contentType raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute boolean shuffleMode raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> repeatState raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
+    readonly attribute DOMString? index;
+    readonly attribute DOMString? playlistName;
+    void updatePlaybackItem(DOMString playlistName, DOMString index) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addChangeRequestListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removeChangeRequestListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };
+  [NoInterfaceObject] interface MediaControllerServerInfoPlaybackInfo {
     readonly attribute <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state;
     readonly attribute unsigned long long position;
     readonly attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating;
@@ -8687,6 +10382,34 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
     readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
     readonly attribute DOMString? index;
     readonly attribute DOMString? playlistName;
+    void sendPlaybackAction(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                            raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendPlaybackPosition(unsigned long long position, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                              raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendShuffleMode(boolean mode, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removePlaybackInfoChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };
+  [NoInterfaceObject] interface MediaControllerPlaylists {
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                        raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };
+  [NoInterfaceObject] interface MediaControllerPlaylistsInfo {
+    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, unsigned long long position,
+                          optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removePlaylistUpdatedListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface MediaControllerAbilities {
     readonly attribute <a href="#MediaControllerPlaybackAbilities">MediaControllerPlaybackAbilities</a> playback;
@@ -8830,6 +10553,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
     attribute DOMString? episodeTitle;
     attribute long resolutionWidth;
     attribute long resolutionHeight;
+    void save() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface MediaControllerPlaylistItem {
     readonly attribute DOMString index;
@@ -8896,12 +10620,12 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
     void onmetadatachanged(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata);
   };
   [Callback, NoInterfaceObject] interface MediaControllerChangeRequestPlaybackInfoCallback {
-    void onplaybackstaterequest(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state,
-                               unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onplaybackactionrequest(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action,
+                                        unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface MediaControllerGetAllPlaylistsSuccessCallback {
     void onsuccess(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a>[] playlists);

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/mediacontroller.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/mediacontroller.html
@@ -4596,7 +4596,7 @@ mcServerInfo.playback.sendShuffleMode(true, function(data, code)
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
 <p><span class="version">Since: </span>
- 5.5
+ 6.0
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/networkbearerselection.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/networkbearerselection.html
@@ -274,8 +274,6 @@ The function must asynchronously acquire success or fail.
             <p>
 When called, it closes a network connection.
             </p>
-           </div>
-<div class="description">
             <p>
 The <em>ErrorCallback</em> method is launched with these error types:
             </p>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/ppm.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/ppm.html
@@ -192,6 +192,9 @@ PPM_DENY_ONCE - The user denied granting permission to use a privacy-related pri
     void requestPermissions(DOMString[] privileges, <a href="#PermissionRequestSuccessCallback">PermissionRequestSuccessCallback</a> successCallback,
                             optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
+<p><span class="version">Since: </span>
+ 4.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/sensor.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/sensor.html
@@ -457,8 +457,6 @@ The supported sensor types are hardware-dependent. <br><br>To check if the given
  ULTRAVIOLET - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.ultraviolet"</em>)               </li>
             </ul>
            </div>
-<div class="description">
-           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -595,8 +593,6 @@ console.log("Capable sensor: " + sensorCapabilities[0]);
             <p>
 The <em>SuccessCallback</em> will be invoked when the first event from the sensor is fired.
             </p>
-           </div>
-<div class="description">
             <p>
 The <em>ErrorCallback</em> method is launched with these error types:
             </p>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/sound.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/sound.html
@@ -404,9 +404,6 @@ There is a tizen.sound object that allows accessing the functionality of the Sou
 <p><span class="version">Since: </span>
  2.3
             </p>
-<p><span class="version">Since: </span>
- 2.3
-            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/systeminfo.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/systeminfo.html
@@ -485,6 +485,9 @@ functionality of the System Information API.
                                                       raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removePropertyValueChangeListener(unsigned long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
+<p><span class="version">Since: </span>
+ 1.0
+          </p>
 <div class="description">
           <p>
 This API offers methods for retrieving system information
@@ -2277,6 +2280,9 @@ Any threshold parameter used in a watch function to monitor this property applie
     readonly attribute boolean isRemovable;
 <span class="nocode deprecated">    readonly attribute boolean isRemoveable;
 </span>  };</pre>
+<p><span class="version">Since: </span>
+ 1.0
+          </p>
         
       <div class="attributes">
 <h4>Attributes</h4>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/systemsetting.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/systemsetting.html
@@ -183,6 +183,9 @@ access to the module functionalities.
     void getProperty(<a href="#SystemSettingType">SystemSettingType</a> type, <a href="#SystemSettingSuccessCallback">SystemSettingSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
+<p><span class="version">Since: </span>
+ 2.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -313,8 +316,6 @@ else
             <p>
 This method allows the user to get the value of the specified system property as wallpaper or ringtone of a device.
             </p>
-           </div>
-<div class="description">
             <p>
 The <em>ErrorCallback</em> method is launched with these error types:
             </p>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/voicecontrol.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/voicecontrol.html
@@ -738,6 +738,9 @@ client.release();
     attribute DOMString command;
     attribute <a href="#VoiceControlCommandType">VoiceControlCommandType</a> type;
   };</pre>
+<p><span class="version">Since: </span>
+ 4.0
+          </p>
 <div class="constructors">
 <h4 id="VoiceControlCommand::constructor">Constructors</h4>
 <dl>
@@ -765,6 +768,9 @@ client.release();
 The command should be set as text you want to be recognized.
             </p>
            </div>
+<p><span class="version">Since: </span>
+ 4.0
+            </p>
 </li>
 <li class="attribute" id="VoiceControlCommand::type">
 <span class="attrName"><span class="type">VoiceControlCommandType </span><span class="name">type</span></span><div class="brief">
@@ -774,6 +780,9 @@ The command should be set as text you want to be recognized.
             <p>
 The default value is <var>"FOREGROUND"</var>            </p>
            </div>
+<p><span class="version">Since: </span>
+ 4.0
+            </p>
 </li>
 </ul>
 </div>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/websetting.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/websetting.html
@@ -107,6 +107,9 @@ For more information on the Web Setting features, see <a href="/application/web/
                             raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeAllCookies(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
+<p><span class="version">Since: </span>
+ 2.2
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/cordova/cordova.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/cordova/cordova.html
@@ -102,6 +102,9 @@
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {
     void onsuccess();
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -128,6 +131,9 @@
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="#DOMException">DOMException</a> error);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -165,6 +171,9 @@
     readonly attribute DOMString name;
     readonly attribute DOMString message;
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="attributes">
 <h4>Attributes</h4>
 <ul>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/cordova/device-motion.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/cordova/device-motion.html
@@ -361,6 +361,9 @@ Acceleration values include the effect of gravity (9.81 m/s^2), so that when a d
     readonly attribute double z;
     readonly attribute long timestamp;
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <p><span class="privilegelevel">Privilege level: </span>
  public
           </p>
@@ -441,6 +444,9 @@ Acceleration values include the effect of gravity (9.81 m/s^2), so that when a d
 <pre class="webidl prettyprint">  dictionary AccelerationOptions {
     long frequency;
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="attributes">
 <h4>Dictionary members</h4>
 <dl>
@@ -464,6 +470,9 @@ Acceleration values include the effect of gravity (9.81 m/s^2), so that when a d
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface AccelerometerSuccessCallback {
     void onsuccess(<a href="#Acceleration">Acceleration</a> acceleration);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -496,6 +505,9 @@ Acceleration values include the effect of gravity (9.81 m/s^2), so that when a d
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/cordova/dialogs.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/cordova/dialogs.html
@@ -397,6 +397,9 @@ the index uses one-based indexing, so the values could be 1, 2, 3, etc.
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ConfirmCallback {
     void onsuccess(long buttonIndex);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <p><span class="remark">Remark: </span>
  Example usage is described on method <a href="#DialogsManager::confirm">confirm</a>.
           </p>
@@ -436,6 +439,9 @@ the index uses one-based indexing, so the values could be 1, 2, 3, etc.
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PromptCallback {
     void onsuccess(<a href="#PromptData">PromptData</a> data);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <p><span class="remark">Remark: </span>
  Example usage is described on method <a href="#DialogsManager::prompt">prompt</a>.
           </p>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/cordova/file.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/cordova/file.html
@@ -253,6 +253,9 @@ for accessing internal and external storage using this API, privileges (<a href=
 See <a href="https://www.w3.org/TR/FileAPI/#blob-section">The Blob Interface and Binary Data</a>.
           </div>
 <pre class="webidl prettyprint">  typedef <a href="#Blob">Blob</a> Blob;</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 </div>
 <div class="typedef" id="WriteData">
 <a class="backward-compatibility-anchor" name="::File::WriteData"></a><h3>1.2. WriteData</h3>
@@ -2012,6 +2015,9 @@ Otherwise, if no other error occurs, getFile must return a FileEntry correspondi
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface DirectoryReader {
     void readEntries(<a href="#EntriesCallback">EntriesCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <p><span class="privilegelevel">Privilege level: </span>
  public
           </p>
@@ -2086,6 +2092,9 @@ Otherwise, if no other error occurs, getFile must return a FileEntry correspondi
     void createWriter(<a href="#FileWriterCallback">FileWriterCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror);
     void file(<a href="#FileCallback">FileCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a> onerror);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <p><span class="privilegelevel">Privilege level: </span>
  public
           </p>
@@ -2716,6 +2725,9 @@ ByteLength: 3
 <a class="backward-compatibility-anchor" name="::File::FileWriter::DONE"></a><span class="name">DONE</span><div class="brief">
  Above constants describe current state of FileWriter object.
             </div>
+<p><span class="version">Since: </span>
+ 3.0
+            </p>
 <br><br>
 </li>
 </dl>
@@ -3109,6 +3121,9 @@ entry.createWriter(successCallback, errorCallback);
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ProgressCallback {
     void onsuccess(<a href="#ProgressEvent">ProgressEvent</a> event);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -3366,6 +3381,9 @@ entry.createWriter(successCallback, errorCallback);
  Used to supply a File as a response to a user query.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void handleEvent(<a href="#File">File</a> file);</pre></div>
+<p><span class="version">Since: </span>
+ 3.0
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/cordova/filetransfer.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/cordova/filetransfer.html
@@ -942,6 +942,9 @@ Upload error target http://some.server.com/file.txt
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileDownloadSuccessCallback {
     void onsuccess(<a href="file.html#FileEntry">FileEntry</a> file);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -980,6 +983,9 @@ Upload error target http://some.server.com/file.txt
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileTransferErrorCallback {
     void onerror(<a href="#FileTransferError">FileTransferError</a> error);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/cordova/globalization.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/cordova/globalization.html
@@ -1196,6 +1196,9 @@ Valid values are:
 "full"              </li>
             </ul>
            </div>
+<p><span class="version">Since: </span>
+ 3.0
+            </p>
 </dd>
 <dt class="member" id="DateOptions::selector"><span class="attrName">DOMString selector</span></dt>
 <dd>
@@ -1215,6 +1218,9 @@ Valid values are:
 "date and time"              </li>
             </ul>
            </div>
+<p><span class="version">Since: </span>
+ 3.0
+            </p>
 </dd>
 </dl>
 </div>
@@ -1232,6 +1238,9 @@ Valid values are:
     DOMString decimal;
     DOMString grouping;
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="attributes">
 <h4>Dictionary members</h4>
 <dl>
@@ -2096,6 +2105,9 @@ The GlobalizationError interface
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/cordova/media.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/cordova/media.html
@@ -772,6 +772,9 @@ setTimeout(function()
     const short MEDIA_ERR_NONE_SUPPORTED = 4;
     readonly attribute short code;
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="attributes">
 <h4>Attributes</h4>
 <ul><li class="attribute" id="MediaError::code">
@@ -793,6 +796,9 @@ setTimeout(function()
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface MediaErrorCallback {
     void onerror(<a href="#MediaError">MediaError</a> error);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -828,6 +834,9 @@ setTimeout(function()
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface StatusChangeCallback {
     void onchanged(short status);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -863,6 +872,9 @@ setTimeout(function()
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PositionSuccessCallback {
     void onsuccess(double position);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/filesystem.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/filesystem.html
@@ -2531,8 +2531,6 @@ The <em>ErrorCallback</em> is launched with these error types:
               <li>
 IOError, if any error related to file handle occurs.               </li>
             </ul>
-           </div>
-<div class="description">
             <p>
 Note, that current position indicator value, can be obtained in SeekSuccessCallback by calling <var>seekNonBlocking(0, "CURRENT")</var>.
 seekNonBlocking is executed in background and does not block further instructions.
@@ -3871,8 +3869,6 @@ The <em>ErrorCallback</em> is launched with these error types:
               <li>
 IOError, if flush fails or any error related to file handle occurs.              </li>
             </ul>
-           </div>
-<div class="description">
             <p>
 This method is asynchronous. Its execution will occur in background and after all previously commissioned background jobs will finish.
             </p>
@@ -4033,8 +4029,6 @@ The <em>ErrorCallback</em> is launched with these error types:
               <li>
 IOError, if sync fails or any error related to file handle occurs.              </li>
             </ul>
-           </div>
-<div class="description">
             <p>
 This method is asynchronous. Its execution will occur in background and after all previously commissioned background jobs will finish.
             </p>
@@ -4181,8 +4175,6 @@ The <em>ErrorCallback</em> is launched with these error types:
               <li>
 IOError, if close fails or any error related to file handle occurs.              </li>
             </ul>
-           </div>
-<div class="description">
             <p>
 This method is asynchronous. Its execution will occur in background and after all previously commissioned background jobs will finish.
             </p>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/mediacontroller.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/mediacontroller.html
@@ -39,25 +39,28 @@ For more information on the Media Controller features, see <a href="/application
                     1.3. <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a>
 </li>
 <li>
-                    1.4. <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a>
+                    1.4. <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a>
 </li>
 <li>
-                    1.5. <a href="#MediaControllerContentType">MediaControllerContentType</a>
+                    1.5. <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a>
 </li>
 <li>
-                    1.6. <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a>
+                    1.6. <a href="#MediaControllerContentType">MediaControllerContentType</a>
 </li>
 <li>
-                    1.7. <a href="#MediaControllerAbilitySupport">MediaControllerAbilitySupport</a>
+                    1.7. <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a>
 </li>
 <li>
-                    1.8. <a href="#MediaControllerSimpleAbility">MediaControllerSimpleAbility</a>
+                    1.8. <a href="#MediaControllerAbilitySupport">MediaControllerAbilitySupport</a>
 </li>
 <li>
-                    1.9. <a href="#MediaControllerDisplayModeType">MediaControllerDisplayModeType</a>
+                    1.9. <a href="#MediaControllerSimpleAbility">MediaControllerSimpleAbility</a>
 </li>
 <li>
-                    1.10. <a href="#MediaControllerDisplayRotationType">MediaControllerDisplayRotationType</a>
+                    1.10. <a href="#MediaControllerDisplayModeType">MediaControllerDisplayModeType</a>
+</li>
+<li>
+                    1.11. <a href="#MediaControllerDisplayRotationType">MediaControllerDisplayRotationType</a>
 </li>
 </ul>
 </li>
@@ -72,89 +75,97 @@ For more information on the Media Controller features, see <a href="/application
 </li>
 <li>2.5. <a href="#MediaControllerServerInfo">MediaControllerServerInfo</a>
 </li>
-<li>2.6. <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a>
+<li class="deprecated">2.6. <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a>
 </li>
-<li>2.7. <a href="#MediaControllerAbilities">MediaControllerAbilities</a>
+<li>2.7. <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>
 </li>
-<li>2.8. <a href="#MediaControllerPlaybackAbilities">MediaControllerPlaybackAbilities</a>
+<li>2.8. <a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a>
 </li>
-<li>2.9. <a href="#MediaControllerDisplayModeAbilities">MediaControllerDisplayModeAbilities</a>
+<li>2.9. <a href="#MediaControllerPlaylists">MediaControllerPlaylists</a>
 </li>
-<li>2.10. <a href="#MediaControllerDisplayRotationAbilities">MediaControllerDisplayRotationAbilities</a>
+<li>2.10. <a href="#MediaControllerPlaylistsInfo">MediaControllerPlaylistsInfo</a>
 </li>
-<li>2.11. <a href="#MediaControllerAbilitiesInfo">MediaControllerAbilitiesInfo</a>
+<li>2.11. <a href="#MediaControllerAbilities">MediaControllerAbilities</a>
 </li>
-<li>2.12. <a href="#MediaControllerPlaybackAbilitiesInfo">MediaControllerPlaybackAbilitiesInfo</a>
+<li>2.12. <a href="#MediaControllerPlaybackAbilities">MediaControllerPlaybackAbilities</a>
 </li>
-<li>2.13. <a href="#MediaControllerDisplayModeAbilitiesInfo">MediaControllerDisplayModeAbilitiesInfo</a>
+<li>2.13. <a href="#MediaControllerDisplayModeAbilities">MediaControllerDisplayModeAbilities</a>
 </li>
-<li>2.14. <a href="#MediaControllerDisplayRotationAbilitiesInfo">MediaControllerDisplayRotationAbilitiesInfo</a>
+<li>2.14. <a href="#MediaControllerDisplayRotationAbilities">MediaControllerDisplayRotationAbilities</a>
 </li>
-<li>2.15. <a href="#MediaControllerSubtitles">MediaControllerSubtitles</a>
+<li>2.15. <a href="#MediaControllerAbilitiesInfo">MediaControllerAbilitiesInfo</a>
 </li>
-<li>2.16. <a href="#MediaControllerSubtitlesInfo">MediaControllerSubtitlesInfo</a>
+<li>2.16. <a href="#MediaControllerPlaybackAbilitiesInfo">MediaControllerPlaybackAbilitiesInfo</a>
 </li>
-<li>2.17. <a href="#MediaControllerMode360">MediaControllerMode360</a>
+<li>2.17. <a href="#MediaControllerDisplayModeAbilitiesInfo">MediaControllerDisplayModeAbilitiesInfo</a>
 </li>
-<li>2.18. <a href="#MediaControllerMode360Info">MediaControllerMode360Info</a>
+<li>2.18. <a href="#MediaControllerDisplayRotationAbilitiesInfo">MediaControllerDisplayRotationAbilitiesInfo</a>
 </li>
-<li>2.19. <a href="#MediaControllerDisplayMode">MediaControllerDisplayMode</a>
+<li>2.19. <a href="#MediaControllerSubtitles">MediaControllerSubtitles</a>
 </li>
-<li>2.20. <a href="#MediaControllerDisplayModeInfo">MediaControllerDisplayModeInfo</a>
+<li>2.20. <a href="#MediaControllerSubtitlesInfo">MediaControllerSubtitlesInfo</a>
 </li>
-<li>2.21. <a href="#MediaControllerDisplayRotation">MediaControllerDisplayRotation</a>
+<li>2.21. <a href="#MediaControllerMode360">MediaControllerMode360</a>
 </li>
-<li>2.22. <a href="#MediaControllerClientInfo">MediaControllerClientInfo</a>
+<li>2.22. <a href="#MediaControllerMode360Info">MediaControllerMode360Info</a>
 </li>
-<li>2.23. <a href="#MediaControllerDisplayRotationInfo">MediaControllerDisplayRotationInfo</a>
+<li>2.23. <a href="#MediaControllerDisplayMode">MediaControllerDisplayMode</a>
 </li>
-<li>2.24. <a href="#MediaControllerMetadata">MediaControllerMetadata</a>
+<li>2.24. <a href="#MediaControllerDisplayModeInfo">MediaControllerDisplayModeInfo</a>
 </li>
-<li>2.25. <a href="#MediaControllerPlaylistItem">MediaControllerPlaylistItem</a>
+<li>2.25. <a href="#MediaControllerDisplayRotation">MediaControllerDisplayRotation</a>
 </li>
-<li>2.26. <a href="#MediaControllerMetadataInit">MediaControllerMetadataInit</a>
+<li>2.26. <a href="#MediaControllerClientInfo">MediaControllerClientInfo</a>
 </li>
-<li>2.27. <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a>
+<li>2.27. <a href="#MediaControllerDisplayRotationInfo">MediaControllerDisplayRotationInfo</a>
 </li>
-<li>2.28. <a href="#SearchFilter">SearchFilter</a>
+<li>2.28. <a href="#MediaControllerMetadata">MediaControllerMetadata</a>
 </li>
-<li>2.29. <a href="#MediaControllerServerInfoArraySuccessCallback">MediaControllerServerInfoArraySuccessCallback</a>
+<li>2.29. <a href="#MediaControllerPlaylistItem">MediaControllerPlaylistItem</a>
 </li>
-<li>2.30. <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>
+<li>2.30. <a href="#MediaControllerMetadataInit">MediaControllerMetadataInit</a>
 </li>
-<li>2.31. <a href="#RequestReply">RequestReply</a>
+<li>2.31. <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a>
 </li>
-<li>2.32. <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a>
+<li>2.32. <a href="#SearchFilter">SearchFilter</a>
 </li>
-<li>2.33. <a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a>
+<li>2.33. <a href="#MediaControllerServerInfoArraySuccessCallback">MediaControllerServerInfoArraySuccessCallback</a>
 </li>
-<li>2.34. <a href="#MediaControllerReceiveCommandCallback">MediaControllerReceiveCommandCallback</a>
+<li>2.34. <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>
 </li>
-<li>2.35. <a href="#MediaControllerEnabledChangeRequestCallback">MediaControllerEnabledChangeRequestCallback</a>
+<li>2.35. <a href="#RequestReply">RequestReply</a>
 </li>
-<li>2.36. <a href="#MediaControllerEnabledChangeCallback">MediaControllerEnabledChangeCallback</a>
+<li>2.36. <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a>
 </li>
-<li>2.37. <a href="#MediaControllerDisplayModeChangeRequestCallback">MediaControllerDisplayModeChangeRequestCallback</a>
+<li>2.37. <a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a>
 </li>
-<li>2.38. <a href="#MediaControllerDisplayModeChangeCallback">MediaControllerDisplayModeChangeCallback</a>
+<li>2.38. <a href="#MediaControllerReceiveCommandCallback">MediaControllerReceiveCommandCallback</a>
 </li>
-<li>2.39. <a href="#MediaControllerDisplayRotationChangeRequestCallback">MediaControllerDisplayRotationChangeRequestCallback</a>
+<li>2.39. <a href="#MediaControllerEnabledChangeRequestCallback">MediaControllerEnabledChangeRequestCallback</a>
 </li>
-<li>2.40. <a href="#MediaControllerDisplayRotationChangeCallback">MediaControllerDisplayRotationChangeCallback</a>
+<li>2.40. <a href="#MediaControllerEnabledChangeCallback">MediaControllerEnabledChangeCallback</a>
 </li>
-<li>2.41. <a href="#MediaControllerServerStatusChangeCallback">MediaControllerServerStatusChangeCallback</a>
+<li>2.41. <a href="#MediaControllerDisplayModeChangeRequestCallback">MediaControllerDisplayModeChangeRequestCallback</a>
 </li>
-<li>2.42. <a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a>
+<li>2.42. <a href="#MediaControllerDisplayModeChangeCallback">MediaControllerDisplayModeChangeCallback</a>
 </li>
-<li>2.43. <a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a>
+<li>2.43. <a href="#MediaControllerDisplayRotationChangeRequestCallback">MediaControllerDisplayRotationChangeRequestCallback</a>
 </li>
-<li>2.44. <a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a>
+<li>2.44. <a href="#MediaControllerDisplayRotationChangeCallback">MediaControllerDisplayRotationChangeCallback</a>
 </li>
-<li>2.45. <a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a>
+<li>2.45. <a href="#MediaControllerServerStatusChangeCallback">MediaControllerServerStatusChangeCallback</a>
 </li>
-<li>2.46. <a href="#MediaControllerGetItemsSuccessCallback">MediaControllerGetItemsSuccessCallback</a>
+<li>2.46. <a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a>
 </li>
-<li>2.47. <a href="#MediaControllerAbilityChangeCallback">MediaControllerAbilityChangeCallback</a>
+<li>2.47. <a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a>
+</li>
+<li>2.48. <a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a>
+</li>
+<li>2.49. <a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a>
+</li>
+<li>2.50. <a href="#MediaControllerGetItemsSuccessCallback">MediaControllerGetItemsSuccessCallback</a>
+</li>
+<li>2.51. <a href="#MediaControllerAbilityChangeCallback">MediaControllerAbilityChangeCallback</a>
 </li>
 </ul>
 </li>
@@ -187,26 +198,10 @@ For more information on the Media Controller features, see <a href="/application
 <td>
 <div>
 <a href="#MediaControllerClientInfo">MediaControllerClientInfo</a>[] <a href="#MediaControllerServer::getAllClientsInfo">getAllClientsInfo</a> ()</div>
-<div>void <a href="#MediaControllerServer::updatePlaybackState">updatePlaybackState</a> (<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state)</div>
-<div>void <a href="#MediaControllerServer::updateIconURI">updateIconURI</a> (DOMString? iconURI)</div>
-<div>void <a href="#MediaControllerServer::updatePlaybackPosition">updatePlaybackPosition</a> (unsigned long long position)</div>
-<div>void <a href="#MediaControllerServer::updatePlaybackAgeRating">updatePlaybackAgeRating</a> (<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating)</div>
-<div>void <a href="#MediaControllerServer::updatePlaybackContentType">updatePlaybackContentType</a> (<a href="#MediaControllerContentType">MediaControllerContentType</a> type)</div>
-<div>void <a href="#MediaControllerServer::updateShuffleMode">updateShuffleMode</a> (boolean mode)</div>
-<div>void <a href="#MediaControllerServer::updateRepeatState">updateRepeatState</a> (<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state)</div>
-<div>void <a href="#MediaControllerServer::updateMetadata">updateMetadata</a> (<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata)</div>
-<div>long <a href="#MediaControllerServer::addChangeRequestPlaybackInfoListener">addChangeRequestPlaybackInfoListener</a> (<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener)</div>
-<div>void <a href="#MediaControllerServer::removeChangeRequestPlaybackInfoListener">removeChangeRequestPlaybackInfoListener</a> (long watchId)</div>
 <div>void <a href="#MediaControllerServer::setSearchRequestListener">setSearchRequestListener</a> (<a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a> listener)</div>
 <div>void <a href="#MediaControllerServer::unsetSearchRequestListener">unsetSearchRequestListener</a> ()</div>
 <div>long <a href="#MediaControllerServer::addCommandListener">addCommandListener</a> (<a href="#MediaControllerReceiveCommandCallback">MediaControllerReceiveCommandCallback</a> listener)</div>
 <div>void <a href="#MediaControllerServer::removeCommandListener">removeCommandListener</a> (long watchId)</div>
-<div>
-<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> <a href="#MediaControllerServer::createPlaylist">createPlaylist</a> (DOMString name)</div>
-<div>void <a href="#MediaControllerServer::savePlaylist">savePlaylist</a> (<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServer::deletePlaylist">deletePlaylist</a> (DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServer::updatePlaybackItem">updatePlaybackItem</a> (DOMString playlistName, DOMString index)</div>
-<div>void <a href="#MediaControllerServer::getAllPlaylists">getAllPlaylists</a> (<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
 </td>
 </tr>
 <tr>
@@ -225,25 +220,53 @@ For more information on the Media Controller features, see <a href="/application
 <tr>
 <td><a href="#MediaControllerServerInfo">MediaControllerServerInfo</a></td>
 <td>
-<div>void <a href="#MediaControllerServerInfo::sendPlaybackState">sendPlaybackState</a> (<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServerInfo::sendPlaybackPosition">sendPlaybackPosition</a> (unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServerInfo::sendShuffleMode">sendShuffleMode</a> (boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServerInfo::sendRepeatState">sendRepeatState</a> (<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
 <div>void <a href="#MediaControllerServerInfo::sendSearchRequest">sendSearchRequest</a> (<a href="#SearchFilter">SearchFilter</a>[] request, <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a> replyCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
 <div>void <a href="#MediaControllerServerInfo::sendCommand">sendCommand</a> (DOMString command, <a href="tizen.html#Bundle">Bundle</a>? data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
 <div>long <a href="#MediaControllerServerInfo::addServerStatusChangeListener">addServerStatusChangeListener</a> (<a href="#MediaControllerServerStatusChangeCallback">MediaControllerServerStatusChangeCallback</a> listener)</div>
 <div>void <a href="#MediaControllerServerInfo::removeServerStatusChangeListener">removeServerStatusChangeListener</a> (long watchId)</div>
-<div>long <a href="#MediaControllerServerInfo::addPlaybackInfoChangeListener">addPlaybackInfoChangeListener</a> (<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener)</div>
-<div>void <a href="#MediaControllerServerInfo::removePlaybackInfoChangeListener">removePlaybackInfoChangeListener</a> (long watchId)</div>
-<div>void <a href="#MediaControllerServerInfo::getAllPlaylists">getAllPlaylists</a> (<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServerInfo::sendPlaybackItem">sendPlaybackItem</a> (DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position)</div>
-<div>long <a href="#MediaControllerServerInfo::addPlaylistUpdatedListener">addPlaylistUpdatedListener</a> (<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener)</div>
-<div>void <a href="#MediaControllerServerInfo::removePlaylistUpdatedListener">removePlaylistUpdatedListener</a> (long listenerId)</div>
 </td>
 </tr>
 <tr>
-<td><a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a></td>
-<td></td>
+<td><a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a></td>
+<td>
+<div>void <a href="#MediaControllerServerPlaybackInfo::updatePlaybackItem">updatePlaybackItem</a> (DOMString playlistName, DOMString index)</div>
+<div>long <a href="#MediaControllerServerPlaybackInfo::addChangeRequestListener">addChangeRequestListener</a> (<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener)</div>
+<div>void <a href="#MediaControllerServerPlaybackInfo::removeChangeRequestListener">removeChangeRequestListener</a> (long watchId)</div>
+</td>
+</tr>
+<tr>
+<td><a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a></td>
+<td>
+<div>void <a href="#MediaControllerServerInfoPlaybackInfo::sendPlaybackAction">sendPlaybackAction</a> (<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)</div>
+<div>void <a href="#MediaControllerServerInfoPlaybackInfo::sendPlaybackPosition">sendPlaybackPosition</a> (unsigned long long position, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)</div>
+<div>void <a href="#MediaControllerServerInfoPlaybackInfo::sendShuffleMode">sendShuffleMode</a> (boolean mode, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)</div>
+<div>void <a href="#MediaControllerServerInfoPlaybackInfo::sendRepeatState">sendRepeatState</a> (<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)</div>
+<div>long <a href="#MediaControllerServerInfoPlaybackInfo::addPlaybackInfoChangeListener">addPlaybackInfoChangeListener</a> (<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener)</div>
+<div>void <a href="#MediaControllerServerInfoPlaybackInfo::removePlaybackInfoChangeListener">removePlaybackInfoChangeListener</a> (long watchId)</div>
+</td>
+</tr>
+<tr>
+<td><a href="#MediaControllerPlaylists">MediaControllerPlaylists</a></td>
+<td>
+<div>
+<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> <a href="#MediaControllerPlaylists::createPlaylist">createPlaylist</a> (DOMString name)</div>
+<div>void <a href="#MediaControllerPlaylists::savePlaylist">savePlaylist</a> (<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
+<div>void <a href="#MediaControllerPlaylists::deletePlaylist">deletePlaylist</a> (DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
+<div>void <a href="#MediaControllerPlaylists::getAllPlaylists">getAllPlaylists</a> (<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
+<div>
+<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> <a href="#MediaControllerPlaylists::getPlaylist">getPlaylist</a> (DOMString playlistName)</div>
+</td>
+</tr>
+<tr>
+<td><a href="#MediaControllerPlaylistsInfo">MediaControllerPlaylistsInfo</a></td>
+<td>
+<div>void <a href="#MediaControllerPlaylistsInfo::getAllPlaylists">getAllPlaylists</a> (<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
+<div>void <a href="#MediaControllerPlaylistsInfo::sendPlaybackItem">sendPlaybackItem</a> (DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, unsigned long long position, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)</div>
+<div>long <a href="#MediaControllerPlaylistsInfo::addPlaylistUpdatedListener">addPlaylistUpdatedListener</a> (<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener)</div>
+<div>void <a href="#MediaControllerPlaylistsInfo::removePlaylistUpdatedListener">removePlaylistUpdatedListener</a> (long listenerId)</div>
+<div>
+<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> <a href="#MediaControllerPlaylistsInfo::getPlaylist">getPlaylist</a> (DOMString playlistName)</div>
+</td>
 </tr>
 <tr>
 <td><a href="#MediaControllerAbilities">MediaControllerAbilities</a></td>
@@ -346,7 +369,7 @@ For more information on the Media Controller features, see <a href="/application
 </tr>
 <tr>
 <td><a href="#MediaControllerMetadata">MediaControllerMetadata</a></td>
-<td></td>
+<td><div>void <a href="#MediaControllerMetadata::save">save</a> ()</div></td>
 </tr>
 <tr>
 <td><a href="#MediaControllerPlaylistItem">MediaControllerPlaylistItem</a></td>
@@ -436,11 +459,16 @@ For more information on the Media Controller features, see <a href="/application
 <tr>
 <td><a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a></td>
 <td>
-<div>void <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackstaterequest">onplaybackstaterequest</a> (<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
-<div>void <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackpositionrequest">onplaybackpositionrequest</a> (unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
-<div>void <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onshufflemoderequest">onshufflemoderequest</a> (boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
-<div>void <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onrepeatstaterequest">onrepeatstaterequest</a> (<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
-<div>void <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackitemrequest">onplaybackitemrequest</a> (DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
+<div>
+<a href="#RequestReply">RequestReply</a>? <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackactionrequest">onplaybackactionrequest</a> (<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
+<div>
+<a href="#RequestReply">RequestReply</a>? <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackpositionrequest">onplaybackpositionrequest</a> (unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
+<div>
+<a href="#RequestReply">RequestReply</a>? <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onshufflemoderequest">onshufflemoderequest</a> (boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
+<div>
+<a href="#RequestReply">RequestReply</a>? <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onrepeatstaterequest">onrepeatstaterequest</a> (<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
+<div>
+<a href="#RequestReply">RequestReply</a>? <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackitemrequest">onplaybackitemrequest</a> (DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
 </td>
 </tr>
 <tr>
@@ -527,24 +555,54 @@ TPO - Search by Time Place Occasion.            </li>
 <div class="description">
           <ul>
             <li>
-PLAY - Corresponds to play media controller playback state.            </li>
+PLAY - Corresponds to the "playing" media controller playback state.            </li>
             <li>
-PAUSE - Corresponds to pause media controller playback state.            </li>
+PAUSE - Corresponds to the "paused" media controller playback state.            </li>
             <li>
-STOP - Corresponds to stop media controller playback state.            </li>
+STOP - Corresponds to the "stopped" media controller playback state.            </li>
             <li>
-NEXT - Corresponds to next media controller playback state.            </li>
+NEXT - Corresponds to the "moving to next" media controller playback state.            </li>
             <li>
-PREV - Corresponds to previous media controller playback state.            </li>
+PREV - Corresponds to the "moving to previous" media controller playback state.            </li>
             <li>
-FORWARD - Corresponds to forward media controller playback state.            </li>
+FORWARD - Corresponds to the "forwarding" media controller playback state.            </li>
             <li>
-REWIND - Corresponds to rewind media controller playback state.            </li>
+REWIND - Corresponds to the "rewinding" media controller playback state.            </li>
+          </ul>
+         </div>
+</div>
+<div class="enum" id="MediaControllerPlaybackAction">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackAction"></a><h3>1.4. MediaControllerPlaybackAction</h3>
+<div class="brief">
+ Defines media playback actions.
+          </div>
+<pre class="webidl prettyprint">  enum MediaControllerPlaybackAction { "PLAY", "PAUSE", "STOP", "NEXT", "PREV", "FORWARD", "REWIND", "TOGGLE_PLAY_PAUSE" };</pre>
+<p><span class="version">Since: </span>
+ 6.0
+          </p>
+<div class="description">
+          <ul>
+            <li>
+PLAY - Corresponds to the "play" media controller playback action.            </li>
+            <li>
+PAUSE - Corresponds to "pause" media controller playback action.            </li>
+            <li>
+STOP - Corresponds to the "stop" media controller playback action.            </li>
+            <li>
+NEXT - Corresponds to the "next" media controller playback action.            </li>
+            <li>
+PREV - Corresponds to the "previous" media controller playback action.            </li>
+            <li>
+FORWARD - Corresponds to the "forward" media controller playback action.            </li>
+            <li>
+REWIND - Corresponds to the "rewind" media controller playback action.            </li>
+            <li>
+TOGGLE_PLAY_PAUSE - Corresponds to the "toggle play/pause" media controller playback action.            </li>
           </ul>
          </div>
 </div>
 <div class="enum" id="MediaControllerRepeatState">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerRepeatState"></a><h3>1.4. MediaControllerRepeatState</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerRepeatState"></a><h3>1.5. MediaControllerRepeatState</h3>
 <div class="brief">
  Defines states for repeating media.
           </div>
@@ -567,7 +625,7 @@ REPEAT_ALL - repeating all media.            </li>
          </div>
 </div>
 <div class="enum" id="MediaControllerContentType">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerContentType"></a><h3>1.5. MediaControllerContentType</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerContentType"></a><h3>1.6. MediaControllerContentType</h3>
 <div class="brief">
  Content type.
           </div>
@@ -591,7 +649,7 @@ UNDECIDED - content type for unspecified media types.            </li>
          </div>
 </div>
 <div class="enum" id="MediaControllerContentAgeRating">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerContentAgeRating"></a><h3>1.6. MediaControllerContentAgeRating</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerContentAgeRating"></a><h3>1.7. MediaControllerContentAgeRating</h3>
 <div class="brief">
  Media Controller content age rating.
           </div>
@@ -607,7 +665,7 @@ Each value represents the minimum age restriction for the media.
          </div>
 </div>
 <div class="enum" id="MediaControllerAbilitySupport">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilitySupport"></a><h3>1.7. MediaControllerAbilitySupport</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilitySupport"></a><h3>1.8. MediaControllerAbilitySupport</h3>
 <div class="brief">
  The media controller ability support values.
           </div>
@@ -627,7 +685,7 @@ UNDECIDED - The support of ability is not set.            </li>
          </div>
 </div>
 <div class="enum" id="MediaControllerSimpleAbility">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSimpleAbility"></a><h3>1.8. MediaControllerSimpleAbility</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSimpleAbility"></a><h3>1.9. MediaControllerSimpleAbility</h3>
 <div class="brief">
  The media controller simple ability types. Simple means, that each ability is described by a single <a href="#MediaControllerAbilitySupport">MediaControllerAbilitySupport</a> value and is not a part of a complex ability structure.
           </div>
@@ -658,7 +716,7 @@ MODE_360 - Ability to receive requests for spherical (360°) mode change from me
          </div>
 </div>
 <div class="enum" id="MediaControllerDisplayModeType">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeType"></a><h3>1.9. MediaControllerDisplayModeType</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeType"></a><h3>1.10. MediaControllerDisplayModeType</h3>
 <div class="brief">
  Types of supported media controller display modes.
           </div>
@@ -680,7 +738,7 @@ CROPPED_FULL - Cropped full screen display mode type.            </li>
          </div>
 </div>
 <div class="enum" id="MediaControllerDisplayRotationType">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationType"></a><h3>1.10. MediaControllerDisplayRotationType</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationType"></a><h3>1.11. MediaControllerDisplayRotationType</h3>
 <div class="brief">
  The media controller rotation values.
           </div>
@@ -861,38 +919,40 @@ catch (err)
  Provides functions for sending the server information to the client.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerServer {
-    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo;
-    readonly attribute DOMString? iconURI;
+<span class="nocode deprecated">    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo;
+</span>    readonly attribute <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a> playback;
+    readonly attribute <a href="#MediaControllerPlaylists">MediaControllerPlaylists</a> playlists;
+    attribute DOMString? iconURI raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute <a href="#MediaControllerAbilities">MediaControllerAbilities</a> abilities;
     readonly attribute <a href="#MediaControllerSubtitles">MediaControllerSubtitles</a> subtitles;
     readonly attribute <a href="#MediaControllerMode360">MediaControllerMode360</a> mode360;
     readonly attribute <a href="#MediaControllerDisplayMode">MediaControllerDisplayMode</a> displayMode;
     readonly attribute <a href="#MediaControllerDisplayRotation">MediaControllerDisplayRotation</a> displayRotation;
     <a href="#MediaControllerClientInfo">MediaControllerClientInfo</a>[] getAllClientsInfo() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateIconURI(DOMString? iconURI) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackPosition(unsigned long long position) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackAgeRating(<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackContentType(<a href="#MediaControllerContentType">MediaControllerContentType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateShuffleMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-<span class="nocode deprecated">    void updateRepeatMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-</span>    void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateMetadata(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addChangeRequestPlaybackInfoListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removeChangeRequestPlaybackInfoListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void setSearchRequestListener(<a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    void updatePlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updateIconURI(DOMString? iconURI) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updatePlaybackPosition(unsigned long long position) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updatePlaybackAgeRating(<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updatePlaybackContentType(<a href="#MediaControllerContentType">MediaControllerContentType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updateShuffleMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updateRepeatMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updateMetadata(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    long addChangeRequestPlaybackInfoListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void removeChangeRequestPlaybackInfoListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void setSearchRequestListener(<a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unsetSearchRequestListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addCommandListener(<a href="#MediaControllerReceiveCommandCallback">MediaControllerReceiveCommandCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeCommandListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+<span class="nocode deprecated">    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+</span><span class="nocode deprecated">    void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackItem(DOMString playlistName, DOMString index) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+</span><span class="nocode deprecated">    void updatePlaybackItem(DOMString playlistName, DOMString index) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };</pre>
+</span>  };</pre>
 <p><span class="version">Since: </span>
  5.0
           </p>
@@ -905,11 +965,14 @@ and be controlled by other application(client) remotely.
 <div class="attributes">
 <h4>Attributes</h4>
 <ul>
-<li class="attribute" id="MediaControllerServer::playbackInfo">
+<li class="attribute deprecated" id="MediaControllerServer::playbackInfo">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">MediaControllerPlaybackInfo </span><span class="name">playbackInfo</span></span><div class="brief">
  Current playback info.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a> <var>playback</var> attribute.
+            </p>
 <p><span class="version">Since: </span>
  5.0
             </p>
@@ -917,14 +980,41 @@ and be controlled by other application(client) remotely.
  Object holds state which is automatically updated by update methods.
             </p>
 </li>
-<li class="attribute" id="MediaControllerServer::iconURI">
+<li class="attribute" id="MediaControllerServer::playback">
 <span class="attrName"><span class="readonly">                readonly
-</span><span class="type">DOMString </span><span class="name">iconURI</span><span class="optional"> [nullable]</span></span><div class="brief">
+</span><span class="type">MediaControllerServerPlaybackInfo </span><span class="name">playback</span></span><div class="brief">
+ Current playback info.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServer::playlists">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerPlaylists </span><span class="name">playlists</span></span><div class="brief">
+ Object representing features related to playlists of a media controller server.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServer::iconURI">
+<span class="attrName"><span class="type">DOMString </span><span class="name">iconURI</span><span class="optional"> [nullable]</span></span><div class="brief">
  Server icon URI.
             </div>
 <p><span class="version">Since: </span>
  5.5
             </p>
+<p><span class="remark">Remark: </span>
+ The readonly modifier is removed since 6.0 version.
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
 </li>
 <li class="attribute" id="MediaControllerServer::abilities">
 <span class="attrName"><span class="readonly">                readonly
@@ -1005,15 +1095,18 @@ and be controlled by other application(client) remotely.
 </li></ul>
         </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updatePlaybackState">
+<dt class="deprecated method" id="MediaControllerServer::updatePlaybackState">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updatePlaybackState"></a><code><b><span class="methodName">updatePlaybackState</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates playback state and send notification to the listening clients.
 See <em>MediaControllerServerInfo.addPlaybackInfoChangeListener</em> to check
 how to receive playback info changes from server on client side.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>state</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updatePlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1051,13 +1144,16 @@ console.log("Current playback state is: " + mcServer.playbackInfo.state);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updateIconURI">
+<dt class="deprecated method" id="MediaControllerServer::updateIconURI">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updateIconURI"></a><code><b><span class="methodName">updateIconURI</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates server icon URI.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>iconURI</var> attribute in <a href="#MediaControllerServer">MediaControllerServer</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updateIconURI(DOMString? iconURI);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1092,13 +1188,16 @@ console.log(mcServerInfo.iconURI);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updatePlaybackPosition">
+<dt class="deprecated method" id="MediaControllerServer::updatePlaybackPosition">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updatePlaybackPosition"></a><code><b><span class="methodName">updatePlaybackPosition</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates playback position and send notification to the listening clients.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>position</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updatePlaybackPosition(unsigned long long position);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1136,13 +1235,16 @@ console.log("Current playback position is: " + mcServer.playbackInfo.position);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updatePlaybackAgeRating">
+<dt class="deprecated method" id="MediaControllerServer::updatePlaybackAgeRating">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updatePlaybackAgeRating"></a><code><b><span class="methodName">updatePlaybackAgeRating</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Sets content age rating for current playback item.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>ageRating</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updatePlaybackAgeRating(<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1182,13 +1284,16 @@ console.log("Only viewers older than " + mcServerInfo.playbackInfo.ageRating +
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updatePlaybackContentType">
+<dt class="deprecated method" id="MediaControllerServer::updatePlaybackContentType">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updatePlaybackContentType"></a><code><b><span class="methodName">updatePlaybackContentType</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Sets content type for the current playback item.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>contentType</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updatePlaybackContentType(<a href="#MediaControllerContentType">MediaControllerContentType</a> type);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1227,13 +1332,16 @@ console.log("Content type of current item is " + mcServerInfo.playbackInfo.conte
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updateShuffleMode">
+<dt class="deprecated method" id="MediaControllerServer::updateShuffleMode">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updateShuffleMode"></a><code><b><span class="methodName">updateShuffleMode</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates shuffle mode and send notification to the listening clients.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>shuffleMode</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updateShuffleMode(boolean mode);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1304,13 +1412,16 @@ console.log("Current repeat mode is: " + mcServer.playbackInfo.repeatMode);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updateRepeatState">
+<dt class="deprecated method" id="MediaControllerServer::updateRepeatState">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updateRepeatState"></a><code><b><span class="methodName">updateRepeatState</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates repeat state and sends notification to the listening clients.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>repeatState</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1348,13 +1459,16 @@ console.log("Current repeat state is: " + mcServer.playbackInfo.repeatState);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updateMetadata">
+<dt class="deprecated method" id="MediaControllerServer::updateMetadata">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updateMetadata"></a><code><b><span class="methodName">updateMetadata</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates metadata and send notification to the listening clients.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerMetadata::save">save()</a> on metadata object.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updateMetadata(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1397,15 +1511,18 @@ console.log("Current metadata is: " + JSON.stringify(mcServer.playbackInfo.metad
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::addChangeRequestPlaybackInfoListener">
+<dt class="deprecated method" id="MediaControllerServer::addChangeRequestPlaybackInfoListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::addChangeRequestPlaybackInfoListener"></a><code><b><span class="methodName">addChangeRequestPlaybackInfoListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Adds the listener for a media playback info requests from client.
 See <em>MediaControllerServerInfo</em> to check how to send playback info change
 requests from client.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerPlaybackInfo::addChangeRequestListener">addChangeRequestListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">long addChangeRequestPlaybackInfoListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1472,13 +1589,16 @@ watcherId = mcServer.addChangeRequestPlaybackInfoListener(playbackRequestListene
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::removeChangeRequestPlaybackInfoListener">
+<dt class="deprecated method" id="MediaControllerServer::removeChangeRequestPlaybackInfoListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::removeChangeRequestPlaybackInfoListener"></a><code><b><span class="methodName">removeChangeRequestPlaybackInfoListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Removes the listener, so stop receiving playback state requests from clients.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerPlaybackInfo::removeChangeRequestListener">removeChangeRequestListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void removeChangeRequestPlaybackInfoListener(long watchId);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -1731,13 +1851,16 @@ mcServer.removeCommandListener(watcherId);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::createPlaylist">
+<dt class="deprecated method" id="MediaControllerServer::createPlaylist">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::createPlaylist"></a><code><b><span class="methodName">createPlaylist</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Creates <em>MediaControllerPlaylist</em> object.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylists::createPlaylist">createPlaylist()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint"><a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1779,13 +1902,16 @@ var playlist = mcServer.createPlaylist("testPlaylistName");
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::savePlaylist">
+<dt class="deprecated method" id="MediaControllerServer::savePlaylist">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::savePlaylist"></a><code><b><span class="methodName">savePlaylist</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
- Saves playlist in local database.
+ Saves the playlist in a local database.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylists::savePlaylist">savePlaylist()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                   optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
@@ -1797,13 +1923,13 @@ The <em>errorCallback</em> may be triggered for one of the following errors:
             </p>
             <ul>
               <li>
-<em>InvalidValuesError</em>: if playlist with given name does not exists.              </li>
+<em>InvalidValuesError</em>: if playlist with given name does not exist.              </li>
               <li>
-<em>UnknownError</em>: if any other error prevents function from successful completion.              </li>
+<em>UnknownError</em>: if any other error prevents the function from successful completion.              </li>
             </ul>
            </div>
 <p><span class="remark">Remark: </span>
- All playlists will be deleted after application is closed.
+ All playlists will be deleted after the application is closed.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -1853,13 +1979,16 @@ mcServer.savePlaylist(playlist, successCallback, errorCallback);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::deletePlaylist">
+<dt class="deprecated method" id="MediaControllerServer::deletePlaylist">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::deletePlaylist"></a><code><b><span class="methodName">deletePlaylist</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Deletes playlist from local database.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylists::deletePlaylist">deletePlaylist()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1870,9 +1999,9 @@ The <em>errorCallback</em> may be triggered for one of the following errors:
             </p>
             <ul>
               <li>
-<em>InvalidValuesError</em>: if playlist with given name does not exists.              </li>
+<em>InvalidValuesError</em>: if playlist with given name does not exist.              </li>
               <li>
-<em>UnknownError</em>: if any other error prevents function from successful completion.              </li>
+<em>UnknownError</em>: if any other error prevents the function from successful completion.              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1927,13 +2056,16 @@ mcServer.savePlaylist(playlist, saveSuccess);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updatePlaybackItem">
+<dt class="deprecated method" id="MediaControllerServer::updatePlaybackItem">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updatePlaybackItem"></a><code><b><span class="methodName">updatePlaybackItem</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Sets index and playlist name properties of playback info object.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerPlaybackInfo::updatePlaybackItem">updatePlaybackItem()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updatePlaybackItem(DOMString playlistName, DOMString index);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1990,13 +2122,16 @@ Current index: index1
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::getAllPlaylists">
+<dt class="deprecated method" id="MediaControllerServer::getAllPlaylists">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::getAllPlaylists"></a><code><b><span class="methodName">getAllPlaylists</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
- Retrieves all playlists from local database.
+ Retrieves all playlists from a local database.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylists::getAllPlaylists">getAllPlaylists()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -2553,38 +2688,40 @@ Provides methods to send commands to server and listen for server status change.
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerServerInfo {
     readonly attribute <a href="application.html#ApplicationId">ApplicationId</a> name;
     readonly attribute <a href="#MediaControllerServerState">MediaControllerServerState</a> state;
-    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    readonly attribute <a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a> playback raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    readonly attribute <a href="#MediaControllerPlaylistsInfo">MediaControllerPlaylistsInfo</a> playlists;
     readonly attribute DOMString? iconURI raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute <a href="#MediaControllerAbilitiesInfo">MediaControllerAbilitiesInfo</a> abilities;
     readonly attribute <a href="#MediaControllerSubtitlesInfo">MediaControllerSubtitlesInfo</a> subtitles;
     readonly attribute <a href="#MediaControllerMode360Info">MediaControllerMode360Info</a> mode360;
     readonly attribute <a href="#MediaControllerDisplayModeInfo">MediaControllerDisplayModeInfo</a> displayMode;
     readonly attribute <a href="#MediaControllerDisplayRotationInfo">MediaControllerDisplayRotationInfo</a> displayRotation;
-    void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+<span class="nocode deprecated">    void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                            optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+</span><span class="nocode deprecated">    void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendShuffleMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+</span><span class="nocode deprecated">    void sendShuffleMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-<span class="nocode deprecated">    void sendRepeatMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+</span><span class="nocode deprecated">    void sendRepeatMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-</span>    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+</span><span class="nocode deprecated">    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                          optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendSearchRequest(<a href="#SearchFilter">SearchFilter</a>[] request, <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a> replyCallback,
+</span>    void sendSearchRequest(<a href="#SearchFilter">SearchFilter</a>[] request, <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a> replyCallback,
                            optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void sendCommand(DOMString command, <a href="tizen.html#Bundle">Bundle</a>? data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addServerStatusChangeListener(<a href="#MediaControllerServerStatusChangeCallback">MediaControllerServerStatusChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeServerStatusChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removePlaybackInfoChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+<span class="nocode deprecated">    long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void removePlaybackInfoChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position)
+</span><span class="nocode deprecated">    void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position)
                           raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removePlaylistUpdatedListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };</pre>
+</span><span class="nocode deprecated">    long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void removePlaylistUpdatedListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</pre>
 <p><span class="version">Since: </span>
  5.0
           </p>
@@ -2609,11 +2746,14 @@ Provides methods to send commands to server and listen for server status change.
  5.0
             </p>
 </li>
-<li class="attribute" id="MediaControllerServerInfo::playbackInfo">
+<li class="attribute deprecated" id="MediaControllerServerInfo::playbackInfo">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">MediaControllerPlaybackInfo </span><span class="name">playbackInfo</span></span><div class="brief">
  Current playback info.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a> <var>playback</var> attribute.
+            </p>
 <p><span class="version">Since: </span>
  5.0
             </p>
@@ -2624,6 +2764,31 @@ Provides methods to send commands to server and listen for server status change.
                 </p></li></ul>
 </li></ul>
         </div>
+</li>
+<li class="attribute" id="MediaControllerServerInfo::playback">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerServerInfoPlaybackInfo </span><span class="name">playback</span></span><div class="brief">
+ Playback info of current server info.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerInfo::playlists">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerPlaylistsInfo </span><span class="name">playlists</span></span><div class="brief">
+ An attribute providing access to the playlist information from the server.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
 </li>
 <li class="attribute" id="MediaControllerServerInfo::iconURI">
 <span class="attrName"><span class="readonly">                readonly
@@ -2691,13 +2856,16 @@ Provides methods to send commands to server and listen for server status change.
 <div class="methods">
 <h4>Methods</h4>
 <dl>
-<dt class="method" id="MediaControllerServerInfo::sendPlaybackState">
+<dt class="deprecated method" id="MediaControllerServerInfo::sendPlaybackState">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::sendPlaybackState"></a><code><b><span class="methodName">sendPlaybackState</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Allows to change playback state of media controller server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::sendPlaybackAction">sendPlaybackAction()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                        optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
@@ -2752,13 +2920,16 @@ mcServerInfo.sendPlaybackState("STOP",
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::sendPlaybackPosition">
+<dt class="deprecated method" id="MediaControllerServerInfo::sendPlaybackPosition">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::sendPlaybackPosition"></a><code><b><span class="methodName">sendPlaybackPosition</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Allows to change playback position of media controller server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::sendPlaybackPosition">sendPlaybackPosition()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                           optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
@@ -2816,13 +2987,16 @@ mcServerInfo.sendPlaybackPosition(164,
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::sendShuffleMode">
+<dt class="deprecated method" id="MediaControllerServerInfo::sendShuffleMode">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::sendShuffleMode"></a><code><b><span class="methodName">sendShuffleMode</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Allows to change shuffle mode of media controller server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::sendShuffleMode">sendShuffleMode()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void sendShuffleMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -2935,13 +3109,16 @@ mcServerInfo.sendRepeatMode(false,
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::sendRepeatState">
+<dt class="deprecated method" id="MediaControllerServerInfo::sendRepeatState">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::sendRepeatState"></a><code><b><span class="methodName">sendRepeatState</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Allows to change repeat state of media controller server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::sendRepeatState">sendRepeatState()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
@@ -3255,13 +3432,16 @@ mcServerInfo.removeServerStatusChangeListener(watcherId);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::addPlaybackInfoChangeListener">
+<dt class="deprecated method" id="MediaControllerServerInfo::addPlaybackInfoChangeListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::addPlaybackInfoChangeListener"></a><code><b><span class="methodName">addPlaybackInfoChangeListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Adds the listener for a media playback info changes.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::addPlaybackInfoChangeListener">addPlaybackInfoChangeListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -3325,13 +3505,16 @@ watcherId = mcServerInfo.addPlaybackInfoChangeListener(playbackListener);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::removePlaybackInfoChangeListener">
+<dt class="deprecated method" id="MediaControllerServerInfo::removePlaybackInfoChangeListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::removePlaybackInfoChangeListener"></a><code><b><span class="methodName">removePlaybackInfoChangeListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Removes the listener, so stop receiving notifications about media playback info changes.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::removePlaybackInfoChangeListener">removePlaybackInfoChangeListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void removePlaybackInfoChangeListener(long watchId);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -3392,13 +3575,16 @@ mcServerInfo.removePlaybackInfoChangeListener(watcherId);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::getAllPlaylists">
+<dt class="deprecated method" id="MediaControllerServerInfo::getAllPlaylists">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::getAllPlaylists"></a><code><b><span class="methodName">getAllPlaylists</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Retrieves all playlists saved in local database.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylistsInfo::getAllPlaylists">getAllPlaylists()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -3474,13 +3660,16 @@ Playlist name: testPlaylist
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::sendPlaybackItem">
+<dt class="deprecated method" id="MediaControllerServerInfo::sendPlaybackItem">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::sendPlaybackItem"></a><code><b><span class="methodName">sendPlaybackItem</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Requests setting new playback item to server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylistsInfo::sendPlaybackItem">sendPlaybackItem()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -3523,13 +3712,16 @@ mcServerInfo.sendPlaybackItem("testPlaylist", "1", "PLAY", 0);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::addPlaylistUpdatedListener">
+<dt class="deprecated method" id="MediaControllerServerInfo::addPlaylistUpdatedListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::addPlaylistUpdatedListener"></a><code><b><span class="methodName">addPlaylistUpdatedListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Adds listener to be invoked when playlist is updated by server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylistsInfo::addPlaylistUpdatedListener">addPlaylistUpdatedListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -3581,13 +3773,16 @@ var listenerId = mcServerInfo.addPlaylistUpdatedListener(listener);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::removePlaylistUpdatedListener">
+<dt class="deprecated method" id="MediaControllerServerInfo::removePlaylistUpdatedListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::removePlaylistUpdatedListener"></a><code><b><span class="methodName">removePlaylistUpdatedListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Stops listening for playlist updates and removals.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylistsInfo::removePlaylistUpdatedListener">removePlaylistUpdatedListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void removePlaylistUpdatedListener(long listenerId);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -3628,12 +3823,17 @@ mcServerInfo.removePlaylistUpdatedListener(listenerId);
 </dl>
 </div>
 </div>
-<div class="interface" id="MediaControllerPlaybackInfo">
+<div class="interface deprecated" id="MediaControllerPlaybackInfo">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackInfo"></a><h3>2.6. MediaControllerPlaybackInfo</h3>
 <div class="brief">
  Current playback info.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerPlaybackInfo {
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a> for
+server-side object of playback info and <a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a> for
+client-side object of playback info.
+          </p>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface MediaControllerPlaybackInfo {
     readonly attribute <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state;
     readonly attribute unsigned long long position;
     readonly attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating;
@@ -3644,7 +3844,7 @@ mcServerInfo.removePlaylistUpdatedListener(listenerId);
     readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
     readonly attribute DOMString? index;
     readonly attribute DOMString? playlistName;
-  };</pre>
+  };</span></pre>
 <p><span class="version">Since: </span>
  5.0
           </p>
@@ -3780,8 +3980,1445 @@ Default value is <var>REPEAT_ALL</var>.
 </ul>
 </div>
 </div>
+<div class="interface" id="MediaControllerServerPlaybackInfo">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerPlaybackInfo"></a><h3>2.7. MediaControllerServerPlaybackInfo</h3>
+<div class="brief">
+ Server-side object representing current playback info.
+          </div>
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerServerPlaybackInfo {
+    attribute <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute unsigned long long position raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerContentType">MediaControllerContentType</a> contentType raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute boolean shuffleMode raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> repeatState raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
+    readonly attribute DOMString? index;
+    readonly attribute DOMString? playlistName;
+    void updatePlaybackItem(DOMString playlistName, DOMString index) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addChangeRequestListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removeChangeRequestListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };</pre>
+<p><span class="version">Since: </span>
+ 6.0
+          </p>
+<div class="attributes">
+<h4>Attributes</h4>
+<ul>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::state">
+<span class="attrName"><span class="type">MediaControllerPlaybackState </span><span class="name">state</span></span><div class="brief">
+ Current playback state.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if the set value will not be compatible with <var>MediaControllerPlaybackState</var> enum.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::position">
+<span class="attrName"><span class="type">unsigned long long </span><span class="name">position</span></span><div class="brief">
+ Current playback position.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type InvalidValuesError, if the set value is less than 0.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::ageRating">
+<span class="attrName"><span class="type">MediaControllerContentAgeRating </span><span class="name">ageRating</span></span><div class="brief">
+ Current playback age rating.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if the set value will not be compatible with <var>MediaControllerContentAgeRating</var> enum.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::contentType">
+<span class="attrName"><span class="type">MediaControllerContentType </span><span class="name">contentType</span></span><div class="brief">
+ Current playback content type.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if the set value will not be compatible with <var>MediaControllerContentType</var> enum.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::shuffleMode">
+<span class="attrName"><span class="type">boolean </span><span class="name">shuffleMode</span></span><div class="brief">
+ Current shuffle mode.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::repeatState">
+<span class="attrName"><span class="type">MediaControllerRepeatState </span><span class="name">repeatState</span></span><div class="brief">
+ Current repeat state.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if the set value will not be compatible with <var>MediaControllerRepeatState</var> enum.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::metadata">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerMetadata </span><span class="name">metadata</span></span><div class="brief">
+ Current playback metadata.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::index">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">DOMString </span><span class="name">index</span><span class="optional"> [nullable]</span></span><div class="brief">
+ Current item index.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::playlistName">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">DOMString </span><span class="name">playlistName</span><span class="optional"> [nullable]</span></span><div class="brief">
+ Current playlist name.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+</ul>
+</div>
+<div class="methods">
+<h4>Methods</h4>
+<dl>
+<dt class="method" id="MediaControllerServerPlaybackInfo::updatePlaybackItem">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerPlaybackInfo::updatePlaybackItem"></a><code><b><span class="methodName">updatePlaybackItem</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Sets index and playlist name properties of playback info object.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void updatePlaybackItem(DOMString playlistName, DOMString index);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlistName</span>:
+ Name of playlist to be set.
+                </li>
+          <li class="param">
+<span class="name">index</span>:
+ Index of item on playlist <em>playlistName</em> to be set.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+
+mcServer.playback.updatePlaybackItem("testPlaylistName", "index1");
+console.log("Current playlist: " + mcServer.playback.playlistName);
+console.log("Current index: " + mcServer.playback.index);
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>Current playlist: testPlaylistName
+Current index: index1
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerPlaybackInfo::addChangeRequestListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerPlaybackInfo::addChangeRequestListener"></a><code><b><span class="methodName">addChangeRequestListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Adds the listener for change requests of a media controller playback info.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">long addChangeRequestListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">listener</span>:
+ Change request listener to add.
+                </li>
+        </ul>
+</div>
+<div class="returntype">
+<p><span class="return">Return value:</span></p>
+<ul>
+<span class="return">long:</span>
+ The identifier used to remove the listener.
+              </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var watcherId = 0;  /* Watcher identifier. */
+var mcServer = tizen.mediacontroller.createServer();
+
+var playbackRequestListener =
+{
+  onplaybackactionrequest: function(action, clientName)
+  {
+    console.log("Playback action requested to: " + action + " by " + clientName);
+  },
+  onplaybackpositionrequest: function(position, clientName)
+  {
+    console.log("Playback position requested to: " + position + " by " + clientName);
+  },
+  onshufflemoderequest: function(mode, clientName)
+  {
+    console.log("Shuffle mode requested to: " + mode + " by " + clientName);
+  },
+  onrepeatstaterequest: function(state, clientName)
+  {
+    console.log("Repeat state requested to: " + state + " by " + clientName);
+  },
+  onplaybackitemrequest: function(playlistName, index, state, position, clientName)
+  {
+    console.log("Playlist: " + playlistName + " index: " + index + " state: " + state +
+                " position " + position + " requested by " + clientName);
+  }
+};
+
+/* Registers to receive playback info change requests from client. */
+watcherId = mcServer.playback.addChangeRequestListener(playbackRequestListener);
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerPlaybackInfo::removeChangeRequestListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerPlaybackInfo::removeChangeRequestListener"></a><code><b><span class="methodName">removeChangeRequestListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Removes the listener and stops receiving change requests of media controller playback info.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void removeChangeRequestListener(long watchId);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">watchId</span>:
+ Watcher identifier.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var watcherId = 0;  /* Watcher identifier. */
+var mcServer = tizen.mediacontroller.createServer();
+
+var playbackRequestListener =
+{
+  onplaybackactionrequest: function(action, clientName) {},
+  onplaybackpositionrequest: function(position, clientName) {},
+  onshufflemoderequest: function(mode, clientName) {},
+  onrepeatstaterequest: function(state, clientName) {},
+  onplaybackitemrequest: function(playlistName, index, state, position, clientName) {}
+};
+
+/* Registers to receive playback info change requests from client. */
+watcherId = mcServer.playback.addChangeRequestListener(playbackRequestListener);
+
+/* Cancels the watch operation. */
+mcServer.playback.removeChangeRequestListener(watcherId);
+</pre>
+</div>
+</dd>
+</dl>
+</div>
+</div>
+<div class="interface" id="MediaControllerServerInfoPlaybackInfo">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo"></a><h3>2.8. MediaControllerServerInfoPlaybackInfo</h3>
+<div class="brief">
+ Client-side object representing current playback info.
+          </div>
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerServerInfoPlaybackInfo {
+    readonly attribute <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state;
+    readonly attribute unsigned long long position;
+    readonly attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating;
+    readonly attribute <a href="#MediaControllerContentType">MediaControllerContentType</a> contentType;
+    readonly attribute boolean shuffleMode;
+    readonly attribute <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> repeatState;
+    readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
+    readonly attribute DOMString? index;
+    readonly attribute DOMString? playlistName;
+    void sendPlaybackAction(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                            raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendPlaybackPosition(unsigned long long position, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                              raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendShuffleMode(boolean mode, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removePlaybackInfoChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };</pre>
+<p><span class="version">Since: </span>
+ 6.0
+          </p>
+<div class="attributes">
+<h4>Attributes</h4>
+<ul>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::state">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerPlaybackState </span><span class="name">state</span></span><div class="brief">
+ Current playback state.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::position">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">unsigned long long </span><span class="name">position</span></span><div class="brief">
+ Current playback position.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::ageRating">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerContentAgeRating </span><span class="name">ageRating</span></span><div class="brief">
+ Current playback age rating.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::contentType">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerContentType </span><span class="name">contentType</span></span><div class="brief">
+ Current playback content type.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::shuffleMode">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">boolean </span><span class="name">shuffleMode</span></span><div class="brief">
+ Current shuffle mode.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::repeatState">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerRepeatState </span><span class="name">repeatState</span></span><div class="brief">
+ Current repeat state.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::metadata">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerMetadata </span><span class="name">metadata</span></span><div class="brief">
+ Current playback metadata.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::index">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">DOMString </span><span class="name">index</span><span class="optional"> [nullable]</span></span><div class="brief">
+ Current item index. Value set to <var>null</var> means no playlist set in playback
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::playlistName">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">DOMString </span><span class="name">playlistName</span><span class="optional"> [nullable]</span></span><div class="brief">
+ Current playlist name. Value set to <var>null</var> means no playlist set in playback
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+</ul>
+</div>
+<div class="methods">
+<h4>Methods</h4>
+<dl>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::sendPlaybackAction">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::sendPlaybackAction"></a><code><b><span class="methodName">sendPlaybackAction</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Sends request to change the playback state of a media controller server.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackAction(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">action</span>:
+ Playback action.
+                </li>
+          <li class="param">
+<span class="name">replyCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method to invoke when server responded to change request.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+mcServerInfo.playback.sendPlaybackAction("STOP", function(data, code)
+{
+  console.log("Server replied with return data: " + JSON.stringify(data) + " and code: " + code);
+});
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::sendPlaybackPosition">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::sendPlaybackPosition"></a><code><b><span class="methodName">sendPlaybackPosition</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Sends request to change the playback position of a media controller server.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackPosition(unsigned long long position, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">position</span>:
+ Playback position.
+                </li>
+          <li class="param">
+<span class="name">replyCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method to invoke when server responded to change request.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type InvalidValuesError, if any of the input parameters contain an invalid value.
+                </p></li>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+mcServerInfo.playback.sendPlaybackPosition(164, function(data, code)
+{
+  console.log("Server replied with return data: " + JSON.stringify(data) + " and code: " + code);
+});
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::sendShuffleMode">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::sendShuffleMode"></a><code><b><span class="methodName">sendShuffleMode</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Sends request to change the shuffle mode of a media controller server.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void sendShuffleMode(boolean mode, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">mode</span>:
+ Shuffle mode.
+                </li>
+          <li class="param">
+<span class="name">replyCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method to invoke when server responded to change request.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+mcServerInfo.playback.sendShuffleMode(true, function(data, code)
+{
+  console.log("Server replied with return data: " + JSON.stringify(data) + " and code: " + code);
+});
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::sendRepeatState">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::sendRepeatState"></a><code><b><span class="methodName">sendRepeatState</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Sends request to change the repeat state of a media controller server.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 5.5
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">state</span>:
+ Repeat state to be set.
+                </li>
+          <li class="param">
+<span class="name">replyCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method to invoke when server responded to change request.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+mcServerInfo.playback.sendRepeatState("REPEAT_ALL", function(data, code)
+{
+  console.log("Server replied with return data: " + JSON.stringify(data) + " and code: " + code);
+});
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::addPlaybackInfoChangeListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::addPlaybackInfoChangeListener"></a><code><b><span class="methodName">addPlaybackInfoChangeListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Adds the listener for a media playback info changes.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">listener</span>:
+ Status change listener to add.
+                </li>
+        </ul>
+</div>
+<div class="returntype">
+<p><span class="return">Return value:</span></p>
+<ul>
+<span class="return">long:</span>
+ The identifier used to clear the watch subscription.
+              </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var watcherId = 0;  /* Watcher identifier. */
+var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+/* receives playback state changes. */
+var playbackListener =
+{
+  onplaybackchanged: function(state, position)
+  {
+    console.log("Current playback state: " + state);
+    console.log("Current playback position: " + position);
+  },
+  onshufflemodechanged: function(mode)
+  {
+    console.log("Shuffle mode changed to: " + mode);
+  },
+  onrepeatstatechanged: function(state)
+  {
+    console.log("Repeat state changed to: " + state);
+  },
+  onmetadatachanged: function(metadata)
+  {
+    console.log("Playback metadata changed: " + JSON.stringify(metadata));
+  }
+};
+
+/* Registers to be notified when playback state changes. */
+watcherId = mcServerInfo.playback.addPlaybackInfoChangeListener(playbackListener);
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::removePlaybackInfoChangeListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::removePlaybackInfoChangeListener"></a><code><b><span class="methodName">removePlaybackInfoChangeListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Removes the listener, so stop receiving notifications about media playback info changes.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void removePlaybackInfoChangeListener(long watchId);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">watchId</span>:
+ Subscription identifier.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var watcherId = 0;  /* Watcher identifier. */
+var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+/* receives playback state changes. */
+var playbackListener =
+{
+  onplaybackchanged: function(state, position) {},
+  onshufflemodechanged: function(mode) {},
+  onrepeatstatechanged: function(state) {},
+  onmetadatachanged: function(metadata) {}
+};
+
+/* Registers to be notified when playback state changes. */
+watcherId = mcServerInfo.playback.addPlaybackInfoChangeListener(playbackListener);
+
+/* Cancels the watch operation. */
+mcServerInfo.playback.removePlaybackInfoChangeListener(watcherId);
+</pre>
+</div>
+</dd>
+</dl>
+</div>
+</div>
+<div class="interface" id="MediaControllerPlaylists">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists"></a><h3>2.9. MediaControllerPlaylists</h3>
+<div class="brief">
+ Server-side object representing methods for playlists of a media controller server.
+          </div>
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerPlaylists {
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                        raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };</pre>
+<p><span class="version">Since: </span>
+ 6.0
+          </p>
+<div class="methods">
+<h4>Methods</h4>
+<dl>
+<dt class="method" id="MediaControllerPlaylists::createPlaylist">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists::createPlaylist"></a><code><b><span class="methodName">createPlaylist</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Creates <em>MediaControllerPlaylist</em> object.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<p><span class="remark">Remark: </span>
+ Please note that there is a need to use <a href="#MediaControllerPlaylists::savePlaylist">savePlaylist()</a>, otherwise playlist creation will have no effect on a device. All playlists will be deleted after application is closed.
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">name</span>:
+ Name of the new playlist.
+                </li>
+        </ul>
+</div>
+<div class="returntype">
+<p><span class="return">Return value:</span></p>
+<ul>
+<span class="return">MediaControllerPlaylist:</span>
+ New empty <em>MediaControllerPlaylist</em> object with given name.
+              </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type InvalidValuesError, if playlist with given name already exists.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var playlist = mcServer.playlists.createPlaylist("testPlaylistName");
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylists::savePlaylist">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists::savePlaylist"></a><code><b><span class="methodName">savePlaylist</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Saves the playlist in a local database.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+                  optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+The <em>errorCallback</em> may be triggered for one of the following errors:
+            </p>
+            <ul>
+              <li>
+<em>InvalidValuesError</em>: if playlist with given name does not exist.              </li>
+              <li>
+<em>UnknownError</em>: if any other error prevents the function from successful completion.              </li>
+            </ul>
+           </div>
+<p><span class="remark">Remark: </span>
+ All playlists will be deleted after the application is closed.
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlist</span>:
+ <em>MediaControllerPlaylist</em> object to save.
+                </li>
+          <li class="param">
+<span class="name">successCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called when <em>savePlaylist</em> is finished without error.
+                </li>
+          <li class="param">
+<span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called when <em>savePlaylist</em> fails.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var playlist = mcServer.playlists.createPlaylist("testPlaylistName");
+function successCallback()
+{
+  console.log("savePlaylist successful.");
+}
+function errorCallback(error)
+{
+  console.log("savePlaylist failed with error: " + error);
+}
+mcServer.playlists.savePlaylist(playlist, successCallback, errorCallback);
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>savePlaylist successful.
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylists::deletePlaylist">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists::deletePlaylist"></a><code><b><span class="methodName">deletePlaylist</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Deletes the playlist from a local database.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+The <em>errorCallback</em> may be triggered for one of the following errors:
+            </p>
+            <ul>
+              <li>
+<em>InvalidValuesError</em>: if playlist with given name does not exist.              </li>
+              <li>
+<em>UnknownError</em>: if any other error prevents the function from successful completion.              </li>
+            </ul>
+           </div>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlistName</span>:
+ Name of the playlist to remove.
+                </li>
+          <li class="param">
+<span class="name">successCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called when <em>deletePlaylist</em> is finished without error.
+                </li>
+          <li class="param">
+<span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called when <em>deletePlaylist</em> fails.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var playlist = mcServer.playlists.createPlaylist("testPlaylistName");
+function deleteSuccess()
+{
+  console.log("deletePlaylist successful.");
+}
+function deleteFailure(error)
+{
+  console.log("deletePlaylist failed with error: " + error);
+}
+function saveSuccess()
+{
+  mcServer.playlists.deletePlaylist(playlist.name, deleteSuccess, deleteFailure);
+}
+mcServer.playlists.savePlaylist(playlist, saveSuccess);
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>deletePlaylist successful.
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylists::getAllPlaylists">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists::getAllPlaylists"></a><code><b><span class="methodName">getAllPlaylists</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Retrieves all playlists from a local database.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+The <em>errorCallback</em> may be triggered for one of the following errors:
+            </p>
+            <ul>
+              <li>
+<em>UnknownError</em>: if any error prevents function from successful completion.              </li>
+            </ul>
+           </div>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">successCallback</span>:
+ Function to be called on <em>getAllPlaylists</em> success.
+                </li>
+          <li class="param">
+<span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called when <em>getAllPlaylists</em> fails.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any parameter has invalid type.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var playlist = mcServer.playlists.createPlaylist("testPlaylist");
+
+function saveSuccess()
+{
+  console.log("savePlaylist successful");
+  function successCallback(playlists)
+  {
+    playlists.forEach(function(playlist)
+    {
+      console.log("Playlist name: " + playlist.name);
+    });
+  }
+  function errorCallback(error)
+  {
+    console.log("getAllPlaylists failed with error: " + error);
+  }
+  mcServer.playlists.getAllPlaylists(successCallback, errorCallback);
+}
+function saveError(error)
+{
+  console.log("savePlaylist failed with error: " + error);
+}
+
+mcServer.playlists.savePlaylist(playlist, saveSuccess, saveError);
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>savePlaylist successful
+Playlist name: testPlaylistName
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylists::getPlaylist">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists::getPlaylist"></a><code><b><span class="methodName">getPlaylist</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Returns the playlist with the given name.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlistName</span>:
+ The name of playlist to get.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type NotFoundError, if the playlist with the given name does not exist.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">/* assuming that the playlist was previously created */
+var mcServer = tizen.mediacontroller.createServer();
+var playlist = null;
+try
+{
+  playlist = mcServer.playlists.getPlaylist("testPlaylist");
+}
+catch (err)
+{
+  console.log(err.name + ": " + err.message);
+}
+</pre>
+</div>
+</dd>
+</dl>
+</div>
+</div>
+<div class="interface" id="MediaControllerPlaylistsInfo">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo"></a><h3>2.10. MediaControllerPlaylistsInfo</h3>
+<div class="brief">
+ Client-side object representing methods for playlists of a media controller server.
+          </div>
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerPlaylistsInfo {
+    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, unsigned long long position,
+                          optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removePlaylistUpdatedListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };</pre>
+<p><span class="version">Since: </span>
+ 6.0
+          </p>
+<div class="methods">
+<h4>Methods</h4>
+<dl>
+<dt class="method" id="MediaControllerPlaylistsInfo::getAllPlaylists">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo::getAllPlaylists"></a><code><b><span class="methodName">getAllPlaylists</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Retrieves all playlists saved in local database.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+The <em>errorCallback</em> may be triggered for one of the following errors:
+            </p>
+            <ul>
+              <li>
+<em>UnknownError</em>: if any error prevents function from successful completion.              </li>
+            </ul>
+           </div>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">successCallback</span>:
+ Function to be called upon success.
+                </li>
+          <li class="param">
+<span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called upon failure.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any parameter has invalid type.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+var playlist = mcServer.playlists.createPlaylist("testPlaylist");
+
+function saveSuccess()
+{
+  console.log("savePlaylist successful");
+  function successCallback(playlists)
+  {
+    playlists.forEach(function(playlist)
+    {
+      console.log("Playlist name: " + playlist.name);
+    });
+  }
+  function errorCallback(error)
+  {
+    console.log("getAllPlaylists failed with error: " + error);
+  }
+  mcServerInfo.playlists.getAllPlaylists(successCallback, errorCallback);
+}
+
+function saveError(error)
+{
+  console.log("savePlaylist failed with error: " + error);
+}
+
+mcServer.playlists.savePlaylist(playlist, saveSuccess, saveError);
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>savePlaylist successful
+Playlist name: testPlaylist
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylistsInfo::sendPlaybackItem">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo::sendPlaybackItem"></a><code><b><span class="methodName">sendPlaybackItem</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Asks the server to set a new playback item.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, unsigned long long position,
+                      optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<p><span class="remark">Remark: </span>
+ <em>PlaybackInfoChangeListener</em> should be invoked, if registered.
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlistName</span>:
+ Name of playlist to be set.
+                </li>
+          <li class="param">
+<span class="name">index</span>:
+ Index of item on playlist to be set.
+                </li>
+          <li class="param">
+<span class="name">action</span>:
+ Playback action.
+                </li>
+          <li class="param">
+<span class="name">position</span>:
+ Playback position.
+                </li>
+          <li class="param">
+<span class="name">replyCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method to invoke when server responded to change request.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var serverInfo = mcClient.getLatestServerInfo();
+serverInfo.playlists.sendPlaybackItem("testPlaylist", "1", "PLAY", 0);
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylistsInfo::addPlaylistUpdatedListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo::addPlaylistUpdatedListener"></a><code><b><span class="methodName">addPlaylistUpdatedListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Adds listener to be invoked when playlist is updated by server.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">listener</span>:
+ Listener for adding, updating or deleting of any playlist.
+                </li>
+        </ul>
+</div>
+<div class="returntype">
+<p><span class="return">Return value:</span></p>
+<ul>
+<span class="return">long:</span>
+ The identifier used to clear the watch subscription.
+              </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+var listener =
+{
+  onplaylistupdated: function(serverName, playlist)
+  {
+    console.log("updated playlist " + playlist);
+  },
+  onplaylistdeleted: function(serverName, playlistName)
+  {
+    console.log("deleted playlist " + playlistName);
+  }
+};
+var listenerId = mcServerInfo.playlists.addPlaylistUpdatedListener(listener);
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylistsInfo::removePlaylistUpdatedListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo::removePlaylistUpdatedListener"></a><code><b><span class="methodName">removePlaylistUpdatedListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Stops listening for playlist updates.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void removePlaylistUpdatedListener(long listenerId);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<p><span class="remark">Remark: </span>
+ This function has no effect, if there is no listener for given id.
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">listenerId</span>:
+ Listener ID returned by <em>addPlaylistUpdatedListener</em>.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+var listener =
+{
+  onplaylistupdated: function(serverName, playlist) {},
+  onplaylistdeleted: function(serverName, playlistName) {}
+};
+var listenerId = mcServerInfo.playlists.addPlaylistUpdatedListener(listener);
+mcServerInfo.playlists.removePlaylistUpdatedListener(listenerId);
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylistsInfo::getPlaylist">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo::getPlaylist"></a><code><b><span class="methodName">getPlaylist</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Returns the playlist with the given name.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlistName</span>:
+ The name of the playlist to get.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type NotFoundError, if the playlist with the given name does not exist.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">/* assuming that the playlist was previously created */
+var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+var playlist = null;
+try
+{
+  playlist = mcServerInfo.playlists.getPlaylist("testPlaylist");
+}
+catch (err)
+{
+  console.log(err.name + ": " + err.message);
+}
+</pre>
+</div>
+</dd>
+</dl>
+</div>
+</div>
 <div class="interface" id="MediaControllerAbilities">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilities"></a><h3>2.7. MediaControllerAbilities</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilities"></a><h3>2.11. MediaControllerAbilities</h3>
 <div class="brief">
  Server-side object representing abilities of the media controller server.
           </div>
@@ -4059,7 +5696,7 @@ Default value is NO.
 </div>
 </div>
 <div class="interface" id="MediaControllerPlaybackAbilities">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackAbilities"></a><h3>2.8. MediaControllerPlaybackAbilities</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackAbilities"></a><h3>2.12. MediaControllerPlaybackAbilities</h3>
 <div class="brief">
  Server-side object representing playback abilities of the media controller server.
           </div>
@@ -4384,7 +6021,7 @@ ability FORWARD: NO
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayModeAbilities">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeAbilities"></a><h3>2.9. MediaControllerDisplayModeAbilities</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeAbilities"></a><h3>2.13. MediaControllerDisplayModeAbilities</h3>
 <div class="brief">
  Server-side object representing display mode abilities of the media controller server.
           </div>
@@ -4516,7 +6153,7 @@ Default value is NO.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotationAbilities">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationAbilities"></a><h3>2.10. MediaControllerDisplayRotationAbilities</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationAbilities"></a><h3>2.14. MediaControllerDisplayRotationAbilities</h3>
 <div class="brief">
  The server-side object representing display rotation abilities
 of the media controller server.
@@ -4649,7 +6286,7 @@ Default value is NO.
 </div>
 </div>
 <div class="interface" id="MediaControllerAbilitiesInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilitiesInfo"></a><h3>2.11. MediaControllerAbilitiesInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilitiesInfo"></a><h3>2.15. MediaControllerAbilitiesInfo</h3>
 <div class="brief">
  Client-side object representing abilities of the media controller server.
           </div>
@@ -4940,7 +6577,7 @@ REPEAT ability changed, server name: GC8qUW5iQf.SecondMCServer, ability: "NO"
 </div>
 </div>
 <div class="interface" id="MediaControllerPlaybackAbilitiesInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackAbilitiesInfo"></a><h3>2.12. MediaControllerPlaybackAbilitiesInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackAbilitiesInfo"></a><h3>2.16. MediaControllerPlaybackAbilitiesInfo</h3>
 <div class="brief">
  Client-side object representing playback abilities of the media controller server.
           </div>
@@ -5092,7 +6729,7 @@ REPEAT ability changed, server name: GC8qUW5iQf.SecondMCServer, ability: "NO"
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayModeAbilitiesInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeAbilitiesInfo"></a><h3>2.13. MediaControllerDisplayModeAbilitiesInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeAbilitiesInfo"></a><h3>2.17. MediaControllerDisplayModeAbilitiesInfo</h3>
 <div class="brief">
  Client-side object representing display mode abilities of the media controller server.
           </div>
@@ -5196,7 +6833,7 @@ Default value is NO.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotationAbilitiesInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationAbilitiesInfo"></a><h3>2.14. MediaControllerDisplayRotationAbilitiesInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationAbilitiesInfo"></a><h3>2.18. MediaControllerDisplayRotationAbilitiesInfo</h3>
 <div class="brief">
  The client-side object representing display rotation abilities
 of the media controller server.
@@ -5281,7 +6918,7 @@ of the media controller server.
 </div>
 </div>
 <div class="interface" id="MediaControllerSubtitles">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSubtitles"></a><h3>2.15. MediaControllerSubtitles</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSubtitles"></a><h3>2.19. MediaControllerSubtitles</h3>
 <div class="brief">
  Server-side object representing subtitles mode of a media controller server.
           </div>
@@ -5433,7 +7070,7 @@ mcServer.subtitles.removeChangeRequestListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerSubtitlesInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSubtitlesInfo"></a><h3>2.16. MediaControllerSubtitlesInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSubtitlesInfo"></a><h3>2.20. MediaControllerSubtitlesInfo</h3>
 <div class="brief">
  Client-side object representing subtitles mode of a media controller server.
           </div>
@@ -5627,7 +7264,7 @@ mcServerInfo.subtitles.removeModeChangeListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerMode360">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMode360"></a><h3>2.17. MediaControllerMode360</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMode360"></a><h3>2.21. MediaControllerMode360</h3>
 <div class="brief">
  Server-side object representing spherical (360°) mode of a media controller server.
           </div>
@@ -5779,7 +7416,7 @@ mcServer.mode360.removeChangeRequestListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerMode360Info">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMode360Info"></a><h3>2.18. MediaControllerMode360Info</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMode360Info"></a><h3>2.22. MediaControllerMode360Info</h3>
 <div class="brief">
  Client-side object representing spherical (360°) mode of a media controller server.
           </div>
@@ -5973,7 +7610,7 @@ mcServerInfo.mode360.removeModeChangeListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayMode">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayMode"></a><h3>2.19. MediaControllerDisplayMode</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayMode"></a><h3>2.23. MediaControllerDisplayMode</h3>
 <div class="brief">
  Server-side object representing display mode of a media controller server.
           </div>
@@ -6129,7 +7766,7 @@ mcServer.displayMode.removeChangeRequestListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayModeInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeInfo"></a><h3>2.20. MediaControllerDisplayModeInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeInfo"></a><h3>2.24. MediaControllerDisplayModeInfo</h3>
 <div class="brief">
  Client-side object representing display mode of a media controller server.
           </div>
@@ -6324,7 +7961,7 @@ mcServerInfo.displayMode.removeModeChangeListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotation">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotation"></a><h3>2.21. MediaControllerDisplayRotation</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotation"></a><h3>2.25. MediaControllerDisplayRotation</h3>
 <div class="brief">
  Server-side object representing display rotation of a media controller server.
           </div>
@@ -6481,7 +8118,7 @@ mcServer.displayRotation.removeChangeRequestListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerClientInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerClientInfo"></a><h3>2.22. MediaControllerClientInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerClientInfo"></a><h3>2.26. MediaControllerClientInfo</h3>
 <div class="brief">
  This interface provides communication methods from the server to the client.
           </div>
@@ -6593,7 +8230,7 @@ Media controller server received a reply to the event:
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotationInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationInfo"></a><h3>2.23. MediaControllerDisplayRotationInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationInfo"></a><h3>2.27. MediaControllerDisplayRotationInfo</h3>
 <div class="brief">
  Client-side object representing display rotation of a media controller server.
           </div>
@@ -6788,7 +8425,7 @@ mcServerInfo.displayRotation.removeDisplayRotationChangeListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerMetadata">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMetadata"></a><h3>2.24. MediaControllerMetadata</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMetadata"></a><h3>2.28. MediaControllerMetadata</h3>
 <div class="brief">
  Playback metadata.
           </div>
@@ -6810,6 +8447,7 @@ mcServerInfo.displayRotation.removeDisplayRotationChangeListener(watcherId);
     attribute DOMString? episodeTitle;
     attribute long resolutionWidth;
     attribute long resolutionHeight;
+    void save() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
 <p><span class="version">Since: </span>
  5.0
@@ -6955,9 +8593,54 @@ mcServerInfo.displayRotation.removeDisplayRotationChangeListener(watcherId);
 </li>
 </ul>
 </div>
+<div class="methods">
+<h4>Methods</h4>
+<dl>
+<dt class="method" id="MediaControllerMetadata::save">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMetadata::save"></a><code><b><span class="methodName">save</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Saves current state of metadata to the database and sends notification to the listening clients.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void save();</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+mcServer.playback.metadata.artist = "Artist Name";
+
+console.log("Before save metadata is: " + JSON.stringify(mcServerInfo.playback.metadata));
+
+mcServer.playback.metadata.save();
+console.log("After save metadata is: " + JSON.stringify(mcServerInfo.playback.metadata));
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>Before save metadata is: {"title":"","artist":"","album":"","author":"","genre":"","duration":"","date":"",
+"copyright":"","description":"","trackNum":"","picture":"","seasonNumber":0,"seasonTitle":null,
+"episodeNumber":0,"episodeTitle":null,"resolutionWidth":0,"resolutionHeight":0}
+After save metadata is: {"title":"","artist":"ArtistName","album":"","author":"","genre":"","duration":"","date":"",
+"copyright":"","description":"","trackNum":"","picture":"","seasonNumber":0,"seasonTitle":null,
+"episodeNumber":0,"episodeTitle":null,"resolutionWidth":0,"resolutionHeight":0}
+</pre>
+</div>
+</dd>
+</dl>
+</div>
 </div>
 <div class="interface" id="MediaControllerPlaylistItem">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistItem"></a><h3>2.25. MediaControllerPlaylistItem</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistItem"></a><h3>2.29. MediaControllerPlaylistItem</h3>
 <div class="brief">
  Object represents single playlist item.
           </div>
@@ -6993,7 +8676,7 @@ mcServerInfo.displayRotation.removeDisplayRotationChangeListener(watcherId);
 </div>
 </div>
 <div class="dictionary" id="MediaControllerMetadataInit">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMetadataInit"></a><h3>2.26. MediaControllerMetadataInit</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMetadataInit"></a><h3>2.30. MediaControllerMetadataInit</h3>
 <div class="brief">
  The MediaControllerMetadataInit dictionary defines the properties of a MediaControllerMetadata to add in addItem method.
           </div>
@@ -7026,7 +8709,7 @@ See <a href="#MediaControllerMetadata">MediaControllerMetadata</a> interface for
          </div>
 </div>
 <div class="interface" id="MediaControllerPlaylist">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylist"></a><h3>2.27. MediaControllerPlaylist</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylist"></a><h3>2.31. MediaControllerPlaylist</h3>
 <div class="brief">
  Object represents single playlist (collection of items).
           </div>
@@ -7207,7 +8890,7 @@ playlist.getItems(successCallback, errorCallback);
 </div>
 </div>
 <div class="interface" id="SearchFilter">
-<a class="backward-compatibility-anchor" name="::MediaController::SearchFilter"></a><h3>2.28. SearchFilter</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::SearchFilter"></a><h3>2.32. SearchFilter</h3>
 <div class="brief">
  Search filter representation.
           </div>
@@ -7304,7 +8987,7 @@ playlist.getItems(successCallback, errorCallback);
 </div>
 </div>
 <div class="interface" id="MediaControllerServerInfoArraySuccessCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoArraySuccessCallback"></a><h3>2.29. MediaControllerServerInfoArraySuccessCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoArraySuccessCallback"></a><h3>2.33. MediaControllerServerInfoArraySuccessCallback</h3>
 <div class="brief">
  The MediaControllerServerInfoArraySuccessCallback interface that defines the success method
 for <em>MediaControllerClient.findServers()</em>.
@@ -7343,7 +9026,7 @@ for <em>MediaControllerClient.findServers()</em>.
 </div>
 </div>
 <div class="interface" id="MediaControllerSendCommandSuccessCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSendCommandSuccessCallback"></a><h3>2.30. MediaControllerSendCommandSuccessCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSendCommandSuccessCallback"></a><h3>2.34. MediaControllerSendCommandSuccessCallback</h3>
 <div class="brief">
  The MediaControllerSendCommandSuccessCallback interface that defines the success method which is triggered, when the server responds to a command.
           </div>
@@ -7404,7 +9087,7 @@ Interface is used as a success method for:
 </div>
 </div>
 <div class="interface" id="RequestReply">
-<a class="backward-compatibility-anchor" name="::MediaController::RequestReply"></a><h3>2.31. RequestReply</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::RequestReply"></a><h3>2.35. RequestReply</h3>
 <div class="brief">
  Representation of server's response to a request.
           </div>
@@ -7448,7 +9131,7 @@ Interface is used as a success method for:
 </div>
 </div>
 <div class="interface" id="MediaControllerSearchRequestReplyCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSearchRequestReplyCallback"></a><h3>2.32. MediaControllerSearchRequestReplyCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSearchRequestReplyCallback"></a><h3>2.36. MediaControllerSearchRequestReplyCallback</h3>
 <div class="brief">
  The MediaControllerSearchRequestReplyCallback interface defines reply callback for
 <em>MediaControllerServerInfo.sendSearchRequest()</em>.
@@ -7492,7 +9175,7 @@ Interpretation of status and data parameters depends on the server implementatio
 </div>
 </div>
 <div class="interface" id="MediaControllerSearchRequestCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSearchRequestCallback"></a><h3>2.33. MediaControllerSearchRequestCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSearchRequestCallback"></a><h3>2.37. MediaControllerSearchRequestCallback</h3>
 <div class="brief">
  Server search request listener interface.
           </div>
@@ -7542,7 +9225,7 @@ It will be passed to the replyCallback of <a href="#MediaControllerServerInfo::s
 </div>
 </div>
 <div class="interface" id="MediaControllerReceiveCommandCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerReceiveCommandCallback"></a><h3>2.34. MediaControllerReceiveCommandCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerReceiveCommandCallback"></a><h3>2.38. MediaControllerReceiveCommandCallback</h3>
 <div class="brief">
  The MediaControllerReceiveCommandCallback interface that defines the listener
 for custom communication between server and client.
@@ -7611,7 +9294,7 @@ Related functions:
 </div>
 </div>
 <div class="interface" id="MediaControllerEnabledChangeRequestCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerEnabledChangeRequestCallback"></a><h3>2.35. MediaControllerEnabledChangeRequestCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerEnabledChangeRequestCallback"></a><h3>2.39. MediaControllerEnabledChangeRequestCallback</h3>
 <div class="brief">
  The MediaControllerEnabledChangeRequestCallback interface that defines the listener
 for change requests for spherical mode in <em>MediaControllerMode360.addChangeRequestListener()</em> and
@@ -7668,7 +9351,7 @@ to check how to handle and respond to commands.
 </div>
 </div>
 <div class="interface" id="MediaControllerEnabledChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerEnabledChangeCallback"></a><h3>2.36. MediaControllerEnabledChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerEnabledChangeCallback"></a><h3>2.40. MediaControllerEnabledChangeCallback</h3>
 <div class="brief">
  The MediaControllerEnabledChangeCallback interface that defines the listener
 for a media controller server's attribute changes.
@@ -7707,7 +9390,7 @@ for a media controller server's attribute changes.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayModeChangeRequestCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeChangeRequestCallback"></a><h3>2.37. MediaControllerDisplayModeChangeRequestCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeChangeRequestCallback"></a><h3>2.41. MediaControllerDisplayModeChangeRequestCallback</h3>
 <div class="brief">
  The MediaControllerDisplayModeChangeRequestCallback interface that defines the listener
 for change requests for display mode in <em>MediaControllerDisplayMode.addChangeRequestListener()</em>.
@@ -7762,7 +9445,7 @@ to check how to handle and respond to commands.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayModeChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeChangeCallback"></a><h3>2.38. MediaControllerDisplayModeChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeChangeCallback"></a><h3>2.42. MediaControllerDisplayModeChangeCallback</h3>
 <div class="brief">
  The MediaControllerDisplayModeChangeCallback interface that defines the listener
 for display mode changes of the media controller server.
@@ -7801,7 +9484,7 @@ for display mode changes of the media controller server.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotationChangeRequestCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationChangeRequestCallback"></a><h3>2.39. MediaControllerDisplayRotationChangeRequestCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationChangeRequestCallback"></a><h3>2.43. MediaControllerDisplayRotationChangeRequestCallback</h3>
 <div class="brief">
  The MediaControllerDisplayRotationChangeRequestCallback interface that defines the listener
 for change requests for display rotation in <em>MediaControllerDisplayRotation.addChangeRequestListener().
@@ -7856,7 +9539,7 @@ to check how to handle and respond to commands.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotationChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationChangeCallback"></a><h3>2.40. MediaControllerDisplayRotationChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationChangeCallback"></a><h3>2.44. MediaControllerDisplayRotationChangeCallback</h3>
 <div class="brief">
  The MediaControllerDisplayModeChangeCallback interface that defines the listener
 for changes of a media controller server's display rotation.
@@ -7895,7 +9578,7 @@ for changes of a media controller server's display rotation.
 </div>
 </div>
 <div class="interface" id="MediaControllerServerStatusChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerStatusChangeCallback"></a><h3>2.41. MediaControllerServerStatusChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerStatusChangeCallback"></a><h3>2.45. MediaControllerServerStatusChangeCallback</h3>
 <div class="brief">
  The MediaControllerServerStatusChangeCallback interface that defines the listener
 for media controller server status changes.
@@ -7934,7 +9617,7 @@ for media controller server status changes.
 </div>
 </div>
 <div class="interface" id="MediaControllerPlaybackInfoChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackInfoChangeCallback"></a><h3>2.42. MediaControllerPlaybackInfoChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackInfoChangeCallback"></a><h3>2.46. MediaControllerPlaybackInfoChangeCallback</h3>
 <div class="brief">
  The MediaControllerPlaybackInfoChangeCallback interface that defines the listeners
 object for receiving media controller playback info changes from server.
@@ -8078,19 +9761,20 @@ will be invoked after the <a href="#MediaControllerPlaybackInfoChangeCallback::o
 </div>
 </div>
 <div class="interface" id="MediaControllerChangeRequestPlaybackInfoCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerChangeRequestPlaybackInfoCallback"></a><h3>2.43. MediaControllerChangeRequestPlaybackInfoCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerChangeRequestPlaybackInfoCallback"></a><h3>2.47. MediaControllerChangeRequestPlaybackInfoCallback</h3>
 <div class="brief">
  The MediaControllerChangeRequestPlaybackInfoCallback interface that defines the listeners
 object for receiving playback info change requests from client.
           </div>
 <pre class="webidl prettyprint">  [Callback, NoInterfaceObject] interface MediaControllerChangeRequestPlaybackInfoCallback {
-    void onplaybackstaterequest(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+<span class="nocode deprecated">    void onplaybackstaterequest(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+</span>    <a href="#RequestReply">RequestReply</a>? onplaybackactionrequest(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
 <span class="nocode deprecated">    void onrepeatmoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-</span>    void onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state,
-                               unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+</span>    <a href="#RequestReply">RequestReply</a>? onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action,
+                                        unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
   };</pre>
 <p><span class="version">Since: </span>
  5.0
@@ -8098,13 +9782,16 @@ object for receiving playback info change requests from client.
 <div class="methods">
 <h4>Methods</h4>
 <dl>
-<dt class="method" id="MediaControllerChangeRequestPlaybackInfoCallback::onplaybackstaterequest">
+<dt class="deprecated method" id="MediaControllerChangeRequestPlaybackInfoCallback::onplaybackstaterequest">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerChangeRequestPlaybackInfoCallback::onplaybackstaterequest"></a><code><b><span class="methodName">onplaybackstaterequest</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Called when client requested playback state changes.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackactionrequest">onplaybackactionrequest()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void onplaybackstaterequest(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  5.0
@@ -8126,6 +9813,31 @@ object for receiving playback info change requests from client.
         </ul>
 </div>
 </dd>
+<dt class="method" id="MediaControllerChangeRequestPlaybackInfoCallback::onplaybackactionrequest">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerChangeRequestPlaybackInfoCallback::onplaybackactionrequest"></a><code><b><span class="methodName">onplaybackactionrequest</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Called when a client requested the playback state changes by sending the playback action.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#RequestReply">RequestReply</a>? onplaybackactionrequest(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">action</span>:
+ Playback action sent by the client.
+                </li>
+          <li class="param">
+<span class="name">clientName</span>:
+ Id of client application, which sent a command.
+                </li>
+        </ul>
+</div>
+</dd>
 <dt class="method" id="MediaControllerChangeRequestPlaybackInfoCallback::onplaybackpositionrequest">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerChangeRequestPlaybackInfoCallback::onplaybackpositionrequest"></a><code><b><span class="methodName">onplaybackpositionrequest</span></b></code>
 </dt>
@@ -8133,7 +9845,7 @@ object for receiving playback info change requests from client.
 <div class="brief">
  Called when client requested playback position changes.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#RequestReply">RequestReply</a>? onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  5.0
             </p>
@@ -8161,7 +9873,7 @@ object for receiving playback info change requests from client.
 <div class="brief">
  Called when client requested shuffle mode changes.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#RequestReply">RequestReply</a>? onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  5.0
             </p>
@@ -8224,7 +9936,7 @@ will not be invoked, if the <a href="#MediaControllerPlaybackInfo::repeatState">
 <div class="brief">
  Called when client requested change of repeat state.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#RequestReply">RequestReply</a>? onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  5.5
             </p>
@@ -8255,8 +9967,8 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 <div class="brief">
  Called when client request change of playback item.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state,
-                           unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#RequestReply">RequestReply</a>? onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action,
+                                    unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  5.5
             </p>
@@ -8265,19 +9977,19 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 <ul>
           <li class="param">
 <span class="name">playlistName</span>:
- Name of a requested playlist.
+ Name of playlist.
                 </li>
           <li class="param">
 <span class="name">index</span>:
- Requested index.
+ Index of the item to be changed.
                 </li>
           <li class="param">
-<span class="name">state</span>:
- Requested playback state.
+<span class="name">action</span>:
+ Playback action.
                 </li>
           <li class="param">
 <span class="name">position</span>:
- Requested playback position.
+ Playback position.
                 </li>
           <li class="param">
 <span class="name">clientName</span>:
@@ -8290,7 +10002,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 </div>
 </div>
 <div class="interface" id="MediaControllerGetAllPlaylistsSuccessCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerGetAllPlaylistsSuccessCallback"></a><h3>2.44. MediaControllerGetAllPlaylistsSuccessCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerGetAllPlaylistsSuccessCallback"></a><h3>2.48. MediaControllerGetAllPlaylistsSuccessCallback</h3>
 <div class="brief">
  Interface for success callback for <em>getAllPlaylists</em> function.
           </div>
@@ -8328,7 +10040,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 </div>
 </div>
 <div class="interface" id="MediaControllerPlaylistUpdatedCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistUpdatedCallback"></a><h3>2.45. MediaControllerPlaylistUpdatedCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistUpdatedCallback"></a><h3>2.49. MediaControllerPlaylistUpdatedCallback</h3>
 <div class="brief">
  Interface for specific playlist update events (including deletion).
           </div>
@@ -8396,7 +10108,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 </div>
 </div>
 <div class="interface" id="MediaControllerGetItemsSuccessCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerGetItemsSuccessCallback"></a><h3>2.46. MediaControllerGetItemsSuccessCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerGetItemsSuccessCallback"></a><h3>2.50. MediaControllerGetItemsSuccessCallback</h3>
 <div class="brief">
  Interface for success callback for <em>getItems</em> function.
           </div>
@@ -8434,7 +10146,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 </div>
 </div>
 <div class="interface" id="MediaControllerAbilityChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilityChangeCallback"></a><h3>2.47. MediaControllerAbilityChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilityChangeCallback"></a><h3>2.51. MediaControllerAbilityChangeCallback</h3>
 <div class="brief">
  Interface for handling ability events.
           </div>
@@ -8565,6 +10277,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
   enum MediaControllerServerState { "ACTIVE", "INACTIVE" };
   enum MediaControllerSearchCategory { "NO_CATEGORY", "TITLE", "ARTIST", "ALBUM", "GENRE", "TPO" };
   enum MediaControllerPlaybackState { "PLAY", "PAUSE", "STOP", "NEXT", "PREV", "FORWARD", "REWIND" };
+  enum MediaControllerPlaybackAction { "PLAY", "PAUSE", "STOP", "NEXT", "PREV", "FORWARD", "REWIND", "TOGGLE_PLAY_PAUSE" };
   enum MediaControllerRepeatState { "REPEAT_OFF", "REPEAT_ONE", "REPEAT_ALL" };
   enum MediaControllerContentType { "IMAGE", "MUSIC", "VIDEO", "OTHER", "UNDECIDED" };
   enum MediaControllerContentAgeRating { "ALL", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13",
@@ -8602,36 +10315,19 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
     <a href="#MediaControllerServer">MediaControllerServer</a> createServer() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface MediaControllerServer {
-    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo;
-    readonly attribute DOMString? iconURI;
+    readonly attribute <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a> playback;
+    readonly attribute <a href="#MediaControllerPlaylists">MediaControllerPlaylists</a> playlists;
+    attribute DOMString? iconURI raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute <a href="#MediaControllerAbilities">MediaControllerAbilities</a> abilities;
     readonly attribute <a href="#MediaControllerSubtitles">MediaControllerSubtitles</a> subtitles;
     readonly attribute <a href="#MediaControllerMode360">MediaControllerMode360</a> mode360;
     readonly attribute <a href="#MediaControllerDisplayMode">MediaControllerDisplayMode</a> displayMode;
     readonly attribute <a href="#MediaControllerDisplayRotation">MediaControllerDisplayRotation</a> displayRotation;
     <a href="#MediaControllerClientInfo">MediaControllerClientInfo</a>[] getAllClientsInfo() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateIconURI(DOMString? iconURI) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackPosition(unsigned long long position) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackAgeRating(<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackContentType(<a href="#MediaControllerContentType">MediaControllerContentType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateShuffleMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateMetadata(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addChangeRequestPlaybackInfoListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removeChangeRequestPlaybackInfoListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void setSearchRequestListener(<a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unsetSearchRequestListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addCommandListener(<a href="#MediaControllerReceiveCommandCallback">MediaControllerReceiveCommandCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeCommandListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
-                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                        raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackItem(DOMString playlistName, DOMString index) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface MediaControllerClient {
     void findServers(<a href="#MediaControllerServerInfoArraySuccessCallback">MediaControllerServerInfoArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
@@ -8647,37 +10343,36 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
   [NoInterfaceObject] interface MediaControllerServerInfo {
     readonly attribute <a href="application.html#ApplicationId">ApplicationId</a> name;
     readonly attribute <a href="#MediaControllerServerState">MediaControllerServerState</a> state;
-    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    readonly attribute <a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a> playback raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    readonly attribute <a href="#MediaControllerPlaylistsInfo">MediaControllerPlaylistsInfo</a> playlists;
     readonly attribute DOMString? iconURI raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute <a href="#MediaControllerAbilitiesInfo">MediaControllerAbilitiesInfo</a> abilities;
     readonly attribute <a href="#MediaControllerSubtitlesInfo">MediaControllerSubtitlesInfo</a> subtitles;
     readonly attribute <a href="#MediaControllerMode360Info">MediaControllerMode360Info</a> mode360;
     readonly attribute <a href="#MediaControllerDisplayModeInfo">MediaControllerDisplayModeInfo</a> displayMode;
     readonly attribute <a href="#MediaControllerDisplayRotationInfo">MediaControllerDisplayRotationInfo</a> displayRotation;
-    void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
-                           optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
-                              optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendShuffleMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
-                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void sendSearchRequest(<a href="#SearchFilter">SearchFilter</a>[] request, <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a> replyCallback,
                            optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void sendCommand(DOMString command, <a href="tizen.html#Bundle">Bundle</a>? data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addServerStatusChangeListener(<a href="#MediaControllerServerStatusChangeCallback">MediaControllerServerStatusChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeServerStatusChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removePlaybackInfoChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position)
-                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removePlaylistUpdatedListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
-  [NoInterfaceObject] interface MediaControllerPlaybackInfo {
+  [NoInterfaceObject] interface MediaControllerServerPlaybackInfo {
+    attribute <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute unsigned long long position raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerContentType">MediaControllerContentType</a> contentType raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute boolean shuffleMode raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> repeatState raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
+    readonly attribute DOMString? index;
+    readonly attribute DOMString? playlistName;
+    void updatePlaybackItem(DOMString playlistName, DOMString index) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addChangeRequestListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removeChangeRequestListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };
+  [NoInterfaceObject] interface MediaControllerServerInfoPlaybackInfo {
     readonly attribute <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state;
     readonly attribute unsigned long long position;
     readonly attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating;
@@ -8687,6 +10382,34 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
     readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
     readonly attribute DOMString? index;
     readonly attribute DOMString? playlistName;
+    void sendPlaybackAction(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                            raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendPlaybackPosition(unsigned long long position, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                              raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendShuffleMode(boolean mode, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removePlaybackInfoChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };
+  [NoInterfaceObject] interface MediaControllerPlaylists {
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                        raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };
+  [NoInterfaceObject] interface MediaControllerPlaylistsInfo {
+    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, unsigned long long position,
+                          optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removePlaylistUpdatedListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface MediaControllerAbilities {
     readonly attribute <a href="#MediaControllerPlaybackAbilities">MediaControllerPlaybackAbilities</a> playback;
@@ -8830,6 +10553,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
     attribute DOMString? episodeTitle;
     attribute long resolutionWidth;
     attribute long resolutionHeight;
+    void save() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface MediaControllerPlaylistItem {
     readonly attribute DOMString index;
@@ -8896,12 +10620,12 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
     void onmetadatachanged(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata);
   };
   [Callback, NoInterfaceObject] interface MediaControllerChangeRequestPlaybackInfoCallback {
-    void onplaybackstaterequest(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state,
-                               unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onplaybackactionrequest(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action,
+                                        unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface MediaControllerGetAllPlaylistsSuccessCallback {
     void onsuccess(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a>[] playlists);

--- a/docs/application/web/api/6.0/device_api/tv/tizen/mediacontroller.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/mediacontroller.html
@@ -4596,7 +4596,7 @@ mcServerInfo.playback.sendShuffleMode(true, function(data, code)
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
 <p><span class="version">Since: </span>
- 5.5
+ 6.0
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/systeminfo.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/systeminfo.html
@@ -636,6 +636,9 @@ functionality of the System Information API.
                                                       raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removePropertyValueChangeListener(unsigned long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
+<p><span class="version">Since: </span>
+ 1.0
+          </p>
 <div class="description">
           <p>
 This API offers methods for retrieving system information
@@ -2428,6 +2431,9 @@ Any threshold parameter used in a watch function to monitor this property applie
     readonly attribute boolean isRemovable;
 <span class="nocode deprecated">    readonly attribute boolean isRemoveable;
 </span>  };</pre>
+<p><span class="version">Since: </span>
+ 1.0
+          </p>
         
       <div class="attributes">
 <h4>Attributes</h4>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/tvinputdevice.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/tvinputdevice.html
@@ -91,6 +91,9 @@ An application can handle device dependent key events after registration.
  Name which identifies the key
           </div>
 <pre class="webidl prettyprint">  typedef DOMString InputDeviceKeyName;</pre>
+<p><span class="version">Since: </span>
+ 2.3
+          </p>
 <div class="description">
           <p>
 Name of the key may be, for example:

--- a/docs/application/web/api/6.0/device_api/tv/tizen/voicecontrol.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/voicecontrol.html
@@ -738,6 +738,9 @@ client.release();
     attribute DOMString command;
     attribute <a href="#VoiceControlCommandType">VoiceControlCommandType</a> type;
   };</pre>
+<p><span class="version">Since: </span>
+ 4.0
+          </p>
 <div class="constructors">
 <h4 id="VoiceControlCommand::constructor">Constructors</h4>
 <dl>
@@ -765,6 +768,9 @@ client.release();
 The command should be set as text you want to be recognized.
             </p>
            </div>
+<p><span class="version">Since: </span>
+ 4.0
+            </p>
 </li>
 <li class="attribute" id="VoiceControlCommand::type">
 <span class="attrName"><span class="type">VoiceControlCommandType </span><span class="name">type</span></span><div class="brief">
@@ -774,6 +780,9 @@ The command should be set as text you want to be recognized.
             <p>
 The default value is <var>"FOREGROUND"</var>            </p>
            </div>
+<p><span class="version">Since: </span>
+ 4.0
+            </p>
 </li>
 </ul>
 </div>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/websetting.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/websetting.html
@@ -107,6 +107,9 @@ For more information on the Web Setting features, see <a href="/application/web/
                             raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeAllCookies(optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
+<p><span class="version">Since: </span>
+ 2.2
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/calendar.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/calendar.html
@@ -2376,8 +2376,6 @@ The default value for this attribute is <var>null</var>.
             <p>
 <em>startDate</em> must be specified in the same time zone as <em>endDate / dueDate</em> if provided.
             </p>
-           </div>
-<div class="description">
             <p>
 This attribute is precise to the second. Milliseconds are ignored.
             </p>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/cordova.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/cordova.html
@@ -102,6 +102,9 @@
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface SuccessCallback {
     void onsuccess();
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -128,6 +131,9 @@
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="#DOMException">DOMException</a> error);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -165,6 +171,9 @@
     readonly attribute DOMString name;
     readonly attribute DOMString message;
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="attributes">
 <h4>Attributes</h4>
 <ul>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/device-motion.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/device-motion.html
@@ -361,6 +361,9 @@ Acceleration values include the effect of gravity (9.81 m/s^2), so that when a d
     readonly attribute double z;
     readonly attribute long timestamp;
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <p><span class="privilegelevel">Privilege level: </span>
  public
           </p>
@@ -441,6 +444,9 @@ Acceleration values include the effect of gravity (9.81 m/s^2), so that when a d
 <pre class="webidl prettyprint">  dictionary AccelerationOptions {
     long frequency;
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="attributes">
 <h4>Dictionary members</h4>
 <dl>
@@ -464,6 +470,9 @@ Acceleration values include the effect of gravity (9.81 m/s^2), so that when a d
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface AccelerometerSuccessCallback {
     void onsuccess(<a href="#Acceleration">Acceleration</a> acceleration);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -496,6 +505,9 @@ Acceleration values include the effect of gravity (9.81 m/s^2), so that when a d
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/dialogs.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/dialogs.html
@@ -397,6 +397,9 @@ the index uses one-based indexing, so the values could be 1, 2, 3, etc.
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ConfirmCallback {
     void onsuccess(long buttonIndex);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <p><span class="remark">Remark: </span>
  Example usage is described on method <a href="#DialogsManager::confirm">confirm</a>.
           </p>
@@ -436,6 +439,9 @@ the index uses one-based indexing, so the values could be 1, 2, 3, etc.
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PromptCallback {
     void onsuccess(<a href="#PromptData">PromptData</a> data);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <p><span class="remark">Remark: </span>
  Example usage is described on method <a href="#DialogsManager::prompt">prompt</a>.
           </p>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/file.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/file.html
@@ -255,6 +255,9 @@ Storage privileges are privacy-related privileges and there is a need of asking 
 See <a href="https://www.w3.org/TR/FileAPI/#blob-section">The Blob Interface and Binary Data</a>.
           </div>
 <pre class="webidl prettyprint">  typedef <a href="#Blob">Blob</a> Blob;</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 </div>
 <div class="typedef" id="WriteData">
 <a class="backward-compatibility-anchor" name="::File::WriteData"></a><h3>1.2. WriteData</h3>
@@ -2014,6 +2017,9 @@ Otherwise, if no other error occurs, getFile must return a FileEntry correspondi
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface DirectoryReader {
     void readEntries(<a href="#EntriesCallback">EntriesCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror) raises(FileException);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <p><span class="privilegelevel">Privilege level: </span>
  public
           </p>
@@ -2088,6 +2094,9 @@ Otherwise, if no other error occurs, getFile must return a FileEntry correspondi
     void createWriter(<a href="#FileWriterCallback">FileWriterCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a>? onerror);
     void file(<a href="#FileCallback">FileCallback</a> onsuccess, optional <a href="#ErrorCallback">ErrorCallback</a> onerror);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <p><span class="privilegelevel">Privilege level: </span>
  public
           </p>
@@ -2718,6 +2727,9 @@ ByteLength: 3
 <a class="backward-compatibility-anchor" name="::File::FileWriter::DONE"></a><span class="name">DONE</span><div class="brief">
  Above constants describe current state of FileWriter object.
             </div>
+<p><span class="version">Since: </span>
+ 3.0
+            </p>
 <br><br>
 </li>
 </dl>
@@ -3111,6 +3123,9 @@ entry.createWriter(successCallback, errorCallback);
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ProgressCallback {
     void onsuccess(<a href="#ProgressEvent">ProgressEvent</a> event);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -3368,6 +3383,9 @@ entry.createWriter(successCallback, errorCallback);
  Used to supply a File as a response to a user query.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void handleEvent(<a href="#File">File</a> file);</pre></div>
+<p><span class="version">Since: </span>
+ 3.0
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/filetransfer.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/filetransfer.html
@@ -944,6 +944,9 @@ Upload error target http://some.server.com/file.txt
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileDownloadSuccessCallback {
     void onsuccess(<a href="file.html#FileEntry">FileEntry</a> file);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -982,6 +985,9 @@ Upload error target http://some.server.com/file.txt
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileTransferErrorCallback {
     void onerror(<a href="#FileTransferError">FileTransferError</a> error);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/globalization.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/globalization.html
@@ -1196,6 +1196,9 @@ Valid values are:
 "full"              </li>
             </ul>
            </div>
+<p><span class="version">Since: </span>
+ 3.0
+            </p>
 </dd>
 <dt class="member" id="DateOptions::selector"><span class="attrName">DOMString selector</span></dt>
 <dd>
@@ -1215,6 +1218,9 @@ Valid values are:
 "date and time"              </li>
             </ul>
            </div>
+<p><span class="version">Since: </span>
+ 3.0
+            </p>
 </dd>
 </dl>
 </div>
@@ -1232,6 +1238,9 @@ Valid values are:
     DOMString decimal;
     DOMString grouping;
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="attributes">
 <h4>Dictionary members</h4>
 <dl>
@@ -2096,6 +2105,9 @@ The GlobalizationError interface
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface ErrorCallback {
     void onerror(<a href="cordova.html#DOMException">DOMException</a> error);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/media.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/media.html
@@ -774,6 +774,9 @@ setTimeout(function()
     const short MEDIA_ERR_NONE_SUPPORTED = 4;
     readonly attribute short code;
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="attributes">
 <h4>Attributes</h4>
 <ul><li class="attribute" id="MediaError::code">
@@ -795,6 +798,9 @@ setTimeout(function()
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface MediaErrorCallback {
     void onerror(<a href="#MediaError">MediaError</a> error);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -830,6 +836,9 @@ setTimeout(function()
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface StatusChangeCallback {
     void onchanged(short status);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -865,6 +874,9 @@ setTimeout(function()
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PositionSuccessCallback {
     void onsuccess(double position);
   };</pre>
+<p><span class="version">Since: </span>
+ 3.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/filesystem.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/filesystem.html
@@ -2534,8 +2534,6 @@ The <em>ErrorCallback</em> is launched with these error types:
               <li>
 IOError, if any error related to file handle occurs.               </li>
             </ul>
-           </div>
-<div class="description">
             <p>
 Note, that current position indicator value, can be obtained in SeekSuccessCallback by calling <var>seekNonBlocking(0, "CURRENT")</var>.
 seekNonBlocking is executed in background and does not block further instructions.
@@ -3874,8 +3872,6 @@ The <em>ErrorCallback</em> is launched with these error types:
               <li>
 IOError, if flush fails or any error related to file handle occurs.              </li>
             </ul>
-           </div>
-<div class="description">
             <p>
 This method is asynchronous. Its execution will occur in background and after all previously commissioned background jobs will finish.
             </p>
@@ -4036,8 +4032,6 @@ The <em>ErrorCallback</em> is launched with these error types:
               <li>
 IOError, if sync fails or any error related to file handle occurs.              </li>
             </ul>
-           </div>
-<div class="description">
             <p>
 This method is asynchronous. Its execution will occur in background and after all previously commissioned background jobs will finish.
             </p>
@@ -4184,8 +4178,6 @@ The <em>ErrorCallback</em> is launched with these error types:
               <li>
 IOError, if close fails or any error related to file handle occurs.              </li>
             </ul>
-           </div>
-<div class="description">
             <p>
 This method is asynchronous. Its execution will occur in background and after all previously commissioned background jobs will finish.
             </p>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/humanactivitymonitor.html
@@ -648,6 +648,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
 {
   console.log("Step status: " + pedometerInfo.stepStatus);
   console.log("Cumulative total step count: " + pedometerInfo.cumulativeTotalStepCount);
+  console.log("Accumulative total step count: " + pedometerInfo.accumulativeTotalStepCount);
 }
 
 function onerrorCB(error)
@@ -2096,6 +2097,11 @@ The <em>interval</em> should be greater than or equal to zero.<br>For the PEDOME
     readonly attribute double cumulativeTotalStepCount;
     readonly attribute double cumulativeWalkStepCount;
     readonly attribute double cumulativeRunStepCount;
+    readonly attribute double accumulativeDistance;
+    readonly attribute double accumulativeCalorie;
+    readonly attribute double accumulativeTotalStepCount;
+    readonly attribute double accumulativeWalkStepCount;
+    readonly attribute double accumulativeRunStepCount;
     readonly attribute <a href="#StepDifference">StepDifference</a>[] stepCountDifferences;
   };</pre>
 <p><span class="version">Since: </span>
@@ -2144,7 +2150,7 @@ The <em>interval</em> should be greater than or equal to zero.<br>For the PEDOME
 <li class="attribute" id="HumanActivityPedometerData::cumulativeCalorie">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">cumulativeCalorie</span></span><div class="brief">
- Cumulative calories burned since the last <a href="#HumanActivityMonitorManager::start">start()</a> method call in kcal.
+ Cumulative calories burnt since the last <a href="#HumanActivityMonitorManager::start">start()</a> method call in kcal.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2182,6 +2188,51 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
  2.3
             </p>
 </li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeDistance">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeDistance</span></span><div class="brief">
+ Accumulative distance traveled since the device boot in meters.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeCalorie">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeCalorie</span></span><div class="brief">
+ Accumulative calories burnt since the device boot in kcal.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeTotalStepCount">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeTotalStepCount</span></span><div class="brief">
+ Accumulative walking and running step count since the device boot.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeWalkStepCount">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeWalkStepCount</span></span><div class="brief">
+ Accumulative walking step count since the device boot.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="HumanActivityPedometerData::accumulativeRunStepCount">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">double </span><span class="name">accumulativeRunStepCount</span></span><div class="brief">
+ Accumulative running step count since the device boot.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
 <li class="attribute" id="HumanActivityPedometerData::stepCountDifferences">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">StepDifference[]
@@ -2198,7 +2249,7 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
 <div class="interface" id="HumanActivityAccumulativePedometerData">
 <a class="backward-compatibility-anchor" name="::HumanActivityMonitor::HumanActivityAccumulativePedometerData"></a><h3>2.8. HumanActivityAccumulativePedometerData</h3>
 <div class="brief">
- The HumanActivityAccumulativePedometerData interface represents pedometer motion data since the device is booted.
+ The HumanActivityAccumulativePedometerData interface represents pedometer motion data since the device boot.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface HumanActivityAccumulativePedometerData : <a href="#HumanActivityData">HumanActivityData</a> {
     readonly attribute <a href="#PedometerStepStatus">PedometerStepStatus</a> stepStatus;
@@ -2248,7 +2299,7 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeDistance">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeDistance</span></span><div class="brief">
- Accumulative distance traveled since the device is booted in meters.
+ Accumulative distance traveled since the device boot in meters.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2257,7 +2308,7 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeCalorie">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeCalorie</span></span><div class="brief">
- Accumulative calories burnt since the device is booted in kcal.
+ Accumulative calories burnt since the device boot in kcal.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2266,7 +2317,7 @@ The value is the sum of <em>cumulativeWalkStepCount</em> and <em>cumulativeRunSt
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeTotalStepCount">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeTotalStepCount</span></span><div class="brief">
- Accumulative walking and running step count since the device is booted.
+ Accumulative walking and running step count since the device boot.
             </div>
 <div class="description">
             <p>
@@ -2280,7 +2331,7 @@ The value is the sum of <em>accumulativeWalkStepCount</em> and <em>accumulativeR
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeWalkStepCount">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeWalkStepCount</span></span><div class="brief">
- Accumulative walking step count since the device is booted.
+ Accumulative walking step count since the device boot.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2289,7 +2340,7 @@ The value is the sum of <em>accumulativeWalkStepCount</em> and <em>accumulativeR
 <li class="attribute" id="HumanActivityAccumulativePedometerData::accumulativeRunStepCount">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">accumulativeRunStepCount</span></span><div class="brief">
- Accumulative running step count since the device is booted.
+ Accumulative running step count since the device boot.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2692,7 +2743,7 @@ It's a <a href="https://www.researchgate.net/publication/313837778_Microcontroll
 <li class="attribute" id="HumanActivityRecorderPedometerData::calorie">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">calorie</span></span><div class="brief">
- Calories burned from <em>startTime</em> to <em>endTime</em> in kcal.
+ Calories burnt from <em>startTime</em> to <em>endTime</em> in kcal.
             </div>
 <p><span class="version">Since: </span>
  2.3.2
@@ -3253,6 +3304,11 @@ To guarantee that the stress monitor vector sensor application runs on a device 
     readonly attribute double cumulativeTotalStepCount;
     readonly attribute double cumulativeWalkStepCount;
     readonly attribute double cumulativeRunStepCount;
+    readonly attribute double accumulativeDistance;
+    readonly attribute double accumulativeCalorie;
+    readonly attribute double accumulativeTotalStepCount;
+    readonly attribute double accumulativeWalkStepCount;
+    readonly attribute double accumulativeRunStepCount;
     readonly attribute <a href="#StepDifference">StepDifference</a>[] stepCountDifferences;
   };
   [NoInterfaceObject] interface HumanActivityAccumulativePedometerData : <a href="#HumanActivityData">HumanActivityData</a> {

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/inputdevice.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/inputdevice.html
@@ -81,6 +81,9 @@ For more information on the Input Device features, see <a href="/application/web
  Name which identifies the key
           </div>
 <pre class="webidl prettyprint">  typedef DOMString InputDeviceKeyName;</pre>
+<p><span class="version">Since: </span>
+ 2.4
+          </p>
 <div class="description">
           <p>
 Name of the key may be, for example:

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/mediacontroller.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/mediacontroller.html
@@ -39,25 +39,28 @@ For more information on the Media Controller features, see <a href="/application
                     1.3. <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a>
 </li>
 <li>
-                    1.4. <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a>
+                    1.4. <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a>
 </li>
 <li>
-                    1.5. <a href="#MediaControllerContentType">MediaControllerContentType</a>
+                    1.5. <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a>
 </li>
 <li>
-                    1.6. <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a>
+                    1.6. <a href="#MediaControllerContentType">MediaControllerContentType</a>
 </li>
 <li>
-                    1.7. <a href="#MediaControllerAbilitySupport">MediaControllerAbilitySupport</a>
+                    1.7. <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a>
 </li>
 <li>
-                    1.8. <a href="#MediaControllerSimpleAbility">MediaControllerSimpleAbility</a>
+                    1.8. <a href="#MediaControllerAbilitySupport">MediaControllerAbilitySupport</a>
 </li>
 <li>
-                    1.9. <a href="#MediaControllerDisplayModeType">MediaControllerDisplayModeType</a>
+                    1.9. <a href="#MediaControllerSimpleAbility">MediaControllerSimpleAbility</a>
 </li>
 <li>
-                    1.10. <a href="#MediaControllerDisplayRotationType">MediaControllerDisplayRotationType</a>
+                    1.10. <a href="#MediaControllerDisplayModeType">MediaControllerDisplayModeType</a>
+</li>
+<li>
+                    1.11. <a href="#MediaControllerDisplayRotationType">MediaControllerDisplayRotationType</a>
 </li>
 </ul>
 </li>
@@ -72,89 +75,97 @@ For more information on the Media Controller features, see <a href="/application
 </li>
 <li>2.5. <a href="#MediaControllerServerInfo">MediaControllerServerInfo</a>
 </li>
-<li>2.6. <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a>
+<li class="deprecated">2.6. <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a>
 </li>
-<li>2.7. <a href="#MediaControllerAbilities">MediaControllerAbilities</a>
+<li>2.7. <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>
 </li>
-<li>2.8. <a href="#MediaControllerPlaybackAbilities">MediaControllerPlaybackAbilities</a>
+<li>2.8. <a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a>
 </li>
-<li>2.9. <a href="#MediaControllerDisplayModeAbilities">MediaControllerDisplayModeAbilities</a>
+<li>2.9. <a href="#MediaControllerPlaylists">MediaControllerPlaylists</a>
 </li>
-<li>2.10. <a href="#MediaControllerDisplayRotationAbilities">MediaControllerDisplayRotationAbilities</a>
+<li>2.10. <a href="#MediaControllerPlaylistsInfo">MediaControllerPlaylistsInfo</a>
 </li>
-<li>2.11. <a href="#MediaControllerAbilitiesInfo">MediaControllerAbilitiesInfo</a>
+<li>2.11. <a href="#MediaControllerAbilities">MediaControllerAbilities</a>
 </li>
-<li>2.12. <a href="#MediaControllerPlaybackAbilitiesInfo">MediaControllerPlaybackAbilitiesInfo</a>
+<li>2.12. <a href="#MediaControllerPlaybackAbilities">MediaControllerPlaybackAbilities</a>
 </li>
-<li>2.13. <a href="#MediaControllerDisplayModeAbilitiesInfo">MediaControllerDisplayModeAbilitiesInfo</a>
+<li>2.13. <a href="#MediaControllerDisplayModeAbilities">MediaControllerDisplayModeAbilities</a>
 </li>
-<li>2.14. <a href="#MediaControllerDisplayRotationAbilitiesInfo">MediaControllerDisplayRotationAbilitiesInfo</a>
+<li>2.14. <a href="#MediaControllerDisplayRotationAbilities">MediaControllerDisplayRotationAbilities</a>
 </li>
-<li>2.15. <a href="#MediaControllerSubtitles">MediaControllerSubtitles</a>
+<li>2.15. <a href="#MediaControllerAbilitiesInfo">MediaControllerAbilitiesInfo</a>
 </li>
-<li>2.16. <a href="#MediaControllerSubtitlesInfo">MediaControllerSubtitlesInfo</a>
+<li>2.16. <a href="#MediaControllerPlaybackAbilitiesInfo">MediaControllerPlaybackAbilitiesInfo</a>
 </li>
-<li>2.17. <a href="#MediaControllerMode360">MediaControllerMode360</a>
+<li>2.17. <a href="#MediaControllerDisplayModeAbilitiesInfo">MediaControllerDisplayModeAbilitiesInfo</a>
 </li>
-<li>2.18. <a href="#MediaControllerMode360Info">MediaControllerMode360Info</a>
+<li>2.18. <a href="#MediaControllerDisplayRotationAbilitiesInfo">MediaControllerDisplayRotationAbilitiesInfo</a>
 </li>
-<li>2.19. <a href="#MediaControllerDisplayMode">MediaControllerDisplayMode</a>
+<li>2.19. <a href="#MediaControllerSubtitles">MediaControllerSubtitles</a>
 </li>
-<li>2.20. <a href="#MediaControllerDisplayModeInfo">MediaControllerDisplayModeInfo</a>
+<li>2.20. <a href="#MediaControllerSubtitlesInfo">MediaControllerSubtitlesInfo</a>
 </li>
-<li>2.21. <a href="#MediaControllerDisplayRotation">MediaControllerDisplayRotation</a>
+<li>2.21. <a href="#MediaControllerMode360">MediaControllerMode360</a>
 </li>
-<li>2.22. <a href="#MediaControllerClientInfo">MediaControllerClientInfo</a>
+<li>2.22. <a href="#MediaControllerMode360Info">MediaControllerMode360Info</a>
 </li>
-<li>2.23. <a href="#MediaControllerDisplayRotationInfo">MediaControllerDisplayRotationInfo</a>
+<li>2.23. <a href="#MediaControllerDisplayMode">MediaControllerDisplayMode</a>
 </li>
-<li>2.24. <a href="#MediaControllerMetadata">MediaControllerMetadata</a>
+<li>2.24. <a href="#MediaControllerDisplayModeInfo">MediaControllerDisplayModeInfo</a>
 </li>
-<li>2.25. <a href="#MediaControllerPlaylistItem">MediaControllerPlaylistItem</a>
+<li>2.25. <a href="#MediaControllerDisplayRotation">MediaControllerDisplayRotation</a>
 </li>
-<li>2.26. <a href="#MediaControllerMetadataInit">MediaControllerMetadataInit</a>
+<li>2.26. <a href="#MediaControllerClientInfo">MediaControllerClientInfo</a>
 </li>
-<li>2.27. <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a>
+<li>2.27. <a href="#MediaControllerDisplayRotationInfo">MediaControllerDisplayRotationInfo</a>
 </li>
-<li>2.28. <a href="#SearchFilter">SearchFilter</a>
+<li>2.28. <a href="#MediaControllerMetadata">MediaControllerMetadata</a>
 </li>
-<li>2.29. <a href="#MediaControllerServerInfoArraySuccessCallback">MediaControllerServerInfoArraySuccessCallback</a>
+<li>2.29. <a href="#MediaControllerPlaylistItem">MediaControllerPlaylistItem</a>
 </li>
-<li>2.30. <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>
+<li>2.30. <a href="#MediaControllerMetadataInit">MediaControllerMetadataInit</a>
 </li>
-<li>2.31. <a href="#RequestReply">RequestReply</a>
+<li>2.31. <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a>
 </li>
-<li>2.32. <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a>
+<li>2.32. <a href="#SearchFilter">SearchFilter</a>
 </li>
-<li>2.33. <a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a>
+<li>2.33. <a href="#MediaControllerServerInfoArraySuccessCallback">MediaControllerServerInfoArraySuccessCallback</a>
 </li>
-<li>2.34. <a href="#MediaControllerReceiveCommandCallback">MediaControllerReceiveCommandCallback</a>
+<li>2.34. <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>
 </li>
-<li>2.35. <a href="#MediaControllerEnabledChangeRequestCallback">MediaControllerEnabledChangeRequestCallback</a>
+<li>2.35. <a href="#RequestReply">RequestReply</a>
 </li>
-<li>2.36. <a href="#MediaControllerEnabledChangeCallback">MediaControllerEnabledChangeCallback</a>
+<li>2.36. <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a>
 </li>
-<li>2.37. <a href="#MediaControllerDisplayModeChangeRequestCallback">MediaControllerDisplayModeChangeRequestCallback</a>
+<li>2.37. <a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a>
 </li>
-<li>2.38. <a href="#MediaControllerDisplayModeChangeCallback">MediaControllerDisplayModeChangeCallback</a>
+<li>2.38. <a href="#MediaControllerReceiveCommandCallback">MediaControllerReceiveCommandCallback</a>
 </li>
-<li>2.39. <a href="#MediaControllerDisplayRotationChangeRequestCallback">MediaControllerDisplayRotationChangeRequestCallback</a>
+<li>2.39. <a href="#MediaControllerEnabledChangeRequestCallback">MediaControllerEnabledChangeRequestCallback</a>
 </li>
-<li>2.40. <a href="#MediaControllerDisplayRotationChangeCallback">MediaControllerDisplayRotationChangeCallback</a>
+<li>2.40. <a href="#MediaControllerEnabledChangeCallback">MediaControllerEnabledChangeCallback</a>
 </li>
-<li>2.41. <a href="#MediaControllerServerStatusChangeCallback">MediaControllerServerStatusChangeCallback</a>
+<li>2.41. <a href="#MediaControllerDisplayModeChangeRequestCallback">MediaControllerDisplayModeChangeRequestCallback</a>
 </li>
-<li>2.42. <a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a>
+<li>2.42. <a href="#MediaControllerDisplayModeChangeCallback">MediaControllerDisplayModeChangeCallback</a>
 </li>
-<li>2.43. <a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a>
+<li>2.43. <a href="#MediaControllerDisplayRotationChangeRequestCallback">MediaControllerDisplayRotationChangeRequestCallback</a>
 </li>
-<li>2.44. <a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a>
+<li>2.44. <a href="#MediaControllerDisplayRotationChangeCallback">MediaControllerDisplayRotationChangeCallback</a>
 </li>
-<li>2.45. <a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a>
+<li>2.45. <a href="#MediaControllerServerStatusChangeCallback">MediaControllerServerStatusChangeCallback</a>
 </li>
-<li>2.46. <a href="#MediaControllerGetItemsSuccessCallback">MediaControllerGetItemsSuccessCallback</a>
+<li>2.46. <a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a>
 </li>
-<li>2.47. <a href="#MediaControllerAbilityChangeCallback">MediaControllerAbilityChangeCallback</a>
+<li>2.47. <a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a>
+</li>
+<li>2.48. <a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a>
+</li>
+<li>2.49. <a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a>
+</li>
+<li>2.50. <a href="#MediaControllerGetItemsSuccessCallback">MediaControllerGetItemsSuccessCallback</a>
+</li>
+<li>2.51. <a href="#MediaControllerAbilityChangeCallback">MediaControllerAbilityChangeCallback</a>
 </li>
 </ul>
 </li>
@@ -187,26 +198,10 @@ For more information on the Media Controller features, see <a href="/application
 <td>
 <div>
 <a href="#MediaControllerClientInfo">MediaControllerClientInfo</a>[] <a href="#MediaControllerServer::getAllClientsInfo">getAllClientsInfo</a> ()</div>
-<div>void <a href="#MediaControllerServer::updatePlaybackState">updatePlaybackState</a> (<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state)</div>
-<div>void <a href="#MediaControllerServer::updateIconURI">updateIconURI</a> (DOMString? iconURI)</div>
-<div>void <a href="#MediaControllerServer::updatePlaybackPosition">updatePlaybackPosition</a> (unsigned long long position)</div>
-<div>void <a href="#MediaControllerServer::updatePlaybackAgeRating">updatePlaybackAgeRating</a> (<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating)</div>
-<div>void <a href="#MediaControllerServer::updatePlaybackContentType">updatePlaybackContentType</a> (<a href="#MediaControllerContentType">MediaControllerContentType</a> type)</div>
-<div>void <a href="#MediaControllerServer::updateShuffleMode">updateShuffleMode</a> (boolean mode)</div>
-<div>void <a href="#MediaControllerServer::updateRepeatState">updateRepeatState</a> (<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state)</div>
-<div>void <a href="#MediaControllerServer::updateMetadata">updateMetadata</a> (<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata)</div>
-<div>long <a href="#MediaControllerServer::addChangeRequestPlaybackInfoListener">addChangeRequestPlaybackInfoListener</a> (<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener)</div>
-<div>void <a href="#MediaControllerServer::removeChangeRequestPlaybackInfoListener">removeChangeRequestPlaybackInfoListener</a> (long watchId)</div>
 <div>void <a href="#MediaControllerServer::setSearchRequestListener">setSearchRequestListener</a> (<a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a> listener)</div>
 <div>void <a href="#MediaControllerServer::unsetSearchRequestListener">unsetSearchRequestListener</a> ()</div>
 <div>long <a href="#MediaControllerServer::addCommandListener">addCommandListener</a> (<a href="#MediaControllerReceiveCommandCallback">MediaControllerReceiveCommandCallback</a> listener)</div>
 <div>void <a href="#MediaControllerServer::removeCommandListener">removeCommandListener</a> (long watchId)</div>
-<div>
-<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> <a href="#MediaControllerServer::createPlaylist">createPlaylist</a> (DOMString name)</div>
-<div>void <a href="#MediaControllerServer::savePlaylist">savePlaylist</a> (<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServer::deletePlaylist">deletePlaylist</a> (DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServer::updatePlaybackItem">updatePlaybackItem</a> (DOMString playlistName, DOMString index)</div>
-<div>void <a href="#MediaControllerServer::getAllPlaylists">getAllPlaylists</a> (<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
 </td>
 </tr>
 <tr>
@@ -225,25 +220,53 @@ For more information on the Media Controller features, see <a href="/application
 <tr>
 <td><a href="#MediaControllerServerInfo">MediaControllerServerInfo</a></td>
 <td>
-<div>void <a href="#MediaControllerServerInfo::sendPlaybackState">sendPlaybackState</a> (<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServerInfo::sendPlaybackPosition">sendPlaybackPosition</a> (unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServerInfo::sendShuffleMode">sendShuffleMode</a> (boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServerInfo::sendRepeatState">sendRepeatState</a> (<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
 <div>void <a href="#MediaControllerServerInfo::sendSearchRequest">sendSearchRequest</a> (<a href="#SearchFilter">SearchFilter</a>[] request, <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a> replyCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
 <div>void <a href="#MediaControllerServerInfo::sendCommand">sendCommand</a> (DOMString command, <a href="tizen.html#Bundle">Bundle</a>? data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
 <div>long <a href="#MediaControllerServerInfo::addServerStatusChangeListener">addServerStatusChangeListener</a> (<a href="#MediaControllerServerStatusChangeCallback">MediaControllerServerStatusChangeCallback</a> listener)</div>
 <div>void <a href="#MediaControllerServerInfo::removeServerStatusChangeListener">removeServerStatusChangeListener</a> (long watchId)</div>
-<div>long <a href="#MediaControllerServerInfo::addPlaybackInfoChangeListener">addPlaybackInfoChangeListener</a> (<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener)</div>
-<div>void <a href="#MediaControllerServerInfo::removePlaybackInfoChangeListener">removePlaybackInfoChangeListener</a> (long watchId)</div>
-<div>void <a href="#MediaControllerServerInfo::getAllPlaylists">getAllPlaylists</a> (<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
-<div>void <a href="#MediaControllerServerInfo::sendPlaybackItem">sendPlaybackItem</a> (DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position)</div>
-<div>long <a href="#MediaControllerServerInfo::addPlaylistUpdatedListener">addPlaylistUpdatedListener</a> (<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener)</div>
-<div>void <a href="#MediaControllerServerInfo::removePlaylistUpdatedListener">removePlaylistUpdatedListener</a> (long listenerId)</div>
 </td>
 </tr>
 <tr>
-<td><a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a></td>
-<td></td>
+<td><a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a></td>
+<td>
+<div>void <a href="#MediaControllerServerPlaybackInfo::updatePlaybackItem">updatePlaybackItem</a> (DOMString playlistName, DOMString index)</div>
+<div>long <a href="#MediaControllerServerPlaybackInfo::addChangeRequestListener">addChangeRequestListener</a> (<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener)</div>
+<div>void <a href="#MediaControllerServerPlaybackInfo::removeChangeRequestListener">removeChangeRequestListener</a> (long watchId)</div>
+</td>
+</tr>
+<tr>
+<td><a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a></td>
+<td>
+<div>void <a href="#MediaControllerServerInfoPlaybackInfo::sendPlaybackAction">sendPlaybackAction</a> (<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)</div>
+<div>void <a href="#MediaControllerServerInfoPlaybackInfo::sendPlaybackPosition">sendPlaybackPosition</a> (unsigned long long position, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)</div>
+<div>void <a href="#MediaControllerServerInfoPlaybackInfo::sendShuffleMode">sendShuffleMode</a> (boolean mode, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)</div>
+<div>void <a href="#MediaControllerServerInfoPlaybackInfo::sendRepeatState">sendRepeatState</a> (<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)</div>
+<div>long <a href="#MediaControllerServerInfoPlaybackInfo::addPlaybackInfoChangeListener">addPlaybackInfoChangeListener</a> (<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener)</div>
+<div>void <a href="#MediaControllerServerInfoPlaybackInfo::removePlaybackInfoChangeListener">removePlaybackInfoChangeListener</a> (long watchId)</div>
+</td>
+</tr>
+<tr>
+<td><a href="#MediaControllerPlaylists">MediaControllerPlaylists</a></td>
+<td>
+<div>
+<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> <a href="#MediaControllerPlaylists::createPlaylist">createPlaylist</a> (DOMString name)</div>
+<div>void <a href="#MediaControllerPlaylists::savePlaylist">savePlaylist</a> (<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
+<div>void <a href="#MediaControllerPlaylists::deletePlaylist">deletePlaylist</a> (DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
+<div>void <a href="#MediaControllerPlaylists::getAllPlaylists">getAllPlaylists</a> (<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
+<div>
+<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> <a href="#MediaControllerPlaylists::getPlaylist">getPlaylist</a> (DOMString playlistName)</div>
+</td>
+</tr>
+<tr>
+<td><a href="#MediaControllerPlaylistsInfo">MediaControllerPlaylistsInfo</a></td>
+<td>
+<div>void <a href="#MediaControllerPlaylistsInfo::getAllPlaylists">getAllPlaylists</a> (<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)</div>
+<div>void <a href="#MediaControllerPlaylistsInfo::sendPlaybackItem">sendPlaybackItem</a> (DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, unsigned long long position, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)</div>
+<div>long <a href="#MediaControllerPlaylistsInfo::addPlaylistUpdatedListener">addPlaylistUpdatedListener</a> (<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener)</div>
+<div>void <a href="#MediaControllerPlaylistsInfo::removePlaylistUpdatedListener">removePlaylistUpdatedListener</a> (long listenerId)</div>
+<div>
+<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> <a href="#MediaControllerPlaylistsInfo::getPlaylist">getPlaylist</a> (DOMString playlistName)</div>
+</td>
 </tr>
 <tr>
 <td><a href="#MediaControllerAbilities">MediaControllerAbilities</a></td>
@@ -346,7 +369,7 @@ For more information on the Media Controller features, see <a href="/application
 </tr>
 <tr>
 <td><a href="#MediaControllerMetadata">MediaControllerMetadata</a></td>
-<td></td>
+<td><div>void <a href="#MediaControllerMetadata::save">save</a> ()</div></td>
 </tr>
 <tr>
 <td><a href="#MediaControllerPlaylistItem">MediaControllerPlaylistItem</a></td>
@@ -436,11 +459,16 @@ For more information on the Media Controller features, see <a href="/application
 <tr>
 <td><a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a></td>
 <td>
-<div>void <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackstaterequest">onplaybackstaterequest</a> (<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
-<div>void <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackpositionrequest">onplaybackpositionrequest</a> (unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
-<div>void <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onshufflemoderequest">onshufflemoderequest</a> (boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
-<div>void <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onrepeatstaterequest">onrepeatstaterequest</a> (<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
-<div>void <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackitemrequest">onplaybackitemrequest</a> (DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
+<div>
+<a href="#RequestReply">RequestReply</a>? <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackactionrequest">onplaybackactionrequest</a> (<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
+<div>
+<a href="#RequestReply">RequestReply</a>? <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackpositionrequest">onplaybackpositionrequest</a> (unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
+<div>
+<a href="#RequestReply">RequestReply</a>? <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onshufflemoderequest">onshufflemoderequest</a> (boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
+<div>
+<a href="#RequestReply">RequestReply</a>? <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onrepeatstaterequest">onrepeatstaterequest</a> (<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
+<div>
+<a href="#RequestReply">RequestReply</a>? <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackitemrequest">onplaybackitemrequest</a> (DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName)</div>
 </td>
 </tr>
 <tr>
@@ -527,24 +555,54 @@ TPO - Search by Time Place Occasion.            </li>
 <div class="description">
           <ul>
             <li>
-PLAY - Corresponds to play media controller playback state.            </li>
+PLAY - Corresponds to the "playing" media controller playback state.            </li>
             <li>
-PAUSE - Corresponds to pause media controller playback state.            </li>
+PAUSE - Corresponds to the "paused" media controller playback state.            </li>
             <li>
-STOP - Corresponds to stop media controller playback state.            </li>
+STOP - Corresponds to the "stopped" media controller playback state.            </li>
             <li>
-NEXT - Corresponds to next media controller playback state.            </li>
+NEXT - Corresponds to the "moving to next" media controller playback state.            </li>
             <li>
-PREV - Corresponds to previous media controller playback state.            </li>
+PREV - Corresponds to the "moving to previous" media controller playback state.            </li>
             <li>
-FORWARD - Corresponds to forward media controller playback state.            </li>
+FORWARD - Corresponds to the "forwarding" media controller playback state.            </li>
             <li>
-REWIND - Corresponds to rewind media controller playback state.            </li>
+REWIND - Corresponds to the "rewinding" media controller playback state.            </li>
+          </ul>
+         </div>
+</div>
+<div class="enum" id="MediaControllerPlaybackAction">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackAction"></a><h3>1.4. MediaControllerPlaybackAction</h3>
+<div class="brief">
+ Defines media playback actions.
+          </div>
+<pre class="webidl prettyprint">  enum MediaControllerPlaybackAction { "PLAY", "PAUSE", "STOP", "NEXT", "PREV", "FORWARD", "REWIND", "TOGGLE_PLAY_PAUSE" };</pre>
+<p><span class="version">Since: </span>
+ 6.0
+          </p>
+<div class="description">
+          <ul>
+            <li>
+PLAY - Corresponds to the "play" media controller playback action.            </li>
+            <li>
+PAUSE - Corresponds to "pause" media controller playback action.            </li>
+            <li>
+STOP - Corresponds to the "stop" media controller playback action.            </li>
+            <li>
+NEXT - Corresponds to the "next" media controller playback action.            </li>
+            <li>
+PREV - Corresponds to the "previous" media controller playback action.            </li>
+            <li>
+FORWARD - Corresponds to the "forward" media controller playback action.            </li>
+            <li>
+REWIND - Corresponds to the "rewind" media controller playback action.            </li>
+            <li>
+TOGGLE_PLAY_PAUSE - Corresponds to the "toggle play/pause" media controller playback action.            </li>
           </ul>
          </div>
 </div>
 <div class="enum" id="MediaControllerRepeatState">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerRepeatState"></a><h3>1.4. MediaControllerRepeatState</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerRepeatState"></a><h3>1.5. MediaControllerRepeatState</h3>
 <div class="brief">
  Defines states for repeating media.
           </div>
@@ -567,7 +625,7 @@ REPEAT_ALL - repeating all media.            </li>
          </div>
 </div>
 <div class="enum" id="MediaControllerContentType">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerContentType"></a><h3>1.5. MediaControllerContentType</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerContentType"></a><h3>1.6. MediaControllerContentType</h3>
 <div class="brief">
  Content type.
           </div>
@@ -591,7 +649,7 @@ UNDECIDED - content type for unspecified media types.            </li>
          </div>
 </div>
 <div class="enum" id="MediaControllerContentAgeRating">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerContentAgeRating"></a><h3>1.6. MediaControllerContentAgeRating</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerContentAgeRating"></a><h3>1.7. MediaControllerContentAgeRating</h3>
 <div class="brief">
  Media Controller content age rating.
           </div>
@@ -607,7 +665,7 @@ Each value represents the minimum age restriction for the media.
          </div>
 </div>
 <div class="enum" id="MediaControllerAbilitySupport">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilitySupport"></a><h3>1.7. MediaControllerAbilitySupport</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilitySupport"></a><h3>1.8. MediaControllerAbilitySupport</h3>
 <div class="brief">
  The media controller ability support values.
           </div>
@@ -627,7 +685,7 @@ UNDECIDED - The support of ability is not set.            </li>
          </div>
 </div>
 <div class="enum" id="MediaControllerSimpleAbility">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSimpleAbility"></a><h3>1.8. MediaControllerSimpleAbility</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSimpleAbility"></a><h3>1.9. MediaControllerSimpleAbility</h3>
 <div class="brief">
  The media controller simple ability types. Simple means, that each ability is described by a single <a href="#MediaControllerAbilitySupport">MediaControllerAbilitySupport</a> value and is not a part of a complex ability structure.
           </div>
@@ -658,7 +716,7 @@ MODE_360 - Ability to receive requests for spherical (360°) mode change from me
          </div>
 </div>
 <div class="enum" id="MediaControllerDisplayModeType">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeType"></a><h3>1.9. MediaControllerDisplayModeType</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeType"></a><h3>1.10. MediaControllerDisplayModeType</h3>
 <div class="brief">
  Types of supported media controller display modes.
           </div>
@@ -680,7 +738,7 @@ CROPPED_FULL - Cropped full screen display mode type.            </li>
          </div>
 </div>
 <div class="enum" id="MediaControllerDisplayRotationType">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationType"></a><h3>1.10. MediaControllerDisplayRotationType</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationType"></a><h3>1.11. MediaControllerDisplayRotationType</h3>
 <div class="brief">
  The media controller rotation values.
           </div>
@@ -861,38 +919,40 @@ catch (err)
  Provides functions for sending the server information to the client.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerServer {
-    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo;
-    readonly attribute DOMString? iconURI;
+<span class="nocode deprecated">    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo;
+</span>    readonly attribute <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a> playback;
+    readonly attribute <a href="#MediaControllerPlaylists">MediaControllerPlaylists</a> playlists;
+    attribute DOMString? iconURI raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute <a href="#MediaControllerAbilities">MediaControllerAbilities</a> abilities;
     readonly attribute <a href="#MediaControllerSubtitles">MediaControllerSubtitles</a> subtitles;
     readonly attribute <a href="#MediaControllerMode360">MediaControllerMode360</a> mode360;
     readonly attribute <a href="#MediaControllerDisplayMode">MediaControllerDisplayMode</a> displayMode;
     readonly attribute <a href="#MediaControllerDisplayRotation">MediaControllerDisplayRotation</a> displayRotation;
     <a href="#MediaControllerClientInfo">MediaControllerClientInfo</a>[] getAllClientsInfo() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateIconURI(DOMString? iconURI) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackPosition(unsigned long long position) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackAgeRating(<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackContentType(<a href="#MediaControllerContentType">MediaControllerContentType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateShuffleMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-<span class="nocode deprecated">    void updateRepeatMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-</span>    void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateMetadata(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addChangeRequestPlaybackInfoListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removeChangeRequestPlaybackInfoListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void setSearchRequestListener(<a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    void updatePlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updateIconURI(DOMString? iconURI) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updatePlaybackPosition(unsigned long long position) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updatePlaybackAgeRating(<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updatePlaybackContentType(<a href="#MediaControllerContentType">MediaControllerContentType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updateShuffleMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updateRepeatMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void updateMetadata(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    long addChangeRequestPlaybackInfoListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void removeChangeRequestPlaybackInfoListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    void setSearchRequestListener(<a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unsetSearchRequestListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addCommandListener(<a href="#MediaControllerReceiveCommandCallback">MediaControllerReceiveCommandCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeCommandListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+<span class="nocode deprecated">    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+</span><span class="nocode deprecated">    void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackItem(DOMString playlistName, DOMString index) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+</span><span class="nocode deprecated">    void updatePlaybackItem(DOMString playlistName, DOMString index) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };</pre>
+</span>  };</pre>
 <p><span class="version">Since: </span>
  2.4
           </p>
@@ -905,11 +965,14 @@ and be controlled by other application(client) remotely.
 <div class="attributes">
 <h4>Attributes</h4>
 <ul>
-<li class="attribute" id="MediaControllerServer::playbackInfo">
+<li class="attribute deprecated" id="MediaControllerServer::playbackInfo">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">MediaControllerPlaybackInfo </span><span class="name">playbackInfo</span></span><div class="brief">
  Current playback info.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a> <var>playback</var> attribute.
+            </p>
 <p><span class="version">Since: </span>
  2.4
             </p>
@@ -917,14 +980,41 @@ and be controlled by other application(client) remotely.
  Object holds state which is automatically updated by update methods.
             </p>
 </li>
-<li class="attribute" id="MediaControllerServer::iconURI">
+<li class="attribute" id="MediaControllerServer::playback">
 <span class="attrName"><span class="readonly">                readonly
-</span><span class="type">DOMString </span><span class="name">iconURI</span><span class="optional"> [nullable]</span></span><div class="brief">
+</span><span class="type">MediaControllerServerPlaybackInfo </span><span class="name">playback</span></span><div class="brief">
+ Current playback info.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServer::playlists">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerPlaylists </span><span class="name">playlists</span></span><div class="brief">
+ Object representing features related to playlists of a media controller server.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServer::iconURI">
+<span class="attrName"><span class="type">DOMString </span><span class="name">iconURI</span><span class="optional"> [nullable]</span></span><div class="brief">
  Server icon URI.
             </div>
 <p><span class="version">Since: </span>
  5.5
             </p>
+<p><span class="remark">Remark: </span>
+ The readonly modifier is removed since 6.0 version.
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
 </li>
 <li class="attribute" id="MediaControllerServer::abilities">
 <span class="attrName"><span class="readonly">                readonly
@@ -1005,15 +1095,18 @@ and be controlled by other application(client) remotely.
 </li></ul>
         </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updatePlaybackState">
+<dt class="deprecated method" id="MediaControllerServer::updatePlaybackState">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updatePlaybackState"></a><code><b><span class="methodName">updatePlaybackState</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates playback state and send notification to the listening clients.
 See <em>MediaControllerServerInfo.addPlaybackInfoChangeListener</em> to check
 how to receive playback info changes from server on client side.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>state</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updatePlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1051,13 +1144,16 @@ console.log("Current playback state is: " + mcServer.playbackInfo.state);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updateIconURI">
+<dt class="deprecated method" id="MediaControllerServer::updateIconURI">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updateIconURI"></a><code><b><span class="methodName">updateIconURI</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates server icon URI.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>iconURI</var> attribute in <a href="#MediaControllerServer">MediaControllerServer</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updateIconURI(DOMString? iconURI);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1092,13 +1188,16 @@ console.log(mcServerInfo.iconURI);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updatePlaybackPosition">
+<dt class="deprecated method" id="MediaControllerServer::updatePlaybackPosition">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updatePlaybackPosition"></a><code><b><span class="methodName">updatePlaybackPosition</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates playback position and send notification to the listening clients.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>position</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updatePlaybackPosition(unsigned long long position);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1136,13 +1235,16 @@ console.log("Current playback position is: " + mcServer.playbackInfo.position);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updatePlaybackAgeRating">
+<dt class="deprecated method" id="MediaControllerServer::updatePlaybackAgeRating">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updatePlaybackAgeRating"></a><code><b><span class="methodName">updatePlaybackAgeRating</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Sets content age rating for current playback item.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>ageRating</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updatePlaybackAgeRating(<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1182,13 +1284,16 @@ console.log("Only viewers older than " + mcServerInfo.playbackInfo.ageRating +
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updatePlaybackContentType">
+<dt class="deprecated method" id="MediaControllerServer::updatePlaybackContentType">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updatePlaybackContentType"></a><code><b><span class="methodName">updatePlaybackContentType</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Sets content type for the current playback item.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>contentType</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updatePlaybackContentType(<a href="#MediaControllerContentType">MediaControllerContentType</a> type);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1227,13 +1332,16 @@ console.log("Content type of current item is " + mcServerInfo.playbackInfo.conte
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updateShuffleMode">
+<dt class="deprecated method" id="MediaControllerServer::updateShuffleMode">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updateShuffleMode"></a><code><b><span class="methodName">updateShuffleMode</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates shuffle mode and send notification to the listening clients.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>shuffleMode</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updateShuffleMode(boolean mode);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1304,13 +1412,16 @@ console.log("Current repeat mode is: " + mcServer.playbackInfo.repeatMode);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updateRepeatState">
+<dt class="deprecated method" id="MediaControllerServer::updateRepeatState">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updateRepeatState"></a><code><b><span class="methodName">updateRepeatState</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates repeat state and sends notification to the listening clients.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use setter of <var>repeatState</var> attribute in <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1348,13 +1459,16 @@ console.log("Current repeat state is: " + mcServer.playbackInfo.repeatState);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updateMetadata">
+<dt class="deprecated method" id="MediaControllerServer::updateMetadata">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updateMetadata"></a><code><b><span class="methodName">updateMetadata</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Updates metadata and send notification to the listening clients.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerMetadata::save">save()</a> on metadata object.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updateMetadata(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1397,15 +1511,18 @@ console.log("Current metadata is: " + JSON.stringify(mcServer.playbackInfo.metad
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::addChangeRequestPlaybackInfoListener">
+<dt class="deprecated method" id="MediaControllerServer::addChangeRequestPlaybackInfoListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::addChangeRequestPlaybackInfoListener"></a><code><b><span class="methodName">addChangeRequestPlaybackInfoListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Adds the listener for a media playback info requests from client.
 See <em>MediaControllerServerInfo</em> to check how to send playback info change
 requests from client.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerPlaybackInfo::addChangeRequestListener">addChangeRequestListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">long addChangeRequestPlaybackInfoListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1472,13 +1589,16 @@ watcherId = mcServer.addChangeRequestPlaybackInfoListener(playbackRequestListene
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::removeChangeRequestPlaybackInfoListener">
+<dt class="deprecated method" id="MediaControllerServer::removeChangeRequestPlaybackInfoListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::removeChangeRequestPlaybackInfoListener"></a><code><b><span class="methodName">removeChangeRequestPlaybackInfoListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Removes the listener, so stop receiving playback state requests from clients.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerPlaybackInfo::removeChangeRequestListener">removeChangeRequestListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void removeChangeRequestPlaybackInfoListener(long watchId);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -1731,13 +1851,16 @@ mcServer.removeCommandListener(watcherId);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::createPlaylist">
+<dt class="deprecated method" id="MediaControllerServer::createPlaylist">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::createPlaylist"></a><code><b><span class="methodName">createPlaylist</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Creates <em>MediaControllerPlaylist</em> object.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylists::createPlaylist">createPlaylist()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint"><a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1779,13 +1902,16 @@ var playlist = mcServer.createPlaylist("testPlaylistName");
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::savePlaylist">
+<dt class="deprecated method" id="MediaControllerServer::savePlaylist">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::savePlaylist"></a><code><b><span class="methodName">savePlaylist</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
- Saves playlist in local database.
+ Saves the playlist in a local database.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylists::savePlaylist">savePlaylist()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                   optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
@@ -1797,13 +1923,13 @@ The <em>errorCallback</em> may be triggered for one of the following errors:
             </p>
             <ul>
               <li>
-<em>InvalidValuesError</em>: if playlist with given name does not exists.              </li>
+<em>InvalidValuesError</em>: if playlist with given name does not exist.              </li>
               <li>
-<em>UnknownError</em>: if any other error prevents function from successful completion.              </li>
+<em>UnknownError</em>: if any other error prevents the function from successful completion.              </li>
             </ul>
            </div>
 <p><span class="remark">Remark: </span>
- All playlists will be deleted after application is closed.
+ All playlists will be deleted after the application is closed.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -1853,13 +1979,16 @@ mcServer.savePlaylist(playlist, successCallback, errorCallback);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::deletePlaylist">
+<dt class="deprecated method" id="MediaControllerServer::deletePlaylist">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::deletePlaylist"></a><code><b><span class="methodName">deletePlaylist</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Deletes playlist from local database.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylists::deletePlaylist">deletePlaylist()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1870,9 +1999,9 @@ The <em>errorCallback</em> may be triggered for one of the following errors:
             </p>
             <ul>
               <li>
-<em>InvalidValuesError</em>: if playlist with given name does not exists.              </li>
+<em>InvalidValuesError</em>: if playlist with given name does not exist.              </li>
               <li>
-<em>UnknownError</em>: if any other error prevents function from successful completion.              </li>
+<em>UnknownError</em>: if any other error prevents the function from successful completion.              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1927,13 +2056,16 @@ mcServer.savePlaylist(playlist, saveSuccess);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::updatePlaybackItem">
+<dt class="deprecated method" id="MediaControllerServer::updatePlaybackItem">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::updatePlaybackItem"></a><code><b><span class="methodName">updatePlaybackItem</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Sets index and playlist name properties of playback info object.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerPlaybackInfo::updatePlaybackItem">updatePlaybackItem()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void updatePlaybackItem(DOMString playlistName, DOMString index);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -1990,13 +2122,16 @@ Current index: index1
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServer::getAllPlaylists">
+<dt class="deprecated method" id="MediaControllerServer::getAllPlaylists">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServer::getAllPlaylists"></a><code><b><span class="methodName">getAllPlaylists</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
- Retrieves all playlists from local database.
+ Retrieves all playlists from a local database.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylists::getAllPlaylists">getAllPlaylists()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -2553,38 +2688,40 @@ Provides methods to send commands to server and listen for server status change.
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerServerInfo {
     readonly attribute <a href="application.html#ApplicationId">ApplicationId</a> name;
     readonly attribute <a href="#MediaControllerServerState">MediaControllerServerState</a> state;
-    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+<span class="nocode deprecated">    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>    readonly attribute <a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a> playback raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    readonly attribute <a href="#MediaControllerPlaylistsInfo">MediaControllerPlaylistsInfo</a> playlists;
     readonly attribute DOMString? iconURI raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute <a href="#MediaControllerAbilitiesInfo">MediaControllerAbilitiesInfo</a> abilities;
     readonly attribute <a href="#MediaControllerSubtitlesInfo">MediaControllerSubtitlesInfo</a> subtitles;
     readonly attribute <a href="#MediaControllerMode360Info">MediaControllerMode360Info</a> mode360;
     readonly attribute <a href="#MediaControllerDisplayModeInfo">MediaControllerDisplayModeInfo</a> displayMode;
     readonly attribute <a href="#MediaControllerDisplayRotationInfo">MediaControllerDisplayRotationInfo</a> displayRotation;
-    void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+<span class="nocode deprecated">    void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                            optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+</span><span class="nocode deprecated">    void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                               optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendShuffleMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+</span><span class="nocode deprecated">    void sendShuffleMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-<span class="nocode deprecated">    void sendRepeatMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+</span><span class="nocode deprecated">    void sendRepeatMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-</span>    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+</span><span class="nocode deprecated">    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                          optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendSearchRequest(<a href="#SearchFilter">SearchFilter</a>[] request, <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a> replyCallback,
+</span>    void sendSearchRequest(<a href="#SearchFilter">SearchFilter</a>[] request, <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a> replyCallback,
                            optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void sendCommand(DOMString command, <a href="tizen.html#Bundle">Bundle</a>? data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addServerStatusChangeListener(<a href="#MediaControllerServerStatusChangeCallback">MediaControllerServerStatusChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeServerStatusChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removePlaybackInfoChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+<span class="nocode deprecated">    long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void removePlaybackInfoChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position)
+</span><span class="nocode deprecated">    void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position)
                           raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removePlaylistUpdatedListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-  };</pre>
+</span><span class="nocode deprecated">    long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span><span class="nocode deprecated">    void removePlaylistUpdatedListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+</span>  };</pre>
 <p><span class="version">Since: </span>
  2.4
           </p>
@@ -2609,11 +2746,14 @@ Provides methods to send commands to server and listen for server status change.
  2.4
             </p>
 </li>
-<li class="attribute" id="MediaControllerServerInfo::playbackInfo">
+<li class="attribute deprecated" id="MediaControllerServerInfo::playbackInfo">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">MediaControllerPlaybackInfo </span><span class="name">playbackInfo</span></span><div class="brief">
  Current playback info.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a> <var>playback</var> attribute.
+            </p>
 <p><span class="version">Since: </span>
  2.4
             </p>
@@ -2624,6 +2764,31 @@ Provides methods to send commands to server and listen for server status change.
                 </p></li></ul>
 </li></ul>
         </div>
+</li>
+<li class="attribute" id="MediaControllerServerInfo::playback">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerServerInfoPlaybackInfo </span><span class="name">playback</span></span><div class="brief">
+ Playback info of current server info.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerInfo::playlists">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerPlaylistsInfo </span><span class="name">playlists</span></span><div class="brief">
+ An attribute providing access to the playlist information from the server.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
 </li>
 <li class="attribute" id="MediaControllerServerInfo::iconURI">
 <span class="attrName"><span class="readonly">                readonly
@@ -2691,13 +2856,16 @@ Provides methods to send commands to server and listen for server status change.
 <div class="methods">
 <h4>Methods</h4>
 <dl>
-<dt class="method" id="MediaControllerServerInfo::sendPlaybackState">
+<dt class="deprecated method" id="MediaControllerServerInfo::sendPlaybackState">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::sendPlaybackState"></a><code><b><span class="methodName">sendPlaybackState</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Allows to change playback state of media controller server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::sendPlaybackAction">sendPlaybackAction()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                        optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
@@ -2752,13 +2920,16 @@ mcServerInfo.sendPlaybackState("STOP",
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::sendPlaybackPosition">
+<dt class="deprecated method" id="MediaControllerServerInfo::sendPlaybackPosition">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::sendPlaybackPosition"></a><code><b><span class="methodName">sendPlaybackPosition</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Allows to change playback position of media controller server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::sendPlaybackPosition">sendPlaybackPosition()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                           optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
@@ -2816,13 +2987,16 @@ mcServerInfo.sendPlaybackPosition(164,
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::sendShuffleMode">
+<dt class="deprecated method" id="MediaControllerServerInfo::sendShuffleMode">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::sendShuffleMode"></a><code><b><span class="methodName">sendShuffleMode</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Allows to change shuffle mode of media controller server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::sendShuffleMode">sendShuffleMode()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void sendShuffleMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -2935,13 +3109,16 @@ mcServerInfo.sendRepeatMode(false,
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::sendRepeatState">
+<dt class="deprecated method" id="MediaControllerServerInfo::sendRepeatState">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::sendRepeatState"></a><code><b><span class="methodName">sendRepeatState</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Allows to change repeat state of media controller server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::sendRepeatState">sendRepeatState()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
@@ -3255,13 +3432,16 @@ mcServerInfo.removeServerStatusChangeListener(watcherId);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::addPlaybackInfoChangeListener">
+<dt class="deprecated method" id="MediaControllerServerInfo::addPlaybackInfoChangeListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::addPlaybackInfoChangeListener"></a><code><b><span class="methodName">addPlaybackInfoChangeListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Adds the listener for a media playback info changes.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::addPlaybackInfoChangeListener">addPlaybackInfoChangeListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -3325,13 +3505,16 @@ watcherId = mcServerInfo.addPlaybackInfoChangeListener(playbackListener);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::removePlaybackInfoChangeListener">
+<dt class="deprecated method" id="MediaControllerServerInfo::removePlaybackInfoChangeListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::removePlaybackInfoChangeListener"></a><code><b><span class="methodName">removePlaybackInfoChangeListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Removes the listener, so stop receiving notifications about media playback info changes.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerInfoPlaybackInfo::removePlaybackInfoChangeListener">removePlaybackInfoChangeListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void removePlaybackInfoChangeListener(long watchId);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -3392,13 +3575,16 @@ mcServerInfo.removePlaybackInfoChangeListener(watcherId);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::getAllPlaylists">
+<dt class="deprecated method" id="MediaControllerServerInfo::getAllPlaylists">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::getAllPlaylists"></a><code><b><span class="methodName">getAllPlaylists</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Retrieves all playlists saved in local database.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylistsInfo::getAllPlaylists">getAllPlaylists()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -3474,13 +3660,16 @@ Playlist name: testPlaylist
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::sendPlaybackItem">
+<dt class="deprecated method" id="MediaControllerServerInfo::sendPlaybackItem">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::sendPlaybackItem"></a><code><b><span class="methodName">sendPlaybackItem</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Requests setting new playback item to server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylistsInfo::sendPlaybackItem">sendPlaybackItem()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -3523,13 +3712,16 @@ mcServerInfo.sendPlaybackItem("testPlaylist", "1", "PLAY", 0);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::addPlaylistUpdatedListener">
+<dt class="deprecated method" id="MediaControllerServerInfo::addPlaylistUpdatedListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::addPlaylistUpdatedListener"></a><code><b><span class="methodName">addPlaylistUpdatedListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Adds listener to be invoked when playlist is updated by server.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylistsInfo::addPlaylistUpdatedListener">addPlaylistUpdatedListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -3581,13 +3773,16 @@ var listenerId = mcServerInfo.addPlaylistUpdatedListener(listener);
 </pre>
 </div>
 </dd>
-<dt class="method" id="MediaControllerServerInfo::removePlaylistUpdatedListener">
+<dt class="deprecated method" id="MediaControllerServerInfo::removePlaylistUpdatedListener">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfo::removePlaylistUpdatedListener"></a><code><b><span class="methodName">removePlaylistUpdatedListener</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Stops listening for playlist updates and removals.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerPlaylistsInfo::removePlaylistUpdatedListener">removePlaylistUpdatedListener()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void removePlaylistUpdatedListener(long listenerId);</pre></div>
 <p><span class="version">Since: </span>
  5.5
@@ -3628,12 +3823,17 @@ mcServerInfo.removePlaylistUpdatedListener(listenerId);
 </dl>
 </div>
 </div>
-<div class="interface" id="MediaControllerPlaybackInfo">
+<div class="interface deprecated" id="MediaControllerPlaybackInfo">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackInfo"></a><h3>2.6. MediaControllerPlaybackInfo</h3>
 <div class="brief">
  Current playback info.
           </div>
-<pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerPlaybackInfo {
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a> for
+server-side object of playback info and <a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a> for
+client-side object of playback info.
+          </p>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  [NoInterfaceObject] interface MediaControllerPlaybackInfo {
     readonly attribute <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state;
     readonly attribute unsigned long long position;
     readonly attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating;
@@ -3644,7 +3844,7 @@ mcServerInfo.removePlaylistUpdatedListener(listenerId);
     readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
     readonly attribute DOMString? index;
     readonly attribute DOMString? playlistName;
-  };</pre>
+  };</span></pre>
 <p><span class="version">Since: </span>
  2.4
           </p>
@@ -3780,8 +3980,1445 @@ Default value is <var>REPEAT_ALL</var>.
 </ul>
 </div>
 </div>
+<div class="interface" id="MediaControllerServerPlaybackInfo">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerPlaybackInfo"></a><h3>2.7. MediaControllerServerPlaybackInfo</h3>
+<div class="brief">
+ Server-side object representing current playback info.
+          </div>
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerServerPlaybackInfo {
+    attribute <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute unsigned long long position raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerContentType">MediaControllerContentType</a> contentType raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute boolean shuffleMode raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> repeatState raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
+    readonly attribute DOMString? index;
+    readonly attribute DOMString? playlistName;
+    void updatePlaybackItem(DOMString playlistName, DOMString index) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addChangeRequestListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removeChangeRequestListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };</pre>
+<p><span class="version">Since: </span>
+ 6.0
+          </p>
+<div class="attributes">
+<h4>Attributes</h4>
+<ul>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::state">
+<span class="attrName"><span class="type">MediaControllerPlaybackState </span><span class="name">state</span></span><div class="brief">
+ Current playback state.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if the set value will not be compatible with <var>MediaControllerPlaybackState</var> enum.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::position">
+<span class="attrName"><span class="type">unsigned long long </span><span class="name">position</span></span><div class="brief">
+ Current playback position.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type InvalidValuesError, if the set value is less than 0.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::ageRating">
+<span class="attrName"><span class="type">MediaControllerContentAgeRating </span><span class="name">ageRating</span></span><div class="brief">
+ Current playback age rating.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if the set value will not be compatible with <var>MediaControllerContentAgeRating</var> enum.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::contentType">
+<span class="attrName"><span class="type">MediaControllerContentType </span><span class="name">contentType</span></span><div class="brief">
+ Current playback content type.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if the set value will not be compatible with <var>MediaControllerContentType</var> enum.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::shuffleMode">
+<span class="attrName"><span class="type">boolean </span><span class="name">shuffleMode</span></span><div class="brief">
+ Current shuffle mode.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::repeatState">
+<span class="attrName"><span class="type">MediaControllerRepeatState </span><span class="name">repeatState</span></span><div class="brief">
+ Current repeat state.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if the set value will not be compatible with <var>MediaControllerRepeatState</var> enum.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::metadata">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerMetadata </span><span class="name">metadata</span></span><div class="brief">
+ Current playback metadata.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::index">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">DOMString </span><span class="name">index</span><span class="optional"> [nullable]</span></span><div class="brief">
+ Current item index.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerPlaybackInfo::playlistName">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">DOMString </span><span class="name">playlistName</span><span class="optional"> [nullable]</span></span><div class="brief">
+ Current playlist name.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+</ul>
+</div>
+<div class="methods">
+<h4>Methods</h4>
+<dl>
+<dt class="method" id="MediaControllerServerPlaybackInfo::updatePlaybackItem">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerPlaybackInfo::updatePlaybackItem"></a><code><b><span class="methodName">updatePlaybackItem</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Sets index and playlist name properties of playback info object.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void updatePlaybackItem(DOMString playlistName, DOMString index);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlistName</span>:
+ Name of playlist to be set.
+                </li>
+          <li class="param">
+<span class="name">index</span>:
+ Index of item on playlist <em>playlistName</em> to be set.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+
+mcServer.playback.updatePlaybackItem("testPlaylistName", "index1");
+console.log("Current playlist: " + mcServer.playback.playlistName);
+console.log("Current index: " + mcServer.playback.index);
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>Current playlist: testPlaylistName
+Current index: index1
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerPlaybackInfo::addChangeRequestListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerPlaybackInfo::addChangeRequestListener"></a><code><b><span class="methodName">addChangeRequestListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Adds the listener for change requests of a media controller playback info.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">long addChangeRequestListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">listener</span>:
+ Change request listener to add.
+                </li>
+        </ul>
+</div>
+<div class="returntype">
+<p><span class="return">Return value:</span></p>
+<ul>
+<span class="return">long:</span>
+ The identifier used to remove the listener.
+              </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var watcherId = 0;  /* Watcher identifier. */
+var mcServer = tizen.mediacontroller.createServer();
+
+var playbackRequestListener =
+{
+  onplaybackactionrequest: function(action, clientName)
+  {
+    console.log("Playback action requested to: " + action + " by " + clientName);
+  },
+  onplaybackpositionrequest: function(position, clientName)
+  {
+    console.log("Playback position requested to: " + position + " by " + clientName);
+  },
+  onshufflemoderequest: function(mode, clientName)
+  {
+    console.log("Shuffle mode requested to: " + mode + " by " + clientName);
+  },
+  onrepeatstaterequest: function(state, clientName)
+  {
+    console.log("Repeat state requested to: " + state + " by " + clientName);
+  },
+  onplaybackitemrequest: function(playlistName, index, state, position, clientName)
+  {
+    console.log("Playlist: " + playlistName + " index: " + index + " state: " + state +
+                " position " + position + " requested by " + clientName);
+  }
+};
+
+/* Registers to receive playback info change requests from client. */
+watcherId = mcServer.playback.addChangeRequestListener(playbackRequestListener);
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerPlaybackInfo::removeChangeRequestListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerPlaybackInfo::removeChangeRequestListener"></a><code><b><span class="methodName">removeChangeRequestListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Removes the listener and stops receiving change requests of media controller playback info.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void removeChangeRequestListener(long watchId);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">watchId</span>:
+ Watcher identifier.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var watcherId = 0;  /* Watcher identifier. */
+var mcServer = tizen.mediacontroller.createServer();
+
+var playbackRequestListener =
+{
+  onplaybackactionrequest: function(action, clientName) {},
+  onplaybackpositionrequest: function(position, clientName) {},
+  onshufflemoderequest: function(mode, clientName) {},
+  onrepeatstaterequest: function(state, clientName) {},
+  onplaybackitemrequest: function(playlistName, index, state, position, clientName) {}
+};
+
+/* Registers to receive playback info change requests from client. */
+watcherId = mcServer.playback.addChangeRequestListener(playbackRequestListener);
+
+/* Cancels the watch operation. */
+mcServer.playback.removeChangeRequestListener(watcherId);
+</pre>
+</div>
+</dd>
+</dl>
+</div>
+</div>
+<div class="interface" id="MediaControllerServerInfoPlaybackInfo">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo"></a><h3>2.8. MediaControllerServerInfoPlaybackInfo</h3>
+<div class="brief">
+ Client-side object representing current playback info.
+          </div>
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerServerInfoPlaybackInfo {
+    readonly attribute <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state;
+    readonly attribute unsigned long long position;
+    readonly attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating;
+    readonly attribute <a href="#MediaControllerContentType">MediaControllerContentType</a> contentType;
+    readonly attribute boolean shuffleMode;
+    readonly attribute <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> repeatState;
+    readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
+    readonly attribute DOMString? index;
+    readonly attribute DOMString? playlistName;
+    void sendPlaybackAction(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                            raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendPlaybackPosition(unsigned long long position, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                              raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendShuffleMode(boolean mode, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removePlaybackInfoChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };</pre>
+<p><span class="version">Since: </span>
+ 6.0
+          </p>
+<div class="attributes">
+<h4>Attributes</h4>
+<ul>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::state">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerPlaybackState </span><span class="name">state</span></span><div class="brief">
+ Current playback state.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::position">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">unsigned long long </span><span class="name">position</span></span><div class="brief">
+ Current playback position.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::ageRating">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerContentAgeRating </span><span class="name">ageRating</span></span><div class="brief">
+ Current playback age rating.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::contentType">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerContentType </span><span class="name">contentType</span></span><div class="brief">
+ Current playback content type.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::shuffleMode">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">boolean </span><span class="name">shuffleMode</span></span><div class="brief">
+ Current shuffle mode.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::repeatState">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerRepeatState </span><span class="name">repeatState</span></span><div class="brief">
+ Current repeat state.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::metadata">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">MediaControllerMetadata </span><span class="name">metadata</span></span><div class="brief">
+ Current playback metadata.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::index">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">DOMString </span><span class="name">index</span><span class="optional"> [nullable]</span></span><div class="brief">
+ Current item index. Value set to <var>null</var> means no playlist set in playback
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+<li class="attribute" id="MediaControllerServerInfoPlaybackInfo::playlistName">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">DOMString </span><span class="name">playlistName</span><span class="optional"> [nullable]</span></span><div class="brief">
+ Current playlist name. Value set to <var>null</var> means no playlist set in playback
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+</li>
+</ul>
+</div>
+<div class="methods">
+<h4>Methods</h4>
+<dl>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::sendPlaybackAction">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::sendPlaybackAction"></a><code><b><span class="methodName">sendPlaybackAction</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Sends request to change the playback state of a media controller server.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackAction(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">action</span>:
+ Playback action.
+                </li>
+          <li class="param">
+<span class="name">replyCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method to invoke when server responded to change request.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+mcServerInfo.playback.sendPlaybackAction("STOP", function(data, code)
+{
+  console.log("Server replied with return data: " + JSON.stringify(data) + " and code: " + code);
+});
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::sendPlaybackPosition">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::sendPlaybackPosition"></a><code><b><span class="methodName">sendPlaybackPosition</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Sends request to change the playback position of a media controller server.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackPosition(unsigned long long position, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">position</span>:
+ Playback position.
+                </li>
+          <li class="param">
+<span class="name">replyCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method to invoke when server responded to change request.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type InvalidValuesError, if any of the input parameters contain an invalid value.
+                </p></li>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+mcServerInfo.playback.sendPlaybackPosition(164, function(data, code)
+{
+  console.log("Server replied with return data: " + JSON.stringify(data) + " and code: " + code);
+});
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::sendShuffleMode">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::sendShuffleMode"></a><code><b><span class="methodName">sendShuffleMode</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Sends request to change the shuffle mode of a media controller server.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void sendShuffleMode(boolean mode, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">mode</span>:
+ Shuffle mode.
+                </li>
+          <li class="param">
+<span class="name">replyCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method to invoke when server responded to change request.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+mcServerInfo.playback.sendShuffleMode(true, function(data, code)
+{
+  console.log("Server replied with return data: " + JSON.stringify(data) + " and code: " + code);
+});
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::sendRepeatState">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::sendRepeatState"></a><code><b><span class="methodName">sendRepeatState</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Sends request to change the repeat state of a media controller server.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 5.5
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">state</span>:
+ Repeat state to be set.
+                </li>
+          <li class="param">
+<span class="name">replyCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method to invoke when server responded to change request.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+mcServerInfo.playback.sendRepeatState("REPEAT_ALL", function(data, code)
+{
+  console.log("Server replied with return data: " + JSON.stringify(data) + " and code: " + code);
+});
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::addPlaybackInfoChangeListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::addPlaybackInfoChangeListener"></a><code><b><span class="methodName">addPlaybackInfoChangeListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Adds the listener for a media playback info changes.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">listener</span>:
+ Status change listener to add.
+                </li>
+        </ul>
+</div>
+<div class="returntype">
+<p><span class="return">Return value:</span></p>
+<ul>
+<span class="return">long:</span>
+ The identifier used to clear the watch subscription.
+              </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var watcherId = 0;  /* Watcher identifier. */
+var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+/* receives playback state changes. */
+var playbackListener =
+{
+  onplaybackchanged: function(state, position)
+  {
+    console.log("Current playback state: " + state);
+    console.log("Current playback position: " + position);
+  },
+  onshufflemodechanged: function(mode)
+  {
+    console.log("Shuffle mode changed to: " + mode);
+  },
+  onrepeatstatechanged: function(state)
+  {
+    console.log("Repeat state changed to: " + state);
+  },
+  onmetadatachanged: function(metadata)
+  {
+    console.log("Playback metadata changed: " + JSON.stringify(metadata));
+  }
+};
+
+/* Registers to be notified when playback state changes. */
+watcherId = mcServerInfo.playback.addPlaybackInfoChangeListener(playbackListener);
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerServerInfoPlaybackInfo::removePlaybackInfoChangeListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoPlaybackInfo::removePlaybackInfoChangeListener"></a><code><b><span class="methodName">removePlaybackInfoChangeListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Removes the listener, so stop receiving notifications about media playback info changes.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void removePlaybackInfoChangeListener(long watchId);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+Calling this function has no effect if there is no listener with given id.
+            </p>
+           </div>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">watchId</span>:
+ Subscription identifier.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var watcherId = 0;  /* Watcher identifier. */
+var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+/* receives playback state changes. */
+var playbackListener =
+{
+  onplaybackchanged: function(state, position) {},
+  onshufflemodechanged: function(mode) {},
+  onrepeatstatechanged: function(state) {},
+  onmetadatachanged: function(metadata) {}
+};
+
+/* Registers to be notified when playback state changes. */
+watcherId = mcServerInfo.playback.addPlaybackInfoChangeListener(playbackListener);
+
+/* Cancels the watch operation. */
+mcServerInfo.playback.removePlaybackInfoChangeListener(watcherId);
+</pre>
+</div>
+</dd>
+</dl>
+</div>
+</div>
+<div class="interface" id="MediaControllerPlaylists">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists"></a><h3>2.9. MediaControllerPlaylists</h3>
+<div class="brief">
+ Server-side object representing methods for playlists of a media controller server.
+          </div>
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerPlaylists {
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                        raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };</pre>
+<p><span class="version">Since: </span>
+ 6.0
+          </p>
+<div class="methods">
+<h4>Methods</h4>
+<dl>
+<dt class="method" id="MediaControllerPlaylists::createPlaylist">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists::createPlaylist"></a><code><b><span class="methodName">createPlaylist</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Creates <em>MediaControllerPlaylist</em> object.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<p><span class="remark">Remark: </span>
+ Please note that there is a need to use <a href="#MediaControllerPlaylists::savePlaylist">savePlaylist()</a>, otherwise playlist creation will have no effect on a device. All playlists will be deleted after application is closed.
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">name</span>:
+ Name of the new playlist.
+                </li>
+        </ul>
+</div>
+<div class="returntype">
+<p><span class="return">Return value:</span></p>
+<ul>
+<span class="return">MediaControllerPlaylist:</span>
+ New empty <em>MediaControllerPlaylist</em> object with given name.
+              </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type InvalidValuesError, if playlist with given name already exists.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var playlist = mcServer.playlists.createPlaylist("testPlaylistName");
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylists::savePlaylist">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists::savePlaylist"></a><code><b><span class="methodName">savePlaylist</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Saves the playlist in a local database.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+                  optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+The <em>errorCallback</em> may be triggered for one of the following errors:
+            </p>
+            <ul>
+              <li>
+<em>InvalidValuesError</em>: if playlist with given name does not exist.              </li>
+              <li>
+<em>UnknownError</em>: if any other error prevents the function from successful completion.              </li>
+            </ul>
+           </div>
+<p><span class="remark">Remark: </span>
+ All playlists will be deleted after the application is closed.
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlist</span>:
+ <em>MediaControllerPlaylist</em> object to save.
+                </li>
+          <li class="param">
+<span class="name">successCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called when <em>savePlaylist</em> is finished without error.
+                </li>
+          <li class="param">
+<span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called when <em>savePlaylist</em> fails.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var playlist = mcServer.playlists.createPlaylist("testPlaylistName");
+function successCallback()
+{
+  console.log("savePlaylist successful.");
+}
+function errorCallback(error)
+{
+  console.log("savePlaylist failed with error: " + error);
+}
+mcServer.playlists.savePlaylist(playlist, successCallback, errorCallback);
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>savePlaylist successful.
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylists::deletePlaylist">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists::deletePlaylist"></a><code><b><span class="methodName">deletePlaylist</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Deletes the playlist from a local database.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+The <em>errorCallback</em> may be triggered for one of the following errors:
+            </p>
+            <ul>
+              <li>
+<em>InvalidValuesError</em>: if playlist with given name does not exist.              </li>
+              <li>
+<em>UnknownError</em>: if any other error prevents the function from successful completion.              </li>
+            </ul>
+           </div>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlistName</span>:
+ Name of the playlist to remove.
+                </li>
+          <li class="param">
+<span class="name">successCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called when <em>deletePlaylist</em> is finished without error.
+                </li>
+          <li class="param">
+<span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called when <em>deletePlaylist</em> fails.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var playlist = mcServer.playlists.createPlaylist("testPlaylistName");
+function deleteSuccess()
+{
+  console.log("deletePlaylist successful.");
+}
+function deleteFailure(error)
+{
+  console.log("deletePlaylist failed with error: " + error);
+}
+function saveSuccess()
+{
+  mcServer.playlists.deletePlaylist(playlist.name, deleteSuccess, deleteFailure);
+}
+mcServer.playlists.savePlaylist(playlist, saveSuccess);
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>deletePlaylist successful.
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylists::getAllPlaylists">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists::getAllPlaylists"></a><code><b><span class="methodName">getAllPlaylists</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Retrieves all playlists from a local database.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+The <em>errorCallback</em> may be triggered for one of the following errors:
+            </p>
+            <ul>
+              <li>
+<em>UnknownError</em>: if any error prevents function from successful completion.              </li>
+            </ul>
+           </div>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">successCallback</span>:
+ Function to be called on <em>getAllPlaylists</em> success.
+                </li>
+          <li class="param">
+<span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called when <em>getAllPlaylists</em> fails.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any parameter has invalid type.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var playlist = mcServer.playlists.createPlaylist("testPlaylist");
+
+function saveSuccess()
+{
+  console.log("savePlaylist successful");
+  function successCallback(playlists)
+  {
+    playlists.forEach(function(playlist)
+    {
+      console.log("Playlist name: " + playlist.name);
+    });
+  }
+  function errorCallback(error)
+  {
+    console.log("getAllPlaylists failed with error: " + error);
+  }
+  mcServer.playlists.getAllPlaylists(successCallback, errorCallback);
+}
+function saveError(error)
+{
+  console.log("savePlaylist failed with error: " + error);
+}
+
+mcServer.playlists.savePlaylist(playlist, saveSuccess, saveError);
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>savePlaylist successful
+Playlist name: testPlaylistName
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylists::getPlaylist">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylists::getPlaylist"></a><code><b><span class="methodName">getPlaylist</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Returns the playlist with the given name.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlistName</span>:
+ The name of playlist to get.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type NotFoundError, if the playlist with the given name does not exist.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">/* assuming that the playlist was previously created */
+var mcServer = tizen.mediacontroller.createServer();
+var playlist = null;
+try
+{
+  playlist = mcServer.playlists.getPlaylist("testPlaylist");
+}
+catch (err)
+{
+  console.log(err.name + ": " + err.message);
+}
+</pre>
+</div>
+</dd>
+</dl>
+</div>
+</div>
+<div class="interface" id="MediaControllerPlaylistsInfo">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo"></a><h3>2.10. MediaControllerPlaylistsInfo</h3>
+<div class="brief">
+ Client-side object representing methods for playlists of a media controller server.
+          </div>
+<pre class="webidl prettyprint">  [NoInterfaceObject] interface MediaControllerPlaylistsInfo {
+    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, unsigned long long position,
+                          optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removePlaylistUpdatedListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };</pre>
+<p><span class="version">Since: </span>
+ 6.0
+          </p>
+<div class="methods">
+<h4>Methods</h4>
+<dl>
+<dt class="method" id="MediaControllerPlaylistsInfo::getAllPlaylists">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo::getAllPlaylists"></a><code><b><span class="methodName">getAllPlaylists</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Retrieves all playlists saved in local database.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="description">
+            <p>
+The <em>errorCallback</em> may be triggered for one of the following errors:
+            </p>
+            <ul>
+              <li>
+<em>UnknownError</em>: if any error prevents function from successful completion.              </li>
+            </ul>
+           </div>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">successCallback</span>:
+ Function to be called upon success.
+                </li>
+          <li class="param">
+<span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ Function to be called upon failure.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any parameter has invalid type.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+var playlist = mcServer.playlists.createPlaylist("testPlaylist");
+
+function saveSuccess()
+{
+  console.log("savePlaylist successful");
+  function successCallback(playlists)
+  {
+    playlists.forEach(function(playlist)
+    {
+      console.log("Playlist name: " + playlist.name);
+    });
+  }
+  function errorCallback(error)
+  {
+    console.log("getAllPlaylists failed with error: " + error);
+  }
+  mcServerInfo.playlists.getAllPlaylists(successCallback, errorCallback);
+}
+
+function saveError(error)
+{
+  console.log("savePlaylist failed with error: " + error);
+}
+
+mcServer.playlists.savePlaylist(playlist, saveSuccess, saveError);
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>savePlaylist successful
+Playlist name: testPlaylist
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylistsInfo::sendPlaybackItem">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo::sendPlaybackItem"></a><code><b><span class="methodName">sendPlaybackItem</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Asks the server to set a new playback item.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, unsigned long long position,
+                      optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<p><span class="remark">Remark: </span>
+ <em>PlaybackInfoChangeListener</em> should be invoked, if registered.
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlistName</span>:
+ Name of playlist to be set.
+                </li>
+          <li class="param">
+<span class="name">index</span>:
+ Index of item on playlist to be set.
+                </li>
+          <li class="param">
+<span class="name">action</span>:
+ Playback action.
+                </li>
+          <li class="param">
+<span class="name">position</span>:
+ Playback position.
+                </li>
+          <li class="param">
+<span class="name">replyCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
+ The method to invoke when server responded to change request.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var serverInfo = mcClient.getLatestServerInfo();
+serverInfo.playlists.sendPlaybackItem("testPlaylist", "1", "PLAY", 0);
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylistsInfo::addPlaylistUpdatedListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo::addPlaylistUpdatedListener"></a><code><b><span class="methodName">addPlaylistUpdatedListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Adds listener to be invoked when playlist is updated by server.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">listener</span>:
+ Listener for adding, updating or deleting of any playlist.
+                </li>
+        </ul>
+</div>
+<div class="returntype">
+<p><span class="return">Return value:</span></p>
+<ul>
+<span class="return">long:</span>
+ The identifier used to clear the watch subscription.
+              </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+var listener =
+{
+  onplaylistupdated: function(serverName, playlist)
+  {
+    console.log("updated playlist " + playlist);
+  },
+  onplaylistdeleted: function(serverName, playlistName)
+  {
+    console.log("deleted playlist " + playlistName);
+  }
+};
+var listenerId = mcServerInfo.playlists.addPlaylistUpdatedListener(listener);
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylistsInfo::removePlaylistUpdatedListener">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo::removePlaylistUpdatedListener"></a><code><b><span class="methodName">removePlaylistUpdatedListener</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Stops listening for playlist updates.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void removePlaylistUpdatedListener(long listenerId);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<p><span class="remark">Remark: </span>
+ This function has no effect, if there is no listener for given id.
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">listenerId</span>:
+ Listener ID returned by <em>addPlaylistUpdatedListener</em>.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+
+var listener =
+{
+  onplaylistupdated: function(serverName, playlist) {},
+  onplaylistdeleted: function(serverName, playlistName) {}
+};
+var listenerId = mcServerInfo.playlists.addPlaylistUpdatedListener(listener);
+mcServerInfo.playlists.removePlaylistUpdatedListener(listenerId);
+</pre>
+</div>
+</dd>
+<dt class="method" id="MediaControllerPlaylistsInfo::getPlaylist">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistsInfo::getPlaylist"></a><code><b><span class="methodName">getPlaylist</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Returns the playlist with the given name.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">playlistName</span>:
+ The name of the playlist to get.
+                </li>
+        </ul>
+</div>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul>
+<li class="list"><p>
+ with error type NotFoundError, if the playlist with the given name does not exist.
+                </p></li>
+<li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li>
+</ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">/* assuming that the playlist was previously created */
+var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+var playlist = null;
+try
+{
+  playlist = mcServerInfo.playlists.getPlaylist("testPlaylist");
+}
+catch (err)
+{
+  console.log(err.name + ": " + err.message);
+}
+</pre>
+</div>
+</dd>
+</dl>
+</div>
+</div>
 <div class="interface" id="MediaControllerAbilities">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilities"></a><h3>2.7. MediaControllerAbilities</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilities"></a><h3>2.11. MediaControllerAbilities</h3>
 <div class="brief">
  Server-side object representing abilities of the media controller server.
           </div>
@@ -4059,7 +5696,7 @@ Default value is NO.
 </div>
 </div>
 <div class="interface" id="MediaControllerPlaybackAbilities">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackAbilities"></a><h3>2.8. MediaControllerPlaybackAbilities</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackAbilities"></a><h3>2.12. MediaControllerPlaybackAbilities</h3>
 <div class="brief">
  Server-side object representing playback abilities of the media controller server.
           </div>
@@ -4384,7 +6021,7 @@ ability FORWARD: NO
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayModeAbilities">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeAbilities"></a><h3>2.9. MediaControllerDisplayModeAbilities</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeAbilities"></a><h3>2.13. MediaControllerDisplayModeAbilities</h3>
 <div class="brief">
  Server-side object representing display mode abilities of the media controller server.
           </div>
@@ -4516,7 +6153,7 @@ Default value is NO.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotationAbilities">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationAbilities"></a><h3>2.10. MediaControllerDisplayRotationAbilities</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationAbilities"></a><h3>2.14. MediaControllerDisplayRotationAbilities</h3>
 <div class="brief">
  The server-side object representing display rotation abilities
 of the media controller server.
@@ -4649,7 +6286,7 @@ Default value is NO.
 </div>
 </div>
 <div class="interface" id="MediaControllerAbilitiesInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilitiesInfo"></a><h3>2.11. MediaControllerAbilitiesInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilitiesInfo"></a><h3>2.15. MediaControllerAbilitiesInfo</h3>
 <div class="brief">
  Client-side object representing abilities of the media controller server.
           </div>
@@ -4940,7 +6577,7 @@ REPEAT ability changed, server name: GC8qUW5iQf.SecondMCServer, ability: "NO"
 </div>
 </div>
 <div class="interface" id="MediaControllerPlaybackAbilitiesInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackAbilitiesInfo"></a><h3>2.12. MediaControllerPlaybackAbilitiesInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackAbilitiesInfo"></a><h3>2.16. MediaControllerPlaybackAbilitiesInfo</h3>
 <div class="brief">
  Client-side object representing playback abilities of the media controller server.
           </div>
@@ -5092,7 +6729,7 @@ REPEAT ability changed, server name: GC8qUW5iQf.SecondMCServer, ability: "NO"
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayModeAbilitiesInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeAbilitiesInfo"></a><h3>2.13. MediaControllerDisplayModeAbilitiesInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeAbilitiesInfo"></a><h3>2.17. MediaControllerDisplayModeAbilitiesInfo</h3>
 <div class="brief">
  Client-side object representing display mode abilities of the media controller server.
           </div>
@@ -5196,7 +6833,7 @@ Default value is NO.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotationAbilitiesInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationAbilitiesInfo"></a><h3>2.14. MediaControllerDisplayRotationAbilitiesInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationAbilitiesInfo"></a><h3>2.18. MediaControllerDisplayRotationAbilitiesInfo</h3>
 <div class="brief">
  The client-side object representing display rotation abilities
 of the media controller server.
@@ -5281,7 +6918,7 @@ of the media controller server.
 </div>
 </div>
 <div class="interface" id="MediaControllerSubtitles">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSubtitles"></a><h3>2.15. MediaControllerSubtitles</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSubtitles"></a><h3>2.19. MediaControllerSubtitles</h3>
 <div class="brief">
  Server-side object representing subtitles mode of a media controller server.
           </div>
@@ -5433,7 +7070,7 @@ mcServer.subtitles.removeChangeRequestListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerSubtitlesInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSubtitlesInfo"></a><h3>2.16. MediaControllerSubtitlesInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSubtitlesInfo"></a><h3>2.20. MediaControllerSubtitlesInfo</h3>
 <div class="brief">
  Client-side object representing subtitles mode of a media controller server.
           </div>
@@ -5627,7 +7264,7 @@ mcServerInfo.subtitles.removeModeChangeListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerMode360">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMode360"></a><h3>2.17. MediaControllerMode360</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMode360"></a><h3>2.21. MediaControllerMode360</h3>
 <div class="brief">
  Server-side object representing spherical (360°) mode of a media controller server.
           </div>
@@ -5779,7 +7416,7 @@ mcServer.mode360.removeChangeRequestListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerMode360Info">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMode360Info"></a><h3>2.18. MediaControllerMode360Info</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMode360Info"></a><h3>2.22. MediaControllerMode360Info</h3>
 <div class="brief">
  Client-side object representing spherical (360°) mode of a media controller server.
           </div>
@@ -5973,7 +7610,7 @@ mcServerInfo.mode360.removeModeChangeListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayMode">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayMode"></a><h3>2.19. MediaControllerDisplayMode</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayMode"></a><h3>2.23. MediaControllerDisplayMode</h3>
 <div class="brief">
  Server-side object representing display mode of a media controller server.
           </div>
@@ -6129,7 +7766,7 @@ mcServer.displayMode.removeChangeRequestListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayModeInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeInfo"></a><h3>2.20. MediaControllerDisplayModeInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeInfo"></a><h3>2.24. MediaControllerDisplayModeInfo</h3>
 <div class="brief">
  Client-side object representing display mode of a media controller server.
           </div>
@@ -6324,7 +7961,7 @@ mcServerInfo.displayMode.removeModeChangeListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotation">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotation"></a><h3>2.21. MediaControllerDisplayRotation</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotation"></a><h3>2.25. MediaControllerDisplayRotation</h3>
 <div class="brief">
  Server-side object representing display rotation of a media controller server.
           </div>
@@ -6481,7 +8118,7 @@ mcServer.displayRotation.removeChangeRequestListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerClientInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerClientInfo"></a><h3>2.22. MediaControllerClientInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerClientInfo"></a><h3>2.26. MediaControllerClientInfo</h3>
 <div class="brief">
  This interface provides communication methods from the server to the client.
           </div>
@@ -6593,7 +8230,7 @@ Media controller server received a reply to the event:
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotationInfo">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationInfo"></a><h3>2.23. MediaControllerDisplayRotationInfo</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationInfo"></a><h3>2.27. MediaControllerDisplayRotationInfo</h3>
 <div class="brief">
  Client-side object representing display rotation of a media controller server.
           </div>
@@ -6788,7 +8425,7 @@ mcServerInfo.displayRotation.removeDisplayRotationChangeListener(watcherId);
 </div>
 </div>
 <div class="interface" id="MediaControllerMetadata">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMetadata"></a><h3>2.24. MediaControllerMetadata</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMetadata"></a><h3>2.28. MediaControllerMetadata</h3>
 <div class="brief">
  Playback metadata.
           </div>
@@ -6810,6 +8447,7 @@ mcServerInfo.displayRotation.removeDisplayRotationChangeListener(watcherId);
     attribute DOMString? episodeTitle;
     attribute long resolutionWidth;
     attribute long resolutionHeight;
+    void save() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
 <p><span class="version">Since: </span>
  2.4
@@ -6955,9 +8593,54 @@ mcServerInfo.displayRotation.removeDisplayRotationChangeListener(watcherId);
 </li>
 </ul>
 </div>
+<div class="methods">
+<h4>Methods</h4>
+<dl>
+<dt class="method" id="MediaControllerMetadata::save">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMetadata::save"></a><code><b><span class="methodName">save</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Saves current state of metadata to the database and sends notification to the listening clients.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint">void save();</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="exceptionlist">
+<p><span class="except">Exceptions:</span></p>
+          <ul class="exception"><li>WebAPIException<ul><li class="list"><p>
+ with error type UnknownError, if any other error occurs.
+                </p></li></ul>
+</li></ul>
+        </div>
+<div class="example">
+<span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var mcServer = tizen.mediacontroller.createServer();
+var mcClient = tizen.mediacontroller.getClient();
+var mcServerInfo = mcClient.getLatestServerInfo();
+mcServer.playback.metadata.artist = "Artist Name";
+
+console.log("Before save metadata is: " + JSON.stringify(mcServerInfo.playback.metadata));
+
+mcServer.playback.metadata.save();
+console.log("After save metadata is: " + JSON.stringify(mcServerInfo.playback.metadata));
+</pre>
+</div>
+<div class="output">
+<span class="title"><p>Output example:</p></span><pre>Before save metadata is: {"title":"","artist":"","album":"","author":"","genre":"","duration":"","date":"",
+"copyright":"","description":"","trackNum":"","picture":"","seasonNumber":0,"seasonTitle":null,
+"episodeNumber":0,"episodeTitle":null,"resolutionWidth":0,"resolutionHeight":0}
+After save metadata is: {"title":"","artist":"ArtistName","album":"","author":"","genre":"","duration":"","date":"",
+"copyright":"","description":"","trackNum":"","picture":"","seasonNumber":0,"seasonTitle":null,
+"episodeNumber":0,"episodeTitle":null,"resolutionWidth":0,"resolutionHeight":0}
+</pre>
+</div>
+</dd>
+</dl>
+</div>
 </div>
 <div class="interface" id="MediaControllerPlaylistItem">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistItem"></a><h3>2.25. MediaControllerPlaylistItem</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistItem"></a><h3>2.29. MediaControllerPlaylistItem</h3>
 <div class="brief">
  Object represents single playlist item.
           </div>
@@ -6993,7 +8676,7 @@ mcServerInfo.displayRotation.removeDisplayRotationChangeListener(watcherId);
 </div>
 </div>
 <div class="dictionary" id="MediaControllerMetadataInit">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMetadataInit"></a><h3>2.26. MediaControllerMetadataInit</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerMetadataInit"></a><h3>2.30. MediaControllerMetadataInit</h3>
 <div class="brief">
  The MediaControllerMetadataInit dictionary defines the properties of a MediaControllerMetadata to add in addItem method.
           </div>
@@ -7026,7 +8709,7 @@ See <a href="#MediaControllerMetadata">MediaControllerMetadata</a> interface for
          </div>
 </div>
 <div class="interface" id="MediaControllerPlaylist">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylist"></a><h3>2.27. MediaControllerPlaylist</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylist"></a><h3>2.31. MediaControllerPlaylist</h3>
 <div class="brief">
  Object represents single playlist (collection of items).
           </div>
@@ -7207,7 +8890,7 @@ playlist.getItems(successCallback, errorCallback);
 </div>
 </div>
 <div class="interface" id="SearchFilter">
-<a class="backward-compatibility-anchor" name="::MediaController::SearchFilter"></a><h3>2.28. SearchFilter</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::SearchFilter"></a><h3>2.32. SearchFilter</h3>
 <div class="brief">
  Search filter representation.
           </div>
@@ -7304,7 +8987,7 @@ playlist.getItems(successCallback, errorCallback);
 </div>
 </div>
 <div class="interface" id="MediaControllerServerInfoArraySuccessCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoArraySuccessCallback"></a><h3>2.29. MediaControllerServerInfoArraySuccessCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerInfoArraySuccessCallback"></a><h3>2.33. MediaControllerServerInfoArraySuccessCallback</h3>
 <div class="brief">
  The MediaControllerServerInfoArraySuccessCallback interface that defines the success method
 for <em>MediaControllerClient.findServers()</em>.
@@ -7343,7 +9026,7 @@ for <em>MediaControllerClient.findServers()</em>.
 </div>
 </div>
 <div class="interface" id="MediaControllerSendCommandSuccessCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSendCommandSuccessCallback"></a><h3>2.30. MediaControllerSendCommandSuccessCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSendCommandSuccessCallback"></a><h3>2.34. MediaControllerSendCommandSuccessCallback</h3>
 <div class="brief">
  The MediaControllerSendCommandSuccessCallback interface that defines the success method which is triggered, when the server responds to a command.
           </div>
@@ -7404,7 +9087,7 @@ Interface is used as a success method for:
 </div>
 </div>
 <div class="interface" id="RequestReply">
-<a class="backward-compatibility-anchor" name="::MediaController::RequestReply"></a><h3>2.31. RequestReply</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::RequestReply"></a><h3>2.35. RequestReply</h3>
 <div class="brief">
  Representation of server's response to a request.
           </div>
@@ -7448,7 +9131,7 @@ Interface is used as a success method for:
 </div>
 </div>
 <div class="interface" id="MediaControllerSearchRequestReplyCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSearchRequestReplyCallback"></a><h3>2.32. MediaControllerSearchRequestReplyCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSearchRequestReplyCallback"></a><h3>2.36. MediaControllerSearchRequestReplyCallback</h3>
 <div class="brief">
  The MediaControllerSearchRequestReplyCallback interface defines reply callback for
 <em>MediaControllerServerInfo.sendSearchRequest()</em>.
@@ -7492,7 +9175,7 @@ Interpretation of status and data parameters depends on the server implementatio
 </div>
 </div>
 <div class="interface" id="MediaControllerSearchRequestCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSearchRequestCallback"></a><h3>2.33. MediaControllerSearchRequestCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerSearchRequestCallback"></a><h3>2.37. MediaControllerSearchRequestCallback</h3>
 <div class="brief">
  Server search request listener interface.
           </div>
@@ -7542,7 +9225,7 @@ It will be passed to the replyCallback of <a href="#MediaControllerServerInfo::s
 </div>
 </div>
 <div class="interface" id="MediaControllerReceiveCommandCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerReceiveCommandCallback"></a><h3>2.34. MediaControllerReceiveCommandCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerReceiveCommandCallback"></a><h3>2.38. MediaControllerReceiveCommandCallback</h3>
 <div class="brief">
  The MediaControllerReceiveCommandCallback interface that defines the listener
 for custom communication between server and client.
@@ -7611,7 +9294,7 @@ Related functions:
 </div>
 </div>
 <div class="interface" id="MediaControllerEnabledChangeRequestCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerEnabledChangeRequestCallback"></a><h3>2.35. MediaControllerEnabledChangeRequestCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerEnabledChangeRequestCallback"></a><h3>2.39. MediaControllerEnabledChangeRequestCallback</h3>
 <div class="brief">
  The MediaControllerEnabledChangeRequestCallback interface that defines the listener
 for change requests for spherical mode in <em>MediaControllerMode360.addChangeRequestListener()</em> and
@@ -7668,7 +9351,7 @@ to check how to handle and respond to commands.
 </div>
 </div>
 <div class="interface" id="MediaControllerEnabledChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerEnabledChangeCallback"></a><h3>2.36. MediaControllerEnabledChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerEnabledChangeCallback"></a><h3>2.40. MediaControllerEnabledChangeCallback</h3>
 <div class="brief">
  The MediaControllerEnabledChangeCallback interface that defines the listener
 for a media controller server's attribute changes.
@@ -7707,7 +9390,7 @@ for a media controller server's attribute changes.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayModeChangeRequestCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeChangeRequestCallback"></a><h3>2.37. MediaControllerDisplayModeChangeRequestCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeChangeRequestCallback"></a><h3>2.41. MediaControllerDisplayModeChangeRequestCallback</h3>
 <div class="brief">
  The MediaControllerDisplayModeChangeRequestCallback interface that defines the listener
 for change requests for display mode in <em>MediaControllerDisplayMode.addChangeRequestListener()</em>.
@@ -7762,7 +9445,7 @@ to check how to handle and respond to commands.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayModeChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeChangeCallback"></a><h3>2.38. MediaControllerDisplayModeChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayModeChangeCallback"></a><h3>2.42. MediaControllerDisplayModeChangeCallback</h3>
 <div class="brief">
  The MediaControllerDisplayModeChangeCallback interface that defines the listener
 for display mode changes of the media controller server.
@@ -7801,7 +9484,7 @@ for display mode changes of the media controller server.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotationChangeRequestCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationChangeRequestCallback"></a><h3>2.39. MediaControllerDisplayRotationChangeRequestCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationChangeRequestCallback"></a><h3>2.43. MediaControllerDisplayRotationChangeRequestCallback</h3>
 <div class="brief">
  The MediaControllerDisplayRotationChangeRequestCallback interface that defines the listener
 for change requests for display rotation in <em>MediaControllerDisplayRotation.addChangeRequestListener().
@@ -7856,7 +9539,7 @@ to check how to handle and respond to commands.
 </div>
 </div>
 <div class="interface" id="MediaControllerDisplayRotationChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationChangeCallback"></a><h3>2.40. MediaControllerDisplayRotationChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerDisplayRotationChangeCallback"></a><h3>2.44. MediaControllerDisplayRotationChangeCallback</h3>
 <div class="brief">
  The MediaControllerDisplayModeChangeCallback interface that defines the listener
 for changes of a media controller server's display rotation.
@@ -7895,7 +9578,7 @@ for changes of a media controller server's display rotation.
 </div>
 </div>
 <div class="interface" id="MediaControllerServerStatusChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerStatusChangeCallback"></a><h3>2.41. MediaControllerServerStatusChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerServerStatusChangeCallback"></a><h3>2.45. MediaControllerServerStatusChangeCallback</h3>
 <div class="brief">
  The MediaControllerServerStatusChangeCallback interface that defines the listener
 for media controller server status changes.
@@ -7934,7 +9617,7 @@ for media controller server status changes.
 </div>
 </div>
 <div class="interface" id="MediaControllerPlaybackInfoChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackInfoChangeCallback"></a><h3>2.42. MediaControllerPlaybackInfoChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaybackInfoChangeCallback"></a><h3>2.46. MediaControllerPlaybackInfoChangeCallback</h3>
 <div class="brief">
  The MediaControllerPlaybackInfoChangeCallback interface that defines the listeners
 object for receiving media controller playback info changes from server.
@@ -8078,19 +9761,20 @@ will be invoked after the <a href="#MediaControllerPlaybackInfoChangeCallback::o
 </div>
 </div>
 <div class="interface" id="MediaControllerChangeRequestPlaybackInfoCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerChangeRequestPlaybackInfoCallback"></a><h3>2.43. MediaControllerChangeRequestPlaybackInfoCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerChangeRequestPlaybackInfoCallback"></a><h3>2.47. MediaControllerChangeRequestPlaybackInfoCallback</h3>
 <div class="brief">
  The MediaControllerChangeRequestPlaybackInfoCallback interface that defines the listeners
 object for receiving playback info change requests from client.
           </div>
 <pre class="webidl prettyprint">  [Callback, NoInterfaceObject] interface MediaControllerChangeRequestPlaybackInfoCallback {
-    void onplaybackstaterequest(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+<span class="nocode deprecated">    void onplaybackstaterequest(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+</span>    <a href="#RequestReply">RequestReply</a>? onplaybackactionrequest(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
 <span class="nocode deprecated">    void onrepeatmoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-</span>    void onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state,
-                               unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+</span>    <a href="#RequestReply">RequestReply</a>? onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action,
+                                        unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
   };</pre>
 <p><span class="version">Since: </span>
  2.4
@@ -8098,13 +9782,16 @@ object for receiving playback info change requests from client.
 <div class="methods">
 <h4>Methods</h4>
 <dl>
-<dt class="method" id="MediaControllerChangeRequestPlaybackInfoCallback::onplaybackstaterequest">
+<dt class="deprecated method" id="MediaControllerChangeRequestPlaybackInfoCallback::onplaybackstaterequest">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerChangeRequestPlaybackInfoCallback::onplaybackstaterequest"></a><code><b><span class="methodName">onplaybackstaterequest</span></b></code>
 </dt>
-<dd>
+<dd class="deprecated">
 <div class="brief">
  Called when client requested playback state changes.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Since 6.0. Instead, use <a href="#MediaControllerChangeRequestPlaybackInfoCallback::onplaybackactionrequest">onplaybackactionrequest()</a>.
+            </p>
 <div class="synopsis"><pre class="signature prettyprint">void onplaybackstaterequest(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  2.4
@@ -8126,6 +9813,31 @@ object for receiving playback info change requests from client.
         </ul>
 </div>
 </dd>
+<dt class="method" id="MediaControllerChangeRequestPlaybackInfoCallback::onplaybackactionrequest">
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerChangeRequestPlaybackInfoCallback::onplaybackactionrequest"></a><code><b><span class="methodName">onplaybackactionrequest</span></b></code>
+</dt>
+<dd>
+<div class="brief">
+ Called when a client requested the playback state changes by sending the playback action.
+            </div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#RequestReply">RequestReply</a>? onplaybackactionrequest(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
+<p><span class="version">Since: </span>
+ 6.0
+            </p>
+<div class="parameters">
+<p><span class="param">Parameters:</span></p>
+<ul>
+          <li class="param">
+<span class="name">action</span>:
+ Playback action sent by the client.
+                </li>
+          <li class="param">
+<span class="name">clientName</span>:
+ Id of client application, which sent a command.
+                </li>
+        </ul>
+</div>
+</dd>
 <dt class="method" id="MediaControllerChangeRequestPlaybackInfoCallback::onplaybackpositionrequest">
 <a class="backward-compatibility-anchor" name="::MediaController::MediaControllerChangeRequestPlaybackInfoCallback::onplaybackpositionrequest"></a><code><b><span class="methodName">onplaybackpositionrequest</span></b></code>
 </dt>
@@ -8133,7 +9845,7 @@ object for receiving playback info change requests from client.
 <div class="brief">
  Called when client requested playback position changes.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#RequestReply">RequestReply</a>? onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  2.4
             </p>
@@ -8161,7 +9873,7 @@ object for receiving playback info change requests from client.
 <div class="brief">
  Called when client requested shuffle mode changes.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#RequestReply">RequestReply</a>? onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  2.4
             </p>
@@ -8224,7 +9936,7 @@ will not be invoked, if the <a href="#MediaControllerPlaybackInfo::repeatState">
 <div class="brief">
  Called when client requested change of repeat state.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#RequestReply">RequestReply</a>? onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  5.5
             </p>
@@ -8255,8 +9967,8 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 <div class="brief">
  Called when client request change of playback item.
             </div>
-<div class="synopsis"><pre class="signature prettyprint">void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state,
-                           unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
+<div class="synopsis"><pre class="signature prettyprint"><a href="#RequestReply">RequestReply</a>? onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action,
+                                    unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);</pre></div>
 <p><span class="version">Since: </span>
  5.5
             </p>
@@ -8265,19 +9977,19 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 <ul>
           <li class="param">
 <span class="name">playlistName</span>:
- Name of a requested playlist.
+ Name of playlist.
                 </li>
           <li class="param">
 <span class="name">index</span>:
- Requested index.
+ Index of the item to be changed.
                 </li>
           <li class="param">
-<span class="name">state</span>:
- Requested playback state.
+<span class="name">action</span>:
+ Playback action.
                 </li>
           <li class="param">
 <span class="name">position</span>:
- Requested playback position.
+ Playback position.
                 </li>
           <li class="param">
 <span class="name">clientName</span>:
@@ -8290,7 +10002,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 </div>
 </div>
 <div class="interface" id="MediaControllerGetAllPlaylistsSuccessCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerGetAllPlaylistsSuccessCallback"></a><h3>2.44. MediaControllerGetAllPlaylistsSuccessCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerGetAllPlaylistsSuccessCallback"></a><h3>2.48. MediaControllerGetAllPlaylistsSuccessCallback</h3>
 <div class="brief">
  Interface for success callback for <em>getAllPlaylists</em> function.
           </div>
@@ -8328,7 +10040,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 </div>
 </div>
 <div class="interface" id="MediaControllerPlaylistUpdatedCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistUpdatedCallback"></a><h3>2.45. MediaControllerPlaylistUpdatedCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerPlaylistUpdatedCallback"></a><h3>2.49. MediaControllerPlaylistUpdatedCallback</h3>
 <div class="brief">
  Interface for specific playlist update events (including deletion).
           </div>
@@ -8396,7 +10108,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 </div>
 </div>
 <div class="interface" id="MediaControllerGetItemsSuccessCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerGetItemsSuccessCallback"></a><h3>2.46. MediaControllerGetItemsSuccessCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerGetItemsSuccessCallback"></a><h3>2.50. MediaControllerGetItemsSuccessCallback</h3>
 <div class="brief">
  Interface for success callback for <em>getItems</em> function.
           </div>
@@ -8434,7 +10146,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
 </div>
 </div>
 <div class="interface" id="MediaControllerAbilityChangeCallback">
-<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilityChangeCallback"></a><h3>2.47. MediaControllerAbilityChangeCallback</h3>
+<a class="backward-compatibility-anchor" name="::MediaController::MediaControllerAbilityChangeCallback"></a><h3>2.51. MediaControllerAbilityChangeCallback</h3>
 <div class="brief">
  Interface for handling ability events.
           </div>
@@ -8565,6 +10277,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
   enum MediaControllerServerState { "ACTIVE", "INACTIVE" };
   enum MediaControllerSearchCategory { "NO_CATEGORY", "TITLE", "ARTIST", "ALBUM", "GENRE", "TPO" };
   enum MediaControllerPlaybackState { "PLAY", "PAUSE", "STOP", "NEXT", "PREV", "FORWARD", "REWIND" };
+  enum MediaControllerPlaybackAction { "PLAY", "PAUSE", "STOP", "NEXT", "PREV", "FORWARD", "REWIND", "TOGGLE_PLAY_PAUSE" };
   enum MediaControllerRepeatState { "REPEAT_OFF", "REPEAT_ONE", "REPEAT_ALL" };
   enum MediaControllerContentType { "IMAGE", "MUSIC", "VIDEO", "OTHER", "UNDECIDED" };
   enum MediaControllerContentAgeRating { "ALL", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13",
@@ -8602,36 +10315,19 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
     <a href="#MediaControllerServer">MediaControllerServer</a> createServer() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface MediaControllerServer {
-    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo;
-    readonly attribute DOMString? iconURI;
+    readonly attribute <a href="#MediaControllerServerPlaybackInfo">MediaControllerServerPlaybackInfo</a> playback;
+    readonly attribute <a href="#MediaControllerPlaylists">MediaControllerPlaylists</a> playlists;
+    attribute DOMString? iconURI raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute <a href="#MediaControllerAbilities">MediaControllerAbilities</a> abilities;
     readonly attribute <a href="#MediaControllerSubtitles">MediaControllerSubtitles</a> subtitles;
     readonly attribute <a href="#MediaControllerMode360">MediaControllerMode360</a> mode360;
     readonly attribute <a href="#MediaControllerDisplayMode">MediaControllerDisplayMode</a> displayMode;
     readonly attribute <a href="#MediaControllerDisplayRotation">MediaControllerDisplayRotation</a> displayRotation;
     <a href="#MediaControllerClientInfo">MediaControllerClientInfo</a>[] getAllClientsInfo() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateIconURI(DOMString? iconURI) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackPosition(unsigned long long position) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackAgeRating(<a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> rating) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackContentType(<a href="#MediaControllerContentType">MediaControllerContentType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateShuffleMode(boolean mode) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updateMetadata(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addChangeRequestPlaybackInfoListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removeChangeRequestPlaybackInfoListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void setSearchRequestListener(<a href="#MediaControllerSearchRequestCallback">MediaControllerSearchRequestCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void unsetSearchRequestListener() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addCommandListener(<a href="#MediaControllerReceiveCommandCallback">MediaControllerReceiveCommandCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeCommandListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
-                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                        raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void updatePlaybackItem(DOMString playlistName, DOMString index) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface MediaControllerClient {
     void findServers(<a href="#MediaControllerServerInfoArraySuccessCallback">MediaControllerServerInfoArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
@@ -8647,37 +10343,36 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
   [NoInterfaceObject] interface MediaControllerServerInfo {
     readonly attribute <a href="application.html#ApplicationId">ApplicationId</a> name;
     readonly attribute <a href="#MediaControllerServerState">MediaControllerServerState</a> state;
-    readonly attribute <a href="#MediaControllerPlaybackInfo">MediaControllerPlaybackInfo</a> playbackInfo raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    readonly attribute <a href="#MediaControllerServerInfoPlaybackInfo">MediaControllerServerInfoPlaybackInfo</a> playback raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    readonly attribute <a href="#MediaControllerPlaylistsInfo">MediaControllerPlaylistsInfo</a> playlists;
     readonly attribute DOMString? iconURI raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     readonly attribute <a href="#MediaControllerAbilitiesInfo">MediaControllerAbilitiesInfo</a> abilities;
     readonly attribute <a href="#MediaControllerSubtitlesInfo">MediaControllerSubtitlesInfo</a> subtitles;
     readonly attribute <a href="#MediaControllerMode360Info">MediaControllerMode360Info</a> mode360;
     readonly attribute <a href="#MediaControllerDisplayModeInfo">MediaControllerDisplayModeInfo</a> displayMode;
     readonly attribute <a href="#MediaControllerDisplayRotationInfo">MediaControllerDisplayRotationInfo</a> displayRotation;
-    void sendPlaybackState(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
-                           optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendPlaybackPosition(unsigned long long position, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
-                              optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendShuffleMode(boolean mode, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
-                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void sendSearchRequest(<a href="#SearchFilter">SearchFilter</a>[] request, <a href="#MediaControllerSearchRequestReplyCallback">MediaControllerSearchRequestReplyCallback</a> replyCallback,
                            optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void sendCommand(DOMString command, <a href="tizen.html#Bundle">Bundle</a>? data, <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a> successCallback,
                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     long addServerStatusChangeListener(<a href="#MediaControllerServerStatusChangeCallback">MediaControllerServerStatusChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removeServerStatusChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removePlaybackInfoChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
-                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, unsigned long long position)
-                          raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
-    void removePlaylistUpdatedListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
-  [NoInterfaceObject] interface MediaControllerPlaybackInfo {
+  [NoInterfaceObject] interface MediaControllerServerPlaybackInfo {
+    attribute <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute unsigned long long position raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerContentType">MediaControllerContentType</a> contentType raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute boolean shuffleMode raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    attribute <a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> repeatState raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
+    readonly attribute DOMString? index;
+    readonly attribute DOMString? playlistName;
+    void updatePlaybackItem(DOMString playlistName, DOMString index) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addChangeRequestListener(<a href="#MediaControllerChangeRequestPlaybackInfoCallback">MediaControllerChangeRequestPlaybackInfoCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removeChangeRequestListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };
+  [NoInterfaceObject] interface MediaControllerServerInfoPlaybackInfo {
     readonly attribute <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state;
     readonly attribute unsigned long long position;
     readonly attribute <a href="#MediaControllerContentAgeRating">MediaControllerContentAgeRating</a> ageRating;
@@ -8687,6 +10382,34 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
     readonly attribute <a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata;
     readonly attribute DOMString? index;
     readonly attribute DOMString? playlistName;
+    void sendPlaybackAction(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                            raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendPlaybackPosition(unsigned long long position, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                              raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendShuffleMode(boolean mode, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addPlaybackInfoChangeListener(<a href="#MediaControllerPlaybackInfoChangeCallback">MediaControllerPlaybackInfoChangeCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removePlaybackInfoChangeListener(long watchId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };
+  [NoInterfaceObject] interface MediaControllerPlaylists {
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> createPlaylist(DOMString name) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void savePlaylist(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> playlist, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback,
+                      optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void deletePlaylist(DOMString playlistName, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                        raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+  };
+  [NoInterfaceObject] interface MediaControllerPlaylistsInfo {
+    void getAllPlaylists(<a href="#MediaControllerGetAllPlaylistsSuccessCallback">MediaControllerGetAllPlaylistsSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
+                         raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void sendPlaybackItem(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, unsigned long long position,
+                          optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    long addPlaylistUpdatedListener(<a href="#MediaControllerPlaylistUpdatedCallback">MediaControllerPlaylistUpdatedCallback</a> listener) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    void removePlaylistUpdatedListener(long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
+    <a href="#MediaControllerPlaylist">MediaControllerPlaylist</a> getPlaylist(DOMString playlistName) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface MediaControllerAbilities {
     readonly attribute <a href="#MediaControllerPlaybackAbilities">MediaControllerPlaybackAbilities</a> playback;
@@ -8830,6 +10553,7 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
     attribute DOMString? episodeTitle;
     attribute long resolutionWidth;
     attribute long resolutionHeight;
+    void save() raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };
   [NoInterfaceObject] interface MediaControllerPlaylistItem {
     readonly attribute DOMString index;
@@ -8896,12 +10620,12 @@ will be invoked after the <a href="#MediaControllerChangeRequestPlaybackInfoCall
     void onmetadatachanged(<a href="#MediaControllerMetadata">MediaControllerMetadata</a> metadata);
   };
   [Callback, NoInterfaceObject] interface MediaControllerChangeRequestPlaybackInfoCallback {
-    void onplaybackstaterequest(<a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
-    void onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackState">MediaControllerPlaybackState</a> state,
-                               unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onplaybackactionrequest(<a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onplaybackpositionrequest(unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onshufflemoderequest(boolean mode, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onrepeatstaterequest(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
+    <a href="#RequestReply">RequestReply</a>? onplaybackitemrequest(DOMString playlistName, DOMString index, <a href="#MediaControllerPlaybackAction">MediaControllerPlaybackAction</a> action,
+                                        unsigned long long position, <a href="application.html#ApplicationId">ApplicationId</a> clientName);
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface MediaControllerGetAllPlaylistsSuccessCallback {
     void onsuccess(<a href="#MediaControllerPlaylist">MediaControllerPlaylist</a>[] playlists);

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/mediacontroller.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/mediacontroller.html
@@ -4596,7 +4596,7 @@ mcServerInfo.playback.sendShuffleMode(true, function(data, code)
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void sendRepeatState(<a href="#MediaControllerRepeatState">MediaControllerRepeatState</a> state, optional <a href="#MediaControllerSendCommandSuccessCallback">MediaControllerSendCommandSuccessCallback</a>? replyCallback);</pre></div>
 <p><span class="version">Since: </span>
- 5.5
+ 6.0
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/ppm.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/ppm.html
@@ -192,6 +192,9 @@ PPM_DENY_ONCE - The user denied granting permission to use a privacy-related pri
     void requestPermissions(DOMString[] privileges, <a href="#PermissionRequestSuccessCallback">PermissionRequestSuccessCallback</a> successCallback,
                             optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
+<p><span class="version">Since: </span>
+ 4.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/sensor.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/sensor.html
@@ -457,8 +457,6 @@ The supported sensor types are hardware-dependent. <br><br>To check if the given
  ULTRAVIOLET - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.ultraviolet"</em>)               </li>
             </ul>
            </div>
-<div class="description">
-           </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
@@ -595,8 +593,6 @@ console.log("Capable sensor: " + sensorCapabilities[0]);
             <p>
 The <em>SuccessCallback</em> will be invoked when the first event from the sensor is fired.
             </p>
-           </div>
-<div class="description">
             <p>
 The <em>ErrorCallback</em> method is launched with these error types:
             </p>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/sound.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/sound.html
@@ -404,9 +404,6 @@ There is a tizen.sound object that allows accessing the functionality of the Sou
 <p><span class="version">Since: </span>
  2.3
             </p>
-<p><span class="version">Since: </span>
- 2.3
-            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/systeminfo.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/systeminfo.html
@@ -485,6 +485,9 @@ functionality of the System Information API.
                                                       raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
     void removePropertyValueChangeListener(unsigned long listenerId) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
+<p><span class="version">Since: </span>
+ 1.0
+          </p>
 <div class="description">
           <p>
 This API offers methods for retrieving system information
@@ -2277,6 +2280,9 @@ Any threshold parameter used in a watch function to monitor this property applie
     readonly attribute boolean isRemovable;
 <span class="nocode deprecated">    readonly attribute boolean isRemoveable;
 </span>  };</pre>
+<p><span class="version">Since: </span>
+ 1.0
+          </p>
         
       <div class="attributes">
 <h4>Attributes</h4>
@@ -3311,8 +3317,6 @@ EXTERNAL - external camera flash              </li>
               <li>
 OTHER - a flash attached to any other camera              </li>
             </ul>
-           </div>
-<div class="description">
             <p>
 The <a href="#SystemInfo::getPropertyValue">getPropertyValue()</a> method retrieves the <var>SystemInfoCameraFlash</var> for <var>BACK</var> camera.
             </p>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/systemsetting.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/systemsetting.html
@@ -183,6 +183,9 @@ access to the module functionalities.
     void getProperty(<a href="#SystemSettingType">SystemSettingType</a> type, <a href="#SystemSettingSuccessCallback">SystemSettingSuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
                      raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
   };</pre>
+<p><span class="version">Since: </span>
+ 2.0
+          </p>
 <div class="methods">
 <h4>Methods</h4>
 <dl>
@@ -313,8 +316,6 @@ else
             <p>
 This method allows the user to get the value of the specified system property as wallpaper or ringtone of a device.
             </p>
-           </div>
-<div class="description">
             <p>
 The <em>ErrorCallback</em> method is launched with these error types:
             </p>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/voicecontrol.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/voicecontrol.html
@@ -738,6 +738,9 @@ client.release();
     attribute DOMString command;
     attribute <a href="#VoiceControlCommandType">VoiceControlCommandType</a> type;
   };</pre>
+<p><span class="version">Since: </span>
+ 4.0
+          </p>
 <div class="constructors">
 <h4 id="VoiceControlCommand::constructor">Constructors</h4>
 <dl>
@@ -765,6 +768,9 @@ client.release();
 The command should be set as text you want to be recognized.
             </p>
            </div>
+<p><span class="version">Since: </span>
+ 4.0
+            </p>
 </li>
 <li class="attribute" id="VoiceControlCommand::type">
 <span class="attrName"><span class="type">VoiceControlCommandType </span><span class="name">type</span></span><div class="brief">
@@ -774,6 +780,9 @@ The command should be set as text you want to be recognized.
             <p>
 The default value is <var>"FOREGROUND"</var>            </p>
            </div>
+<p><span class="version">Since: </span>
+ 4.0
+            </p>
 </li>
 </ul>
 </div>


### PR DESCRIPTION
Version information was missing for some of the methods:
- 'Since' tags missing

Also there was some grammar fixes in mediacontroller and humanactivitymonitor modules:
- fixed some descriptions and language mistakes
- fixed some 'description' tags with merging into one