### PR TITLE
Delete ui-viewmgr Docs.

### DIFF
--- a/docs/application/native/guides/index.md
+++ b/docs/application/native/guides/index.md
@@ -235,7 +235,6 @@ The following list defines Tizen Native API. The list describes the API modules 
   | SDL                       | Provides a low level hardware abstraction layer to computer multimedia hardware components. It manages video, audio, input devices, threads, and timers. | [mobile](../api/mobile/latest/group__OPENSRC__SDL__FRAMEWORK.html) (since 3.0), [wearable](../api/wearable/latest/group__OPENSRC__SDL__FRAMEWORK.html) (since 3.0) | [SDL](graphics/sdl.md)   |
   | TBM Surface               | Provides functions for the graphics buffer.  | [mobile](../api/mobile/latest/group__CAPI__UI__TBM__SURFACE__MODULE.html), [wearable](../api/wearable/latest/group__CAPI__UI__TBM__SURFACE__MODULE.html) | [Graphic Buffer and Surface](graphics/graphic-buffer.md) |
   | Tizen Window System Shell            | Allows you to communicate with the window manager.   | [mobile](../api/mobile/latest/group__TIZEN__WS__SHELL__MODULE.html) (since 3.0), [wearable](../api/wearable/latest/group__TIZEN__WS__SHELL__MODULE.html) (since 3.0) | [Tizen Window System Shell](ui/tizen-ws-shell/index.md) |
-  | UI View Manager           | Provides functions for application view management.  | [mobile](../api/mobile/latest/group__CAPI__UI__VIEWMGR__MODULE.html) (since 3.0) |  |
   | Vulkan                    | Provides functions for rendering 3D and 2D graphics in embedded systems. | [mobile](../api/mobile/latest/group__OPENSRC__VULKAN__FRAMEWORK.html) (since 3.0), [wearable](../api/wearable/latest/group__OPENSRC__VULKAN__FRAMEWORK.html) (since 3.0) | [Vulkan](graphics/vulkan.md)     |
 
 - **UIX**


### PR DESCRIPTION
### Change Description ###

According to ACR-1532 The Ui-Viewmgr has been deprecated.

### Bugs Fixed ###

N/A

### API Changes ###

 - https://code.sec.samsung.net/jira/browse/ACR-1521

