### PR TITLE
[6.0][Web API]Add missing closing tag

### DIFF
--- a/docs/application/web/api/6.0/w3c_api/w3c_api_tv.html
+++ b/docs/application/web/api/6.0/w3c_api/w3c_api_tv.html
@@ -32,42 +32,42 @@
                     </thead>
                     <tbody>
                         <tr>
-                            <td><a href="http://tizen.org/privilege/appmanager.launch" target="_blank">http://tizen.org/privilege/appmanager.launch</td>
+                            <td><a href="http://tizen.org/privilege/appmanager.launch" target="_blank">http://tizen.org/privilege/appmanager.launch</a></td>
                             <td align="center"> all </td>
                             <td>The application can open other applications.</td>
                         </tr>
                         <tr>
-                            <td><a href="http://tizen.org/privilege/haptic" target="_blank">http://tizen.org/privilege/haptic</td>
+                            <td><a href="http://tizen.org/privilege/haptic" target="_blank">http://tizen.org/privilege/haptic</a></td>
                             <td align="center"> all </td>
                             <td>The application can control vibration feedback.</td>
                         </tr>
                         <tr>
-                            <td><a href="http://tizen.org/privilege/network.get" target="_blank">http://tizen.org/privilege/network.get</td>
+                            <td><a href="http://tizen.org/privilege/network.get" target="_blank">http://tizen.org/privilege/network.get</a></td>
                             <td align="center"> all </td>
                             <td>The application can retrieve network information such as the status of each network, its type, and detailed network profile information.</td>
                         </tr>
                         <tr>
-                            <td><a href="http://tizen.org/privilege/notification" target="_blank">http://tizen.org/privilege/notification</td>
+                            <td><a href="http://tizen.org/privilege/notification" target="_blank">http://tizen.org/privilege/notification</a></td>
                             <td align="center"> all </td>
                             <td>The application can show and hide its own notifications and badges.</td>
                         </tr>
                         <tr>
-                            <td><a href="http://tizen.org/privilege/packagemanager.info" target="_blank">http://tizen.org/privilege/packagemanager.info</td>
+                            <td><a href="http://tizen.org/privilege/packagemanager.info" target="_blank">http://tizen.org/privilege/packagemanager.info</a></td>
                             <td align="center"> all </td>
                             <td>The application can retrieve detailed application package information.</td>
                         </tr>
                         <tr>
-                            <td><a href="http://tizen.org/privilege/mediastorage" target="_blank">http://tizen.org/privilege/mediastorage</td>
+                            <td><a href="http://tizen.org/privilege/mediastorage" target="_blank">http://tizen.org/privilege/mediastorage</a></td>
                             <td align="center"> all </td>
                             <td>The application can read and write files in media folders.</td>
                         </tr>
                         <tr>
-                            <td><a href="http://tizen.org/privilege/externalstorage" target="_blank">http://tizen.org/privilege/externalstorage</td>
+                            <td><a href="http://tizen.org/privilege/externalstorage" target="_blank">http://tizen.org/privilege/externalstorage</a></td>
                             <td align="center"> all </td>
                             <td>The application can read and write files that are saved to external storage, such as SD cards.</td>
                         </tr>
                         <tr>
-                            <td><a href="http://tizen.org/privilege/display" target="_blank">http://tizen.org/privilege/display</td>
+                            <td><a href="http://tizen.org/privilege/display" target="_blank">http://tizen.org/privilege/display</a></td>
                             <td align="center"> all </td>
                             <td>The application can manage display settings, such as brightness. This may increase battery consumption.</td>
                         </tr>


### PR DESCRIPTION
Signed-off-by: Mijin, Cho <mijin85.cho@samsung.com>

### Change Description ###

In w3c_api_tv.html, some \<a> tags are missing closing tags.
Same fix with https://github.com/Samsung/tizen-docs/pull/1134 for tizen_6.0_prepare.

### Bugs Fixed ###

- Issue https://github.sec.samsung.net/RS8-TIZENWEBSITE/docs.tizen.org/issues/278?email_source=notifications&email_token=AAAHCPWEHWZNGGAOI5M2GIDRUXQODA5CNFSM4AAKQLFKYY3PNVWWK3TUL52HS4DFVREXG43VMVBW63LNMVXHJKTDN5WW2ZLOORPWSZGOAAFL7PQ
