### PR TITLE
[6.0][tvwindow] Adding PictureSizeType implementation instead of AspectRatio

### DIFF
--- a/docs/application/web/api/6.0/device_api/tv/tizen/tvwindow.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/tvwindow.html
@@ -4,6 +4,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <link rel="stylesheet" type="text/css" href="../../../scripts/tizen.css" media="screen">
 <script type="text/javascript" src="../../../scripts/snippet.js"></script><title>TVWindow API</title>
+<meta data-version="6.0" data-profile="tv">
 </head>
 <body id="page-content" onload="prettyPrint()">
 <div class="api" id="::TVWindow">
@@ -35,11 +36,14 @@ do not want to interact with the TV image.
 <li>
                     1.2. <a href="#MeasurementUnit">MeasurementUnit</a>
 </li>
-<li>
+<li class="deprecated">
                     1.3. <a href="#AspectRatio">AspectRatio</a>
 </li>
 <li>
-                    1.4. <a href="#ZPosition">ZPosition</a>
+                    1.4. <a href="#PictureSizeType">PictureSizeType</a>
+</li>
+<li>
+                    1.5. <a href="#ZPosition">ZPosition</a>
 </li>
 </ul>
 </li>
@@ -168,12 +172,15 @@ do not want to interact with the TV image.
           </ul>
          </div>
 </div>
-<div class="enum" id="AspectRatio">
+<div class="enum deprecated" id="AspectRatio">
 <a class="backward-compatibility-anchor" name="::TVWindow::AspectRatio"></a><h3>1.3. AspectRatio</h3>
 <div class="brief">
  An enumerator to indicate the aspect ratio of the video source.
           </div>
-<pre class="webidl prettyprint">  enum AspectRatio { "ASPECT_RATIO_1x1", "ASPECT_RATIO_4x3", "ASPECT_RATIO_16x9", "ASPECT_RATIO_221x100", "ASPECT_RATIO_UNKNOWN" };</pre>
+<p class="deprecated"><b>Deprecated.</b>
+ Deprecated since 6.0.
+          </p>
+<pre class="webidl prettyprint"><span class="nocode deprecated">  enum AspectRatio { "ASPECT_RATIO_1x1", "ASPECT_RATIO_4x3", "ASPECT_RATIO_16x9", "ASPECT_RATIO_221x100", "ASPECT_RATIO_UNKNOWN" };</span></pre>
 <p><span class="version">Since: </span>
  2.4
           </p>
@@ -195,8 +202,57 @@ do not want to interact with the TV image.
  <em>ASPECT_RATIO_UNKNOWN<em> is supported since Tizen 3.0
 </em></em>          </p>
 </div>
+<div class="enum" id="PictureSizeType">
+<a class="backward-compatibility-anchor" name="::TVWindow::PictureSizeType"></a><h3>1.4. PictureSizeType</h3>
+<div class="brief">
+ An enumerator to indicate the picture size type of the video source.
+          </div>
+<pre class="webidl prettyprint">  enum PictureSizeType { "PICTURE_SIZE_TYPE_16x9", "PICTURE_SIZE_TYPE_ZOOM", "PICTURE_SIZE_TYPE_CUSTOM", "PICTURE_SIZE_TYPE_4x3",
+    "PICTURE_SIZE_TYPE_21x9_NORMAL", "PICTURE_SIZE_TYPE_21x9_AUTO", "PICTURE_SIZE_TYPE_21x9_CAPTION", "PICTURE_SIZE_TYPE_ORIGINAL_RATIO",
+    "PICTURE_SIZE_TYPE_WSS_4x3", "PICTURE_SIZE_TYPE_WSS_16x9", "PICTURE_SIZE_TYPE_WSS_ZOOM1", "PICTURE_SIZE_TYPE_WSS_ZOOM1_DN",
+    "PICTURE_SIZE_TYPE_WSS_ZOOM2", "PICTURE_SIZE_TYPE_WSS_WIDEZOOM", "PICTURE_SIZE_TYPE_WSS_14x9", "PICTURE_SIZE_TYPE_UNKNOWN" };</pre>
+<p><span class="version">Since: </span>
+ 6.0
+          </p>
+<div class="description">
+          <ul>
+            <li>
+ PICTURE_SIZE_TYPE_16x9 - 16:9            </li>
+            <li>
+ PICTURE_SIZE_TYPE_ZOOM - zoom option has been used            </li>
+            <li>
+ PICTURE_SIZE_TYPE_CUSTOM - aspect ratio customized manually            </li>
+            <li>
+ PICTURE_SIZE_TYPE_4x3 - 4:3            </li>
+            <li>
+ PICTURE_SIZE_TYPE_21x9_NORMAL - 21:9            </li>
+            <li>
+ PICTURE_SIZE_TYPE_21x9_AUTO - 21:9 set automatically by source connected to target device            </li>
+            <li>
+ PICTURE_SIZE_TYPE_21x9_CAPTION - 21:9 with additional space for caption            </li>
+            <li>
+ PICTURE_SIZE_TYPE_ORIGINAL_RATIO - Picture size type original ratio            </li>
+            <li>
+ PICTURE_SIZE_TYPE_WSS_4x3 - 4:3 - widescreen signaling            </li>
+            <li>
+ PICTURE_SIZE_TYPE_WSS_16x9 - 16:9 - widescreen signaling            </li>
+            <li>
+ PICTURE_SIZE_TYPE_WSS_ZOOM1 - widescreen signaling, zoom option set to ZOOM1            </li>
+            <li>
+ PICTURE_SIZE_TYPE_WSS_ZOOM1_DN - widescreen signaling, zoom option set to ZOOM1_DN            </li>
+            <li>
+ PICTURE_SIZE_TYPE_WSS_ZOOM2 - widescreen signaling, zoom option set to ZOOM2            </li>
+            <li>
+ PICTURE_SIZE_TYPE_WSS_WIDEZOOM - widescreen signaling, zoom option set to WIDEZOOM            </li>
+            <li>
+ PICTURE_SIZE_TYPE_WSS_14x9 - 14:9 - widescreen signaling            </li>
+            <li>
+ PICTURE_SIZE_TYPE_UNKNOWN - Unknown size type of a picture            </li>
+          </ul>
+         </div>
+</div>
 <div class="enum" id="ZPosition">
-<a class="backward-compatibility-anchor" name="::TVWindow::ZPosition"></a><h3>1.4. ZPosition</h3>
+<a class="backward-compatibility-anchor" name="::TVWindow::ZPosition"></a><h3>1.5. ZPosition</h3>
 <div class="brief">
  An enumerator to indicate the z position of the TV window or the relative position of the TV window and the Web Application.
           </div>
@@ -855,9 +911,9 @@ catch (error)
 <span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">var res = tizen.tvwindow.getVideoResolution();
 console.log("Video resolution: " + res.width + "x" + res.height + " pixels");
 console.log("Frequency: " + res.frequency + "Hz");
-if (res.aspectRatio === "ASPECT_RATIO_16x9")
+if (res.pictureSizeType === "PICTURE_SIZE_TYPE_CUSTOM")
 {
-  console.log("Widescreen on");
+  console.log("aspect ratio is customized manually");
 }
 </pre>
 </div>
@@ -919,9 +975,9 @@ if (res.aspectRatio === "ASPECT_RATIO_16x9")
 {
   console.log("Switched to new resolution: " + res.width + "x" + res.height);
   console.log("New frequency: " + res.frequency);
-  if (res.aspectRatio === "ASPECT_RATIO_16x9")
+  if (res.pictureSizeType === "PICTURE_SIZE_TYPE_16x9")
   {
-    console.log("Widescreen is now turned on");
+    console.log("Resolution set to 16:9");
   }
 }
 
@@ -992,7 +1048,8 @@ Calling this function has no effect if there is no listener with given id.
     readonly attribute long width;
     readonly attribute long height;
     readonly attribute long frequency;
-    readonly attribute <a href="#AspectRatio">AspectRatio</a> aspectRatio;
+<span class="nocode deprecated">    readonly attribute <a href="#AspectRatio">AspectRatio</a> aspectRatio;
+</span>    readonly attribute <a href="#PictureSizeType">PictureSizeType</a> pictureSizeType;
   };</pre>
 <p><span class="version">Since: </span>
  2.4
@@ -1027,13 +1084,25 @@ Calling this function has no effect if there is no listener with given id.
  2.4
             </p>
 </li>
-<li class="attribute" id="VideoResolution::aspectRatio">
+<li class="attribute deprecated" id="VideoResolution::aspectRatio">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">AspectRatio </span><span class="name">aspectRatio</span></span><div class="brief">
  Video aspect ratio.
             </div>
+<p class="deprecated"><b>Deprecated.</b>
+ Deprecated since 6.0. Use pictureSizeType instead.
+            </p>
 <p><span class="version">Since: </span>
  2.4
+            </p>
+</li>
+<li class="attribute" id="VideoResolution::pictureSizeType">
+<span class="attrName"><span class="readonly">                readonly
+</span><span class="type">PictureSizeType </span><span class="name">pictureSizeType</span></span><div class="brief">
+ Type size of the displayed picture.
+            </div>
+<p><span class="version">Since: </span>
+ 6.0
             </p>
 </li>
 </ul>
@@ -1235,7 +1304,10 @@ To guarantee the running of this application on a device with a TV picture-in-pi
 <pre class="webidl prettyprint">module TVWindow {
   enum WindowType { "MAIN" };
   enum MeasurementUnit { "px", "%" };
-  enum AspectRatio { "ASPECT_RATIO_1x1", "ASPECT_RATIO_4x3", "ASPECT_RATIO_16x9", "ASPECT_RATIO_221x100", "ASPECT_RATIO_UNKNOWN" };
+  enum PictureSizeType { "PICTURE_SIZE_TYPE_16x9", "PICTURE_SIZE_TYPE_ZOOM", "PICTURE_SIZE_TYPE_CUSTOM", "PICTURE_SIZE_TYPE_4x3",
+    "PICTURE_SIZE_TYPE_21x9_NORMAL", "PICTURE_SIZE_TYPE_21x9_AUTO", "PICTURE_SIZE_TYPE_21x9_CAPTION", "PICTURE_SIZE_TYPE_ORIGINAL_RATIO",
+    "PICTURE_SIZE_TYPE_WSS_4x3", "PICTURE_SIZE_TYPE_WSS_16x9", "PICTURE_SIZE_TYPE_WSS_ZOOM1", "PICTURE_SIZE_TYPE_WSS_ZOOM1_DN",
+    "PICTURE_SIZE_TYPE_WSS_ZOOM2", "PICTURE_SIZE_TYPE_WSS_WIDEZOOM", "PICTURE_SIZE_TYPE_WSS_14x9", "PICTURE_SIZE_TYPE_UNKNOWN" };
   enum ZPosition { "FRONT", "BEHIND" };
   <a href="tizen.html#Tizen">Tizen</a> implements <a href="#TVWindowManagerObject">TVWindowManagerObject</a>;
   [NoInterfaceObject] interface TVWindowManagerObject {
@@ -1261,7 +1333,7 @@ To guarantee the running of this application on a device with a TV picture-in-pi
     readonly attribute long width;
     readonly attribute long height;
     readonly attribute long frequency;
-    readonly attribute <a href="#AspectRatio">AspectRatio</a> aspectRatio;
+    readonly attribute <a href="#PictureSizeType">PictureSizeType</a> pictureSizeType;
   };
   [Callback=FunctionOnly, NoInterfaceObject] interface VideoResolutionChangeCallback {
     void onchanged(<a href="#VideoResolution">VideoResolution</a> resolution, <a href="#WindowType">WindowType</a> type);


### PR DESCRIPTION
[6.0][tvwindow] Adding PictureSizeType implementation instead of AspectRatio

[ACR] https://code.sec.samsung.net/jira/browse/TWDAPI-252
