### PR TITLE
Change menu tree for Visual Studio for Mac Extension for Tizen

### DIFF
--- a/docs/application/toc_all.md
+++ b/docs/application/toc_all.md
@@ -1232,6 +1232,4 @@
 ## [Tizen Web](/application/vscode-ext/web.md)
 
 
-# Visual Studio for Mac Extension for Tizen
-
-## [Overview](/application/vstools-mac/overview.md)
+# [Visual Studio for Mac Extension for Tizen](/application/vstools-mac/overview.md)


### PR DESCRIPTION
### Change Description ###

Changed menu tree for Visual Studio for Mac Extension for Tizen.
When there is no child, the page has its own link.

