### PR TITLE
Remove Device Manager screenshots showing the platform version

### DIFF
--- a/docs/application/native/get-started/wearable-watch/first-app-watch.md
+++ b/docs/application/native/get-started/wearable-watch/first-app-watch.md
@@ -398,9 +398,7 @@ To run the application on the target device:
 
         ![Allow Gear to access data](media/remote_allow_gear.png)
 
-    4. In the **Device Manager**, confirm that the device is connected (shown in the device list).
-
-        ![Device is connected](media/remote_connected_w.png)
+    4. In the **Device Manager**, confirm that the device is connected.
 
 2. Generate an author certificate.
 

--- a/docs/application/native/get-started/wearable-widget/first-app-widget.md
+++ b/docs/application/native/get-started/wearable-widget/first-app-widget.md
@@ -504,9 +504,7 @@ To run the application on the target device:
 
         ![Allow Gear to access data](media/remote_allow_gear.png)
 
-    4.  In the **Device Manager**, confirm that the device is connected (shown in the device list).
-
-        ![Device is connected](media/remote_connected_w.png)
+    4.  In the **Device Manager**, confirm that the device is connected.
 
 2.  Generate an author certificate.
 

--- a/docs/application/native/get-started/wearable/first-app.md
+++ b/docs/application/native/get-started/wearable/first-app.md
@@ -323,9 +323,7 @@ To run the application on the target device:
 
         ![Allow Gear to access data](media/remote_allow_gear.png)
 
-    4.  In the **Device Manager**, confirm that the device is connected (shown in the device list).
-
-        ![Device is connected](media/remote_connected_w.png)
+    4.  In the **Device Manager**, confirm that the device is connected.
 
 2.  Generate an author certificate.
 

--- a/docs/application/web/get-started/wearable-watch/first-app-watch.md
+++ b/docs/application/web/get-started/wearable-watch/first-app-watch.md
@@ -326,9 +326,7 @@ To run the application on the target device:
 
         ![Allow Gear to access data](media/remote_allow_gear.png)
 
-    4.  In the **Device Manager**, confirm that the device is connected (shown in the device list).
-
-        ![Device is connected](media/remote_connected_w.png)
+    4.  In the **Device Manager**, confirm that the device is connected.
 
 2.  Generate an author certificate.
 

--- a/docs/application/web/get-started/wearable-widget/first-app-widget.md
+++ b/docs/application/web/get-started/wearable-widget/first-app-widget.md
@@ -391,9 +391,7 @@ To run the application on the target device:
 
         ![Allow Gear to access data](media/remote_allow_gear.png)
 
-    4.  In the **Device Manager**, confirm that the device is connected (shown in the device list).
-
-        ![Device is connected](media/remote_connected_w.png)
+    4.  In the **Device Manager**, confirm that the device is connected.
 
 2.  Generate an author certificate.
 

--- a/docs/application/web/get-started/wearable/first-app.md
+++ b/docs/application/web/get-started/wearable/first-app.md
@@ -284,9 +284,7 @@ To run the application on the target device:
 
         ![Allow Gear to access data](media/remote_allow_gear.png)
 
-    4.  In the **Device Manager**, confirm that the device is connected (shown in the device list).
-
-        ![Device is connected](media/remote_connected_w.png)
+    4.  In the **Device Manager**, confirm that the device is connected.
 
 2.  Generate an author certificate.
 


### PR DESCRIPTION
### Bugs Fixed ###
 
- Cause: If the OS version of the target device is lower than the API version of the package, the package is not installed.
- Resolve: I reemove Device Manager screenshots showing the platform version.
- ToDo: I will update screenshots later so I didn't delete image files. 

Signed-off-by: Young-Ae Kang <youngae.kang@samsung.com>