### PR TITLE
Change platform/index.md to the first page of Platform > Get Started.

### DIFF
--- a/docs/platform/get-started/open-source-project.md
+++ b/docs/platform/get-started/open-source-project.md
@@ -25,6 +25,6 @@ To get started with Tizen development:
 
 - Study the development workflow
 
-  Tizen developers use the Git and [GBS command-line tools](reference/gbs/gbs-overview.md) for most of their work. Tizen source code is managed by [Gerrit](reference/gerrit-usage.md), a code review system for Git-based projects. Source code cloning, development, and review are done under ACL (Access Control Lists). Make sure you have access rights to them.
+  Tizen developers use the Git and [GBS command-line tools](../reference/gbs/gbs-overview.md) for most of their work. Tizen source code is managed by [Gerrit](../reference/gerrit-usage.md), a code review system for Git-based projects. Source code cloning, development, and review are done under ACL (Access Control Lists). Make sure you have access rights to them.
 
-Start by reading the [Development Workflow](get-started/work-flow.md) page.
+Start by reading the [Development Workflow](./work-flow.md) page.

--- a/docs/platform/toc_all.md
+++ b/docs/platform/toc_all.md
@@ -12,6 +12,7 @@
 ### [Tizen 3.0](/platform/what-is-tizen/versions/tizen-3-0.md)
 
 # Get Started
+## [Tizen Open Source Project](/platform/get-started/open-source-project.md)
 ## [Development Workflow](/platform/get-started/work-flow.md)
 ## [Git Repository Structure](/platform/get-started/git-repo-structure.md)
 ## [Typographic Conventions](/platform/get-started/conventions.md)


### PR DESCRIPTION
### Change Description ###

- Issue: platform/index.md was not used after the landing page of Platform was changed to what-is-tizen/overview.md.

- Resolution: The content is fit on the 'get started' page so I moved it to platform/get-started and changed the name.
