### PR TITLE
Add Heading rule to use Verb form to Style Guide

### DIFF
--- a/styleguide/style.md
+++ b/styleguide/style.md
@@ -120,9 +120,24 @@ Lack of spacing makes it a little harder to read in source:
 Text after... DO NOT DO THIS.
 ```
 
+### Capitalization
+
 Use sentence-style capitalization. Always capitalize:
 - The first word of a heading.
 - The word following a colon in a title or heading (for example, "How to: Sort an array").
+
+### Verb form
+
+Use verb form to start headings:
+
+```markdown
+## Use verb form
+```
+Do not gerund form to start headings:
+
+```markdown
+## Using verb form... DO NOT DO THIS.
+```
 
 Headings should be done using atx-style, that is, use 1-6 hash characters (#) at the start of the line to indicate a heading, corresponding to HTML headings levels H1 through H6. Examples of first- and second-level headers are used above.
 


### PR DESCRIPTION
Signed-off-by: Mijin, Cho <mijin85.cho@samsung.com>

### Change Description ###

- We decided to use the verb form in the headings instead of gerund form.
  I add it to the Style Guide.
- (minor) Giving heading style to capitalization rule.