### PR TITLE
Web UI (TAU): Deprecated option "ellipsis" in Marquee widget

### DIFF
--- a/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_marquee.htm
+++ b/docs/application/web/api/5.0/ui_fw_api/Wearable_UIComponents/wearable_marquee.htm
@@ -115,9 +115,11 @@ page.addEventListener(&quot;pagebeforeshow&quot;, function()
 
 			<tr>
 				<td class="option"><span style="font-family: Courier New,Courier,monospace">ellipsisEffect</span></td>
-				<td class="option">&quot;gradient&quot; | &quot;ellipsis&quot; | &quot;none&quot;</td>
+				<td class="option">&quot;gradient&quot; | &quot;none&quot;</td>
 				<td class="option">&quot;gradient&quot;</td>
-				<td class="option">Sets the end-effect(gradient) of marquee</td>
+				<td class="option">Sets the end-effect(gradient) of marquee<br>
+					The option &quot;ellipsis&quot; has been deprecated. Please use &quot;gradient&quot; instead of.
+				</td>
 			</tr>
 
 			<tr>

--- a/docs/application/web/api/5.5/ui_fw_api/Wearable_UIComponents/wearable_marquee.htm
+++ b/docs/application/web/api/5.5/ui_fw_api/Wearable_UIComponents/wearable_marquee.htm
@@ -115,9 +115,11 @@ page.addEventListener(&quot;pagebeforeshow&quot;, function()
 
 			<tr>
 				<td class="option"><span style="font-family: Courier New,Courier,monospace">ellipsisEffect</span></td>
-				<td class="option">&quot;gradient&quot; | &quot;ellipsis&quot; | &quot;none&quot;</td>
+				<td class="option">&quot;gradient&quot; | &quot;none&quot;</td>
 				<td class="option">&quot;gradient&quot;</td>
-				<td class="option">Sets the end-effect(gradient) of marquee</td>
+				<td class="option">Sets the end-effect(gradient) of marquee<br>
+					The option &quot;ellipsis&quot; has been deprecated. Please use &quot;gradient&quot; instead of.
+				</td>
 			</tr>
 
 			<tr>


### PR DESCRIPTION
### Change Description ###

Value "ellipsis" for option "ellipsisEffect" in Marquee widget
has been deprecated. New guiedline defines only "gradient" effect
as marquee border effect.

### Bugs Fixed ###

no issue

### API Changes ###

no ACR
