### PR TITLE
[common] Fixed some spaces issues

### DIFF
--- a/docs/application/web/api/6.0/device_api/mobile/tizen/account.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/account.html
@@ -34,8 +34,8 @@ gmail, gtalk, Picasa, and Youtube with each service having a separate service
 instance bound to the account.          </li>
         </ul>
         <p>
-To use <em>add(), remove(), and update()</em> methods of AccountManager can be invoked only
-by account provider application. A web application is an account provider when its <em>config.xml</em>contains <a href="/application/tizen-studio/web-tools/config-editor#mw_account">Account provider section</a>. For example:<br>&lt;tizen:account multiple-account-support="true"&gt;<br>      &lt;tizen:icon section="Account"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:icon section="AccountSmall"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:display-name xml:lang="en-gb"&gt;Test&lt;/tizen:display-name&gt;<br>      &lt;tizen:capability&gt;http://tizen.org/account/capability/contact&lt;/tizen:capability&gt;<br>&lt;/tizen:account&gt;
+To use <em>add(), remove(), and update()</em> methods of AccountManager can be invoked only by account provider application.
+A web application is an account provider when its <em>config.xml</em> contains <a href="/application/tizen-studio/web-tools/config-editor#mw_account">Account provider section</a>. For example:<br>&lt;tizen:account multiple-account-support="true"&gt;<br>      &lt;tizen:icon section="Account"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:icon section="AccountSmall"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:display-name xml:lang="en-gb"&gt;Test&lt;/tizen:display-name&gt;<br>      &lt;tizen:capability&gt;http://tizen.org/account/capability/contact&lt;/tizen:capability&gt;<br>&lt;/tizen:account&gt;
         </p>
         <p>
 For more information about how to use Account API, see <a href="/application/web/guides/personal/account">Account Guide</a>.

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/account.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/account.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="mobile-mandatory emulator" title="Mandatory, Supported by Tizen Mobile emulator" src="mobile_s_w.png"></div>
 <div class="title"><h1>Account API</h1></div>
 <div class="brief">
-  The Account API provides functionality for using existing configured
+ The Account API provides functionality for using existing configured
 online accounts and providers, and for creating accounts of known types.
         </div>
 <div class="description">
@@ -35,7 +35,7 @@ instance bound to the account.          </li>
         </ul>
         <p>
 To use <em>add(), remove(), and update()</em> methods of AccountManager can be invoked only
-by account provider application. A web application is an account provider when its <em>config.xml </em>contains <a href="/application/tizen-studio/web-tools/config-editor#mw_account">Account provider section</a>. For example:<br>&lt;tizen:account multiple-account-support="true"&gt;<br>      &lt;tizen:icon section="Account"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:icon section="AccountSmall"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:display-name xml:lang="en-gb"&gt;Test&lt;/tizen:display-name&gt;<br>      &lt;tizen:capability&gt;http://tizen.org/account/capability/contact&lt;/tizen:capability&gt;<br>&lt;/tizen:account&gt;
+by account provider application. A web application is an account provider when its <em>config.xml</em>contains <a href="/application/tizen-studio/web-tools/config-editor#mw_account">Account provider section</a>. For example:<br>&lt;tizen:account multiple-account-support="true"&gt;<br>      &lt;tizen:icon section="Account"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:icon section="AccountSmall"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:display-name xml:lang="en-gb"&gt;Test&lt;/tizen:display-name&gt;<br>      &lt;tizen:capability&gt;http://tizen.org/account/capability/contact&lt;/tizen:capability&gt;<br>&lt;/tizen:account&gt;
         </p>
         <p>
 For more information about how to use Account API, see <a href="/application/web/guides/personal/account">Account Guide</a>.

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/alarm.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/alarm.html
@@ -278,7 +278,7 @@ For more information about the application control, see <a href="application.htm
 <ul>
           <li class="param">
 <span class="name">alarm</span>:
- An alarm to add. It can be either <em>AlarmRelative</em>  or <em>AlarmAbsolute</em>.
+ An alarm to add. It can be either <em>AlarmRelative</em> or <em>AlarmAbsolute</em>.
                 </li>
           <li class="param">
 <span class="name">applicationId</span>:

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/alarm.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/alarm.html
@@ -157,8 +157,8 @@ For more information on the Alarm features, see <a href="/application/web/guides
 <div class="interface" id="AlarmManagerObject">
 <a class="backward-compatibility-anchor" name="::Alarm::AlarmManagerObject"></a><h3>2.1. AlarmManagerObject</h3>
 <div class="brief">
- The AlarmManagerObject interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
-The <em>tizen.alarm </em>object allows access to the functionality of the Alarm API.
+ The AlarmManagerObject interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
+The <em>tizen.alarm</em> object allows access to the functionality of the Alarm API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface AlarmManagerObject {
     readonly attribute <a href="#AlarmManager">AlarmManager</a> alarm;
@@ -278,7 +278,7 @@ For more information about the application control, see <a href="application.htm
 <ul>
           <li class="param">
 <span class="name">alarm</span>:
- An alarm to add. It can be either <em>AlarmRelative </em> or <em>AlarmAbsolute</em>.
+ An alarm to add. It can be either <em>AlarmRelative</em>  or <em>AlarmAbsolute</em>.
                 </li>
           <li class="param">
 <span class="name">applicationId</span>:

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/application.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/application.html
@@ -345,7 +345,7 @@ FREQUENTLY - Indicates most frequently used applications, in a descending order 
 <div class="interface" id="ApplicationManagerObject">
 <a class="backward-compatibility-anchor" name="::Application::ApplicationManagerObject"></a><h3>2.1. ApplicationManagerObject</h3>
 <div class="brief">
- This interface defines what is instantiated by the <em>Tizen </em>object on the Tizen Platform.
+ This interface defines what is instantiated by the <em>Tizen</em> object on the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface ApplicationManagerObject {
     readonly attribute <a href="#ApplicationManager">ApplicationManager</a> application;
@@ -356,7 +356,7 @@ FREQUENTLY - Indicates most frequently used applications, in a descending order 
           </p>
 <div class="description">
           <p>
-The <em>tizen.application </em>object allows access to the Application API's functionality.
+The <em>tizen.application</em> object allows access to the Application API's functionality.
           </p>
          </div>
 <div class="attributes">
@@ -416,7 +416,7 @@ The <em>tizen.application </em>object allows access to the Application API's fun
 </dt>
 <dd>
 <div class="brief">
- Gets the <em>Application </em>object defining the current application.
+ Gets the <em>Application</em> object defining the current application.
             </div>
 <div class="synopsis"><pre class="signature prettyprint"><a href="#Application">Application</a> getCurrentApplication();</pre></div>
 <p><span class="version">Since: </span>
@@ -626,10 +626,10 @@ to perform the requested application control, then launches the selected applica
             </p>
             <p>
 The application control request is passed to the newly launched application
-and it can be accessed by the <em>getRequestedAppControl() </em>method. The passed
+and it can be accessed by the <em>getRequestedAppControl()</em> method. The passed
 application control contains the reason the application has been launched and
 information about what the application is doing. The launched application
-can send a result to the caller application with the <em>replyResult() </em>method of the
+can send a result to the caller application with the <em>replyResult()</em> method of the
 <em>RequestedApplicationControl</em> interface.
             </p>
             <p>
@@ -663,7 +663,7 @@ Also, implicit launch requests are NOT delivered to service applications since 2
                 </li>
           <li class="param">
 <span class="name">id</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
- An identifier of the application to be launched. If the ID is <var>null </var>or not specified, then the system tries to find the application to be launched for the requested application control.
+ An identifier of the application to be launched. If the ID is <var>null</var> or not specified, then the system tries to find the application to be launched for the requested application control.
                 </li>
           <li class="param">
 <span class="name">successCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
@@ -883,7 +883,7 @@ tizen.application.getAppsContext(onRunningAppsContext);
 <dd>
 <div class="brief">
  Gets the application context for the specified application context ID.
-If the ID is set to<var> null</var> or is not set at all, the method returns the application context of the current application.
+If the ID is set to <var>null</var> or is not set at all, the method returns the application context of the current application.
 The list of running applications and their application IDs is obtained with <em>getAppsContext()</em>.
             </div>
 <div class="synopsis"><pre class="signature prettyprint"><a href="#ApplicationContext">ApplicationContext</a> getAppContext(optional <a href="#ApplicationContextId">ApplicationContextId</a>? contextId);</pre></div>
@@ -1049,23 +1049,23 @@ The certificate types are listed below:
             </p>
             <ul>
               <li>
- AUTHOR_ROOT - Author Root Certificate               </li>
+AUTHOR_ROOT - Author Root Certificate              </li>
               <li>
- AUTHOR_INTERMEDIATE - Author Intermediate Certificate               </li>
+AUTHOR_INTERMEDIATE - Author Intermediate Certificate              </li>
               <li>
- AUTHOR_SIGNER - Author Signer Certificate               </li>
+AUTHOR_SIGNER - Author Signer Certificate              </li>
               <li>
- DISTRIBUTOR_ROOT - Distributor Root Certificate               </li>
+DISTRIBUTOR_ROOT - Distributor Root Certificate              </li>
               <li>
- DISTRIBUTOR_INTERMEDIATE - Distributor Intermediate Certificate               </li>
+DISTRIBUTOR_INTERMEDIATE - Distributor Intermediate Certificate              </li>
               <li>
- DISTRIBUTOR_SIGNER - Distributor Signer Certificate               </li>
+DISTRIBUTOR_SIGNER - Distributor Signer Certificate              </li>
               <li>
- DISTRIBUTOR2_ROOT - Distributor2 Root Certificate               </li>
+DISTRIBUTOR2_ROOT - Distributor2 Root Certificate              </li>
               <li>
- DISTRIBUTOR2_INTERMEDIATE - Distributor2 Intermediate Certificate               </li>
+DISTRIBUTOR2_INTERMEDIATE - Distributor2 Intermediate Certificate              </li>
               <li>
- DISTRIBUTOR2_SIGNER - Distributor2 Signer Certificate               </li>
+DISTRIBUTOR2_SIGNER - Distributor2 Signer Certificate              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1589,7 +1589,7 @@ The maximum retention period is 90 days.
 <dd>
 <div class="brief">
  The attribute to store period of time, from which data is accumulated, in days.
-The  period of time begins <em>timeSpan</em> days ago and ends with current date.
+The period of time begins <em>timeSpan</em> days ago and ends with current date.
             </div>
 <div class="description">
             <p>
@@ -2292,7 +2292,7 @@ The attribute value scales from <var>0</var> to <var>1</var>, the higher value, 
 <a class="backward-compatibility-anchor" name="::Application::ApplicationControlData"></a><h3>2.9. ApplicationControlData</h3>
 <div class="brief">
  This interface defines a key/value pair used to pass data
-between applications through the <em>ApplicationControl </em>interface.
+between applications through the <em>ApplicationControl</em> interface.
           </div>
 <pre class="webidl prettyprint">  [Constructor(DOMString key, DOMString[] value)]
   interface ApplicationControlData {
@@ -2751,7 +2751,7 @@ This callback interface specifies a success method with an array of
 <div class="description">
           <p>
 This callback interface specifies a success method with an array of
-<em>ApplicationInformation </em>objects as an input parameter. It is used in <em>ApplicationManager.getAppsInfo()</em>.
+<em>ApplicationInformation</em> objects as an input parameter. It is used in <em>ApplicationManager.getAppsInfo()</em>.
           </p>
          </div>
 <div class="methods">
@@ -2807,7 +2807,7 @@ tizen.application.getAppsInfo(onListInstalledApps);
 <div class="description">
           <p>
 This callback interface specifies a success method with an array of
-<em>ApplicationInformation </em>objects and application control as an input parameter.
+<em>ApplicationInformation</em> objects and application control as an input parameter.
 It is used in <em>ApplicationManager.findAppControl()</em>.
           </p>
          </div>
@@ -2900,7 +2900,7 @@ tizen.application.findAppControl(appControl, successCB);
 <div class="description">
           <p>
 This callback interface specifies a success method with
-an array of <em>ApplicationContext </em>objects as an input parameter. It is used in <em>ApplicationManager.getAppsContext()</em>.
+an array of <em>ApplicationContext</em> objects as an input parameter. It is used in <em>ApplicationManager.getAppsContext()</em>.
           </p>
          </div>
 <div class="methods">
@@ -2911,7 +2911,7 @@ an array of <em>ApplicationContext </em>objects as an input parameter. It is use
 </dt>
 <dd>
 <div class="brief">
- Called when <em>ApplicationManager.getAppsContext() </em>completes successfully.
+ Called when <em>ApplicationManager.getAppsContext()</em> completes successfully.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void onsuccess(<a href="#ApplicationContext">ApplicationContext</a>[] contexts);</pre></div>
 <p><span class="version">Since: </span>
@@ -2948,9 +2948,9 @@ This callback interface specifies two methods:
           </p>
           <ul>
             <li>
- <em>onsuccess()</em> - Invoked if the callee application calls <em>RequestedApplicationControl.replyResult()</em>.            </li>
+<em>onsuccess()</em> - Invoked if the callee application calls <em>RequestedApplicationControl.replyResult()</em>.            </li>
             <li>
- <em>onfailure()</em> - Invoked if the callee application calls <em>RequestedApplicationControl.replyFailure()</em>.            </li>
+<em>onfailure()</em> - Invoked if the callee application calls <em>RequestedApplicationControl.replyFailure()</em>.            </li>
           </ul>
          </div>
 <div class="example">

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/archive.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/archive.html
@@ -393,7 +393,7 @@ Description                </th>
                 <td>
 r                </td>
                 <td>
-Use this mode for extracting or getting information about the contents of an archive file. <br><em>file</em> must exist. If the <em>file</em> does not exist, <em>onerror</em> will be invoked (<em>NotFoundError</em>).<br>When an archive file is opened in this mode, <em>add()</em> will not be available. (<em>IOError</em> will be thrown.)                 </td>
+Use this mode for extracting or getting information about the contents of an archive file. <br><em>file</em> must exist. If the <em>file</em> does not exist, <em>onerror</em> will be invoked (<em>NotFoundError</em>).<br>When an archive file is opened in this mode, <em>add()</em> will not be available. (<em>IOError</em> will be thrown.)                </td>
               </tr>
               <tr>
                 <td>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/bookmark.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/bookmark.html
@@ -59,7 +59,7 @@ For more information on the Bookmark features, see <a href="/application/web/gui
 <div class="typedef deprecated" id="Bookmark">
 <a class="backward-compatibility-anchor" name="::Bookmark::Bookmark"></a><h3>1.1. Bookmark</h3>
 <div class="brief">
- A bookmark, which could be either a <em>BookmarkItem </em>or a <em>BookmarkFolder</em>.
+ A bookmark, which could be either a <em>BookmarkItem</em> or a <em>BookmarkFolder</em>.
           </div>
 <p class="deprecated"><b>Deprecated.</b>
  Since Tizen 6.0 Bookmark API is deprecated.
@@ -89,7 +89,7 @@ For more information on the Bookmark features, see <a href="/application/web/gui
           </p>
 <div class="description">
           <p>
-There will be a <em>tizen.bookmark </em>object that allows to access the functionality of the Bookmark API.
+There will be a <em>tizen.bookmark</em> object that allows to access the functionality of the Bookmark API.
           </p>
          </div>
 <div class="attributes">
@@ -126,7 +126,7 @@ There will be a <em>tizen.bookmark </em>object that allows to access the functio
           </p>
 <div class="description">
           <p>
-It provides access to the API functionalities through the <em>tizen.bookmark </em>interface.
+It provides access to the API functionalities through the <em>tizen.bookmark</em> interface.
           </p>
          </div>
 <div class="methods">
@@ -175,7 +175,7 @@ In this case, the return will contain bookmarks under the root bookmark folder.
 <p><span class="return">Return value:</span></p>
 <ul>
 <span class="return">Bookmark[]:</span>
-  Array of Bookmarks.
+ Array of Bookmarks.
               </ul>
 </div>
 <div class="exceptionlist">
@@ -351,7 +351,7 @@ catch (err)
 <div class="interface deprecated" id="BookmarkItem">
 <a class="backward-compatibility-anchor" name="::Bookmark::BookmarkItem"></a><h3>2.3. BookmarkItem</h3>
 <div class="brief">
- The BookmarkItem interface implements the <em>BookmarkItem </em>object.
+ The BookmarkItem interface implements the <em>BookmarkItem</em> object.
           </div>
 <p class="deprecated"><b>Deprecated.</b>
  Since Tizen 6.0 Bookmark API is deprecated.
@@ -443,7 +443,7 @@ If the parent bookmark folder indicates the root bookmark folder, the value will
 <div class="interface deprecated" id="BookmarkFolder">
 <a class="backward-compatibility-anchor" name="::Bookmark::BookmarkFolder"></a><h3>2.4. BookmarkFolder</h3>
 <div class="brief">
- The BookmarkFolder interface implements the <em>BookmarkFolder </em>object.
+ The BookmarkFolder interface implements the <em>BookmarkFolder</em> object.
           </div>
 <p class="deprecated"><b>Deprecated.</b>
  Since Tizen 6.0 Bookmark API is deprecated.

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/calendar.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/calendar.html
@@ -19,7 +19,7 @@ Separate calendars can be implemented for group related events or tasks. For exa
 The Internet Calendaring and Scheduling Core Object Specification (iCalendar), defines a format for exchanging event items. Mapping to specified event/task attributes in this API is as per this specification. For details, see <a href="http://tools.ietf.org/html/rfc5545">RFC 5545</a>.
         </p>
         <p>
-This API provides functionality to read, create, delete, and update items in specific calendars. Calendars can be obtained using the <em>getCalendars() </em>method, which returns an array of Calendar objects.
+This API provides functionality to read, create, delete, and update items in specific calendars. Calendars can be obtained using the <em>getCalendars()</em> method, which returns an array of Calendar objects.
         </p>
         <p>
 For more information on the Calendar features, see <a href="/application/web/guides/personal/calendar">Calendar Guide</a>.
@@ -265,7 +265,7 @@ For more information on the Calendar features, see <a href="/application/web/gui
 <div class="typedef" id="CalendarItemId">
 <a class="backward-compatibility-anchor" name="::Calendar::CalendarItemId"></a><h3>1.3. CalendarItemId</h3>
 <div class="brief">
- The calendar item identifier, which can either be a <em>CalendarEventId </em>or a <em>CalendarTaskId</em>.
+ The calendar item identifier, which can either be a <em>CalendarEventId</em> or a <em>CalendarTaskId</em>.
           </div>
 <pre class="webidl prettyprint">  typedef (<a href="#CalendarEventId">CalendarEventId</a> or <a href="#CalendarTaskId">CalendarTaskId</a>) CalendarItemId;</pre>
 <p><span class="version">Since: </span>
@@ -593,7 +593,7 @@ CANCELLED -  if the task has been cancelled            </li>
 <div class="interface" id="CalendarManagerObject">
 <a class="backward-compatibility-anchor" name="::Calendar::CalendarManagerObject"></a><h3>2.1. CalendarManagerObject</h3>
 <div class="brief">
- The CalendarManagerObject interface gives access to the Calendar API from the <em>tizen.calendar </em>object.
+ The CalendarManagerObject interface gives access to the Calendar API from the <em>tizen.calendar</em> object.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface CalendarManagerObject {
     readonly attribute <a href="#CalendarManager">CalendarManager</a> calendar;
@@ -649,7 +649,7 @@ Once a calendar object is obtained, it is possible to add, remove, or update the
             </p>
 <div class="description">
             <p>
-If the operation completes successfully, the <em>successCallback() </em>must be invoked with all the calendars found and available. The first calendar in the list is always the default calendar.
+If the operation completes successfully, the <em>successCallback()</em> must be invoked with all the calendars found and available. The first calendar in the list is always the default calendar.
             </p>
             <p>
 If no Calendar object is available, the <em>successCallback()</em> is invoked with an empty array.
@@ -1207,15 +1207,15 @@ This interface offers the following methods to manage events in a calendar:
           </p>
           <ul>
             <li>
- Finding items using a key-value filter.            </li>
+Finding items using a key-value filter.            </li>
             <li>
- Adding items to a specific calendar using <em>add() </em>/ <em>addBatch() </em>methods.            </li>
+Adding items to a specific calendar using <em>add()</em> / <em>addBatch()</em> methods.            </li>
             <li>
- Updating existing items using <em>update() </em>/ <em>updateBatch()</em> methods.            </li>
+Updating existing items using <em>update()</em> / <em>updateBatch()</em> methods.            </li>
             <li>
- Deleting existing items using <em>remove()</em> / <em>removeBatch() </em>methods.            </li>
+Deleting existing items using <em>remove()</em> / <em>removeBatch()</em> methods.            </li>
             <li>
- Tracking calendar changes using <em>addChangeListener()</em> / <em>removeChangeListener() </em>methods.            </li>
+Tracking calendar changes using <em>addChangeListener()</em> / <em>removeChangeListener()</em> methods.            </li>
           </ul>
          </div>
 <div class="example">
@@ -1318,7 +1318,7 @@ console.log("The calendar name is " + calendar.name);
 <p><span class="return">Return value:</span></p>
 <ul>
 <span class="return">CalendarItem:</span>
- The matching <em>CalendarItem </em>object.
+ The matching <em>CalendarItem</em> object.
               </ul>
 </div>
 <div class="exceptionlist">
@@ -1373,10 +1373,10 @@ catch (err)
             </p>
 <div class="description">
             <p>
-If the item is successfully inserted in the calendar, the <em>CalendarItem </em>will have its identifier (id attribute) set when the method returns.
+If the item is successfully inserted in the calendar, the <em>CalendarItem</em> will have its identifier (id attribute) set when the method returns.
             </p>
             <p>
-To update an existing item, call the <em>update() </em>method instead. If you wish to add a copy of an existing <em>CalendarItem </em>object, call <em>CalendarItem.clone()</em> method first and pass the clone to the <em>add()</em> method.
+To update an existing item, call the <em>update()</em> method instead. If you wish to add a copy of an existing <em>CalendarItem</em> object, call <em>CalendarItem.clone()</em> method first and pass the clone to the <em>add()</em> method.
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1447,7 +1447,7 @@ console.log("Event added with uid " + ev.id.uid);
             </p>
 <div class="description">
             <p>
-If all the items are successfully added to the calendar, the success callback will be invoked, passing the list of <em>CalendarItem </em>objects that were added, with their identifier set (id attribute).
+If all the items are successfully added to the calendar, the success callback will be invoked, passing the list of <em>CalendarItem</em> objects that were added, with their identifier set (id attribute).
             </p>
             <p>
 The <em>ErrorCallback</em> method is launched with these error types:
@@ -1456,10 +1456,10 @@ The <em>ErrorCallback</em> method is launched with these error types:
               <li>
 InvalidValuesError - if any of the input parameters contain an invalid value, the item has any invalid value or the calendar has some restrictions that cause the attempted insertion of the calendar items to fail (for example, limitations in the size of text attributes).              </li>
               <li>
-UnknownError - if any other error occurs.               </li>
+UnknownError - if any other error occurs.              </li>
             </ul>
             <p>
-If you wish to update an existing item, call the <em>update() </em>method instead. If you wish to add a copy of an existing <em>CalendarItem </em>object, call CalendarItem.clone() method first and pass the clone to the add() method.
+If you wish to update an existing item, call the <em>update()</em> method instead. If you wish to add a copy of an existing <em>CalendarItem</em> object, call CalendarItem.clone() method first and pass the clone to the add() method.
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1651,11 +1651,11 @@ UnknownError - if any other error occurs.              </li>
                 </li>
           <li class="param">
 <span class="name">successCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
- Callback method that is invoked when the <em>updateEvents() </em>request succeeds.
+ Callback method that is invoked when the <em>updateEvents()</em> request succeeds.
                 </li>
           <li class="param">
 <span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
- Callback method that is invoked when the <em>updateEvents() </em>request fails.
+ Callback method that is invoked when the <em>updateEvents()</em> request fails.
                 </li>
           <li class="param">
 <span class="name">updateAllInstances</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
@@ -1805,7 +1805,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
-NotFoundError - if an identifier in the <em>ids </em>parameter does not correspond to the id attribute of an item in the calendar.              </li>
+NotFoundError - if an identifier in the <em>ids</em> parameter does not correspond to the id attribute of an item in the calendar.              </li>
               <li>
 InvalidValuesError - if any of the input parameters contain an invalid value.              </li>
               <li>
@@ -1826,7 +1826,7 @@ UnknownError - if any other error occurs.              </li>
 <ul>
           <li class="param">
 <span class="name">ids</span>:
- The identifiers (<em>id </em>attribute) of the items to delete.
+ The identifiers (<em>id</em> attribute) of the items to delete.
                 </li>
           <li class="param">
 <span class="name">successCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
@@ -1888,7 +1888,7 @@ myCalendar.find(eventSearchSuccessCallback, errorCallback);
 </dt>
 <dd>
 <div class="brief">
- Finds and fetches an array of <em>CalendarItem </em>objects for items stored in the calendar according to the supplied filter if it is valid else it will return all the items stored.
+ Finds and fetches an array of <em>CalendarItem</em> objects for items stored in the calendar according to the supplied filter if it is valid else it will return all the items stored.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void find(<a href="#CalendarItemArraySuccessCallback">CalendarItemArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter,
           optional <a href="tizen.html#SortMode">SortMode</a>? sortMode);</pre></div>
@@ -1897,9 +1897,9 @@ myCalendar.find(eventSearchSuccessCallback, errorCallback);
             </p>
 <div class="description">
             <p>
-If the filter is passed and contains valid values, only those values in the calendar that match the filter criteria as specified in the <em>AbstractFilter </em>interface will be returned in the <em>successCallback()</em>.
-If no filter is passed, or the filter contains any invalid value which is <var>null </var>or undefined, then the implementation must return the full list of items in the <em>successCallback()</em>.
-If no items are available in the calendar (it is empty) or no item matches the filter criteria, the <em>successCallback() </em>will be invoked with an empty array.
+If the filter is passed and contains valid values, only those values in the calendar that match the filter criteria as specified in the <em>AbstractFilter</em> interface will be returned in the <em>successCallback()</em>.
+If no filter is passed, or the filter contains any invalid value which is <var>null</var> or undefined, then the implementation must return the full list of items in the <em>successCallback()</em>.
+If no items are available in the calendar (it is empty) or no item matches the filter criteria, the <em>successCallback()</em> will be invoked with an empty array.
             </p>
             <p>
 The <em>ErrorCallback</em> method is launched with these error types:
@@ -1939,7 +1939,7 @@ If no recurrence ID is given, the filter will match both the parent event and al
                 </li>
           <li class="param">
 <span class="name">filter</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
- Supplied data used to filter the results of the <em>find() </em>method.
+ Supplied data used to filter the results of the <em>find()</em> method.
                 </li>
           <li class="param">
 <span class="name">sortMode</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
@@ -2085,8 +2085,8 @@ watcherId = calendar.addChangeListener(watcher);
             </p>
 <div class="description">
             <p>
-If the <em>watchId </em>argument is valid and corresponds to a subscription already in place, the watch process must immediately stop and no further callbacks must be invoked.
-If the <em>watchId </em>argument is not valid or does not correspond to a valid subscription, the method should return without any further action.
+If the <em>watchId</em> argument is valid and corresponds to a subscription already in place, the watch process must immediately stop and no further callbacks must be invoked.
+If the <em>watchId</em> argument is not valid or does not correspond to a valid subscription, the method should return without any further action.
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2196,7 +2196,7 @@ These attributes are shared by both calendar events and tasks.
           </p>
 <div class="description">
           <p>
-It also provides an interface for specifying task attributes upon task creation (in the <em>CalendarTask </em>constructor).
+It also provides an interface for specifying task attributes upon task creation (in the <em>CalendarTask</em> constructor).
           </p>
           <p>
 All the attributes are optional and are undefined by default.
@@ -2219,7 +2219,7 @@ All the attributes are optional and are undefined by default.
           </p>
 <div class="description">
           <p>
-Provides an interface for specifying event attributes upon event creation (in the <em>CalendarEvent </em>constructor).
+Provides an interface for specifying event attributes upon event creation (in the <em>CalendarEvent</em> constructor).
           </p>
           <p>
 All the attributes are optional and are undefined by default.
@@ -2351,7 +2351,7 @@ The default value is an empty string.
             </div>
 <div class="description">
             <p>
-If set to <var>true</var>, then the time and time zone of the <em>startDate </em>are to be ignored and are not guaranteed to be stored in the database. An all-day event always covers the whole day, regardless of which time zone it was defined in and what the current time zone is. The duration must be <var>n*60*24 </var>minutes for an event lasting <var>n</var> days.
+If set to <var>true</var>, then the time and time zone of the <em>startDate</em> are to be ignored and are not guaranteed to be stored in the database. An all-day event always covers the whole day, regardless of which time zone it was defined in and what the current time zone is. The duration must be <var>n*60*24</var>minutes for an event lasting <var>n</var> days.
             </p>
             <p>
 The default value for this attribute is <var>false</var>.
@@ -2506,7 +2506,7 @@ The default value for this attribute is <var>NONE</var>.
             </div>
 <div class="description">
             <p>
-The default value for this attribute is <var>NONE </var>priority.
+The default value for this attribute is <var>NONE</var> priority.
             </p>
             <p>
 If the native item database supports another priority schema (such as a range from 1 to 9), the implementation must convert those values to the supported values. For instance, RFC 5545 suggests the following mapping for a range from 1 to 9:
@@ -2674,7 +2674,7 @@ myCalendar.find(eventSearchSuccessCallback, errorCallback, filter);
 </dt>
 <dd>
 <div class="brief">
- Clones the <em>CalendarItem </em>object, detached from any calendar.
+ Clones the <em>CalendarItem</em> object, detached from any calendar.
             </div>
 <div class="synopsis"><pre class="signature prettyprint"><a href="#CalendarItem">CalendarItem</a> clone();</pre></div>
 <p><span class="version">Since: </span>
@@ -2682,7 +2682,7 @@ myCalendar.find(eventSearchSuccessCallback, errorCallback, filter);
             </p>
 <div class="description">
             <p>
-The <em>CalendarItem </em>object returned by the <em>clone()</em> method will have its identifier set to <var>null </var>and will be detached from any calendar.
+The <em>CalendarItem</em> object returned by the <em>clone()</em> method will have its identifier set to <var>null</var> and will be detached from any calendar.
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2695,7 +2695,7 @@ The <em>CalendarItem </em>object returned by the <em>clone()</em> method will ha
 <p><span class="return">Return value:</span></p>
 <ul>
 <span class="return">CalendarItem:</span>
- New clone of the <em>CalendarItem </em>object.
+ New clone of the <em>CalendarItem</em> object.
               </ul>
 </div>
 <div class="exceptionlist">
@@ -2737,7 +2737,7 @@ calendar.add(tizenseminar);
 <div class="interface" id="CalendarTask">
 <a class="backward-compatibility-anchor" name="::Calendar::CalendarTask"></a><h3>2.8. CalendarTask</h3>
 <div class="brief">
- This interface implements the <em>CalendarTask </em>object.
+ This interface implements the <em>CalendarTask</em> object.
           </div>
 <pre class="webidl prettyprint">  [Constructor(optional <a href="#CalendarTaskInit">CalendarTaskInit</a>? taskInitDict),
    Constructor(DOMString stringRepresentation, <a href="#CalendarTextFormat">CalendarTextFormat</a> format)]
@@ -2859,7 +2859,7 @@ The default value is <var>null</var>. If no value is provided, the task is not c
             </div>
 <div class="description">
             <p>
-The value is a positive integer between <var>0 </var>and <var>100</var>. A value of <var>0 </var>indicates the task has not been started yet. A value of <var>100 </var>indicates that the task has been completed.
+The value is a positive integer between <var>0</var>and <var>100</var>. A value of <var>0</var>indicates the task has not been started yet. A value of <var>100</var>indicates that the task has been completed.
             </p>
             <p>
 Integer values in between indicate the percent partially complete.
@@ -2883,7 +2883,7 @@ The default value is <var>0</var>, implies that the task has not been started.
 <div class="interface" id="CalendarEvent">
 <a class="backward-compatibility-anchor" name="::Calendar::CalendarEvent"></a><h3>2.9. CalendarEvent</h3>
 <div class="brief">
- This interface implements the <em>calendarEvent </em>object.
+ This interface implements the <em>calendarEvent</em> object.
           </div>
 <pre class="webidl prettyprint">  [Constructor(optional <a href="#CalendarEventInit">CalendarEventInit</a>? eventInitDict),
    Constructor(DOMString stringRepresentation, <a href="#CalendarTextFormat">CalendarTextFormat</a> format)]
@@ -3051,7 +3051,7 @@ event.recurrenceRule = rule;
 This method takes into consideration all the parameters of the event recurrence rule to generate the instances occurring in a given time interval.
             </p>
             <p>
-The call involves retrieving from the database detached instances of an event to replace their corresponding virtual instances in the returned list. The client can then use <em>CalendarEvent.isDetached </em>attribute to identify detached instances. If the event is not saved to a calendar yet, only virtual instances will be returned.
+The call involves retrieving from the database detached instances of an event to replace their corresponding virtual instances in the returned list. The client can then use <em>CalendarEvent.isDetached</em> attribute to identify detached instances. If the event is not saved to a calendar yet, only virtual instances will be returned.
             </p>
             <p>
 The <em>ErrorCallback</em> method is launched with these error types:
@@ -3156,14 +3156,14 @@ if (event.recurrenceRule != null)
           </p>
 <div class="description">
           <p>
-See <em>CalendarAttendee </em>interface for more information about the members.
+See <em>CalendarAttendee</em> interface for more information about the members.
           </p>
          </div>
 </div>
 <div class="interface" id="CalendarAttendee">
 <a class="backward-compatibility-anchor" name="::Calendar::CalendarAttendee"></a><h3>2.11. CalendarAttendee</h3>
 <div class="brief">
- The CalendarAttendee interface implements the <em>CalendarAttendee </em>object that contains information about an event attendee.
+ The CalendarAttendee interface implements the <em>CalendarAttendee</em> object that contains information about an event attendee.
           </div>
 <pre class="webidl prettyprint">  [Constructor(DOMString uri, optional <a href="#CalendarAttendeeInit">CalendarAttendeeInit</a>? attendeeInitDict)]
   interface CalendarAttendee {
@@ -3318,7 +3318,7 @@ The default value is <var>INDIVIDUAL</var>.
             </div>
 <div class="description">
             <p>
-If the contact is not resolved, this attribute will be set to<var> null</var>.
+If the contact is not resolved, this attribute will be set to <var>null</var>.
 For more information, see the <a href="contact.html">Contact API</a>.
             </p>
            </div>
@@ -3347,14 +3347,14 @@ For more information, see the <a href="contact.html">Contact API</a>.
           </p>
 <div class="description">
           <p>
-For more information about the members, see <em>CalendarRecurrenceRule </em>interface.
+For more information about the members, see <em>CalendarRecurrenceRule</em> interface.
           </p>
          </div>
 </div>
 <div class="interface" id="CalendarRecurrenceRule">
 <a class="backward-compatibility-anchor" name="::Calendar::CalendarRecurrenceRule"></a><h3>2.13. CalendarRecurrenceRule</h3>
 <div class="brief">
- The CalendarRecurrenceRule interface implements the<em> CalendarRecurrenceRule </em>object, which contains information about the recurrence of an event.
+ The CalendarRecurrenceRule interface implements the <em>CalendarRecurrenceRule</em> object, which contains information about the recurrence of an event.
 (See RFC 5545, Section 3.3.10.)
           </div>
 <pre class="webidl prettyprint">  [Constructor(<a href="#RecurrenceRuleFrequency">RecurrenceRuleFrequency</a> frequency, optional <a href="#CalendarRecurrenceRuleInit">CalendarRecurrenceRuleInit</a>? ruleInitDict)]
@@ -3407,13 +3407,13 @@ This property corresponds to <em>FREQ</em> in RFC 5545.
             </div>
 <div class="description">
             <p>
-This attribute is linked to the <em>frequency </em>attribute and for an interval of <var>n</var>, the event will recur every <var>n </var>of recurrence attribute.
+This attribute is linked to the <em>frequency</em> attribute and for an interval of <var>n</var>, the event will recur every <var>n</var> of recurrence attribute.
             </p>
             <p>
-For example, if the interval attribute is set to <var>2 </var>and <em>frequency </em>attribute is set to <var>WEEKLY</var>, then the event will recur every 2 weeks.
+For example, if the interval attribute is set to <var>2</var>and <em>frequency</em> attribute is set to <var>WEEKLY</var>, then the event will recur every 2 weeks.
             </p>
             <p>
-The default interval value is <var>1</var>, that is, every day if the <em>CalendarRecurrenceRule frequency</em> attribute is DAILY, every week if frequency is <var>WEEKLY</var>, every month if frequency is <var>MONTHLY </var>or every year if frequency is <var>YEARLY</var>.
+The default interval value is <var>1</var>, that is, every day if the <em>CalendarRecurrenceRule frequency</em> attribute is DAILY, every week if frequency is <var>WEEKLY</var>, every month if frequency is <var>MONTHLY</var> or every year if frequency is <var>YEARLY</var>.
             </p>
             <p>
 This property corresponds to <em>INTERVAL</em> in RFC 5545.
@@ -3425,11 +3425,11 @@ This property corresponds to <em>INTERVAL</em> in RFC 5545.
 </li>
 <li class="attribute" id="CalendarRecurrenceRule::untilDate">
 <span class="attrName"><span class="type">TZDate </span><span class="name">untilDate</span><span class="optional"> [nullable]</span></span><div class="brief">
- The end date of a recurrence duration of an event using either an end date (<em>untilDate </em>attribute) or a number of occurrences (<em>occurrenceCount </em>attribute).
+ The end date of a recurrence duration of an event using either an end date (<em>untilDate</em> attribute) or a number of occurrences (<em>occurrenceCount</em> attribute).
             </div>
 <div class="description">
             <p>
-By default, this attribute is set to <var>null</var>, meaning that the event recurs infinitely, unless <em>occurrenceCount </em>is set.
+By default, this attribute is set to <var>null</var>, meaning that the event recurs infinitely, unless <em>occurrenceCount</em> is set.
             </p>
             <p>
 This attribute is precise to the second. Milliseconds are ignored.
@@ -3451,10 +3451,10 @@ This property corresponds to <em>UNTIL</em> in RFC 5545.
             </div>
 <div class="description">
             <p>
-The recurrence duration of an event can be defined using either an end date (<em>untilDate </em>attribute) or a number of occurrences (<em>occurrenceCount </em>attribute).
+The recurrence duration of an event can be defined using either an end date (<em>untilDate</em> attribute) or a number of occurrences (<em>occurrenceCount</em> attribute).
             </p>
             <p>
-By default, this attribute is set to <var>-1</var>, meaning that the event recurs infinitely, unless <em>untilDate </em>is set.
+By default, this attribute is set to <var>-1</var>, meaning that the event recurs infinitely, unless <em>untilDate</em> is set.
             </p>
             <p>
 This property corresponds to <em>COUNT</em> in RFC 5545.
@@ -3494,7 +3494,7 @@ By default, this attribute is set to an empty array.
             </div>
 <div class="description">
             <p>
-For example, a yearly recurrence rule that has a <em>daysOfTheWeek </em>value that specifies Monday through Friday, and a <em>setPositions </em>array containing <var>2 </var>and <var>-1</var>, occurs only on the second weekday and last weekday of every year.
+For example, a yearly recurrence rule that has a <em>daysOfTheWeek</em> value that specifies Monday through Friday, and a <em>setPositions</em> array containing <var>2</var>and <var>-1</var>, occurs only on the second weekday and last weekday of every year.
             </p>
             <p>
 Values can be from 1 to 366 or -366 to -1.
@@ -3587,7 +3587,7 @@ This value is assigned by the platform when the <em>add()</em> method is success
 </li>
 <li class="attribute" id="CalendarEventId::rid">
 <span class="attrName"><span class="type">DOMString </span><span class="name">rid</span><span class="optional"> [nullable]</span></span><div class="brief">
- The recurrence ID of a <em>CalendarEvent </em>instance.
+ The recurrence ID of a <em>CalendarEvent</em> instance.
             </div>
 <div class="description">
             <p>
@@ -3654,7 +3654,7 @@ var alarm2 = new tizen.CalendarAlarm(new tizen.TimeDuration(1, "MINS"), "SOUND")
             </div>
 <div class="description">
             <p>
-<em>absoluteDate </em>and <em>before </em>are mutually exclusive.
+<em>absoluteDate</em> and <em>before</em> are mutually exclusive.
             </p>
             <p>
 This attribute is precise to the second. Milliseconds are ignored.
@@ -3673,7 +3673,7 @@ This attribute is precise to the second. Milliseconds are ignored.
 The duration should be positive.
             </p>
             <p>
-<em>absoluteDate </em>and <em>before </em>are mutually exclusive.
+<em>absoluteDate</em> and <em>before</em> are mutually exclusive.
             </p>
             <p>
 This attribute is precise to the second. Milliseconds are ignored.
@@ -3740,7 +3740,7 @@ The default value is an empty string.
 <ul>
           <li class="param">
 <span class="name">events</span>:
- Array of <em>CalendarEvent </em>objects.
+ Array of <em>CalendarEvent</em> objects.
                 </li>
         </ul>
 </div>
@@ -3804,7 +3804,7 @@ if (event.recurrenceRule != null)
 <ul>
           <li class="param">
 <span class="name">items</span>:
- Array of <em>CalendarItem </em>objects.
+ Array of <em>CalendarItem</em> objects.
                 </li>
         </ul>
 </div>
@@ -3859,7 +3859,7 @@ calendar.addBatch([ev], calendarItemArraySuccessCB, errorCallback);
 </dt>
 <dd>
 <div class="brief">
- Called when the array of <em>Calendar </em>objects is retrieved successfully.
+ Called when the array of <em>Calendar</em> objects is retrieved successfully.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void onsuccess(<a href="#Calendar">Calendar</a>[] calendars);</pre></div>
 <p><span class="version">Since: </span>
@@ -3870,7 +3870,7 @@ calendar.addBatch([ev], calendarItemArraySuccessCB, errorCallback);
 <ul>
           <li class="param">
 <span class="name">calendars</span>:
- Array of <em>Calendar </em>objects.
+ Array of <em>Calendar</em> objects.
                 </li>
         </ul>
 </div>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/calendar.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/calendar.html
@@ -2351,7 +2351,7 @@ The default value is an empty string.
             </div>
 <div class="description">
             <p>
-If set to <var>true</var>, then the time and time zone of the <em>startDate</em> are to be ignored and are not guaranteed to be stored in the database. An all-day event always covers the whole day, regardless of which time zone it was defined in and what the current time zone is. The duration must be <var>n*60*24</var>minutes for an event lasting <var>n</var> days.
+If set to <var>true</var>, then the time and time zone of the <em>startDate</em> are to be ignored and are not guaranteed to be stored in the database. An all-day event always covers the whole day, regardless of which time zone it was defined in and what the current time zone is. The duration must be <var>n*60*24</var> minutes for an event lasting <var>n</var> days.
             </p>
             <p>
 The default value for this attribute is <var>false</var>.
@@ -2859,7 +2859,7 @@ The default value is <var>null</var>. If no value is provided, the task is not c
             </div>
 <div class="description">
             <p>
-The value is a positive integer between <var>0</var>and <var>100</var>. A value of <var>0</var>indicates the task has not been started yet. A value of <var>100</var>indicates that the task has been completed.
+The value is a positive integer between <var>0</var> and <var>100</var>. A value of <var>0</var> indicates the task has not been started yet. A value of <var>100</var> indicates that the task has been completed.
             </p>
             <p>
 Integer values in between indicate the percent partially complete.
@@ -3410,7 +3410,7 @@ This property corresponds to <em>FREQ</em> in RFC 5545.
 This attribute is linked to the <em>frequency</em> attribute and for an interval of <var>n</var>, the event will recur every <var>n</var> of recurrence attribute.
             </p>
             <p>
-For example, if the interval attribute is set to <var>2</var>and <em>frequency</em> attribute is set to <var>WEEKLY</var>, then the event will recur every 2 weeks.
+For example, if the interval attribute is set to <var>2</var> and <em>frequency</em> attribute is set to <var>WEEKLY</var>, then the event will recur every 2 weeks.
             </p>
             <p>
 The default interval value is <var>1</var>, that is, every day if the <em>CalendarRecurrenceRule frequency</em> attribute is DAILY, every week if frequency is <var>WEEKLY</var>, every month if frequency is <var>MONTHLY</var> or every year if frequency is <var>YEARLY</var>.
@@ -3494,7 +3494,7 @@ By default, this attribute is set to an empty array.
             </div>
 <div class="description">
             <p>
-For example, a yearly recurrence rule that has a <em>daysOfTheWeek</em> value that specifies Monday through Friday, and a <em>setPositions</em> array containing <var>2</var>and <var>-1</var>, occurs only on the second weekday and last weekday of every year.
+For example, a yearly recurrence rule that has a <em>daysOfTheWeek</em> value that specifies Monday through Friday, and a <em>setPositions</em> array containing <var>2</var> and <var>-1</var>, occurs only on the second weekday and last weekday of every year.
             </p>
             <p>
 Values can be from 1 to 366 or -366 to -1.

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/callhistory.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/callhistory.html
@@ -93,7 +93,7 @@ For more information on the Call History features, see <a href="/application/web
 <div class="interface" id="CallHistoryObject">
 <a class="backward-compatibility-anchor" name="::CallHistory::CallHistoryObject"></a><h3>1.1. CallHistoryObject</h3>
 <div class="brief">
- This interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
+ This interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
 The <em>tizen.callhistory</em> object allows access to the Call History API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface CallHistoryObject {
@@ -137,7 +137,7 @@ The <em>tizen.callhistory</em> object allows access to the Call History API.
  An attribute to store the remote party identifier (RPID).
 The RPID is a unique identifier used by a service with call capability. It also includes phone numbers.
 Contacts are also defined per service, so an RPID can be resolved to a Contact.
-A <var>null </var>value means that the remote is hidden (private number).
+A <var>null</var> value means that the remote is hidden (private number).
             </div>
 <p><span class="version">Since: </span>
  2.0
@@ -202,7 +202,7 @@ The following values are supported:
             </p>
             <ul>
               <li>
-TEL - for all protocols with phone number addressing (PSTN, GSM, CDMA, LTE, etc.)               </li>
+TEL - for all protocols with phone number addressing (PSTN, GSM, CDMA, LTE, etc.)              </li>
               <li>
 XMPP -  for generic XMPP calls              </li>
               <li>
@@ -225,7 +225,7 @@ The following values are supported:
               <li>
 CALL - for all call types              </li>
               <li>
-VOICECALL - for voice-only calls               </li>
+VOICECALL - for voice-only calls              </li>
               <li>
 VIDEOCALL - for audio and video channel support in a call              </li>
               <li>
@@ -308,7 +308,7 @@ If there is more than one SIM card in the device, this attribute can be used to 
  2.3
             </p>
 <p><span class="remark">Remark: </span>
- A <var>null </var>value means that the phone number of the device cannot be retrieved because the device user might not allow this functionality.
+ A <var>null</var> value means that the phone number of the device cannot be retrieved because the device user might not allow this functionality.
             </p>
 </li>
 </ul>
@@ -382,7 +382,7 @@ UnknownError - If any other error occurs.              </li>
                 </li>
           <li class="param">
 <span class="name">filter</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
- A filter defined on <em>CallHistoryEntry </em>attributes. It can be a composite filter.
+ A filter defined on <em>CallHistoryEntry</em> attributes. It can be a composite filter.
                 </li>
           <li class="param">
 <span class="name">sortMode</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
@@ -688,7 +688,7 @@ UnknownError - If any other error occurs.              </li>
 <ul>
           <li class="param">
 <span class="name">observer</span>:
- A callback for handling the list of new or changed or <em>CallHistoryEntry </em>objects in the call history.
+ A callback for handling the list of new or changed or <em>CallHistoryEntry</em> objects in the call history.
                 </li>
         </ul>
 </div>
@@ -818,8 +818,8 @@ catch (error)
 <div class="interface" id="CallHistoryEntryArraySuccessCallback">
 <a class="backward-compatibility-anchor" name="::CallHistory::CallHistoryEntryArraySuccessCallback"></a><h3>1.5. CallHistoryEntryArraySuccessCallback</h3>
 <div class="brief">
- This is a callback interface of <em>CallHistory </em>operations.
-For example code, see <em>CallHistory </em>interface.
+ This is a callback interface of <em>CallHistory</em> operations.
+For example code, see <em>CallHistory</em> interface.
           </div>
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface CallHistoryEntryArraySuccessCallback {
     void onsuccess(<a href="#CallHistoryEntry">CallHistoryEntry</a>[] entries);
@@ -846,7 +846,7 @@ For example code, see <em>CallHistory </em>interface.
 <ul>
           <li class="param">
 <span class="name">entries</span>:
- An array of <em>CallHistoryEntry </em>objects, representing the result set of the query over the call history.
+ An array of <em>CallHistoryEntry</em> objects, representing the result set of the query over the call history.
                 </li>
         </ul>
 </div>
@@ -857,8 +857,8 @@ For example code, see <em>CallHistory </em>interface.
 <div class="interface" id="CallHistoryChangeCallback">
 <a class="backward-compatibility-anchor" name="::CallHistory::CallHistoryChangeCallback"></a><h3>1.6. CallHistoryChangeCallback</h3>
 <div class="brief">
- This is a callback interface of <em> CallHistory </em>operations.
-For example code, see <em>CallHistory </em>interface.
+ This is a callback interface of <em>CallHistory</em> operations.
+For example code, see <em>CallHistory</em> interface.
           </div>
 <pre class="webidl prettyprint">  [Callback, NoInterfaceObject] interface CallHistoryChangeCallback {
     void onadded(<a href="#CallHistoryEntry">CallHistoryEntry</a>[] newItems);
@@ -887,7 +887,7 @@ For example code, see <em>CallHistory </em>interface.
 <ul>
           <li class="param">
 <span class="name">newItems</span>:
- An array of <em>CallHistoryEntry </em>objects, representing the new items added to call history.
+ An array of <em>CallHistoryEntry</em> objects, representing the new items added to call history.
                 </li>
         </ul>
 </div>
@@ -908,7 +908,7 @@ For example code, see <em>CallHistory </em>interface.
 <ul>
           <li class="param">
 <span class="name">changedItems</span>:
- An array of <em>CallHistoryEntry </em>objects, representing the changed items in call history.
+ An array of <em>CallHistoryEntry</em> objects, representing the changed items in call history.
                 </li>
         </ul>
 </div>
@@ -929,7 +929,7 @@ For example code, see <em>CallHistory </em>interface.
 <ul>
           <li class="param">
 <span class="name">removedItems</span>:
- An array of a UID of <em>CallHistoryEntry </em>objects, representing the removed items in call history.
+ An array of a UID of <em>CallHistoryEntry</em> objects, representing the removed items in call history.
                 </li>
         </ul>
 </div>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/contact.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/contact.html
@@ -22,7 +22,7 @@ e-mail addresses.
 <a href="http://www.ietf.org/rfc/rfc2426.txt"> RFC 2426 vCard MIME Directory Profile</a> defines a format for exchanging contacts. The Contact API refers to this specification to provide a mapping of the specified contact attributes.
         </p>
         <p>
-A <em>person </em>is a set of information that describes a person. Two different <em>contacts</em> that indicate the same person will have the same person ID. A person has a display contact ID that indicates a contact that represents information of the person. A person is automatically created when a new contact is added.
+A <em>person</em> is a set of information that describes a person. Two different <em>contacts</em> that indicate the same person will have the same person ID. A person has a display contact ID that indicates a contact that represents information of the person. A person is automatically created when a new contact is added.
         </p>
         <p>
 This API provides functionality to read, create, remove, and update contacts in specific address books. Address books can be obtained using the <em>getAddressBooks()</em> method, which returns an array of <em>AddressBook</em> objects.
@@ -439,7 +439,7 @@ CUSTOM - Custom relationship. The actual type can be set in the label.          
 <div class="enum" id="ContactInstantMessengerType">
 <a class="backward-compatibility-anchor" name="::Contact::ContactInstantMessengerType"></a><h3>1.8. ContactInstantMessengerType</h3>
 <div class="brief">
-  Specifies instant messenger types.
+ Specifies instant messenger types.
 The possible values are:
           </div>
 <pre class="webidl prettyprint">  enum ContactInstantMessengerType { "OTHER", "GOOGLE", "WLM", "YAHOO", "FACEBOOK", "ICQ", "AIM", "QQ", "JABBER", "SKYPE", "IRC",
@@ -479,7 +479,7 @@ CUSTOM - Custom IM service provider. The actual type can be set in the label.   
 <div class="enum" id="ContactUsageType">
 <a class="backward-compatibility-anchor" name="::Contact::ContactUsageType"></a><h3>1.9. ContactUsageType</h3>
 <div class="brief">
-  Specifies contact usage types.
+ Specifies contact usage types.
 The possible values are:
           </div>
 <pre class="webidl prettyprint">  enum ContactUsageType { "OUTGOING_CALL", "OUTGOING_MSG", "OUTGOING_EMAIL", "INCOMING_CALL", "INCOMING_MSG", "INCOMING_EMAIL",
@@ -518,7 +518,7 @@ BLOCKED_MSG - blocked message usage type            </li>
 <div class="interface" id="ContactManagerObject">
 <a class="backward-compatibility-anchor" name="::Contact::ContactManagerObject"></a><h3>2.1. ContactManagerObject</h3>
 <div class="brief">
- The ContactManagerObject interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
+ The ContactManagerObject interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface ContactManagerObject {
     readonly attribute <a href="#ContactManager">ContactManager</a> contact;
@@ -529,7 +529,7 @@ BLOCKED_MSG - blocked message usage type            </li>
           </p>
 <div class="description">
           <p>
-The <em>tizen.contact </em>object allows access to the Contact API functionality.
+The <em>tizen.contact</em> object allows access to the Contact API functionality.
           </p>
          </div>
 <div class="attributes">
@@ -1545,7 +1545,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
-NotFoundError - If an identifier in the <em>personIds </em>parameter does not correspond to the ID of any person in the contact DB. (Otherwise, the implementation will attempt to remove the contacts corresponding to these identifiers).              </li>
+NotFoundError - If an identifier in the <em>personIds</em> parameter does not correspond to the ID of any person in the contact DB. (Otherwise, the implementation will attempt to remove the contacts corresponding to these identifiers).              </li>
               <li>
 InvalidValuesError - If any of the input parameters contain an invalid value.              </li>
               <li>
@@ -1639,7 +1639,7 @@ catch (err)
 </dt>
 <dd>
 <div class="brief">
- Gets an array of all <em>Person </em>objects from the contact DB or the ones that match the optionally supplied filter.
+ Gets an array of all <em>Person</em> objects from the contact DB or the ones that match the optionally supplied filter.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void find(<a href="#PersonArraySuccessCallback">PersonArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter,
           optional <a href="tizen.html#SortMode">SortMode</a>? sortMode);</pre></div>
@@ -1651,7 +1651,7 @@ catch (err)
 If the filter is passed and contains valid values, only those values in the
 address book that match the filter criteria as specified in the AbstractFilter
 interface will be returned in the successCallback. If no filter is passed, the filter
-contains any invalid values, the filter is <var>null </var> or undefined, then
+contains any invalid values, the filter is <var>null</var> or undefined, then
 the implementation must return the full list of contact items
 in the successCallback. If no persons are available in the contact DB or no
 person matches the filter criteria, the successCallback will be invoked
@@ -1745,7 +1745,7 @@ catch (err)
 </dt>
 <dd>
 <div class="brief">
- Gets an array of <em>Person </em>objects from the contact DB which match the supplied filter. This method is for filtering usageCount property of Person objects.
+ Gets an array of <em>Person</em> objects from the contact DB which match the supplied filter. This method is for filtering usageCount property of Person objects.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void findByUsageCount(<a href="#ContactUsageCountFilter">ContactUsageCountFilter</a> filter, <a href="#PersonArraySuccessCallback">PersonArraySuccessCallback</a> successCallback,
                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#SortModeOrder">SortModeOrder</a>? sortModeOrder, optional unsigned long limit,
@@ -2074,32 +2074,32 @@ An address book is a collection of contacts and groups. This interface offers th
           </p>
           <ul>
             <li>
- <em>get()</em> - To get contacts that have a specific ID            </li>
+<em>get()</em> - To get contacts that have a specific ID            </li>
             <li>
- <em>find()</em> - To find contacts using filters            </li>
+<em>find()</em> - To find contacts using filters            </li>
             <li>
- <em>add() </em>or <em>addBatch()</em> - To add contacts to a specific address book            </li>
+<em>add()</em> or <em>addBatch()</em> - To add contacts to a specific address book            </li>
             <li>
- <em>update() </em>or <em>updateBatch()</em> - To update contacts in a specific address book            </li>
+<em>update()</em> or <em>updateBatch()</em> - To update contacts in a specific address book            </li>
             <li>
- <em>remove() </em>or <em>removeBatch() </em> - To remove existing contacts            </li>
+<em>remove()</em> or <em>removeBatch()</em>  - To remove existing contacts            </li>
             <li>
- <em>addChangeListener() </em>or <em>removeChangeListener() </em> - To watch for address book changes            </li>
+<em>addChangeListener()</em> or <em>removeChangeListener()</em>  - To watch for address book changes            </li>
           </ul>
           <p>
 This interface also offers the following methods to manipulate groups within the address book:
           </p>
           <ul>
             <li>
- <em>getGroup()</em> - To get a group having a specific ID            </li>
+<em>getGroup()</em> - To get a group having a specific ID            </li>
             <li>
- <em>getGroups()</em> - To get groups in a specific address book            </li>
+<em>getGroups()</em> - To get groups in a specific address book            </li>
             <li>
- <em>addGroup() </em> - To add groups to a specific address book             </li>
+<em>addGroup()</em>  - To add groups to a specific address book            </li>
             <li>
- <em>updateGroup() </em> - To update groups in a specific address book            </li>
+<em>updateGroup()</em>  - To update groups in a specific address book            </li>
             <li>
- <em>removeGroup() </em> - To remove existing groups            </li>
+<em>removeGroup()</em>  - To remove existing groups            </li>
           </ul>
          </div>
 <div class="example">
@@ -2142,7 +2142,7 @@ tizen.account.getAccounts(
             </div>
 <div class="description">
             <p>
-The value of this attribute is <var>null </var> if the address book
+The value of this attribute is <var>null</var> if the address book
 is the unified address book.
             </p>
            </div>
@@ -2586,7 +2586,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
-NotFoundError - If an identifier in the IDs parameter does not correspond to the <em>id </em>attribute of any contact in the address book.              </li>
+NotFoundError - If an identifier in the IDs parameter does not correspond to the <em>id</em> attribute of any contact in the address book.              </li>
               <li>
 InvalidValuesError - If any of the input parameters contain an invalid value.              </li>
               <li>
@@ -2805,7 +2805,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
-NotFoundError - If an identifier in the IDs parameter does not correspond to the <em>id </em>attribute of any contact in the address book (Otherwise, the implementation will attempt to remove the contacts that correspond to these identifiers).              </li>
+NotFoundError - If an identifier in the IDs parameter does not correspond to the <em>id</em> attribute of any contact in the address book (Otherwise, the implementation will attempt to remove the contacts that correspond to these identifiers).              </li>
               <li>
 InvalidValuesError - If any of the input parameters contain an invalid value.              </li>
               <li>
@@ -4080,7 +4080,7 @@ This dictionary is used to input parameters when contacts are created.
 <div class="interface" id="Contact">
 <a class="backward-compatibility-anchor" name="::Contact::Contact"></a><h3>2.6. Contact</h3>
 <div class="brief">
- The Contact interface is used to create a <em>Contact </em>object.
+ The Contact interface is used to create a <em>Contact</em> object.
           </div>
 <pre class="webidl prettyprint">  [Constructor(optional <a href="#ContactInit">ContactInit</a>? ContactInitDict),
    Constructor(DOMString stringRepresentation)]
@@ -5292,7 +5292,7 @@ By default, this attribute is set to HOMEPAGE.
 <div class="interface" id="ContactAnniversary">
 <a class="backward-compatibility-anchor" name="::Contact::ContactAnniversary"></a><h3>2.13. ContactAnniversary</h3>
 <div class="brief">
- The <em>ContactAnniversary </em>interface contains the date and description of an anniversary.
+ The <em>ContactAnniversary</em> interface contains the date and description of an anniversary.
           </div>
 <pre class="webidl prettyprint">  [Constructor(Date date, optional DOMString? label)]
   interface ContactAnniversary {
@@ -6014,7 +6014,7 @@ This attribute only contains a local file URI.
 </li>
 <li class="attribute" id="ContactGroup::photoURI">
 <span class="attrName"><span class="type">DOMString </span><span class="name">photoURI</span><span class="optional"> [nullable]</span></span><div class="brief">
- The URI that points to an image that can represent the<em> Group </em>object. This attribute only contains a local file URI.
+ The URI that points to an image that can represent the <em>Group</em> object. This attribute only contains a local file URI.
             </div>
 <div class="description">
             <p>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/contact.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/contact.html
@@ -1759,7 +1759,7 @@ If the filter is passed and contains valid value, only this value in the
 address book that match the filter criteria as specified in the ContactUsageCountFilter
 interface will be returned in the successCallback. If no persons are available in the contact DB or no
 person matches the filter criteria, the successCallback will be invoked
-with an empty array. The attributeName in filter must be one of <a href="#ContactUsageType">ContactUsageType</a>  value.
+with an empty array. The attributeName in filter must be one of <a href="#ContactUsageType">ContactUsageType</a> value.
             </p>
             <p>
 The <em>ErrorCallback</em> method is launched with these error types:
@@ -2082,9 +2082,9 @@ An address book is a collection of contacts and groups. This interface offers th
             <li>
 <em>update()</em> or <em>updateBatch()</em> - To update contacts in a specific address book            </li>
             <li>
-<em>remove()</em> or <em>removeBatch()</em>  - To remove existing contacts            </li>
+<em>remove()</em> or <em>removeBatch()</em> - To remove existing contacts            </li>
             <li>
-<em>addChangeListener()</em> or <em>removeChangeListener()</em>  - To watch for address book changes            </li>
+<em>addChangeListener()</em> or <em>removeChangeListener()</em> - To watch for address book changes            </li>
           </ul>
           <p>
 This interface also offers the following methods to manipulate groups within the address book:
@@ -2095,11 +2095,11 @@ This interface also offers the following methods to manipulate groups within the
             <li>
 <em>getGroups()</em> - To get groups in a specific address book            </li>
             <li>
-<em>addGroup()</em>  - To add groups to a specific address book            </li>
+<em>addGroup()</em> - To add groups to a specific address book            </li>
             <li>
-<em>updateGroup()</em>  - To update groups in a specific address book            </li>
+<em>updateGroup()</em> - To update groups in a specific address book            </li>
             <li>
-<em>removeGroup()</em>  - To remove existing groups            </li>
+<em>removeGroup()</em> - To remove existing groups            </li>
           </ul>
          </div>
 <div class="example">

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/content.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/content.html
@@ -365,7 +365,7 @@ ROTATE_270 - corresponds to rotate 270 degrees image content orientation.       
           </p>
 <div class="description">
           <p>
-The <em>tizen.content </em>object allows accessing the functionality of the Content module.
+The <em>tizen.content</em> object allows accessing the functionality of the Content module.
           </p>
          </div>
 <div class="attributes">
@@ -1543,7 +1543,7 @@ tizen.content.find(findCB);
 <ul>
           <li class="param">
 <span class="name">contents</span>:
- The array of <em>Content </em>objects.
+ The array of <em>Content</em> objects.
                 </li>
         </ul>
 </div>
@@ -1581,7 +1581,7 @@ tizen.content.find(findCB);
 <ul>
           <li class="param">
 <span class="name">directories</span>:
- The array of <em>ContentDirectory </em>objects.
+ The array of <em>ContentDirectory</em> objects.
                 </li>
         </ul>
 </div>
@@ -2010,7 +2010,7 @@ The attribute is marked as read-only since Tizen 5.5.
 </li>
 <li class="attribute" id="Content::isFavorite">
 <span class="attrName"><span class="type">boolean </span><span class="name">isFavorite</span></span><div class="brief">
-  Boolean value that indicates whether a content item is marked as a favorite.
+ Boolean value that indicates whether a content item is marked as a favorite.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2022,7 +2022,7 @@ The attribute is marked as read-only since Tizen 5.5.
 <div class="interface" id="VideoContent">
 <a class="backward-compatibility-anchor" name="::Content::VideoContent"></a><h3>2.9. VideoContent</h3>
 <div class="brief">
- The VideoContent interface extends a basic <em>Content </em>object with video-specific attributes.
+ The VideoContent interface extends a basic <em>Content</em> object with video-specific attributes.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface VideoContent : <a href="#Content">Content</a> {
     readonly attribute <a href="tizen.html#SimpleCoordinates">SimpleCoordinates</a>? geolocation;
@@ -2163,7 +2163,7 @@ If the lyrics are not synchronized, the array has only one member with full lyri
 <div class="interface" id="AudioContent">
 <a class="backward-compatibility-anchor" name="::Content::AudioContent"></a><h3>2.11. AudioContent</h3>
 <div class="brief">
- The AudioContent interface extends a basic <em>Content </em>object with audio-specific attributes.
+ The AudioContent interface extends a basic <em>Content</em> object with audio-specific attributes.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface AudioContent : <a href="#Content">Content</a> {
     readonly attribute DOMString? album;
@@ -2280,7 +2280,7 @@ If the lyrics are not synchronized, the array has only one member with full lyri
 <div class="interface" id="ImageContent">
 <a class="backward-compatibility-anchor" name="::Content::ImageContent"></a><h3>2.12. ImageContent</h3>
 <div class="brief">
- The ImageContent interface extends a basic <em>Content </em>object with image-specific attributes.
+ The ImageContent interface extends a basic <em>Content</em> object with image-specific attributes.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface ImageContent : <a href="#Content">Content</a> {
     readonly attribute <a href="tizen.html#SimpleCoordinates">SimpleCoordinates</a>? geolocation;

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/device-motion.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/device-motion.html
@@ -89,7 +89,7 @@ Original documentation: <a href="https://cordova.apache.org/docs/en/3.0.0/cordov
 <div class="interface" id="AccelerometerManagerObject">
 <a class="backward-compatibility-anchor" name="::DeviceMotion::AccelerometerManagerObject"></a><h3>1.1. AccelerometerManagerObject</h3>
 <div class="brief">
- The <em>navigator.accelerometer </em>object allows access to the functionality of the DeviceMotion API.
+ The <em>navigator.accelerometer</em> object allows access to the functionality of the DeviceMotion API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface AccelerometerManagerObject {
     readonly attribute <a href="#Accelerometer">Accelerometer</a> accelerometer;

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/device.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/device.html
@@ -60,7 +60,7 @@ Original documentation: <a href="https://cordova.apache.org/docs/en/3.0.0/cordov
 <div class="interface" id="DeviceManagerObject">
 <a class="backward-compatibility-anchor" name="::Device::DeviceManagerObject"></a><h3>1.1. DeviceManagerObject</h3>
 <div class="brief">
- The <em>window.device </em>object allows access to the functionality of the Device API.
+ The <em>window.device</em> object allows access to the functionality of the Device API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface DeviceManagerObject {
     readonly attribute <a href="#Device">Device</a> device;

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/file.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/cordova/file.html
@@ -347,7 +347,7 @@ See <a href="https://www.w3.org/TR/FileAPI/#blob-section">The Blob Interface and
     readonly attribute boolean lengthComputable;
     readonly attribute unsigned long long loaded;
     readonly attribute unsigned long long total;
-    readonly attribute  target;
+    readonly attribute EventTarget target;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -512,7 +512,7 @@ var event = new ProgressEvent("submit", eventInit);
           </p>
 <div class="description">
           <p>
-There is a <em>cordova.file </em>object that allows accessing the functionality of the Filesystem API.
+There is a <em>cordova.file</em> object that allows accessing the functionality of the Filesystem API.
           </p>
          </div>
 </div>
@@ -735,7 +735,7 @@ This manager interface exposes the Filesystem base API constants.
 <li class="attribute" id="FileSystemManager::tempDirectory">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">DOMString </span><span class="name">tempDirectory</span><span class="optional"> [nullable]</span></span><div class="brief">
-  Temp directory that the OS can clear at will. Do not rely on the OS to clear this directory; your app should always remove files as applicable.
+ Temp directory that the OS can clear at will. Do not rely on the OS to clear this directory; your app should always remove files as applicable.
             </div>
 <p><span class="version">Since: </span>
  3.0
@@ -3499,7 +3499,7 @@ entry.createWriter(successCallback, errorCallback);
     readonly attribute boolean lengthComputable;
     readonly attribute unsigned long long loaded;
     readonly attribute unsigned long long total;
-    readonly attribute  target;
+    readonly attribute EventTarget target;
   };
   [NoInterfaceObject] interface FileSystemManagerObject {
     readonly attribute <a href="#FileSystemManager">FileSystemManager</a> file;

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/datacontrol.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/datacontrol.html
@@ -220,7 +220,7 @@ Data Control API.
 <div class="interface" id="DataControlManager">
 <a class="backward-compatibility-anchor" name="::DataControl::DataControlManager"></a><h3>2.2. DataControlManager</h3>
 <div class="brief">
- This interface provides access to the <em>DataControlManager </em>object.
+ This interface provides access to the <em>DataControlManager</em> object.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface DataControlManager {
     <a href="#DataControlConsumerObject">DataControlConsumerObject</a> getDataControlConsumer(DOMString providerId, DOMString dataId, <a href="#DataType">DataType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -628,7 +628,7 @@ removeChangeListener was invoked
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">insertionData</span>:
@@ -713,7 +713,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">updateData</span>:
@@ -802,7 +802,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">where</span>:
@@ -892,7 +892,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">columns</span>:
@@ -1037,7 +1037,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">key</span>:
@@ -1124,7 +1124,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation. <br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation. <br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">key</span>:
@@ -1214,7 +1214,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">key</span>:
@@ -1300,7 +1300,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">key</span>:

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/datasync.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/datasync.html
@@ -268,7 +268,7 @@ NONE - Indicates the sync had never been performed.            </li>
 <div class="interface" id="DataSynchronizationManagerObject">
 <a class="backward-compatibility-anchor" name="::DataSynchronization::DataSynchronizationManagerObject"></a><h3>2.1. DataSynchronizationManagerObject</h3>
 <div class="brief">
- This interface defines the default data synchronization manager that is instantiated by the <em>Tizen </em>object.
+ This interface defines the default data synchronization manager that is instantiated by the <em>Tizen</em> object.
 The <em>tizen.datasync</em> object allows access to the functionality of the Data Synchronization API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface DataSynchronizationManagerObject {
@@ -1305,7 +1305,7 @@ Normally the packet size from a server affects it, that is, if the server sends 
                 </li>
           <li class="param">
 <span class="name">isFromServer</span>:
- The direction of the operation.<br> If the direction of the operation is from the server to the client, then the value is<var> true</var>.
+ The direction of the operation.<br> If the direction of the operation is from the server to the client, then the value is <var>true</var>.
                 </li>
           <li class="param">
 <span class="name">totalPerService</span>:

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/download.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/download.html
@@ -185,8 +185,8 @@ ALL - Indicates that the download operation is allowed in all network types.    
 <div class="interface" id="DownloadManagerObject">
 <a class="backward-compatibility-anchor" name="::Download::DownloadManagerObject"></a><h3>2.1. DownloadManagerObject</h3>
 <div class="brief">
- This interface defines the default download manager that is instantiated by the <em>Tizen </em>object.
-The <em>tizen.download </em>object allows access to the functionality of the Download API.
+ This interface defines the default download manager that is instantiated by the <em>Tizen</em> object.
+The <em>tizen.download</em> object allows access to the functionality of the Download API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface DownloadManagerObject {
     readonly attribute <a href="#DownloadManager">DownloadManager</a> download;
@@ -900,7 +900,7 @@ tizen.download.setListener(downloadId, listener);
 <dd>
 <div class="brief">
  Called when a download is successful and it is called multiple times as the download progresses.
-The interval between the <em>onprogress()</em> callback is platform-dependent. When the download is started, the <em>receivedSize </em>can be <var>0</var>.
+The interval between the <em>onprogress()</em> callback is platform-dependent. When the download is started, the <em>receivedSize</em> can be <var>0</var>.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void onprogress(long downloadId, unsigned long long receivedSize, unsigned long long totalSize);</pre></div>
 <p><span class="version">Since: </span>
@@ -929,7 +929,7 @@ The interval between the <em>onprogress()</em> callback is platform-dependent. W
 </dt>
 <dd>
 <div class="brief">
- Called when the download operation is paused by the <em>pause() </em>method.
+ Called when the download operation is paused by the <em>pause()</em> method.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void onpaused(long downloadId);</pre></div>
 <p><span class="version">Since: </span>
@@ -950,7 +950,7 @@ The interval between the <em>onprogress()</em> callback is platform-dependent. W
 </dt>
 <dd>
 <div class="brief">
- Called when the download operation is canceled by the <em>cancel() </em>method.
+ Called when the download operation is canceled by the <em>cancel()</em> method.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void oncanceled(long downloadId);</pre></div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/filesystem.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/filesystem.html
@@ -40,15 +40,15 @@ music - the location for sounds          </li>
           <li>
 documents - the location for documents          </li>
           <li>
-downloads - the location for downloaded items           </li>
+downloads - the location for downloaded items          </li>
           <li>
-ringtones - the location for ringtones (read-only location)           </li>
+ringtones - the location for ringtones (read-only location)          </li>
           <li>
-camera - the location for the pictures and videos taken by a device (supported since Tizen 2.3)           </li>
+camera - the location for the pictures and videos taken by a device (supported since Tizen 2.3)          </li>
           <li>
 wgt-package - the location for widget package which is read-only          </li>
           <li>
-wgt-private - the location for a widget's private storage           </li>
+wgt-private - the location for a widget's private storage          </li>
           <li>
 wgt-private-tmp - the location for a widget's private volatile storage          </li>
           <li>
@@ -417,7 +417,7 @@ END - End of the file.            </li>
           </p>
 <div class="description">
           <p>
-There is a <em>tizen.filesystem </em>object that allows accessing the functionality of the Filesystem API.
+There is a <em>tizen.filesystem</em> object that allows accessing the functionality of the Filesystem API.
           </p>
          </div>
 <div class="attributes">
@@ -1907,7 +1907,7 @@ Strips trailing '/', then breaks <em>path</em> into two components by last <em>p
             </p>
 <div class="description">
             <p>
-The <em>onsuccess </em>method receives the data structure as an input argument containing additional information about the drive.
+The <em>onsuccess</em> method receives the data structure as an input argument containing additional information about the drive.
             </p>
             <p>
 The ErrorCallback is launched with these error types:
@@ -1918,7 +1918,7 @@ InvalidValuesError - If any of the input parameters contains an invalid value.  
               <li>
 NotFoundError - If no drive was found with the given label.              </li>
               <li>
-UnknownError - If any other error occurs.               </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2134,7 +2134,7 @@ watchID = tizen.filesystem.addStorageStateChangeListener(onStorageStateChanged);
             </p>
 <div class="description">
             <p>
-If the <em>watchId </em>argument is valid and corresponds to a subscription already in place, the watch process will be stopped and no further callbacks will be invoked.
+If the <em>watchId</em> argument is valid and corresponds to a subscription already in place, the watch process will be stopped and no further callbacks will be invoked.
 Otherwise, the method call has no effect.
             </p>
            </div>
@@ -2399,7 +2399,7 @@ The <em>ErrorCallback</em> is launched with these error types:
             </p>
             <ul>
               <li>
-IOError, if any error related to file handle occurs.               </li>
+IOError, if any error related to file handle occurs.              </li>
             </ul>
             <p>
 Note, that current position indicator value, can be obtained in SeekSuccessCallback by calling <var>seekNonBlocking(0, "CURRENT")</var>.
@@ -2764,7 +2764,7 @@ Sets file handle position indicator at the end of written data.
                 </li>
           <li class="param">
 <span class="name">outputEncoding</span><span class="optional"> [optional]</span>:
-  Default value: UTF-8. Encoding to use for write operation on the file, at least the following encodings must be supported:<br>"<a href="http://www.ietf.org/rfc/rfc2279.txt">UTF-8</a>" default encoding<br>"<a href="http://en.wikipedia.org/wiki/ISO/IEC_8859-1">ISO-8859-1</a>" Latin-1 encoding<br>                </li>
+ Default value: UTF-8. Encoding to use for write operation on the file, at least the following encodings must be supported:<br>"<a href="http://www.ietf.org/rfc/rfc2279.txt">UTF-8</a>" default encoding<br>"<a href="http://en.wikipedia.org/wiki/ISO/IEC_8859-1">ISO-8859-1</a>" Latin-1 encoding<br>                </li>
         </ul>
 </div>
 <div class="returntype">
@@ -4154,12 +4154,12 @@ A file item only matches the <em>FileFilter</em> object if all of the defined fi
 (only matching values other than <var>undefined</var> or <var>null</var>). This is similar to a SQL's "AND" operation.
           </p>
           <p>
-An attribute of the file entry matches the <em>FileFilter </em>attribute value in accordance with the
+An attribute of the file entry matches the <em>FileFilter</em> attribute value in accordance with the
 following rules:
           </p>
           <ul>
             <li>
-For <em>FileFilter </em>attributes of type DOMString, an entry matches this value only if its corresponding attribute is an exact match. If the filter contains U+0025 "PERCENT SIGN" it is interpreted as a wildcard character and "%" matches any string of any length, including no length. If wildcards are used, the behavior is similar to the LIKE condition in SQL. To specify that a "PERCENT SIGN" character is to be considered literally instead of interpreting it as a wildcard, developers can escape it with the backslash character (\). Please, remember that the backslash character has to be escaped itself, to not to be removed from the string - proper escaping of the "PERCENT SIGN" in JavaScript string requires preceding it with double backslash ("\\%").
+For <em>FileFilter</em> attributes of type DOMString, an entry matches this value only if its corresponding attribute is an exact match. If the filter contains U+0025 "PERCENT SIGN" it is interpreted as a wildcard character and "%" matches any string of any length, including no length. If wildcards are used, the behavior is similar to the LIKE condition in SQL. To specify that a "PERCENT SIGN" character is to be considered literally instead of interpreting it as a wildcard, developers can escape it with the backslash character (\). Please, remember that the backslash character has to be escaped itself, to not to be removed from the string - proper escaping of the "PERCENT SIGN" in JavaScript string requires preceding it with double backslash ("\\%").
 The matching is not case sensitive, such as "FOO" matches a "foo" or an "f%" filter.            </li>
             <li>
 For File entry attributes of type Date, attributes start and end are included to allow filtering of File entries between two supplied dates. If either or both of these attributes are specified, the following rules apply:<br>A) If both start and end dates are specified (that is, other than <var>null</var>), a File entry matches the filter if its corresponding attribute is the same as either start or end or between the two supplied dates (that is, after start and before end).<br>B) If only the start attribute contains a value (other than <var>null</var>), a File entry matches the filter if its corresponding attribute is later than or equal to the start one.<br>C) If only the end date contains a value (other than <var>null</var>), a file matches the filter if its corresponding attribute is earlier than or equal to the end date.            </li>
@@ -4307,7 +4307,7 @@ It is used in asynchronous operations, such as FileSystemManager.listStorages().
 <div class="interface" id="FileSystemStorageSuccessCallback">
 <a class="backward-compatibility-anchor" name="::Filesystem::FileSystemStorageSuccessCallback"></a><h3>2.7. FileSystemStorageSuccessCallback</h3>
 <div class="brief">
- The FileSystemStorageSuccessCallback callback interface specifies a success callback with a <em>FileSystemStorage </em>object as input argument.
+ The FileSystemStorageSuccessCallback callback interface specifies a success callback with a <em>FileSystemStorage</em> object as input argument.
           </div>
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileSystemStorageSuccessCallback {
     void onsuccess(<a href="#FileSystemStorage">FileSystemStorage</a> storage);

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/fmradio.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/fmradio.html
@@ -19,9 +19,9 @@ The following functionality is provided:
         </p>
         <ul>
           <li>
- Start and stop radio          </li>
+Start and stop radio          </li>
           <li>
- Seek radio frequency          </li>
+Seek radio frequency          </li>
         </ul>
         <p>
 FM radio works according to the following state table:
@@ -295,10 +295,10 @@ The tizen.fmradio object provides access to the functionality of the FM Radio AP
             </div>
 <div class="description">
             <p>
-If the system detects that the radio antenna is disconnected then the <em>isAntennaConnected </em>is <var>false</var>.
+If the system detects that the radio antenna is disconnected then the <em>isAntennaConnected</em> is <var>false</var>.
             </p>
             <p>
-For example, an earphone cable is commonly used as a FM antenna in mobile phones. In that case, the <em>isAntennaConnected </em>attribute can be used to check if the FM antenna is connected or not.
+For example, an earphone cable is commonly used as a FM antenna in mobile phones. In that case, the <em>isAntennaConnected</em>attribute can be used to check if the FM antenna is connected or not.
             </p>
            </div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/fmradio.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/fmradio.html
@@ -298,7 +298,8 @@ The tizen.fmradio object provides access to the functionality of the FM Radio AP
 If the system detects that the radio antenna is disconnected then the <em>isAntennaConnected</em> is <var>false</var>.
             </p>
             <p>
-For example, an earphone cable is commonly used as a FM antenna in mobile phones. In that case, the <em>isAntennaConnected</em>attribute can be used to check if the FM antenna is connected or not.
+For example, an earphone cable is commonly used as a FM antenna in mobile phones. In that case,
+the <em>isAntennaConnected</em> attribute can be used to check if the FM antenna is connected or not.
             </p>
            </div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/humanactivitymonitor.html
@@ -383,7 +383,7 @@ The activity accuracy defined by this enumerator are:
           </p>
           <ul>
             <li>
-LOW - Low accuracy             </li>
+LOW - Low accuracy            </li>
             <li>
 MEDIUM - Medium accuracy            </li>
             <li>
@@ -579,7 +579,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError: If the <em>getHumanActivityData()</em> method is called without previously calling the <em>start()</em> method              </li>
+ServiceNotAvailableError: If the <em>getHumanActivityData()</em> method is called without previously calling the <em>start()</em> method              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -677,7 +677,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError - If the human activity service is not available. For the GPS type, if the GPS function is disabled by the user in the location settings, it is not possible to receive notifications when the GPS value changes.              </li>
+ServiceNotAvailableError - If the human activity service is not available. For the GPS type, if the GPS function is disabled by the user in the location settings, it is not possible to receive notifications when the GPS value changes.              </li>
             </ul>
            </div>
 <div class="description">
@@ -966,7 +966,7 @@ The <em>ErrorCallback</em> method is launched with this error type:
             </p>
             <ul>
               <li>
- AbortError: If the system operation was aborted.              </li>
+AbortError: If the system operation was aborted.              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1056,7 +1056,7 @@ The <em>ErrorCallback</em> method is launched with this error type:
             </p>
             <ul>
               <li>
- AbortError: If the system operation was aborted.              </li>
+AbortError: If the system operation was aborted.              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1419,7 +1419,7 @@ The <em>ErrorCallback</em> method is launched with this error type:
             </p>
             <ul>
               <li>
- AbortError: If the system operation was aborted.              </li>
+AbortError: If the system operation was aborted.              </li>
             </ul>
            </div>
 <div class="parameters">

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/iotcon.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/iotcon.html
@@ -317,7 +317,7 @@ The following values are supported:
           </p>
           <ul>
             <li>
-HIGH - for a high quality of service. acknowledgments are used to confirm delivery.             </li>
+HIGH - for a high quality of service. acknowledgments are used to confirm delivery.            </li>
             <li>
 LOW - for a low quality of service. packet delivery is best effort            </li>
           </ul>
@@ -415,7 +415,7 @@ The following values are supported:
           </p>
           <ul>
             <li>
-IP - Internet Protocol connectivity. IP includes all internet connectivity (UDP, TCP, IPV4, IPV6).             </li>
+IP - Internet Protocol connectivity. IP includes all internet connectivity (UDP, TCP, IPV4, IPV6).            </li>
             <li>
 PREFER_UDP - UDP is preferred            </li>
             <li>
@@ -492,7 +492,7 @@ The following values are supported:
           </p>
           <ul>
             <li>
-NO_TYPE - no action of observation             </li>
+NO_TYPE - no action of observation            </li>
             <li>
 REGISTER - action of registering observation            </li>
             <li>
@@ -692,7 +692,7 @@ catch (err)
 </dt>
 <dd>
 <div class="brief">
-  Returns the number of seconds set as the timeout threshold of asynchronous API.
+ Returns the number of seconds set as the timeout threshold of asynchronous API.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">long getTimeout();</pre></div>
 <p><span class="version">Since: </span>
@@ -902,9 +902,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  If any system error is invoked              </li>
+AbortError: If any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1174,9 +1174,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  If any system error is invoked              </li>
+AbortError: If any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1293,9 +1293,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  In any system error is invoked              </li>
+AbortError: In any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1858,7 +1858,7 @@ server.stopPresence();
 <li class="attribute" id="RemoteResource::isExplicitDiscoverable">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">boolean </span><span class="name">isExplicitDiscoverable</span></span><div class="brief">
- Indicates if the resource is  is allowed to be discovered only if discovery request contains an explicit query string or not
+ Indicates if the resource is allowed to be discovered only if discovery request contains an explicit query string or not
             </div>
 <p><span class="version">Since: </span>
  3.0
@@ -1933,9 +1933,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  In any system error is invoked              </li>
+AbortError: In any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2046,9 +2046,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  In any system error is invoked              </li>
+AbortError: In any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2165,9 +2165,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  In any system error is invoked              </li>
+AbortError: In any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2281,9 +2281,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  In any system error is invoked              </li>
+AbortError: In any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2964,7 +2964,7 @@ The default value is <var>false</var>            </p>
 <li class="attribute" id="Resource::isExplicitDiscoverable">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">boolean </span><span class="name">isExplicitDiscoverable</span></span><div class="brief">
- Indicates if the resource is  is allowed to be discovered only if discovery request contains an explicit query string or not
+ Indicates if the resource is allowed to be discovered only if discovery request contains an explicit query string or not
             </div>
 <p><span class="version">Since: </span>
  3.0
@@ -4514,7 +4514,7 @@ for <em>Client.findResource()</em>.
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#Client::addPresenceEventListener">addPresenceEventListener </a> code example.
+ Example of using can be find at <a href="iotcon.html#Client::addPresenceEventListener">addPresenceEventListener</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/keymanager.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/keymanager.html
@@ -98,13 +98,13 @@ For more information on the Key Manager features, see <a href="/application/web/
 <div class="description">
           <ul>
             <li>
- NONE - Clears or removes permissions             </li>
+NONE - Clears or removes permissions            </li>
             <li>
- READ - Permission to read data             </li>
+READ - Permission to read data            </li>
             <li>
- REMOVE - Permission to remove data             </li>
+REMOVE - Permission to remove data            </li>
             <li>
- READ_REMOVE - Permission to read and remove data             </li>
+READ_REMOVE - Permission to read and remove data            </li>
           </ul>
          </div>
 </div>
@@ -114,7 +114,7 @@ For more information on the Key Manager features, see <a href="/application/web/
 <div class="interface" id="KeyManagerObject">
 <a class="backward-compatibility-anchor" name="::KeyManager::KeyManagerObject"></a><h3>2.1. KeyManagerObject</h3>
 <div class="brief">
- The KeyManagerObject interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
+ The KeyManagerObject interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface KeyManagerObject {
     readonly attribute <a href="#KeyManager">KeyManager</a> keymanager;
@@ -125,7 +125,7 @@ For more information on the Key Manager features, see <a href="/application/web/
           </p>
 <div class="description">
           <p>
-The <em>tizen.keymanager </em>object allows access to the functionality of the Key Manager API.
+The <em>tizen.keymanager</em> object allows access to the functionality of the Key Manager API.
           </p>
          </div>
 <div class="attributes">

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/mediacontroller.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/mediacontroller.html
@@ -2515,7 +2515,7 @@ The ErrorCallback may be triggered for one of the following errors:
             </p>
             <ul>
               <li>
- UnknownError:  if any error prevents function from successful completion.               </li>
+UnknownError: if any error prevents function from successful completion.              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -9043,17 +9043,17 @@ Interface is used as a success method for:
           </p>
           <ul>
             <li>
- <em>MediaControllerServerInfo.sendCommand()</em>             </li>
+<em>MediaControllerServerInfo.sendCommand()</em>             </li>
             <li>
- <em>MediaControllerMode360Info.sendRequest()</em>             </li>
+<em>MediaControllerMode360Info.sendRequest()</em>             </li>
             <li>
- <em>MediaControllerSubtitlesInfo.sendRequest()</em>             </li>
+<em>MediaControllerSubtitlesInfo.sendRequest()</em>             </li>
             <li>
- <em>MediaControllerDisplayMode.sendRequest()</em>             </li>
+<em>MediaControllerDisplayMode.sendRequest()</em>             </li>
             <li>
- <em>MediaControllerDisplayRotationInfo.sendRequest()</em>             </li>
+<em>MediaControllerDisplayRotationInfo.sendRequest()</em>             </li>
             <li>
- <em>MediaControllerClientInfo.sendEvent()</em>             </li>
+<em>MediaControllerClientInfo.sendEvent()</em>             </li>
           </ul>
          </div>
 <div class="methods">
@@ -9075,7 +9075,7 @@ Interface is used as a success method for:
 <ul>
           <li class="param">
 <span class="name">data</span><span class="optional"> [nullable]</span>:
- Response data object sent by the command handler. This object is compatible with  <a href="tizen.html#Bundle">Bundle</a> object.
+ Response data object sent by the command handler. This object is compatible with <a href="tizen.html#Bundle">Bundle</a> object.
                 </li>
           <li class="param">
 <span class="name">code</span><span class="optional"> [optional]</span>:

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/mediakey.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/mediakey.html
@@ -87,21 +87,21 @@ For more information on the Media Key features, see <a href="/application/web/gu
 <div class="description">
           <ul>
             <li>
- MEDIA_PLAY - the Play media key             </li>
+MEDIA_PLAY - the Play media key            </li>
             <li>
- MEDIA_STOP - the Stop media key            </li>
+MEDIA_STOP - the Stop media key            </li>
             <li>
- MEDIA_PAUSE - the Pause media key            </li>
+MEDIA_PAUSE - the Pause media key            </li>
             <li>
- MEDIA_PREVIOUS - the Previous media key            </li>
+MEDIA_PREVIOUS - the Previous media key            </li>
             <li>
- MEDIA_NEXT - the Next media key            </li>
+MEDIA_NEXT - the Next media key            </li>
             <li>
- MEDIA_FAST_FORWARD - the Fast Forward media key            </li>
+MEDIA_FAST_FORWARD - the Fast Forward media key            </li>
             <li>
- MEDIA_REWIND - the Rewind media key            </li>
+MEDIA_REWIND - the Rewind media key            </li>
             <li>
- MEDIA_PLAY_PAUSE - the Play/Pause media key            </li>
+MEDIA_PLAY_PAUSE - the Play/Pause media key            </li>
           </ul>
          </div>
 </div>
@@ -189,7 +189,7 @@ There is a tizen.mediakey object that allows accessing the functionality of the 
 <span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">tizen.mediakey.setMediaKeyEventListener({
   onpressed: function(key)
   {
-    console.log("Pressed  key: " + key);
+    console.log("Pressed key: " + key);
   },
   onreleased: function(key)
   {

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/messaging.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/messaging.html
@@ -373,7 +373,8 @@ linked to a message.
 It also allows an application to retrieve the content of a
 message through <em>MessageStorage</em> methods. In these
 cases, the implementation can return, in some situations, only the meta-information
-of a message without the loaded body. In such situations, the method <em>MessageService.loadMessageBody()</em>should be used.
+of a message without the loaded body. In such situations, the
+method <em>MessageService.loadMessageBody()</em> should be used.
           </p>
          </div>
 <div class="example">

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/messaging.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/messaging.html
@@ -320,7 +320,7 @@ messaging.email, for email services            </li>
           </p>
 <div class="description">
           <p>
-There is a <em>tizen.messaging </em>object that allows access to the Messaging API.
+There is a <em>tizen.messaging</em> object that allows access to the Messaging API.
           </p>
          </div>
 <div class="attributes">
@@ -371,9 +371,9 @@ linked to a message.
           </p>
           <p>
 It also allows an application to retrieve the content of a
-message through <em>MessageStorage </em>methods. In these
+message through <em>MessageStorage</em> methods. In these
 cases, the implementation can return, in some situations, only the meta-information
-of a message without the loaded body. In such situations, the method <em>MessageService.loadMessageBody() </em>should be used.
+of a message without the loaded body. In such situations, the method <em>MessageService.loadMessageBody()</em>should be used.
           </p>
          </div>
 <div class="example">
@@ -455,7 +455,7 @@ By default, this attribute is set to <var>null</var>.
 By default, this attribute is set to null.
             </p>
             <p>
-For SMS and MMS, <em>folderId </em>can be one of these values:
+For SMS and MMS, <em>folderId</em> can be one of these values:
             </p>
             <ul>
               <li>
@@ -716,7 +716,7 @@ This dictionary is used to input parameters when messages are created using
 the Message constructor.
           </p>
           <p>
-All the attributes are optional and are <var>undefined </var>by default, unless otherwise stated in the parameter description.
+All the attributes are optional and are <var>undefined</var> by default, unless otherwise stated in the parameter description.
           </p>
          </div>
 <div class="attributes">
@@ -860,7 +860,7 @@ It holds the ID of the message containing this body.
             </div>
 <div class="description">
             <p>
-It is set to <var>true </var>if the message body is loaded, else it is set to<var> false </var>if the object is not loaded.
+It is set to <var>true</var> if the message body is loaded, else it is set to <var>false</var> if the object is not loaded.
 The default value is <var>false</var>.
             </p>
            </div>
@@ -1064,7 +1064,7 @@ tizen.messaging.getMessageServices("messaging.sms", serviceListCB, errorCallback
 </dt>
 <dd>
 <div class="brief">
- Gets the messaging service of a given type for a given account, or all existing services supporting the given type, if <em>serviceId </em>is not given.
+ Gets the messaging service of a given type for a given account, or all existing services supporting the given type, if <em>serviceId</em> is not given.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void getMessageServices(<a href="#MessageServiceTag">MessageServiceTag</a> messageServiceType, <a href="#MessageServiceArraySuccessCallback">MessageServiceArraySuccessCallback</a> successCallback,
                         optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback);</pre></div>
@@ -1276,11 +1276,11 @@ tizen.messaging.getMessageServices("messaging.sms", serviceListCB, serviceErrorC
 <li class="attribute" id="MessageService::messageStorage">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">MessageStorage </span><span class="name">messageStorage</span></span><div class="brief">
- The <em>MessageStorage </em>for this messaging service.
+ The <em>MessageStorage</em> for this messaging service.
             </div>
 <div class="description">
             <p>
-If the backend does not support <em>MessageStorage </em>for this messaging service, a WebAPIException is raised with error type NotSupportedError.
+If the backend does not support <em>MessageStorage</em> for this messaging service, a WebAPIException is raised with error type NotSupportedError.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1314,11 +1314,11 @@ These error types may be passed, depending on the error conditions:
             </p>
             <ul>
               <li>
- NetworkError - If the network connection is not accessible.              </li>
+NetworkError - If the network connection is not accessible.              </li>
               <li>
- InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
+InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
             <p>
 The error message contains the name of the recipient who has failed to receive the sent message.
@@ -1448,9 +1448,9 @@ The errorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
+InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1546,9 +1546,9 @@ The errorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
+InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1643,11 +1643,11 @@ The errorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
+InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
               <li>
- AbortError - If the operation has been stopped.              </li>
+AbortError - If the operation has been stopped.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1753,11 +1753,11 @@ The errorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
+InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
               <li>
- AbortError - If the operation is stopped.              </li>
+AbortError - If the operation is stopped.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1859,10 +1859,10 @@ tizen.messaging.getMessageServices("messaging.email", serviceCallback, errorCall
             </p>
 <div class="description">
             <p>
-If the <em>operationId </em>argument is valid and corresponds to a service operation already in progress, the operation must be stopped and its error callback must be invoked with error type AbortError.
+If the <em>operationId</em> argument is valid and corresponds to a service operation already in progress, the operation must be stopped and its error callback must be invoked with error type AbortError.
             </p>
             <p>
-If the <em>operationId </em>argument is not valid or does not correspond to a valid service operation, the method will return without any further action.
+If the <em>operationId</em> argument is not valid or does not correspond to a valid service operation, the method will return without any further action.
             </p>
            </div>
 <div class="parameters">
@@ -1870,7 +1870,7 @@ If the <em>operationId </em>argument is not valid or does not correspond to a va
 <ul>
           <li class="param">
 <span class="name">opId</span>:
-  Service operation identifier.
+ Service operation identifier.
                 </li>
         </ul>
 </div>
@@ -2004,7 +2004,7 @@ It is used in the loadMessageAttachment() asynchronous operation.
 <div class="interface" id="MessageStorage">
 <a class="backward-compatibility-anchor" name="::Messaging::MessageStorage"></a><h3>2.12. MessageStorage</h3>
 <div class="brief">
- The MessageStorage interface allows management capabilities using a web application to query, update, and delete messages, and subscribe to <em>MessageStorage </em>changes.
+ The MessageStorage interface allows management capabilities using a web application to query, update, and delete messages, and subscribe to <em>MessageStorage</em> changes.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface MessageStorage {
     void addDraftMessage(<a href="#Message">Message</a> message, optional <a href="tizen.html#SuccessCallback">SuccessCallback</a>? successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback)
@@ -2035,7 +2035,7 @@ It is used in the loadMessageAttachment() asynchronous operation.
           </p>
 <div class="description">
           <p>
-In addition to simple message queries, the <em>MessageStorage </em>interface provides functionality to find conversations and folders.
+In addition to simple message queries, the <em>MessageStorage</em> interface provides functionality to find conversations and folders.
           </p>
          </div>
 <div class="methods">
@@ -2058,9 +2058,9 @@ The errorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError - If any of the input parameters contain an invalid value.              </li>
+InvalidValuesError - If any of the input parameters contain an invalid value.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2146,9 +2146,9 @@ The errorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
+InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2245,7 +2245,7 @@ The errorCallback is launched with these error types:
               <li>
 InvalidValuesError - If any of the input parameters contain an invalid value.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2341,9 +2341,9 @@ The errorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
+InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2438,9 +2438,9 @@ The errorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
+InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2474,7 +2474,7 @@ The errorCallback is launched with these error types:
                 </li>
           <li class="param">
 <span class="name">offset</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
-          Offset in the result set, from where the results are listed (It is the same semantics as SQL OFFSET) <br>Defaults to<var> 0</var>, meaning no offset.
+          Offset in the result set, from where the results are listed (It is the same semantics as SQL OFFSET) <br>Defaults to <var>0</var>, meaning no offset.
                 </li>
         </ul>
 </div>
@@ -2536,9 +2536,9 @@ The errorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
+InvalidValuesError - If any of the input parameters contains an invalid value.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2637,9 +2637,9 @@ The errorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError: If any of the input parameters contains an invalid value.              </li>
+InvalidValuesError: If any of the input parameters contains an invalid value.              </li>
               <li>
- UnknownError: In any other error case.               </li>
+UnknownError: In any other error case.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2944,7 +2944,7 @@ messageStorage.addFoldersChangeListener(folderChangeCB);
 Calling this function has no effect if there is no listener with given id.
             </p>
             <p>
-If the <em>subscriptionId</em> argument is valid and corresponds to a subscription already in place, the subscription process must stop immediately and further <em>MessagingStorage </em>change notifications must not be invoked.
+If the <em>subscriptionId</em> argument is valid and corresponds to a subscription already in place, the subscription process must stop immediately and further <em>MessagingStorage</em> change notifications must not be invoked.
 If the <em>subscriptionId</em> argument does not correspond to a valid subscription, the method will return without any further action.
             </p>
            </div>
@@ -3326,7 +3326,7 @@ Every element contains only MessageConvId attribute.
 <div class="interface" id="MessageFoldersChangeCallback">
 <a class="backward-compatibility-anchor" name="::Messaging::MessageFoldersChangeCallback"></a><h3>2.18. MessageFoldersChangeCallback</h3>
 <div class="brief">
- The MessageFoldersChangeCallback callback interface specifies a callback as a set of functions that are invoked when message folders from <em>MessageStorage </em>change.
+ The MessageFoldersChangeCallback callback interface specifies a callback as a set of functions that are invoked when message folders from <em>MessageStorage</em> change.
 Each function takes a list of folders as the input argument.
           </div>
 <pre class="webidl prettyprint">  [Callback, NoInterfaceObject] interface MessageFoldersChangeCallback {
@@ -3645,7 +3645,7 @@ The ID is locally unique and persistent property, assigned by the device or the 
 <li class="attribute" id="MessageFolder::parentId">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">MessageFolderId </span><span class="name">parentId</span></span><div class="brief">
- The identifier for the parent folder of  a specified folder.
+ The identifier for the parent folder of a specified folder.
             </div>
 <div class="description">
             <p>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/networkbearerselection.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/networkbearerselection.html
@@ -179,7 +179,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- UnknownError : If the "http://tizen.org/privilege/internet" privilege is not declared in config.xml or any other platform error occurs.               </li>
+UnknownError : If the "http://tizen.org/privilege/internet" privilege is not declared in config.xml or any other platform error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -277,7 +277,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- UnknownError : If the "http://tizen.org/privilege/internet" privilege is not declared in config.xml or any other platform error occurs.               </li>
+UnknownError : If the "http://tizen.org/privilege/internet" privilege is not declared in config.xml or any other platform error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/nfc.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/nfc.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="mobile-optional emulator" title="Optional, Supported by Tizen Mobile emulator" src="mobile_s_w_optional.png"></div>
 <div class="title"><h1>NFC API</h1></div>
 <div class="brief">
-  The NFC API provides a protocol for simple wireless interconnection of
+ The NFC API provides a protocol for simple wireless interconnection of
 closely coupled devices operating at 13.56 MHz using Near Field Communication (NFC),
 which is an international standard (ISO/IEC 18092).
 To know more, see <a href="https://nfc-forum.org/our-work/specifications-and-application-documents/specifications/nfc-forum-technical-specifications/">Technical Specifications</a>.
@@ -353,11 +353,11 @@ The following values are supported:
           </p>
           <ul>
             <li>
-ESE - The eSE (Embedded Secure Element) secure element type             </li>
+ESE - The eSE (Embedded Secure Element) secure element type            </li>
             <li>
-UICC - The UICC (Universal Integrated Circuit Card) secure element type             </li>
+UICC - The UICC (Universal Integrated Circuit Card) secure element type            </li>
             <li>
-HCE - The HCE (Host Card Emulation) type. This allows a card to be emulated without secure element             </li>
+HCE - The HCE (Host Card Emulation) type. This allows a card to be emulated without secure element            </li>
           </ul>
          </div>
 <p><span class="remark">Remark: </span>
@@ -379,9 +379,9 @@ The following values are supported:
           </p>
           <ul>
             <li>
-PAYMENT - Category used for NFC payment services              </li>
+PAYMENT - Category used for NFC payment services            </li>
             <li>
-OTHER - Category that can be used for all other cards             </li>
+OTHER - Category that can be used for all other cards            </li>
           </ul>
          </div>
 </div>
@@ -400,11 +400,11 @@ The following values are supported:
           </p>
           <ul>
             <li>
-DEACTIVATED - HCE deactivated              </li>
+DEACTIVATED - HCE deactivated            </li>
             <li>
-ACTIVATED - HCE activated             </li>
+ACTIVATED - HCE activated            </li>
             <li>
-APDU_RECEIVED - APDU (Application Protocol Data Unit) received             </li>
+APDU_RECEIVED - APDU (Application Protocol Data Unit) received            </li>
           </ul>
          </div>
 </div>
@@ -425,7 +425,7 @@ APDU_RECEIVED - APDU (Application Protocol Data Unit) received             </li>
 <a class="backward-compatibility-anchor" name="::NFC::NFCManagerObject"></a><h3>2.1. NFCManagerObject</h3>
 <div class="brief">
  The NFCManagerObject interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
-The <em>tizen.nfc </em>object allows access to the functionality of the NFC API.
+The <em>tizen.nfc</em> object allows access to the functionality of the NFC API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface NFCManagerObject {
     readonly attribute <a href="#NFCManager">NFCManager</a> nfc;
@@ -1664,7 +1664,7 @@ catch (err)
 {
   var onDetectedCB = function(event_data)
   {
-    console.log("HCE event type  is " + event_data.eventType);
+    console.log("HCE event type is " + event_data.eventType);
     console.log("APDU is " + event_data.apdu);
   };
   var listenerId = adapter.addHCEEventListener(onDetectedCB);
@@ -1751,9 +1751,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError - If the NFC service is not available.              </li>
+ServiceNotAvailableError - If the NFC service is not available.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1858,7 +1858,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">type</span>:
-  The secure element type.
+ The secure element type.
                 </li>
           <li class="param">
 <span class="name">aid</span>:
@@ -1988,7 +1988,7 @@ catch (err)
 </dt>
 <dd>
 <div class="brief">
-  Registers an AID for a specific category and secure element type.
+ Registers an AID for a specific category and secure element type.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void registerAID(<a href="#SecureElementType">SecureElementType</a> type, <a href="#AID">AID</a> aid, <a href="#CardEmulationCategoryType">CardEmulationCategoryType</a> category);</pre></div>
 <p><span class="version">Since: </span>
@@ -2017,7 +2017,7 @@ catch (err)
                 </li>
           <li class="param">
 <span class="name">category</span>:
-  The card emulation category type.
+ The card emulation category type.
                 </li>
         </ul>
 </div>
@@ -2086,7 +2086,7 @@ catch (err)
                 </li>
           <li class="param">
 <span class="name">category</span>:
-  The card emulation category type.
+ The card emulation category type.
                 </li>
         </ul>
 </div>
@@ -2139,9 +2139,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError - If the NFC service is not available.              </li>
+ServiceNotAvailableError - If the NFC service is not available.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2163,11 +2163,11 @@ The ErrorCallback is launched with these error types:
                 </li>
           <li class="param">
 <span class="name">category</span>:
-  The card emulation category type.
+ The card emulation category type.
                 </li>
           <li class="param">
 <span class="name">successCallback</span>:
- Invoked when the  AIDs are retrieved successfully.
+ Invoked when the AIDs are retrieved successfully.
                 </li>
           <li class="param">
 <span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
@@ -2465,11 +2465,11 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError - If the NFC service is not available.              </li>
+ServiceNotAvailableError - If the NFC service is not available.              </li>
               <li>
- InvalidValuesError - If the current Tag doesn't support the NDEF standard.              </li>
+InvalidValuesError - If the current Tag doesn't support the NDEF standard.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2552,11 +2552,11 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError: If any of the input parameters contain an invalid value or the current Tag does not support the NDEF standard.              </li>
+InvalidValuesError: If any of the input parameters contain an invalid value or the current Tag does not support the NDEF standard.              </li>
               <li>
- ServiceNotAvailableError: If the NFC service is not available.               </li>
+ServiceNotAvailableError: If the NFC service is not available.              </li>
               <li>
- UnknownError: In any other error case.               </li>
+UnknownError: In any other error case.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2642,11 +2642,11 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError - If any of the input parameters contain an invalid value.              </li>
+InvalidValuesError - If any of the input parameters contain an invalid value.              </li>
               <li>
- ServiceNotAvailableError - If the NFC service is not available.              </li>
+ServiceNotAvailableError - If the NFC service is not available.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2889,11 +2889,11 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError: If any of the input parameters contain an invalid value.              </li>
+InvalidValuesError: If any of the input parameters contain an invalid value.              </li>
               <li>
- ServiceNotAvailableError: If the NFC service is not available.               </li>
+ServiceNotAvailableError: If the NFC service is not available.              </li>
               <li>
- UnknownError: In any other error case.               </li>
+UnknownError: In any other error case.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -3507,9 +3507,9 @@ This callback interface specifies two methods:
           </p>
           <ul>
             <li>
- onattach: Invoked when an NFC tag is detected            </li>
+onattach: Invoked when an NFC tag is detected            </li>
             <li>
- ondetach: Invoked when an NFC tag is lost            </li>
+ondetach: Invoked when an NFC tag is lost            </li>
           </ul>
           <p>
 It is used in NFCAdapter.setTagListener().
@@ -3617,9 +3617,9 @@ This callback interface specifies two methods:
           </p>
           <ul>
             <li>
- onattach: Invoked when an NFC peer-to-peer target is detected            </li>
+onattach: Invoked when an NFC peer-to-peer target is detected            </li>
             <li>
- ondetach: Invoked when an NFC peer-to-peer target is lost            </li>
+ondetach: Invoked when an NFC peer-to-peer target is lost            </li>
           </ul>
           <p>
 It is used in NFCAdapter.setPeerListener().

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/nfc.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/nfc.html
@@ -361,7 +361,7 @@ HCE - The HCE (Host Card Emulation) type. This allows a card to be emulated with
           </ul>
          </div>
 <p><span class="remark">Remark: </span>
- <em>HCE</em>  is supported since Tizen 2.3.1
+ <em>HCE</em> is supported since Tizen 2.3.1
           </p>
 </div>
 <div class="enum" id="CardEmulationCategoryType">

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/notification.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/notification.html
@@ -211,7 +211,7 @@ THUMBNAIL - The thumbnail user notification posts a thumbnail-format notificatio
 The thumbnail user notification is also removed by user selection.
             </li>
             <li>
-ONGOING - An user notification type that informs the user whether an application is running or not.             </li>
+ONGOING - An user notification type that informs the user whether an application is running or not.            </li>
             <li>
 PROGRESS - An user notification that displays information on the progress of a job. However, this user notification should be removed by the application that posted the notification.            </li>
           </ul>
@@ -232,9 +232,9 @@ The following notification progress types are supported:
           </p>
           <ul>
             <li>
- "BYTE" - The progress is indicated in bytes.            </li>
+"BYTE" - The progress is indicated in bytes.            </li>
             <li>
- "PERCENTAGE" -The progress is indicated in percentage.            </li>
+"PERCENTAGE" -The progress is indicated in percentage.            </li>
           </ul>
          </div>
 </div>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/package.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/package.html
@@ -125,7 +125,7 @@ For more information on the Package features, see <a href="/application/web/guid
 <div class="interface" id="PackageManagerObject">
 <a class="backward-compatibility-anchor" name="::Package::PackageManagerObject"></a><h3>2.1. PackageManagerObject</h3>
 <div class="brief">
- This interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
+ This interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface PackageManagerObject {
     readonly attribute <a href="#PackageManager">PackageManager</a> package;
@@ -136,7 +136,7 @@ For more information on the Package features, see <a href="/application/web/guid
           </p>
 <div class="description">
           <p>
-The <em>tizen.package </em>object allows access to Package API functionality.
+The <em>tizen.package</em> object allows access to Package API functionality.
           </p>
          </div>
 <div class="attributes">
@@ -190,7 +190,7 @@ The <em>tizen.package </em>object allows access to Package API functionality.
 This API provides a way to notify the progress and completion of an installation request through PackageProgressCallback.
             </p>
             <p>
-The <em>ErrorCallback() </em>is launched with these error types:
+The <em>ErrorCallback()</em> is launched with these error types:
             </p>
             <ul>
               <li>
@@ -286,7 +286,7 @@ tizen.filesystem.resolve("downloads/test.wgt",
 This API provides a way to notify about the progress and completion of an uninstallation request through PackageProgressCallback.
             </p>
             <p>
-The <em>ErrorCallback() </em>is launched with these error types:
+The <em>ErrorCallback()</em> is launched with these error types:
             </p>
             <ul>
               <li>
@@ -734,7 +734,7 @@ The relevant application is the one with the same
 <div class="interface" id="PackageInformationArraySuccessCallback">
 <a class="backward-compatibility-anchor" name="::Package::PackageInformationArraySuccessCallback"></a><h3>2.4. PackageInformationArraySuccessCallback</h3>
 <div class="brief">
- This interface invokes the success callback with an array of <em>PackageInformation </em>objects as an input parameter when the installed package list is retrieved.
+ This interface invokes the success callback with an array of <em>PackageInformation</em> objects as an input parameter when the installed package list is retrieved.
           </div>
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PackageInformationArraySuccessCallback {
     void onsuccess(<a href="#PackageInformation">PackageInformation</a>[] informationArray);

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/playerutil.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/playerutil.html
@@ -90,8 +90,8 @@ HIGH - High audio latency mode.            </li>
 <div class="interface" id="PlayerUtilManagerObject">
 <a class="backward-compatibility-anchor" name="::PlayerUtil::PlayerUtilManagerObject"></a><h3>2.1. PlayerUtilManagerObject</h3>
 <div class="brief">
- The PlayerUtilManagerObject interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
-The <em>tizen.playerutil </em>object allows access to the functionality of the Player Util API.
+ The PlayerUtilManagerObject interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
+The <em>tizen.playerutil</em> object allows access to the functionality of the Player Util API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface PlayerUtilManagerObject {
     readonly attribute <a href="#PlayerUtilManager">PlayerUtilManager</a> playerutil;

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/power.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/power.html
@@ -88,7 +88,7 @@ For more information on the Power features, see <a href="/application/web/guides
 <div class="enum" id="PowerResource">
 <a class="backward-compatibility-anchor" name="::Power::PowerResource"></a><h3>1.1. PowerResource</h3>
 <div class="brief">
- Specifies power resources with values aligned with <em>SystemInfo </em>property values.
+ Specifies power resources with values aligned with <em>SystemInfo</em> property values.
           </div>
 <pre class="webidl prettyprint">  enum PowerResource { "SCREEN", "CPU" };</pre>
 <p><span class="version">Since: </span>
@@ -182,7 +182,7 @@ It can be either a PowerScreenState or a PowerCpuState.
           </p>
 <div class="description">
           <p>
-There will be a <em>tizen.power </em>object that allows accessing of a functionality of the Power API.
+There will be a <em>tizen.power</em> object that allows accessing of a functionality of the Power API.
           </p>
          </div>
 <div class="attributes">
@@ -239,7 +239,7 @@ However, these requests can be overridden by the system. If the requests are ove
  public
             </p>
 <p><span class="privilege">Privilege: </span>
-      http://tizen.org/privilege/power
+ http://tizen.org/privilege/power
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/ppm.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/ppm.html
@@ -21,9 +21,9 @@ Privacy Privilege API allows:
         </p>
         <ul>
           <li>
- Checking if user granted permission for using a privacy-related privilege.          </li>
+Checking if user granted permission for using a privacy-related privilege.          </li>
           <li>
- Requesting pop-up about giving permission for using privacy-related privilege.          </li>
+Requesting pop-up about giving permission for using privacy-related privilege.          </li>
         </ul>
        </div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/preference.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/preference.html
@@ -419,7 +419,7 @@ console.log("The current value of the preference key1 is: " + currentValue);
 <p><span class="return">Return value:</span></p>
 <ul>
 <span class="return">boolean:</span>
- If <var>true</var> the key exists in the  application preference, otherwise <var>false</var>.
+ If <var>true</var> the key exists in the application preference, otherwise <var>false</var>.
               </ul>
 </div>
 <div class="exceptionlist">

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/push.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/push.html
@@ -158,7 +158,7 @@ UNREGISTERED - The application is not registered to the push server.            
 <div class="interface" id="PushManagerObject">
 <a class="backward-compatibility-anchor" name="::Push::PushManagerObject"></a><h3>2.1. PushManagerObject</h3>
 <div class="brief">
- The PushManagerObject interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
+ The PushManagerObject interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface PushManagerObject {
     readonly attribute <a href="#PushManager">PushManager</a> push;
@@ -169,7 +169,7 @@ UNREGISTERED - The application is not registered to the push server.            
           </p>
 <div class="description">
           <p>
-The <em>tizen.push </em>object allows access to the functionality of the Push API.
+The <em>tizen.push</em> object allows access to the functionality of the Push API.
           </p>
          </div>
 <div class="attributes">
@@ -525,7 +525,7 @@ tizen.push.disconnect();
 </dt>
 <dd>
 <div class="brief">
- Gets the push service registration ID for this application if the registration process is successful. <var>null </var>is returned if the application has not been registered yet.
+ Gets the push service registration ID for this application if the registration process is successful. <var>null</var> is returned if the application has not been registered yet.
             </div>
 <div class="synopsis"><pre class="signature prettyprint"><a href="#PushRegistrationId">PushRegistrationId</a> getRegistrationId();</pre></div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/se.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/se.html
@@ -196,7 +196,7 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- UnknownError - If any error occurs during retrieval.              </li>
+UnknownError - If any error occurs during retrieval.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -545,11 +545,11 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- IOError - An error occurred in communication with the Secure Element in this reader.              </li>
+IOError - An error occurred in communication with the Secure Element in this reader.              </li>
               <li>
- InvalidStateError - If a Secure Element is not present on this reader.              </li>
+InvalidStateError - If a Secure Element is not present on this reader.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -703,17 +703,17 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- IOError - If an error occurs while communicating with the Secure Element in the reader.              </li>
+IOError - If an error occurs while communicating with the Secure Element in the reader.              </li>
               <li>
- SecurityError - If access to this AID or the default application on this session is not allowed .              </li>
+SecurityError - If access to this AID or the default application on this session is not allowed .              </li>
               <li>
- InvalidStateError - If this session is closed.               </li>
+InvalidStateError - If this session is closed.              </li>
               <li>
- NotFoundError - If the application of the AID does not exist in the Secure Element.              </li>
+NotFoundError - If the application of the AID does not exist in the Secure Element.              </li>
               <li>
- NoChannelError - If basic channel is unavailable.              </li>
+NoChannelError - If basic channel is unavailable.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -814,17 +814,17 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- IOError - If an error occurs while communicating with the Secure Element in the reader.              </li>
+IOError - If an error occurs while communicating with the Secure Element in the reader.              </li>
               <li>
- SecurityError - If access to this AID or the default application in this session is not allowed.              </li>
+SecurityError - If access to this AID or the default application in this session is not allowed.              </li>
               <li>
- InvalidStateError - If this session is closed.              </li>
+InvalidStateError - If this session is closed.              </li>
               <li>
- NotFoundError - If the application of the AID does not exist in the Secure Element.              </li>
+NotFoundError - If the application of the AID does not exist in the Secure Element.              </li>
               <li>
- NoChannelError - If logical channel is unavailable.              </li>
+NoChannelError - If logical channel is unavailable.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1122,26 +1122,26 @@ Some commands that are not allowed to be sent are:
             </p>
             <ul>
               <li>
- MANAGE_CHANNEL commands.               </li>
+MANAGE_CHANNEL commands.              </li>
               <li>
- SELECT by DF Name (p1=04).               </li>
+SELECT by DF Name (p1=04).              </li>
               <li>
- The commands that CLA bytes with channel numbers are de-masked.               </li>
+The commands that CLA bytes with channel numbers are de-masked.              </li>
             </ul>
             <p>
 The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError - If the command contain an invalid value.              </li>
+InvalidValuesError - If the command contain an invalid value.              </li>
               <li>
- IOError - An error occurred while communicating with the Secure Element in the reader.              </li>
+IOError - An error occurred while communicating with the Secure Element in the reader.              </li>
               <li>
- SecurityError - If the command is not allowed.              </li>
+SecurityError - If the command is not allowed.              </li>
               <li>
- InvalidStateError - If this channel is closed.              </li>
+InvalidStateError - If this channel is closed.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1427,7 +1427,7 @@ It is used in asynchronous operations such as <em>Reader.openSession()</em>.
 <div class="description">
           <p>
 This callback interface specifies a success method with a <em>Channel</em> object as an input parameter.
-It is used in asynchronous operations such as <em>Session.openBasicChannel() </em>or <em>Session.openLogicalChannel()</em>.
+It is used in asynchronous operations such as <em>Session.openBasicChannel()</em> or <em>Session.openLogicalChannel()</em>.
           </p>
          </div>
 <div class="methods">
@@ -1460,7 +1460,7 @@ It is used in asynchronous operations such as <em>Session.openBasicChannel() </e
 <div class="interface" id="TransmitSuccessCallback">
 <a class="backward-compatibility-anchor" name="::SecureElement::TransmitSuccessCallback"></a><h3>1.10. TransmitSuccessCallback</h3>
 <div class="brief">
- The TransmitSuccessCallback interface specifies the success callback that is invoked when <em>Channel.transmit() </em>completes successfully.
+ The TransmitSuccessCallback interface specifies the success callback that is invoked when <em>Channel.transmit()</em> completes successfully.
           </div>
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface TransmitSuccessCallback {
     void onsuccess(byte[] response);

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/sensor.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/sensor.html
@@ -489,7 +489,7 @@ ULTRAVIOLET - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/senso
  with error type NotSupportedError, if the given <var>type</var> is not supported on the device.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, this error is only thrown for <em>HRM_RAW</em>  sensor type when an application does not have http://tizen.org/privilege/healthinfo privilege in config.xml.
+ with error type SecurityError, this error is only thrown for <em>HRM_RAW</em> sensor type when an application does not have http://tizen.org/privilege/healthinfo privilege in config.xml.
                 </p></li>
 </ul>
 </li></ul>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/sensor.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/sensor.html
@@ -431,31 +431,31 @@ The supported sensor types are hardware-dependent. <br><br>To check if the given
             </p>
             <ul>
               <li>
- ACCELERATION - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.accelerometer"</em>)               </li>
+ACCELERATION - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.accelerometer"</em>)              </li>
               <li>
- GRAVITY     - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.gravity"</em>)               </li>
+GRAVITY     - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.gravity"</em>)              </li>
               <li>
- GYROSCOPE   - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.gyroscope"</em>)               </li>
+GYROSCOPE   - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.gyroscope"</em>)              </li>
               <li>
- GYROSCOPE_ROTATION_VECTOR - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.gyroscope_rotation_vector"</em>)               </li>
+GYROSCOPE_ROTATION_VECTOR - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.gyroscope_rotation_vector"</em>)              </li>
               <li>
- GYROSCOPE_UNCALIBRATED - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.gyroscope.uncalibrated"</em>)               </li>
+GYROSCOPE_UNCALIBRATED - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.gyroscope.uncalibrated"</em>)              </li>
               <li>
- HRM_RAW     - HRM_RAW is supported, if at least one HRM LED sensor type is supported:<br>tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.heart_rate_monitor.led_green"</em>),<br>tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.heart_rate_monitor.led_ir"</em>),<br>tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.heart_rate_monitor.led_red"</em>)               </li>
+HRM_RAW     - HRM_RAW is supported, if at least one HRM LED sensor type is supported:<br>tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.heart_rate_monitor.led_green"</em>),<br>tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.heart_rate_monitor.led_ir"</em>),<br>tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.heart_rate_monitor.led_red"</em>)              </li>
               <li>
- LIGHT       - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.photometer"</em>)               </li>
+LIGHT       - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.photometer"</em>)              </li>
               <li>
- LINEAR_ACCELERATION - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.linear_acceleration"</em>)               </li>
+LINEAR_ACCELERATION - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.linear_acceleration"</em>)              </li>
               <li>
- MAGNETIC    - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.magnetometer"</em>)               </li>
+MAGNETIC    - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.magnetometer"</em>)              </li>
               <li>
- MAGNETIC_UNCALIBRATED - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.magnetometer.uncalibrated"</em>)               </li>
+MAGNETIC_UNCALIBRATED - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.magnetometer.uncalibrated"</em>)              </li>
               <li>
- PRESSURE    - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.barometer"</em>)               </li>
+PRESSURE    - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.barometer"</em>)              </li>
               <li>
- PROXIMITY   - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.proximity"</em>)               </li>
+PROXIMITY   - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.proximity"</em>)              </li>
               <li>
- ULTRAVIOLET - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.ultraviolet"</em>)               </li>
+ULTRAVIOLET - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.ultraviolet"</em>)              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -489,7 +489,7 @@ The supported sensor types are hardware-dependent. <br><br>To check if the given
  with error type NotSupportedError, if the given <var>type</var> is not supported on the device.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, this error is only thrown for <em> HRM_RAW </em> sensor type when an application does not have http://tizen.org/privilege/healthinfo privilege in config.xml.
+ with error type SecurityError, this error is only thrown for <em>HRM_RAW</em>  sensor type when an application does not have http://tizen.org/privilege/healthinfo privilege in config.xml.
                 </p></li>
 </ul>
 </li></ul>
@@ -703,7 +703,7 @@ The start() method must be called to turn on the sensor, or the sensor data will
                 </li>
           <li class="param">
 <span class="name">batchLatency</span><span class="optional"> [optional]</span>:
- The batch latency time in milliseconds (ms) at which sensor events are stored or delivered when processor stay on sleep or suspend status since Tizen 3.0<br><em>batchLatency</em> has hardware dependency. You can calculate maximum batchLatency value using  <a href="#SensorHardwareInfo">maxBatchCount</a> (e.g. interval x maxBatchCount) . If maxBatchCount is zero, device doesn't support batch latency time.
+ The batch latency time in milliseconds (ms) at which sensor events are stored or delivered when processor stay on sleep or suspend status since Tizen 3.0<br><em>batchLatency</em> has hardware dependency. You can calculate maximum batchLatency value using <a href="#SensorHardwareInfo">maxBatchCount</a> (e.g. interval x maxBatchCount) . If maxBatchCount is zero, device doesn't support batch latency time.
                 </li>
         </ul>
 </div>
@@ -892,9 +892,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getAccelerationSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getAccelerationSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- AbortError : If the system operation was aborted              </li>
+AbortError : If the system operation was aborted              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -990,9 +990,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getGravitySensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getGravitySensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- AbortError : If the system operation was aborted              </li>
+AbortError : If the system operation was aborted              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1088,9 +1088,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getGyroscopeSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getGyroscopeSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- AbortError : If the system operation was aborted              </li>
+AbortError : If the system operation was aborted              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1186,9 +1186,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getGyroscopeRotationVectorSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getGyroscopeRotationVectorSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- AbortError : If the system operation was aborted              </li>
+AbortError : If the system operation was aborted              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1287,9 +1287,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getGyroscopeUncalibratedSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getGyroscopeUncalibratedSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- AbortError : If the system operation was aborted              </li>
+AbortError : If the system operation was aborted              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1379,9 +1379,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the getHRMRawSensorData method is called without calling the start method.              </li>
+ServiceNotAvailableError : If the getHRMRawSensorData method is called without calling the start method.              </li>
               <li>
- UnknownError  : An unknown error has occurred.              </li>
+UnknownError : An unknown error has occurred.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1479,9 +1479,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getLightSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getLightSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- UnknownError  : An unknown error has occurred              </li>
+UnknownError : An unknown error has occurred              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1566,9 +1566,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getLinearAccelerationSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getLinearAccelerationSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- AbortError : If the system operation was aborted              </li>
+AbortError : If the system operation was aborted              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1664,9 +1664,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getMagneticSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getMagneticSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- UnknownError  : An unknown error has occurred              </li>
+UnknownError : An unknown error has occurred              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1753,9 +1753,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getMagneticUncalibratedSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getMagneticUncalibratedSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- AbortError : If the system operation was aborted              </li>
+AbortError : If the system operation was aborted              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1846,9 +1846,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getPressureSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getPressureSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- UnknownError  : An unknown error has occurred              </li>
+UnknownError : An unknown error has occurred              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1933,9 +1933,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getProximitySensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getProximitySensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- UnknownError  : An unknown error has occurred              </li>
+UnknownError : An unknown error has occurred              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -2020,9 +2020,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getUltravioletSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getUltravioletSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- UnknownError  : An unknown error has occurred              </li>
+UnknownError : An unknown error has occurred              </li>
             </ul>
            </div>
 <div class="parameters">

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/sound.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/sound.html
@@ -123,17 +123,17 @@ For more information on the Sound features, see <a href="/application/web/guides
 <div class="description">
           <ul>
             <li>
- SYSTEM - for system sounds            </li>
+SYSTEM - for system sounds            </li>
             <li>
- NOTIFICATION - for notifications            </li>
+NOTIFICATION - for notifications            </li>
             <li>
- ALARM - for alarm            </li>
+ALARM - for alarm            </li>
             <li>
- MEDIA - for media playback            </li>
+MEDIA - for media playback            </li>
             <li>
- VOICE - for voice            </li>
+VOICE - for voice            </li>
             <li>
- RINGTONE - for the phone ring            </li>
+RINGTONE - for the phone ring            </li>
           </ul>
          </div>
 <p><span class="remark">Remark: </span>
@@ -152,11 +152,11 @@ For more information on the Sound features, see <a href="/application/web/guides
 <div class="description">
           <ul>
             <li>
- SOUND - the sound mode            </li>
+SOUND - the sound mode            </li>
             <li>
- VIBRATE - the vibrate mode            </li>
+VIBRATE - the vibrate mode            </li>
             <li>
- MUTE - the mute mode            </li>
+MUTE - the mute mode            </li>
           </ul>
          </div>
 </div>
@@ -175,21 +175,21 @@ The possible types are:
           </p>
           <ul>
             <li>
- SPEAKER - For sound output using the built-in device speaker            </li>
+SPEAKER - For sound output using the built-in device speaker            </li>
             <li>
- RECEIVER - For sound output using the built-in device receiver            </li>
+RECEIVER - For sound output using the built-in device receiver            </li>
             <li>
- AUDIO_JACK - For sound input and/or output using the device audio jack which can be connected to a wired accessory such as a headset or headphone            </li>
+AUDIO_JACK - For sound input and/or output using the device audio jack which can be connected to a wired accessory such as a headset or headphone            </li>
             <li>
- BLUETOOTH - For sound input and/or output through a device that is connected by Bluetooth            </li>
+BLUETOOTH - For sound input and/or output through a device that is connected by Bluetooth            </li>
             <li>
- HDMI - For sound output through a device that is connected by HDMI            </li>
+HDMI - For sound output through a device that is connected by HDMI            </li>
             <li>
- MIRRORING - For sound output through a device that is connected by mirroring            </li>
+MIRRORING - For sound output through a device that is connected by mirroring            </li>
             <li>
- USB_AUDIO - For sound output through a device that is connected by USB            </li>
+USB_AUDIO - For sound output through a device that is connected by USB            </li>
             <li>
- MIC - For sound input using the built-in device microphone            </li>
+MIC - For sound input using the built-in device microphone            </li>
           </ul>
          </div>
 </div>
@@ -208,11 +208,11 @@ The possible types are:
           </p>
           <ul>
             <li>
- IN - For sound device type which <em>only support input</em>            </li>
+IN - For sound device type which <em>only support input</em>            </li>
             <li>
- OUT - For sound device type which <em>only support output</em>            </li>
+OUT - For sound device type which <em>only support output</em>            </li>
             <li>
- BOTH - For sound device type which <em>supports both input and output</em>            </li>
+BOTH - For sound device type which <em>supports both input and output</em>            </li>
           </ul>
          </div>
 </div>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/systeminfo.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/systeminfo.html
@@ -61,21 +61,21 @@ Not all above properties may be available on every Tizen device. For instance, a
         </p>
         <ul>
           <li>
- BATTERY          - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/battery"</em>)          </li>
+BATTERY          - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/battery"</em>)          </li>
           <li>
- CAMERA_FLASH     - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/camera.back.flash"</em>)          </li>
+CAMERA_FLASH     - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/camera.back.flash"</em>)          </li>
           <li>
- CELLULAR_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.telephony"</em>)          </li>
+CELLULAR_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.telephony"</em>)          </li>
           <li>
- DISPLAY          - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/screen"</em>)          </li>
+DISPLAY          - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/screen"</em>)          </li>
           <li>
- ETHERNET_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.ethernet"</em>)          </li>
+ETHERNET_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.ethernet"</em>)          </li>
           <li>
- NET_PROXY_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.net_proxy"</em>)          </li>
+NET_PROXY_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.net_proxy"</em>)          </li>
           <li>
- SIM              - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.telephony"</em>)          </li>
+SIM              - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.telephony"</em>)          </li>
           <li>
- WIFI_NETWORK     - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.wifi"</em>)          </li>
+WIFI_NETWORK     - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.wifi"</em>)          </li>
         </ul>
         <p>
 For more information on the System Information features, see <a href="/application/web/guides/device/system-information">System Information Guide</a>.
@@ -429,7 +429,7 @@ WARNING - indicating the remaining memory is insufficient. Low memory warnings m
 <div class="interface" id="SystemInfoObject">
 <a class="backward-compatibility-anchor" name="::SystemInfo::SystemInfoObject"></a><h3>2.1. SystemInfoObject</h3>
 <div class="brief">
- Defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
+ Defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface SystemInfoObject {
     readonly attribute <a href="#SystemInfo">SystemInfo</a> systeminfo;
@@ -1171,7 +1171,7 @@ This attribute has no effect on the <em>get()</em> method.
             </div>
 <div class="description">
             <p>
-If both <em>highThreshold </em>and <em>lowThreshold </em>parameters are specified, the <em>successCallback()</em> is triggered if and only if the property value is either lower than the value of <em>lowThreshold</em> or higher than the value of <em>highThreshold</em>.
+If both <em>highThreshold</em> and <em>lowThreshold</em> parameters are specified, the <em>successCallback()</em> is triggered if and only if the property value is either lower than the value of <em>lowThreshold</em> or higher than the value of <em>highThreshold</em>.
 This attribute has no effect on the get method.
             </p>
            </div>
@@ -1312,14 +1312,14 @@ Change listener registered on <var>BATTERY</var> property is triggered on
 <li class="attribute" id="SystemInfoBattery::level">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">level</span></span><div class="brief">
- An attribute to specify the remaining level of an internal battery, scaled from <var>0 </var>to <var>1</var>:
+ An attribute to specify the remaining level of an internal battery, scaled from <var>0</var>to <var>1</var>:
             </div>
 <div class="description">
             <ul>
               <li>
-<var>0 </var>indicates that the battery level is the lowest and the system is about to enter shutdown mode.              </li>
+<var>0</var>indicates that the battery level is the lowest and the system is about to enter shutdown mode.              </li>
               <li>
-<var>1 </var>indicates that the system's charge is maximum.              </li>
+<var>1</var>indicates that the system's charge is maximum.              </li>
             </ul>
             <p>
 Any threshold parameter used in a watch operation to monitor this property applies to this attribute.
@@ -1398,7 +1398,7 @@ This process may take up to few days.
 <ul><li class="attribute" id="SystemInfoCpu::load">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">load</span></span><div class="brief">
-  An attribute to indicate the current CPU load, as a number between <var>0.0 </var>and <var>1.0</var>, representing the minimum and maximum values allowed on this system.
+ An attribute to indicate the current CPU load, as a number between <var>0.0</var>and <var>1.0</var>, representing the minimum and maximum values allowed on this system.
             </div>
 <div class="description">
             <p>
@@ -1468,7 +1468,7 @@ The supported storage unit types are:
               <li>
 UNKNOWN              </li>
               <li>
-INTERNAL               </li>
+INTERNAL              </li>
               <li>
 USB_DEVICE              </li>
               <li>
@@ -1611,7 +1611,7 @@ Change listener registered on <var>DISPLAY</var> property is triggered on
 <li class="attribute" id="SystemInfoDisplay::brightness">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">brightness</span></span><div class="brief">
- The current brightness of a display ranging between <var>0 </var>to <var>1</var>.
+ The current brightness of a display ranging between <var>0</var>to <var>1</var>.
             </div>
 <p><span class="version">Since: </span>
  1.0

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/systeminfo.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/systeminfo.html
@@ -1312,14 +1312,14 @@ Change listener registered on <var>BATTERY</var> property is triggered on
 <li class="attribute" id="SystemInfoBattery::level">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">level</span></span><div class="brief">
- An attribute to specify the remaining level of an internal battery, scaled from <var>0</var>to <var>1</var>:
+ An attribute to specify the remaining level of an internal battery, scaled from <var>0</var> to <var>1</var>:
             </div>
 <div class="description">
             <ul>
               <li>
-<var>0</var>indicates that the battery level is the lowest and the system is about to enter shutdown mode.              </li>
+<var>0</var> indicates that the battery level is the lowest and the system is about to enter shutdown mode.              </li>
               <li>
-<var>1</var>indicates that the system's charge is maximum.              </li>
+<var>1</var> indicates that the system's charge is maximum.              </li>
             </ul>
             <p>
 Any threshold parameter used in a watch operation to monitor this property applies to this attribute.
@@ -1398,7 +1398,7 @@ This process may take up to few days.
 <ul><li class="attribute" id="SystemInfoCpu::load">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">load</span></span><div class="brief">
- An attribute to indicate the current CPU load, as a number between <var>0.0</var>and <var>1.0</var>, representing the minimum and maximum values allowed on this system.
+ An attribute to indicate the current CPU load, as a number between <var>0.0</var> and <var>1.0</var>, representing the minimum and maximum values allowed on this system.
             </div>
 <div class="description">
             <p>
@@ -1611,7 +1611,7 @@ Change listener registered on <var>DISPLAY</var> property is triggered on
 <li class="attribute" id="SystemInfoDisplay::brightness">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">brightness</span></span><div class="brief">
- The current brightness of a display ranging between <var>0</var>to <var>1</var>.
+ The current brightness of a display ranging between <var>0</var> to <var>1</var>.
             </div>
 <p><span class="version">Since: </span>
  1.0

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/systemsetting.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/systemsetting.html
@@ -19,13 +19,13 @@ This API provides an interface and methods through features such as:
         </p>
         <ul>
           <li>
- HOME_SCREEN          </li>
+HOME_SCREEN          </li>
           <li>
- LOCK_SCREEN          </li>
+LOCK_SCREEN          </li>
           <li>
- INCOMING_CALL          </li>
+INCOMING_CALL          </li>
           <li>
- NOTIFICATION_EMAIL          </li>
+NOTIFICATION_EMAIL          </li>
         </ul>
         <p>
 System Setting API may not be provided in some devices.
@@ -36,13 +36,13 @@ In addition, not all the above properties may be available even though a device 
         </p>
         <ul>
           <li>
- HOME_SCREEN        - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/systemsetting.home_screen"</em>)          </li>
+HOME_SCREEN        - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/systemsetting.home_screen"</em>)          </li>
           <li>
- LOCK_SCREEN        - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/systemsetting.lock_screen"</em>)          </li>
+LOCK_SCREEN        - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/systemsetting.lock_screen"</em>)          </li>
           <li>
- INCOMING_CALL      - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/systemsetting.incoming_call"</em>)          </li>
+INCOMING_CALL      - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/systemsetting.incoming_call"</em>)          </li>
           <li>
- NOTIFICATION_EMAIL - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/systemsetting.notification_email"</em>)          </li>
+NOTIFICATION_EMAIL - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/systemsetting.notification_email"</em>)          </li>
         </ul>
         <p>
 <b id="StorageRemark">Remark:</b> In order to access files, a proper privilege has to be defined additionally:
@@ -145,7 +145,7 @@ The INCOMING_CALL and NOTIFICATION_EMAIL are supported for sound files.
 <div class="interface" id="SystemSettingObject">
 <a class="backward-compatibility-anchor" name="::SystemSetting::SystemSettingObject"></a><h3>2.1. SystemSettingObject</h3>
 <div class="brief">
- The SystemSettingObject interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
+ The SystemSettingObject interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface SystemSettingObject {
     readonly attribute <a href="#SystemSettingManager">SystemSettingManager</a> systemsetting;
@@ -156,7 +156,7 @@ The INCOMING_CALL and NOTIFICATION_EMAIL are supported for sound files.
           </p>
 <div class="description">
           <p>
-There will be a <em>tizen.systemsetting </em>object that allows accessing the functionality of the System Setting API.
+There will be a <em>tizen.systemsetting</em> object that allows accessing the functionality of the System Setting API.
           </p>
          </div>
 <div class="attributes">
@@ -212,7 +212,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
               <li>
 InvalidValuesError - If any of the input parameters contain an invalid value              </li>
               <li>
-NotSupportedError - If the given <var>type</var> is not supported on the device               </li>
+NotSupportedError - If the given <var>type</var> is not supported on the device              </li>
               <li>
 UnknownError - If any other error occurs              </li>
             </ul>
@@ -322,15 +322,15 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
-TypeMismatchError - If any input parameter is not compatible with the expected type for that parameter               </li>
+TypeMismatchError - If any input parameter is not compatible with the expected type for that parameter              </li>
               <li>
-InvalidValuesError - If any of the input parameters contain an invalid value               </li>
+InvalidValuesError - If any of the input parameters contain an invalid value              </li>
               <li>
-NotSupportedError - If the given <var>type</var> is not supported on the device               </li>
+NotSupportedError - If the given <var>type</var> is not supported on the device              </li>
               <li>
 SecurityError - If the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.              </li>
               <li>
-UnknownError - If any other error occurs               </li>
+UnknownError - If any other error occurs              </li>
             </ul>
            </div>
 <div class="parameters">

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/time.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/time.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="mobile-mandatory emulator" title="Mandatory, Supported by Tizen Mobile emulator" src="mobile_s_w.png"></div>
 <div class="title"><h1>Time API</h1></div>
 <div class="brief">
-  The Time API provides information regarding date/time and time zones.
+ The Time API provides information regarding date/time and time zones.
         </div>
 <div class="description">
         <p>
@@ -182,11 +182,11 @@ At least the following values must be supported:
             <li>
 MSECS - Indicates a duration in milliseconds            </li>
             <li>
-SECS - Indicates a duration in seconds             </li>
+SECS - Indicates a duration in seconds            </li>
             <li>
-MINS - Indicates a duration in minutes             </li>
+MINS - Indicates a duration in minutes            </li>
             <li>
-HOURS - Indicates a duration in hours             </li>
+HOURS - Indicates a duration in hours            </li>
             <li>
 DAYS - Indicates a duration in days            </li>
           </ul>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/tizen.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/tizen.html
@@ -292,7 +292,7 @@ BYTES_ARRAY - array of <a href="#ByteStream">ByteStream</a>            </li>
           </p>
 <div class="description">
           <p>
-The <em>Tizen</em> interface is always available within the <em>Window </em>object in the ECMAScript hierarchy.
+The <em>Tizen</em> interface is always available within the <em>Window</em> object in the ECMAScript hierarchy.
           </p>
          </div>
 <div class="attributes">

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/voicecontrol.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/voicecontrol.html
@@ -113,9 +113,9 @@ The result events defined by this enumeration are:
           </p>
           <ul>
             <li>
- SUCCESS - Successful result            </li>
+SUCCESS - Successful result            </li>
             <li>
- FAILURE - Rejected result by voice control service            </li>
+FAILURE - Rejected result by voice control service            </li>
           </ul>
          </div>
 </div>
@@ -134,7 +134,7 @@ The command type defined by this enumeration is:
           </p>
           <ul>
             <li>
- FOREGROUND - command type used when application is foreground            </li>
+FOREGROUND - command type used when application is foreground            </li>
           </ul>
          </div>
 </div>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/websetting.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/websetting.html
@@ -19,9 +19,9 @@ A Tizen Web application includes a web view and the properties below of the web 
         </p>
         <ul>
           <li>
- Delete all the cookies saved for the web view in the Web application.           </li>
+Delete all the cookies saved for the web view in the Web application.          </li>
           <li>
- Set a custom user agent string of the web view in the Web application.          </li>
+Set a custom user agent string of the web view in the Web application.          </li>
         </ul>
         <p>
 Note that all the settings using the Web Setting API is bound to your application; thus, no other applications are affected via the Web Setting API calls within your application.

--- a/docs/application/web/api/6.0/device_api/tv/tizen/account.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/account.html
@@ -34,8 +34,8 @@ gmail, gtalk, Picasa, and Youtube with each service having a separate service
 instance bound to the account.          </li>
         </ul>
         <p>
-To use <em>add(), remove(), and update()</em> methods of AccountManager can be invoked only
-by account provider application. A web application is an account provider when its <em>config.xml</em>contains <a href="/application/tizen-studio/web-tools/config-editor#mw_account">Account provider section</a>. For example:<br>&lt;tizen:account multiple-account-support="true"&gt;<br>      &lt;tizen:icon section="Account"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:icon section="AccountSmall"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:display-name xml:lang="en-gb"&gt;Test&lt;/tizen:display-name&gt;<br>      &lt;tizen:capability&gt;http://tizen.org/account/capability/contact&lt;/tizen:capability&gt;<br>&lt;/tizen:account&gt;
+To use <em>add(), remove(), and update()</em> methods of AccountManager can be invoked only by account provider application.
+A web application is an account provider when its <em>config.xml</em> contains <a href="/application/tizen-studio/web-tools/config-editor#mw_account">Account provider section</a>. For example:<br>&lt;tizen:account multiple-account-support="true"&gt;<br>      &lt;tizen:icon section="Account"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:icon section="AccountSmall"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:display-name xml:lang="en-gb"&gt;Test&lt;/tizen:display-name&gt;<br>      &lt;tizen:capability&gt;http://tizen.org/account/capability/contact&lt;/tizen:capability&gt;<br>&lt;/tizen:account&gt;
         </p>
         <p>
 For more information about how to use Account API, see <a href="/application/web/guides/personal/account">Account Guide</a>.

--- a/docs/application/web/api/6.0/device_api/tv/tizen/account.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/account.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="tv-optional emulator" title="Optional, Supported by Tizen Tv emulator" src="tv_s_w_optional.png"></div>
 <div class="title"><h1>Account API</h1></div>
 <div class="brief">
-  The Account API provides functionality for using existing configured
+ The Account API provides functionality for using existing configured
 online accounts and providers, and for creating accounts of known types.
         </div>
 <div class="description">
@@ -35,7 +35,7 @@ instance bound to the account.          </li>
         </ul>
         <p>
 To use <em>add(), remove(), and update()</em> methods of AccountManager can be invoked only
-by account provider application. A web application is an account provider when its <em>config.xml </em>contains <a href="/application/tizen-studio/web-tools/config-editor#mw_account">Account provider section</a>. For example:<br>&lt;tizen:account multiple-account-support="true"&gt;<br>      &lt;tizen:icon section="Account"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:icon section="AccountSmall"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:display-name xml:lang="en-gb"&gt;Test&lt;/tizen:display-name&gt;<br>      &lt;tizen:capability&gt;http://tizen.org/account/capability/contact&lt;/tizen:capability&gt;<br>&lt;/tizen:account&gt;
+by account provider application. A web application is an account provider when its <em>config.xml</em>contains <a href="/application/tizen-studio/web-tools/config-editor#mw_account">Account provider section</a>. For example:<br>&lt;tizen:account multiple-account-support="true"&gt;<br>      &lt;tizen:icon section="Account"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:icon section="AccountSmall"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:display-name xml:lang="en-gb"&gt;Test&lt;/tizen:display-name&gt;<br>      &lt;tizen:capability&gt;http://tizen.org/account/capability/contact&lt;/tizen:capability&gt;<br>&lt;/tizen:account&gt;
         </p>
         <p>
 For more information about how to use Account API, see <a href="/application/web/guides/personal/account">Account Guide</a>.

--- a/docs/application/web/api/6.0/device_api/tv/tizen/alarm.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/alarm.html
@@ -271,7 +271,7 @@ For more information about the application control, see <a href="application.htm
 <ul>
           <li class="param">
 <span class="name">alarm</span>:
- An alarm to add. It can be either <em>AlarmRelative</em>  or <em>AlarmAbsolute</em>.
+ An alarm to add. It can be either <em>AlarmRelative</em> or <em>AlarmAbsolute</em>.
                 </li>
           <li class="param">
 <span class="name">applicationId</span>:

--- a/docs/application/web/api/6.0/device_api/tv/tizen/alarm.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/alarm.html
@@ -152,8 +152,8 @@ For more information on the Alarm features, see <a href="/application/web/guides
 <div class="interface" id="AlarmManagerObject">
 <a class="backward-compatibility-anchor" name="::Alarm::AlarmManagerObject"></a><h3>2.1. AlarmManagerObject</h3>
 <div class="brief">
- The AlarmManagerObject interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
-The <em>tizen.alarm </em>object allows access to the functionality of the Alarm API.
+ The AlarmManagerObject interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
+The <em>tizen.alarm</em> object allows access to the functionality of the Alarm API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface AlarmManagerObject {
     readonly attribute <a href="#AlarmManager">AlarmManager</a> alarm;
@@ -271,7 +271,7 @@ For more information about the application control, see <a href="application.htm
 <ul>
           <li class="param">
 <span class="name">alarm</span>:
- An alarm to add. It can be either <em>AlarmRelative </em> or <em>AlarmAbsolute</em>.
+ An alarm to add. It can be either <em>AlarmRelative</em>  or <em>AlarmAbsolute</em>.
                 </li>
           <li class="param">
 <span class="name">applicationId</span>:

--- a/docs/application/web/api/6.0/device_api/tv/tizen/application.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/application.html
@@ -331,7 +331,7 @@ FREQUENTLY - Indicates most frequently used applications, in a descending order 
 <div class="interface" id="ApplicationManagerObject">
 <a class="backward-compatibility-anchor" name="::Application::ApplicationManagerObject"></a><h3>2.1. ApplicationManagerObject</h3>
 <div class="brief">
- This interface defines what is instantiated by the <em>Tizen </em>object on the Tizen Platform.
+ This interface defines what is instantiated by the <em>Tizen</em> object on the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface ApplicationManagerObject {
     readonly attribute <a href="#ApplicationManager">ApplicationManager</a> application;
@@ -342,7 +342,7 @@ FREQUENTLY - Indicates most frequently used applications, in a descending order 
           </p>
 <div class="description">
           <p>
-The <em>tizen.application </em>object allows access to the Application API's functionality.
+The <em>tizen.application</em> object allows access to the Application API's functionality.
           </p>
          </div>
 <div class="attributes">
@@ -397,7 +397,7 @@ The <em>tizen.application </em>object allows access to the Application API's fun
 </dt>
 <dd>
 <div class="brief">
- Gets the <em>Application </em>object defining the current application.
+ Gets the <em>Application</em> object defining the current application.
             </div>
 <div class="synopsis"><pre class="signature prettyprint"><a href="#Application">Application</a> getCurrentApplication();</pre></div>
 <p><span class="version">Since: </span>
@@ -610,10 +610,10 @@ to perform the requested application control, then launches the selected applica
             </p>
             <p>
 The application control request is passed to the newly launched application
-and it can be accessed by the <em>getRequestedAppControl() </em>method. The passed
+and it can be accessed by the <em>getRequestedAppControl()</em> method. The passed
 application control contains the reason the application has been launched and
 information about what the application is doing. The launched application
-can send a result to the caller application with the <em>replyResult() </em>method of the
+can send a result to the caller application with the <em>replyResult()</em> method of the
 <em>RequestedApplicationControl</em> interface.
             </p>
             <p>
@@ -650,7 +650,7 @@ Also, implicit launch requests are NOT delivered to service applications since 2
                 </li>
           <li class="param">
 <span class="name">id</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
- An identifier of the application to be launched. If the ID is <var>null </var>or not specified, then the system tries to find the application to be launched for the requested application control.
+ An identifier of the application to be launched. If the ID is <var>null</var> or not specified, then the system tries to find the application to be launched for the requested application control.
                 </li>
           <li class="param">
 <span class="name">successCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
@@ -870,7 +870,7 @@ tizen.application.getAppsContext(onRunningAppsContext);
 <dd>
 <div class="brief">
  Gets the application context for the specified application context ID.
-If the ID is set to<var> null</var> or is not set at all, the method returns the application context of the current application.
+If the ID is set to <var>null</var> or is not set at all, the method returns the application context of the current application.
 The list of running applications and their application IDs is obtained with <em>getAppsContext()</em>.
             </div>
 <div class="synopsis"><pre class="signature prettyprint"><a href="#ApplicationContext">ApplicationContext</a> getAppContext(optional <a href="#ApplicationContextId">ApplicationContextId</a>? contextId);</pre></div>
@@ -1036,23 +1036,23 @@ The certificate types are listed below:
             </p>
             <ul>
               <li>
- AUTHOR_ROOT - Author Root Certificate               </li>
+AUTHOR_ROOT - Author Root Certificate              </li>
               <li>
- AUTHOR_INTERMEDIATE - Author Intermediate Certificate               </li>
+AUTHOR_INTERMEDIATE - Author Intermediate Certificate              </li>
               <li>
- AUTHOR_SIGNER - Author Signer Certificate               </li>
+AUTHOR_SIGNER - Author Signer Certificate              </li>
               <li>
- DISTRIBUTOR_ROOT - Distributor Root Certificate               </li>
+DISTRIBUTOR_ROOT - Distributor Root Certificate              </li>
               <li>
- DISTRIBUTOR_INTERMEDIATE - Distributor Intermediate Certificate               </li>
+DISTRIBUTOR_INTERMEDIATE - Distributor Intermediate Certificate              </li>
               <li>
- DISTRIBUTOR_SIGNER - Distributor Signer Certificate               </li>
+DISTRIBUTOR_SIGNER - Distributor Signer Certificate              </li>
               <li>
- DISTRIBUTOR2_ROOT - Distributor2 Root Certificate               </li>
+DISTRIBUTOR2_ROOT - Distributor2 Root Certificate              </li>
               <li>
- DISTRIBUTOR2_INTERMEDIATE - Distributor2 Intermediate Certificate               </li>
+DISTRIBUTOR2_INTERMEDIATE - Distributor2 Intermediate Certificate              </li>
               <li>
- DISTRIBUTOR2_SIGNER - Distributor2 Signer Certificate               </li>
+DISTRIBUTOR2_SIGNER - Distributor2 Signer Certificate              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1366,7 +1366,7 @@ The maximum retention period is 90 days.
 <dd>
 <div class="brief">
  The attribute to store period of time, from which data is accumulated, in days.
-The  period of time begins <em>timeSpan</em> days ago and ends with current date.
+The period of time begins <em>timeSpan</em> days ago and ends with current date.
             </div>
 <div class="description">
             <p>
@@ -2069,7 +2069,7 @@ The attribute value scales from <var>0</var> to <var>1</var>, the higher value, 
 <a class="backward-compatibility-anchor" name="::Application::ApplicationControlData"></a><h3>2.9. ApplicationControlData</h3>
 <div class="brief">
  This interface defines a key/value pair used to pass data
-between applications through the <em>ApplicationControl </em>interface.
+between applications through the <em>ApplicationControl</em> interface.
           </div>
 <pre class="webidl prettyprint">  [Constructor(DOMString key, DOMString[] value)]
   interface ApplicationControlData {
@@ -2434,7 +2434,7 @@ if (reqAppControl)
 <div class="description">
           <p>
 This callback interface specifies a success method with an array of
-<em>ApplicationInformation </em>objects as an input parameter. It is used in <em>ApplicationManager.getAppsInfo()</em>.
+<em>ApplicationInformation</em> objects as an input parameter. It is used in <em>ApplicationManager.getAppsInfo()</em>.
           </p>
          </div>
 <div class="methods">
@@ -2490,7 +2490,7 @@ tizen.application.getAppsInfo(onListInstalledApps);
 <div class="description">
           <p>
 This callback interface specifies a success method with an array of
-<em>ApplicationInformation </em>objects and application control as an input parameter.
+<em>ApplicationInformation</em> objects and application control as an input parameter.
 It is used in <em>ApplicationManager.findAppControl()</em>.
           </p>
          </div>
@@ -2583,7 +2583,7 @@ tizen.application.findAppControl(appControl, successCB);
 <div class="description">
           <p>
 This callback interface specifies a success method with
-an array of <em>ApplicationContext </em>objects as an input parameter. It is used in <em>ApplicationManager.getAppsContext()</em>.
+an array of <em>ApplicationContext</em> objects as an input parameter. It is used in <em>ApplicationManager.getAppsContext()</em>.
           </p>
          </div>
 <div class="methods">
@@ -2594,7 +2594,7 @@ an array of <em>ApplicationContext </em>objects as an input parameter. It is use
 </dt>
 <dd>
 <div class="brief">
- Called when <em>ApplicationManager.getAppsContext() </em>completes successfully.
+ Called when <em>ApplicationManager.getAppsContext()</em> completes successfully.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void onsuccess(<a href="#ApplicationContext">ApplicationContext</a>[] contexts);</pre></div>
 <p><span class="version">Since: </span>
@@ -2631,9 +2631,9 @@ This callback interface specifies two methods:
           </p>
           <ul>
             <li>
- <em>onsuccess()</em> - Invoked if the callee application calls <em>RequestedApplicationControl.replyResult()</em>.            </li>
+<em>onsuccess()</em> - Invoked if the callee application calls <em>RequestedApplicationControl.replyResult()</em>.            </li>
             <li>
- <em>onfailure()</em> - Invoked if the callee application calls <em>RequestedApplicationControl.replyFailure()</em>.            </li>
+<em>onfailure()</em> - Invoked if the callee application calls <em>RequestedApplicationControl.replyFailure()</em>.            </li>
           </ul>
          </div>
 <div class="example">

--- a/docs/application/web/api/6.0/device_api/tv/tizen/archive.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/archive.html
@@ -391,7 +391,7 @@ Description                </th>
                 <td>
 r                </td>
                 <td>
-Use this mode for extracting or getting information about the contents of an archive file. <br><em>file</em> must exist. If the <em>file</em> does not exist, <em>onerror</em> will be invoked (<em>NotFoundError</em>).<br>When an archive file is opened in this mode, <em>add()</em> will not be available. (<em>IOError</em> will be thrown.)                 </td>
+Use this mode for extracting or getting information about the contents of an archive file. <br><em>file</em> must exist. If the <em>file</em> does not exist, <em>onerror</em> will be invoked (<em>NotFoundError</em>).<br>When an archive file is opened in this mode, <em>add()</em> will not be available. (<em>IOError</em> will be thrown.)                </td>
               </tr>
               <tr>
                 <td>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/content.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/content.html
@@ -363,7 +363,7 @@ ROTATE_270 - corresponds to rotate 270 degrees image content orientation.       
           </p>
 <div class="description">
           <p>
-The <em>tizen.content </em>object allows accessing the functionality of the Content module.
+The <em>tizen.content</em> object allows accessing the functionality of the Content module.
           </p>
          </div>
 <div class="attributes">
@@ -1541,7 +1541,7 @@ tizen.content.find(findCB);
 <ul>
           <li class="param">
 <span class="name">contents</span>:
- The array of <em>Content </em>objects.
+ The array of <em>Content</em> objects.
                 </li>
         </ul>
 </div>
@@ -1579,7 +1579,7 @@ tizen.content.find(findCB);
 <ul>
           <li class="param">
 <span class="name">directories</span>:
- The array of <em>ContentDirectory </em>objects.
+ The array of <em>ContentDirectory</em> objects.
                 </li>
         </ul>
 </div>
@@ -2008,7 +2008,7 @@ The attribute is marked as read-only since Tizen 5.5.
 </li>
 <li class="attribute" id="Content::isFavorite">
 <span class="attrName"><span class="type">boolean </span><span class="name">isFavorite</span></span><div class="brief">
-  Boolean value that indicates whether a content item is marked as a favorite.
+ Boolean value that indicates whether a content item is marked as a favorite.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2020,7 +2020,7 @@ The attribute is marked as read-only since Tizen 5.5.
 <div class="interface" id="VideoContent">
 <a class="backward-compatibility-anchor" name="::Content::VideoContent"></a><h3>2.9. VideoContent</h3>
 <div class="brief">
- The VideoContent interface extends a basic <em>Content </em>object with video-specific attributes.
+ The VideoContent interface extends a basic <em>Content</em> object with video-specific attributes.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface VideoContent : <a href="#Content">Content</a> {
     readonly attribute <a href="tizen.html#SimpleCoordinates">SimpleCoordinates</a>? geolocation;
@@ -2161,7 +2161,7 @@ If the lyrics are not synchronized, the array has only one member with full lyri
 <div class="interface" id="AudioContent">
 <a class="backward-compatibility-anchor" name="::Content::AudioContent"></a><h3>2.11. AudioContent</h3>
 <div class="brief">
- The AudioContent interface extends a basic <em>Content </em>object with audio-specific attributes.
+ The AudioContent interface extends a basic <em>Content</em> object with audio-specific attributes.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface AudioContent : <a href="#Content">Content</a> {
     readonly attribute DOMString? album;
@@ -2278,7 +2278,7 @@ If the lyrics are not synchronized, the array has only one member with full lyri
 <div class="interface" id="ImageContent">
 <a class="backward-compatibility-anchor" name="::Content::ImageContent"></a><h3>2.12. ImageContent</h3>
 <div class="brief">
- The ImageContent interface extends a basic <em>Content </em>object with image-specific attributes.
+ The ImageContent interface extends a basic <em>Content</em> object with image-specific attributes.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface ImageContent : <a href="#Content">Content</a> {
     readonly attribute <a href="tizen.html#SimpleCoordinates">SimpleCoordinates</a>? geolocation;

--- a/docs/application/web/api/6.0/device_api/tv/tizen/cordova/device-motion.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/cordova/device-motion.html
@@ -89,7 +89,7 @@ Original documentation: <a href="https://cordova.apache.org/docs/en/3.0.0/cordov
 <div class="interface" id="AccelerometerManagerObject">
 <a class="backward-compatibility-anchor" name="::DeviceMotion::AccelerometerManagerObject"></a><h3>1.1. AccelerometerManagerObject</h3>
 <div class="brief">
- The <em>navigator.accelerometer </em>object allows access to the functionality of the DeviceMotion API.
+ The <em>navigator.accelerometer</em> object allows access to the functionality of the DeviceMotion API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface AccelerometerManagerObject {
     readonly attribute <a href="#Accelerometer">Accelerometer</a> accelerometer;

--- a/docs/application/web/api/6.0/device_api/tv/tizen/cordova/device.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/cordova/device.html
@@ -60,7 +60,7 @@ Original documentation: <a href="https://cordova.apache.org/docs/en/3.0.0/cordov
 <div class="interface" id="DeviceManagerObject">
 <a class="backward-compatibility-anchor" name="::Device::DeviceManagerObject"></a><h3>1.1. DeviceManagerObject</h3>
 <div class="brief">
- The <em>window.device </em>object allows access to the functionality of the Device API.
+ The <em>window.device</em> object allows access to the functionality of the Device API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface DeviceManagerObject {
     readonly attribute <a href="#Device">Device</a> device;

--- a/docs/application/web/api/6.0/device_api/tv/tizen/cordova/file.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/cordova/file.html
@@ -345,7 +345,7 @@ See <a href="https://www.w3.org/TR/FileAPI/#blob-section">The Blob Interface and
     readonly attribute boolean lengthComputable;
     readonly attribute unsigned long long loaded;
     readonly attribute unsigned long long total;
-    readonly attribute  target;
+    readonly attribute EventTarget target;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -510,7 +510,7 @@ var event = new ProgressEvent("submit", eventInit);
           </p>
 <div class="description">
           <p>
-There is a <em>cordova.file </em>object that allows accessing the functionality of the Filesystem API.
+There is a <em>cordova.file</em> object that allows accessing the functionality of the Filesystem API.
           </p>
          </div>
 </div>
@@ -733,7 +733,7 @@ This manager interface exposes the Filesystem base API constants.
 <li class="attribute" id="FileSystemManager::tempDirectory">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">DOMString </span><span class="name">tempDirectory</span><span class="optional"> [nullable]</span></span><div class="brief">
-  Temp directory that the OS can clear at will. Do not rely on the OS to clear this directory; your app should always remove files as applicable.
+ Temp directory that the OS can clear at will. Do not rely on the OS to clear this directory; your app should always remove files as applicable.
             </div>
 <p><span class="version">Since: </span>
  3.0
@@ -3497,7 +3497,7 @@ entry.createWriter(successCallback, errorCallback);
     readonly attribute boolean lengthComputable;
     readonly attribute unsigned long long loaded;
     readonly attribute unsigned long long total;
-    readonly attribute  target;
+    readonly attribute EventTarget target;
   };
   [NoInterfaceObject] interface FileSystemManagerObject {
     readonly attribute <a href="#FileSystemManager">FileSystemManager</a> file;

--- a/docs/application/web/api/6.0/device_api/tv/tizen/datacontrol.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/datacontrol.html
@@ -220,7 +220,7 @@ Data Control API.
 <div class="interface" id="DataControlManager">
 <a class="backward-compatibility-anchor" name="::DataControl::DataControlManager"></a><h3>2.2. DataControlManager</h3>
 <div class="brief">
- This interface provides access to the <em>DataControlManager </em>object.
+ This interface provides access to the <em>DataControlManager</em> object.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface DataControlManager {
     <a href="#DataControlConsumerObject">DataControlConsumerObject</a> getDataControlConsumer(DOMString providerId, DOMString dataId, <a href="#DataType">DataType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -628,7 +628,7 @@ removeChangeListener was invoked
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">insertionData</span>:
@@ -713,7 +713,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">updateData</span>:
@@ -802,7 +802,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">where</span>:
@@ -892,7 +892,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">columns</span>:
@@ -1037,7 +1037,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">key</span>:
@@ -1124,7 +1124,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation. <br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation. <br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">key</span>:
@@ -1214,7 +1214,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">key</span>:
@@ -1300,7 +1300,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">key</span>:

--- a/docs/application/web/api/6.0/device_api/tv/tizen/download.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/download.html
@@ -183,8 +183,8 @@ ALL - Indicates that the download operation is allowed in all network types.    
 <div class="interface" id="DownloadManagerObject">
 <a class="backward-compatibility-anchor" name="::Download::DownloadManagerObject"></a><h3>2.1. DownloadManagerObject</h3>
 <div class="brief">
- This interface defines the default download manager that is instantiated by the <em>Tizen </em>object.
-The <em>tizen.download </em>object allows access to the functionality of the Download API.
+ This interface defines the default download manager that is instantiated by the <em>Tizen</em> object.
+The <em>tizen.download</em> object allows access to the functionality of the Download API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface DownloadManagerObject {
     readonly attribute <a href="#DownloadManager">DownloadManager</a> download;
@@ -898,7 +898,7 @@ tizen.download.setListener(downloadId, listener);
 <dd>
 <div class="brief">
  Called when a download is successful and it is called multiple times as the download progresses.
-The interval between the <em>onprogress()</em> callback is platform-dependent. When the download is started, the <em>receivedSize </em>can be <var>0</var>.
+The interval between the <em>onprogress()</em> callback is platform-dependent. When the download is started, the <em>receivedSize</em> can be <var>0</var>.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void onprogress(long downloadId, unsigned long long receivedSize, unsigned long long totalSize);</pre></div>
 <p><span class="version">Since: </span>
@@ -927,7 +927,7 @@ The interval between the <em>onprogress()</em> callback is platform-dependent. W
 </dt>
 <dd>
 <div class="brief">
- Called when the download operation is paused by the <em>pause() </em>method.
+ Called when the download operation is paused by the <em>pause()</em> method.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void onpaused(long downloadId);</pre></div>
 <p><span class="version">Since: </span>
@@ -948,7 +948,7 @@ The interval between the <em>onprogress()</em> callback is platform-dependent. W
 </dt>
 <dd>
 <div class="brief">
- Called when the download operation is canceled by the <em>cancel() </em>method.
+ Called when the download operation is canceled by the <em>cancel()</em> method.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void oncanceled(long downloadId);</pre></div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/filesystem.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/filesystem.html
@@ -40,13 +40,13 @@ music - the location for sounds          </li>
           <li>
 documents - the location for documents          </li>
           <li>
-downloads - the location for downloaded items           </li>
+downloads - the location for downloaded items          </li>
           <li>
-camera - the location for the pictures and videos taken by a device (supported since Tizen 2.3)           </li>
+camera - the location for the pictures and videos taken by a device (supported since Tizen 2.3)          </li>
           <li>
 wgt-package - the location for widget package which is read-only          </li>
           <li>
-wgt-private - the location for a widget's private storage           </li>
+wgt-private - the location for a widget's private storage          </li>
           <li>
 wgt-private-tmp - the location for a widget's private volatile storage          </li>
           <li>
@@ -413,7 +413,7 @@ END - End of the file.            </li>
           </p>
 <div class="description">
           <p>
-There is a <em>tizen.filesystem </em>object that allows accessing the functionality of the Filesystem API.
+There is a <em>tizen.filesystem</em> object that allows accessing the functionality of the Filesystem API.
           </p>
          </div>
 <div class="attributes">
@@ -1904,7 +1904,7 @@ Strips trailing '/', then breaks <em>path</em> into two components by last <em>p
             </p>
 <div class="description">
             <p>
-The <em>onsuccess </em>method receives the data structure as an input argument containing additional information about the drive.
+The <em>onsuccess</em> method receives the data structure as an input argument containing additional information about the drive.
             </p>
             <p>
 The ErrorCallback is launched with these error types:
@@ -1915,7 +1915,7 @@ InvalidValuesError - If any of the input parameters contains an invalid value.  
               <li>
 NotFoundError - If no drive was found with the given label.              </li>
               <li>
-UnknownError - If any other error occurs.               </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2131,7 +2131,7 @@ watchID = tizen.filesystem.addStorageStateChangeListener(onStorageStateChanged);
             </p>
 <div class="description">
             <p>
-If the <em>watchId </em>argument is valid and corresponds to a subscription already in place, the watch process will be stopped and no further callbacks will be invoked.
+If the <em>watchId</em> argument is valid and corresponds to a subscription already in place, the watch process will be stopped and no further callbacks will be invoked.
 Otherwise, the method call has no effect.
             </p>
            </div>
@@ -2396,7 +2396,7 @@ The <em>ErrorCallback</em> is launched with these error types:
             </p>
             <ul>
               <li>
-IOError, if any error related to file handle occurs.               </li>
+IOError, if any error related to file handle occurs.              </li>
             </ul>
             <p>
 Note, that current position indicator value, can be obtained in SeekSuccessCallback by calling <var>seekNonBlocking(0, "CURRENT")</var>.
@@ -2761,7 +2761,7 @@ Sets file handle position indicator at the end of written data.
                 </li>
           <li class="param">
 <span class="name">outputEncoding</span><span class="optional"> [optional]</span>:
-  Default value: UTF-8. Encoding to use for write operation on the file, at least the following encodings must be supported:<br>"<a href="http://www.ietf.org/rfc/rfc2279.txt">UTF-8</a>" default encoding<br>"<a href="http://en.wikipedia.org/wiki/ISO/IEC_8859-1">ISO-8859-1</a>" Latin-1 encoding<br>                </li>
+ Default value: UTF-8. Encoding to use for write operation on the file, at least the following encodings must be supported:<br>"<a href="http://www.ietf.org/rfc/rfc2279.txt">UTF-8</a>" default encoding<br>"<a href="http://en.wikipedia.org/wiki/ISO/IEC_8859-1">ISO-8859-1</a>" Latin-1 encoding<br>                </li>
         </ul>
 </div>
 <div class="returntype">
@@ -4151,12 +4151,12 @@ A file item only matches the <em>FileFilter</em> object if all of the defined fi
 (only matching values other than <var>undefined</var> or <var>null</var>). This is similar to a SQL's "AND" operation.
           </p>
           <p>
-An attribute of the file entry matches the <em>FileFilter </em>attribute value in accordance with the
+An attribute of the file entry matches the <em>FileFilter</em> attribute value in accordance with the
 following rules:
           </p>
           <ul>
             <li>
-For <em>FileFilter </em>attributes of type DOMString, an entry matches this value only if its corresponding attribute is an exact match. If the filter contains U+0025 "PERCENT SIGN" it is interpreted as a wildcard character and "%" matches any string of any length, including no length. If wildcards are used, the behavior is similar to the LIKE condition in SQL. To specify that a "PERCENT SIGN" character is to be considered literally instead of interpreting it as a wildcard, developers can escape it with the backslash character (\). Please, remember that the backslash character has to be escaped itself, to not to be removed from the string - proper escaping of the "PERCENT SIGN" in JavaScript string requires preceding it with double backslash ("\\%").
+For <em>FileFilter</em> attributes of type DOMString, an entry matches this value only if its corresponding attribute is an exact match. If the filter contains U+0025 "PERCENT SIGN" it is interpreted as a wildcard character and "%" matches any string of any length, including no length. If wildcards are used, the behavior is similar to the LIKE condition in SQL. To specify that a "PERCENT SIGN" character is to be considered literally instead of interpreting it as a wildcard, developers can escape it with the backslash character (\). Please, remember that the backslash character has to be escaped itself, to not to be removed from the string - proper escaping of the "PERCENT SIGN" in JavaScript string requires preceding it with double backslash ("\\%").
 The matching is not case sensitive, such as "FOO" matches a "foo" or an "f%" filter.            </li>
             <li>
 For File entry attributes of type Date, attributes start and end are included to allow filtering of File entries between two supplied dates. If either or both of these attributes are specified, the following rules apply:<br>A) If both start and end dates are specified (that is, other than <var>null</var>), a File entry matches the filter if its corresponding attribute is the same as either start or end or between the two supplied dates (that is, after start and before end).<br>B) If only the start attribute contains a value (other than <var>null</var>), a File entry matches the filter if its corresponding attribute is later than or equal to the start one.<br>C) If only the end date contains a value (other than <var>null</var>), a file matches the filter if its corresponding attribute is earlier than or equal to the end date.            </li>
@@ -4304,7 +4304,7 @@ It is used in asynchronous operations, such as FileSystemManager.listStorages().
 <div class="interface" id="FileSystemStorageSuccessCallback">
 <a class="backward-compatibility-anchor" name="::Filesystem::FileSystemStorageSuccessCallback"></a><h3>2.7. FileSystemStorageSuccessCallback</h3>
 <div class="brief">
- The FileSystemStorageSuccessCallback callback interface specifies a success callback with a <em>FileSystemStorage </em>object as input argument.
+ The FileSystemStorageSuccessCallback callback interface specifies a success callback with a <em>FileSystemStorage</em> object as input argument.
           </div>
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileSystemStorageSuccessCallback {
     void onsuccess(<a href="#FileSystemStorage">FileSystemStorage</a> storage);

--- a/docs/application/web/api/6.0/device_api/tv/tizen/iotcon.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/iotcon.html
@@ -315,7 +315,7 @@ The following values are supported:
           </p>
           <ul>
             <li>
-HIGH - for a high quality of service. acknowledgments are used to confirm delivery.             </li>
+HIGH - for a high quality of service. acknowledgments are used to confirm delivery.            </li>
             <li>
 LOW - for a low quality of service. packet delivery is best effort            </li>
           </ul>
@@ -413,7 +413,7 @@ The following values are supported:
           </p>
           <ul>
             <li>
-IP - Internet Protocol connectivity. IP includes all internet connectivity (UDP, TCP, IPV4, IPV6).             </li>
+IP - Internet Protocol connectivity. IP includes all internet connectivity (UDP, TCP, IPV4, IPV6).            </li>
             <li>
 PREFER_UDP - UDP is preferred            </li>
             <li>
@@ -490,7 +490,7 @@ The following values are supported:
           </p>
           <ul>
             <li>
-NO_TYPE - no action of observation             </li>
+NO_TYPE - no action of observation            </li>
             <li>
 REGISTER - action of registering observation            </li>
             <li>
@@ -690,7 +690,7 @@ catch (err)
 </dt>
 <dd>
 <div class="brief">
-  Returns the number of seconds set as the timeout threshold of asynchronous API.
+ Returns the number of seconds set as the timeout threshold of asynchronous API.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">long getTimeout();</pre></div>
 <p><span class="version">Since: </span>
@@ -900,9 +900,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  If any system error is invoked              </li>
+AbortError: If any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1172,9 +1172,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  If any system error is invoked              </li>
+AbortError: If any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1291,9 +1291,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  In any system error is invoked              </li>
+AbortError: In any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1856,7 +1856,7 @@ server.stopPresence();
 <li class="attribute" id="RemoteResource::isExplicitDiscoverable">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">boolean </span><span class="name">isExplicitDiscoverable</span></span><div class="brief">
- Indicates if the resource is  is allowed to be discovered only if discovery request contains an explicit query string or not
+ Indicates if the resource is allowed to be discovered only if discovery request contains an explicit query string or not
             </div>
 <p><span class="version">Since: </span>
  3.0
@@ -1931,9 +1931,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  In any system error is invoked              </li>
+AbortError: In any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2044,9 +2044,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  In any system error is invoked              </li>
+AbortError: In any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2163,9 +2163,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  In any system error is invoked              </li>
+AbortError: In any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2279,9 +2279,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  In any system error is invoked              </li>
+AbortError: In any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2962,7 +2962,7 @@ The default value is <var>false</var>            </p>
 <li class="attribute" id="Resource::isExplicitDiscoverable">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">boolean </span><span class="name">isExplicitDiscoverable</span></span><div class="brief">
- Indicates if the resource is  is allowed to be discovered only if discovery request contains an explicit query string or not
+ Indicates if the resource is allowed to be discovered only if discovery request contains an explicit query string or not
             </div>
 <p><span class="version">Since: </span>
  3.0
@@ -4512,7 +4512,7 @@ for <em>Client.findResource()</em>.
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#Client::addPresenceEventListener">addPresenceEventListener </a> code example.
+ Example of using can be find at <a href="iotcon.html#Client::addPresenceEventListener">addPresenceEventListener</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/keymanager.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/keymanager.html
@@ -98,13 +98,13 @@ For more information on the Key Manager features, see <a href="/application/web/
 <div class="description">
           <ul>
             <li>
- NONE - Clears or removes permissions             </li>
+NONE - Clears or removes permissions            </li>
             <li>
- READ - Permission to read data             </li>
+READ - Permission to read data            </li>
             <li>
- REMOVE - Permission to remove data             </li>
+REMOVE - Permission to remove data            </li>
             <li>
- READ_REMOVE - Permission to read and remove data             </li>
+READ_REMOVE - Permission to read and remove data            </li>
           </ul>
          </div>
 </div>
@@ -114,7 +114,7 @@ For more information on the Key Manager features, see <a href="/application/web/
 <div class="interface" id="KeyManagerObject">
 <a class="backward-compatibility-anchor" name="::KeyManager::KeyManagerObject"></a><h3>2.1. KeyManagerObject</h3>
 <div class="brief">
- The KeyManagerObject interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
+ The KeyManagerObject interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface KeyManagerObject {
     readonly attribute <a href="#KeyManager">KeyManager</a> keymanager;
@@ -125,7 +125,7 @@ For more information on the Key Manager features, see <a href="/application/web/
           </p>
 <div class="description">
           <p>
-The <em>tizen.keymanager </em>object allows access to the functionality of the Key Manager API.
+The <em>tizen.keymanager</em> object allows access to the functionality of the Key Manager API.
           </p>
          </div>
 <div class="attributes">

--- a/docs/application/web/api/6.0/device_api/tv/tizen/mediacontroller.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/mediacontroller.html
@@ -2515,7 +2515,7 @@ The ErrorCallback may be triggered for one of the following errors:
             </p>
             <ul>
               <li>
- UnknownError:  if any error prevents function from successful completion.               </li>
+UnknownError: if any error prevents function from successful completion.              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -9043,17 +9043,17 @@ Interface is used as a success method for:
           </p>
           <ul>
             <li>
- <em>MediaControllerServerInfo.sendCommand()</em>             </li>
+<em>MediaControllerServerInfo.sendCommand()</em>             </li>
             <li>
- <em>MediaControllerMode360Info.sendRequest()</em>             </li>
+<em>MediaControllerMode360Info.sendRequest()</em>             </li>
             <li>
- <em>MediaControllerSubtitlesInfo.sendRequest()</em>             </li>
+<em>MediaControllerSubtitlesInfo.sendRequest()</em>             </li>
             <li>
- <em>MediaControllerDisplayMode.sendRequest()</em>             </li>
+<em>MediaControllerDisplayMode.sendRequest()</em>             </li>
             <li>
- <em>MediaControllerDisplayRotationInfo.sendRequest()</em>             </li>
+<em>MediaControllerDisplayRotationInfo.sendRequest()</em>             </li>
             <li>
- <em>MediaControllerClientInfo.sendEvent()</em>             </li>
+<em>MediaControllerClientInfo.sendEvent()</em>             </li>
           </ul>
          </div>
 <div class="methods">
@@ -9075,7 +9075,7 @@ Interface is used as a success method for:
 <ul>
           <li class="param">
 <span class="name">data</span><span class="optional"> [nullable]</span>:
- Response data object sent by the command handler. This object is compatible with  <a href="tizen.html#Bundle">Bundle</a> object.
+ Response data object sent by the command handler. This object is compatible with <a href="tizen.html#Bundle">Bundle</a> object.
                 </li>
           <li class="param">
 <span class="name">code</span><span class="optional"> [optional]</span>:

--- a/docs/application/web/api/6.0/device_api/tv/tizen/package.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/package.html
@@ -123,7 +123,7 @@ For more information on the Package features, see <a href="/application/web/guid
 <div class="interface" id="PackageManagerObject">
 <a class="backward-compatibility-anchor" name="::Package::PackageManagerObject"></a><h3>2.1. PackageManagerObject</h3>
 <div class="brief">
- This interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
+ This interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface PackageManagerObject {
     readonly attribute <a href="#PackageManager">PackageManager</a> package;
@@ -134,7 +134,7 @@ For more information on the Package features, see <a href="/application/web/guid
           </p>
 <div class="description">
           <p>
-The <em>tizen.package </em>object allows access to Package API functionality.
+The <em>tizen.package</em> object allows access to Package API functionality.
           </p>
          </div>
 <div class="attributes">
@@ -188,7 +188,7 @@ The <em>tizen.package </em>object allows access to Package API functionality.
 This API provides a way to notify the progress and completion of an installation request through PackageProgressCallback.
             </p>
             <p>
-The <em>ErrorCallback() </em>is launched with these error types:
+The <em>ErrorCallback()</em> is launched with these error types:
             </p>
             <ul>
               <li>
@@ -284,7 +284,7 @@ tizen.filesystem.resolve("downloads/test.wgt",
 This API provides a way to notify about the progress and completion of an uninstallation request through PackageProgressCallback.
             </p>
             <p>
-The <em>ErrorCallback() </em>is launched with these error types:
+The <em>ErrorCallback()</em> is launched with these error types:
             </p>
             <ul>
               <li>
@@ -732,7 +732,7 @@ The relevant application is the one with the same
 <div class="interface" id="PackageInformationArraySuccessCallback">
 <a class="backward-compatibility-anchor" name="::Package::PackageInformationArraySuccessCallback"></a><h3>2.4. PackageInformationArraySuccessCallback</h3>
 <div class="brief">
- This interface invokes the success callback with an array of <em>PackageInformation </em>objects as an input parameter when the installed package list is retrieved.
+ This interface invokes the success callback with an array of <em>PackageInformation</em> objects as an input parameter when the installed package list is retrieved.
           </div>
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PackageInformationArraySuccessCallback {
     void onsuccess(<a href="#PackageInformation">PackageInformation</a>[] informationArray);

--- a/docs/application/web/api/6.0/device_api/tv/tizen/push.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/push.html
@@ -158,7 +158,7 @@ UNREGISTERED - The application is not registered to the push server.            
 <div class="interface" id="PushManagerObject">
 <a class="backward-compatibility-anchor" name="::Push::PushManagerObject"></a><h3>2.1. PushManagerObject</h3>
 <div class="brief">
- The PushManagerObject interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
+ The PushManagerObject interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface PushManagerObject {
     readonly attribute <a href="#PushManager">PushManager</a> push;
@@ -169,7 +169,7 @@ UNREGISTERED - The application is not registered to the push server.            
           </p>
 <div class="description">
           <p>
-The <em>tizen.push </em>object allows access to the functionality of the Push API.
+The <em>tizen.push</em> object allows access to the functionality of the Push API.
           </p>
          </div>
 <div class="attributes">
@@ -525,7 +525,7 @@ tizen.push.disconnect();
 </dt>
 <dd>
 <div class="brief">
- Gets the push service registration ID for this application if the registration process is successful. <var>null </var>is returned if the application has not been registered yet.
+ Gets the push service registration ID for this application if the registration process is successful. <var>null</var> is returned if the application has not been registered yet.
             </div>
 <div class="synopsis"><pre class="signature prettyprint"><a href="#PushRegistrationId">PushRegistrationId</a> getRegistrationId();</pre></div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/systeminfo.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/systeminfo.html
@@ -65,21 +65,21 @@ Not all above properties may be available on every Tizen device. For instance, a
         </p>
         <ul>
           <li>
- BATTERY          - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/battery"</em>)          </li>
+BATTERY          - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/battery"</em>)          </li>
           <li>
- CAMERA_FLASH     - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/camera.back.flash"</em>)          </li>
+CAMERA_FLASH     - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/camera.back.flash"</em>)          </li>
           <li>
- CELLULAR_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.telephony"</em>)          </li>
+CELLULAR_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.telephony"</em>)          </li>
           <li>
- DISPLAY          - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/screen"</em>)          </li>
+DISPLAY          - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/screen"</em>)          </li>
           <li>
- ETHERNET_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.ethernet"</em>)          </li>
+ETHERNET_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.ethernet"</em>)          </li>
           <li>
- NET_PROXY_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.net_proxy"</em>)          </li>
+NET_PROXY_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.net_proxy"</em>)          </li>
           <li>
- SIM              - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.telephony"</em>)          </li>
+SIM              - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.telephony"</em>)          </li>
           <li>
- WIFI_NETWORK     - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.wifi"</em>)          </li>
+WIFI_NETWORK     - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.wifi"</em>)          </li>
         </ul>
         <p>
 For more information on the System Information features, see <a href="/application/web/guides/device/system-information">System Information Guide</a>.
@@ -554,23 +554,23 @@ WARNING - indicating the remaining memory is insufficient. Low memory warnings m
 <div class="description">
           <ul>
             <li>
- TV - The input source from TV             </li>
+TV - The input source from TV            </li>
             <li>
- AV - The input source from Component video, three cables, each with RCA plugs (3 or more channels)            </li>
+AV - The input source from Component video, three cables, each with RCA plugs (3 or more channels)            </li>
             <li>
- SVIDEO - S-Video(Super-Video) and Y/C (2 channels)             </li>
+SVIDEO - S-Video(Super-Video) and Y/C (2 channels)            </li>
             <li>
- COMP - The input source from Composite video (1 channel)             </li>
+COMP - The input source from Composite video (1 channel)            </li>
             <li>
- PC - The input source from personal computer (15-pin VGA connector)             </li>
+PC - The input source from personal computer (15-pin VGA connector)            </li>
             <li>
- HDMI - The input source from HDMI(High-Definition Multimedia Interface)             </li>
+HDMI - The input source from HDMI(High-Definition Multimedia Interface)            </li>
             <li>
- SCART - The input source from SCART(21-pin connector)             </li>
+SCART - The input source from SCART(21-pin connector)            </li>
             <li>
- DVI - The input source from DVI(Digital Visual Interface)             </li>
+DVI - The input source from DVI(Digital Visual Interface)            </li>
             <li>
- MEDIA - The input source from media             </li>
+MEDIA - The input source from media            </li>
           </ul>
          </div>
 </div>
@@ -580,7 +580,7 @@ WARNING - indicating the remaining memory is insufficient. Low memory warnings m
 <div class="interface" id="SystemInfoObject">
 <a class="backward-compatibility-anchor" name="::SystemInfo::SystemInfoObject"></a><h3>2.1. SystemInfoObject</h3>
 <div class="brief">
- Defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
+ Defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface SystemInfoObject {
     readonly attribute <a href="#SystemInfo">SystemInfo</a> systeminfo;
@@ -1322,7 +1322,7 @@ This attribute has no effect on the <em>get()</em> method.
             </div>
 <div class="description">
             <p>
-If both <em>highThreshold </em>and <em>lowThreshold </em>parameters are specified, the <em>successCallback()</em> is triggered if and only if the property value is either lower than the value of <em>lowThreshold</em> or higher than the value of <em>highThreshold</em>.
+If both <em>highThreshold</em> and <em>lowThreshold</em> parameters are specified, the <em>successCallback()</em> is triggered if and only if the property value is either lower than the value of <em>lowThreshold</em> or higher than the value of <em>highThreshold</em>.
 This attribute has no effect on the get method.
             </p>
            </div>
@@ -1463,14 +1463,14 @@ Change listener registered on <var>BATTERY</var> property is triggered on
 <li class="attribute" id="SystemInfoBattery::level">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">level</span></span><div class="brief">
- An attribute to specify the remaining level of an internal battery, scaled from <var>0 </var>to <var>1</var>:
+ An attribute to specify the remaining level of an internal battery, scaled from <var>0</var>to <var>1</var>:
             </div>
 <div class="description">
             <ul>
               <li>
-<var>0 </var>indicates that the battery level is the lowest and the system is about to enter shutdown mode.              </li>
+<var>0</var>indicates that the battery level is the lowest and the system is about to enter shutdown mode.              </li>
               <li>
-<var>1 </var>indicates that the system's charge is maximum.              </li>
+<var>1</var>indicates that the system's charge is maximum.              </li>
             </ul>
             <p>
 Any threshold parameter used in a watch operation to monitor this property applies to this attribute.
@@ -1549,7 +1549,7 @@ This process may take up to few days.
 <ul><li class="attribute" id="SystemInfoCpu::load">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">load</span></span><div class="brief">
-  An attribute to indicate the current CPU load, as a number between <var>0.0 </var>and <var>1.0</var>, representing the minimum and maximum values allowed on this system.
+ An attribute to indicate the current CPU load, as a number between <var>0.0</var>and <var>1.0</var>, representing the minimum and maximum values allowed on this system.
             </div>
 <div class="description">
             <p>
@@ -1619,7 +1619,7 @@ The supported storage unit types are:
               <li>
 UNKNOWN              </li>
               <li>
-INTERNAL               </li>
+INTERNAL              </li>
               <li>
 USB_DEVICE              </li>
               <li>
@@ -1762,7 +1762,7 @@ Change listener registered on <var>DISPLAY</var> property is triggered on
 <li class="attribute" id="SystemInfoDisplay::brightness">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">brightness</span></span><div class="brief">
- The current brightness of a display ranging between <var>0 </var>to <var>1</var>.
+ The current brightness of a display ranging between <var>0</var>to <var>1</var>.
             </div>
 <p><span class="version">Since: </span>
  1.0

--- a/docs/application/web/api/6.0/device_api/tv/tizen/systeminfo.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/systeminfo.html
@@ -1463,14 +1463,14 @@ Change listener registered on <var>BATTERY</var> property is triggered on
 <li class="attribute" id="SystemInfoBattery::level">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">level</span></span><div class="brief">
- An attribute to specify the remaining level of an internal battery, scaled from <var>0</var>to <var>1</var>:
+ An attribute to specify the remaining level of an internal battery, scaled from <var>0</var> to <var>1</var>:
             </div>
 <div class="description">
             <ul>
               <li>
-<var>0</var>indicates that the battery level is the lowest and the system is about to enter shutdown mode.              </li>
+<var>0</var> indicates that the battery level is the lowest and the system is about to enter shutdown mode.              </li>
               <li>
-<var>1</var>indicates that the system's charge is maximum.              </li>
+<var>1</var> indicates that the system's charge is maximum.              </li>
             </ul>
             <p>
 Any threshold parameter used in a watch operation to monitor this property applies to this attribute.
@@ -1549,7 +1549,7 @@ This process may take up to few days.
 <ul><li class="attribute" id="SystemInfoCpu::load">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">load</span></span><div class="brief">
- An attribute to indicate the current CPU load, as a number between <var>0.0</var>and <var>1.0</var>, representing the minimum and maximum values allowed on this system.
+ An attribute to indicate the current CPU load, as a number between <var>0.0</var> and <var>1.0</var>, representing the minimum and maximum values allowed on this system.
             </div>
 <div class="description">
             <p>
@@ -1762,7 +1762,7 @@ Change listener registered on <var>DISPLAY</var> property is triggered on
 <li class="attribute" id="SystemInfoDisplay::brightness">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">brightness</span></span><div class="brief">
- The current brightness of a display ranging between <var>0</var>to <var>1</var>.
+ The current brightness of a display ranging between <var>0</var> to <var>1</var>.
             </div>
 <p><span class="version">Since: </span>
  1.0

--- a/docs/application/web/api/6.0/device_api/tv/tizen/time.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/time.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="tv-mandatory emulator" title="Mandatory, Supported by Tizen Tv emulator" src="tv_s_w.png"></div>
 <div class="title"><h1>Time API</h1></div>
 <div class="brief">
-  The Time API provides information regarding date/time and time zones.
+ The Time API provides information regarding date/time and time zones.
         </div>
 <div class="description">
         <p>
@@ -182,11 +182,11 @@ At least the following values must be supported:
             <li>
 MSECS - Indicates a duration in milliseconds            </li>
             <li>
-SECS - Indicates a duration in seconds             </li>
+SECS - Indicates a duration in seconds            </li>
             <li>
-MINS - Indicates a duration in minutes             </li>
+MINS - Indicates a duration in minutes            </li>
             <li>
-HOURS - Indicates a duration in hours             </li>
+HOURS - Indicates a duration in hours            </li>
             <li>
 DAYS - Indicates a duration in days            </li>
           </ul>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/tizen.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/tizen.html
@@ -292,7 +292,7 @@ BYTES_ARRAY - array of <a href="#ByteStream">ByteStream</a>            </li>
           </p>
 <div class="description">
           <p>
-The <em>Tizen</em> interface is always available within the <em>Window </em>object in the ECMAScript hierarchy.
+The <em>Tizen</em> interface is always available within the <em>Window</em> object in the ECMAScript hierarchy.
           </p>
          </div>
 <div class="attributes">

--- a/docs/application/web/api/6.0/device_api/tv/tizen/tvaudiocontrol.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/tvaudiocontrol.html
@@ -85,7 +85,7 @@ There will be a <em>tizen.tvaudiocontrol</em> object that allows access to the f
 <div class="enum" id="AudioOutputMode">
 <a class="backward-compatibility-anchor" name="::TVAudioControl::AudioOutputMode"></a><h3>1.1. AudioOutputMode</h3>
 <div class="brief">
-  An enumerator to indicate the audio output mode.
+ An enumerator to indicate the audio output mode.
           </div>
 <pre class="webidl prettyprint">  enum AudioOutputMode { "PCM", "DOLBY", "DTS", "AAC", "DOLBY_DIGITAL_PLUS" };</pre>
 <p><span class="version">Since: </span>
@@ -94,15 +94,15 @@ There will be a <em>tizen.tvaudiocontrol</em> object that allows access to the f
 <div class="description">
           <ul>
             <li>
- PCM - PCM(Pulse-code modulation) audio output mode            </li>
+PCM - PCM(Pulse-code modulation) audio output mode            </li>
             <li>
- DOLBY - Dolby audio output mode            </li>
+DOLBY - Dolby audio output mode            </li>
             <li>
- DTS - DTS(Digital Theater System) audio output mode            </li>
+DTS - DTS(Digital Theater System) audio output mode            </li>
             <li>
- AAC - AAC(Advanced Audio Coding) audio output mode            </li>
+AAC - AAC(Advanced Audio Coding) audio output mode            </li>
             <li>
- DOLBY_DIGITAL_PLUS - Dolby Digital Plus audio output mode            </li>
+DOLBY_DIGITAL_PLUS - Dolby Digital Plus audio output mode            </li>
           </ul>
          </div>
 <p><span class="remark">Remark: </span>
@@ -112,7 +112,7 @@ There will be a <em>tizen.tvaudiocontrol</em> object that allows access to the f
 <div class="enum" id="AudioBeepType">
 <a class="backward-compatibility-anchor" name="::TVAudioControl::AudioBeepType"></a><h3>1.2. AudioBeepType</h3>
 <div class="brief">
-  An enumerator to indicate the beep type.
+ An enumerator to indicate the beep type.
           </div>
 <pre class="webidl prettyprint">  enum AudioBeepType { "UP", "DOWN", "LEFT", "RIGHT", "PAGE_LEFT", "PAGE_RIGHT", "BACK", "SELECT", "CANCEL", "WARNING", "KEYPAD",
     "KEYPAD_ENTER", "KEYPAD_DEL", "MOVE", "PREPARING" };</pre>
@@ -122,35 +122,35 @@ There will be a <em>tizen.tvaudiocontrol</em> object that allows access to the f
 <div class="description">
           <ul>
             <li>
- UP - The UP sound            </li>
+UP - The UP sound            </li>
             <li>
- DOWN - The DOWN sound            </li>
+DOWN - The DOWN sound            </li>
             <li>
- LEFT - The LEFT sound            </li>
+LEFT - The LEFT sound            </li>
             <li>
- RIGHT - The RIGHT sound            </li>
+RIGHT - The RIGHT sound            </li>
             <li>
- PAGE_LEFT - The PAGE LEFT sound            </li>
+PAGE_LEFT - The PAGE LEFT sound            </li>
             <li>
- PAGE_RIGHT - The PAGE RIGHT sound            </li>
+PAGE_RIGHT - The PAGE RIGHT sound            </li>
             <li>
- BACK - The BACK sound            </li>
+BACK - The BACK sound            </li>
             <li>
- SELECT - The SELECT sound            </li>
+SELECT - The SELECT sound            </li>
             <li>
- CANCEL - The CANCEL sound            </li>
+CANCEL - The CANCEL sound            </li>
             <li>
- WARNING - The WARNING sound            </li>
+WARNING - The WARNING sound            </li>
             <li>
- KEYPAD - The KEYPAD sound            </li>
+KEYPAD - The KEYPAD sound            </li>
             <li>
- KEYPAD_ENTER - The KEYPAD ENTER sound            </li>
+KEYPAD_ENTER - The KEYPAD ENTER sound            </li>
             <li>
- KEYPAD_DEL - The KEYPAD DEL sound            </li>
+KEYPAD_DEL - The KEYPAD DEL sound            </li>
             <li>
- MOVE - The MOVE sound            </li>
+MOVE - The MOVE sound            </li>
             <li>
- PREPARING - The PREPARING sound            </li>
+PREPARING - The PREPARING sound            </li>
           </ul>
          </div>
 </div>
@@ -171,7 +171,7 @@ There will be a <em>tizen.tvaudiocontrol</em> object that allows access to the f
           </p>
 <div class="description">
           <p>
-There will be a <em>tizen.tvaudiocontrol </em>object that allows the access to the
+There will be a <em>tizen.tvaudiocontrol</em> object that allows the access to the
 Audio Control API.
           </p>
          </div>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/tvdisplaycontrol.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/tvdisplaycontrol.html
@@ -135,25 +135,25 @@ functionality of the display control API.
 <div class="description">
           <ul>
             <li>
-OFF - identifier for 3DEffect mode off             </li>
+OFF - identifier for 3DEffect mode off            </li>
             <li>
-TOP_BOTTOM - Left image at the top, right image at the bottom             </li>
+TOP_BOTTOM - Left image at the top, right image at the bottom            </li>
             <li>
 SIDE_BY_SIDE - Left image at the left side, right image at the right
-side             </li>
+side            </li>
             <li>
 LINE_BY_LINE - Left and right image interlaced
-by row             </li>
+by row            </li>
             <li>
 VERTICAL_STRIP - Left and right image interlaced
-by column             </li>
+by column            </li>
             <li>
-FRAME_SEQUENCE -  Left and right image interlaced by frame             </li>
+FRAME_SEQUENCE -  Left and right image interlaced by frame            </li>
             <li>
-CHECKER_BD - Checkerboard (only for PC or game console sources)             </li>
+CHECKER_BD - Checkerboard (only for PC or game console sources)            </li>
             <li>
 FROM_2D_TO_3D - Left and right image computed from
-non-stereoscopic image             </li>
+non-stereoscopic image            </li>
           </ul>
          </div>
 </div>
@@ -169,11 +169,11 @@ non-stereoscopic image             </li>
 <div class="description">
           <ul>
             <li>
- NOT_CONNECTED - The device (e.g. Blu-ray player) supports 3D mode but a 3D display is not connected.            </li>
+NOT_CONNECTED - The device (e.g. Blu-ray player) supports 3D mode but a 3D display is not connected.            </li>
             <li>
- NOT_SUPPORTED - The device does not support 3D mode.            </li>
+NOT_SUPPORTED - The device does not support 3D mode.            </li>
             <li>
- READY - The device supports 3D mode and it can display 3D mode.            </li>
+READY - The device supports 3D mode and it can display 3D mode.            </li>
           </ul>
          </div>
 </div>
@@ -184,7 +184,7 @@ non-stereoscopic image             </li>
 <a class="backward-compatibility-anchor" name="::TVDisplayControl::DisplayControlManagerObject"></a><h3>2.1. DisplayControlManagerObject</h3>
 <div class="brief">
  This interface defines what is instantiated by the <em>tizen</em> object.
-There will be a <em>tizen.tvdisplaycontrol </em>object that allows the access to the Display Control API.
+There will be a <em>tizen.tvdisplaycontrol</em> object that allows the access to the Display Control API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface DisplayControlManagerObject {
     readonly attribute <a href="#DisplayControlManager">DisplayControlManager</a> tvdisplaycontrol;

--- a/docs/application/web/api/6.0/device_api/tv/tizen/tvwindow.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/tvwindow.html
@@ -150,7 +150,7 @@ do not want to interact with the TV image.
 <div class="description">
           <ul>
             <li>
- MAIN - The main video window, which can be show anywhere            </li>
+MAIN - The main video window, which can be show anywhere            </li>
           </ul>
          </div>
 </div>
@@ -166,9 +166,9 @@ do not want to interact with the TV image.
 <div class="description">
           <ul>
             <li>
- px - pixel unit            </li>
+px - pixel unit            </li>
             <li>
- % - percentage unit for specifying relative size            </li>
+% - percentage unit for specifying relative size            </li>
           </ul>
          </div>
 </div>
@@ -187,15 +187,15 @@ do not want to interact with the TV image.
 <div class="description">
           <ul>
             <li>
- ASPECT_RATIO_1x1 - 1:1            </li>
+ASPECT_RATIO_1x1 - 1:1            </li>
             <li>
- ASPECT_RATIO_4x3 - 4:3            </li>
+ASPECT_RATIO_4x3 - 4:3            </li>
             <li>
- ASPECT_RATIO_16x9 - 16:9            </li>
+ASPECT_RATIO_16x9 - 16:9            </li>
             <li>
- ASPECT_RATIO_221x100 - 2.21:1            </li>
+ASPECT_RATIO_221x100 - 2.21:1            </li>
             <li>
- ASPECT_RATIO_UNKNOWN - Unknown aspect ratio            </li>
+ASPECT_RATIO_UNKNOWN - Unknown aspect ratio            </li>
           </ul>
          </div>
 <p><span class="remark">Remark: </span>
@@ -217,37 +217,37 @@ do not want to interact with the TV image.
 <div class="description">
           <ul>
             <li>
- PICTURE_SIZE_TYPE_16x9 - 16:9            </li>
+PICTURE_SIZE_TYPE_16x9 - 16:9            </li>
             <li>
- PICTURE_SIZE_TYPE_ZOOM - zoom option has been used            </li>
+PICTURE_SIZE_TYPE_ZOOM - zoom option has been used            </li>
             <li>
- PICTURE_SIZE_TYPE_CUSTOM - aspect ratio customized manually            </li>
+PICTURE_SIZE_TYPE_CUSTOM - aspect ratio customized manually            </li>
             <li>
- PICTURE_SIZE_TYPE_4x3 - 4:3            </li>
+PICTURE_SIZE_TYPE_4x3 - 4:3            </li>
             <li>
- PICTURE_SIZE_TYPE_21x9_NORMAL - 21:9            </li>
+PICTURE_SIZE_TYPE_21x9_NORMAL - 21:9            </li>
             <li>
- PICTURE_SIZE_TYPE_21x9_AUTO - 21:9 set automatically by source connected to target device            </li>
+PICTURE_SIZE_TYPE_21x9_AUTO - 21:9 set automatically by source connected to target device            </li>
             <li>
- PICTURE_SIZE_TYPE_21x9_CAPTION - 21:9 with additional space for caption            </li>
+PICTURE_SIZE_TYPE_21x9_CAPTION - 21:9 with additional space for caption            </li>
             <li>
- PICTURE_SIZE_TYPE_ORIGINAL_RATIO - Picture size type original ratio            </li>
+PICTURE_SIZE_TYPE_ORIGINAL_RATIO - Picture size type original ratio            </li>
             <li>
- PICTURE_SIZE_TYPE_WSS_4x3 - 4:3 - widescreen signaling            </li>
+PICTURE_SIZE_TYPE_WSS_4x3 - 4:3 - widescreen signaling            </li>
             <li>
- PICTURE_SIZE_TYPE_WSS_16x9 - 16:9 - widescreen signaling            </li>
+PICTURE_SIZE_TYPE_WSS_16x9 - 16:9 - widescreen signaling            </li>
             <li>
- PICTURE_SIZE_TYPE_WSS_ZOOM1 - widescreen signaling, zoom option set to ZOOM1            </li>
+PICTURE_SIZE_TYPE_WSS_ZOOM1 - widescreen signaling, zoom option set to ZOOM1            </li>
             <li>
- PICTURE_SIZE_TYPE_WSS_ZOOM1_DN - widescreen signaling, zoom option set to ZOOM1_DN            </li>
+PICTURE_SIZE_TYPE_WSS_ZOOM1_DN - widescreen signaling, zoom option set to ZOOM1_DN            </li>
             <li>
- PICTURE_SIZE_TYPE_WSS_ZOOM2 - widescreen signaling, zoom option set to ZOOM2            </li>
+PICTURE_SIZE_TYPE_WSS_ZOOM2 - widescreen signaling, zoom option set to ZOOM2            </li>
             <li>
- PICTURE_SIZE_TYPE_WSS_WIDEZOOM - widescreen signaling, zoom option set to WIDEZOOM            </li>
+PICTURE_SIZE_TYPE_WSS_WIDEZOOM - widescreen signaling, zoom option set to WIDEZOOM            </li>
             <li>
- PICTURE_SIZE_TYPE_WSS_14x9 - 14:9 - widescreen signaling            </li>
+PICTURE_SIZE_TYPE_WSS_14x9 - 14:9 - widescreen signaling            </li>
             <li>
- PICTURE_SIZE_TYPE_UNKNOWN - Unknown size type of a picture            </li>
+PICTURE_SIZE_TYPE_UNKNOWN - Unknown size type of a picture            </li>
           </ul>
          </div>
 </div>
@@ -263,9 +263,9 @@ do not want to interact with the TV image.
 <div class="description">
           <ul>
             <li>
- FRONT - Displays the TV window in front of the Web Application            </li>
+FRONT - Displays the TV window in front of the Web Application            </li>
             <li>
- BEHIND - Displays the TV window behind the Web Application            </li>
+BEHIND - Displays the TV window behind the Web Application            </li>
           </ul>
          </div>
 </div>
@@ -599,7 +599,7 @@ The <em>errorCallback</em> is invoked with these error types:
               <li>
 <em>InvalidValuesError</em> will be thrown if <em>rectangle</em> has any element with invalid format (e.g. "10p") or it does not have 4 elements.              </li>
               <li>
-<em>NotSupportedError</em> will be thrown if you set <em>rectangle</em> which is not within the boundary of the display area or when the TV window is not supported in the current screen orientation.               </li>
+<em>NotSupportedError</em> will be thrown if you set <em>rectangle</em> which is not within the boundary of the display area or when the TV window is not supported in the current screen orientation.              </li>
               <li>
 <em>TypeMismatchError</em> will be thrown if <em>rectangle</em> is not an array.              </li>
             </ul>
@@ -1224,7 +1224,7 @@ For more detailed information about <em>windowRect</em>, see the description of 
 <ul>
           <li class="param">
 <span class="name">windowRect</span>:
- An array that contains information about the position and size of a specified TV  window as a string with units.
+ An array that contains information about the position and size of a specified TV window as a string with units.
                 </li>
           <li class="param">
 <span class="name">type</span>:

--- a/docs/application/web/api/6.0/device_api/tv/tizen/voicecontrol.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/voicecontrol.html
@@ -113,9 +113,9 @@ The result events defined by this enumeration are:
           </p>
           <ul>
             <li>
- SUCCESS - Successful result            </li>
+SUCCESS - Successful result            </li>
             <li>
- FAILURE - Rejected result by voice control service            </li>
+FAILURE - Rejected result by voice control service            </li>
           </ul>
          </div>
 </div>
@@ -134,7 +134,7 @@ The command type defined by this enumeration is:
           </p>
           <ul>
             <li>
- FOREGROUND - command type used when application is foreground            </li>
+FOREGROUND - command type used when application is foreground            </li>
           </ul>
          </div>
 </div>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/websetting.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/websetting.html
@@ -19,9 +19,9 @@ A Tizen Web application includes a web view and the properties below of the web 
         </p>
         <ul>
           <li>
- Delete all the cookies saved for the web view in the Web application.           </li>
+Delete all the cookies saved for the web view in the Web application.          </li>
           <li>
- Set a custom user agent string of the web view in the Web application.          </li>
+Set a custom user agent string of the web view in the Web application.          </li>
         </ul>
         <p>
 Note that all the settings using the Web Setting API is bound to your application; thus, no other applications are affected via the Web Setting API calls within your application.

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/account.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/account.html
@@ -34,8 +34,8 @@ gmail, gtalk, Picasa, and Youtube with each service having a separate service
 instance bound to the account.          </li>
         </ul>
         <p>
-To use <em>add(), remove(), and update()</em> methods of AccountManager can be invoked only
-by account provider application. A web application is an account provider when its <em>config.xml</em>contains <a href="/application/tizen-studio/web-tools/config-editor#mw_account">Account provider section</a>. For example:<br>&lt;tizen:account multiple-account-support="true"&gt;<br>      &lt;tizen:icon section="Account"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:icon section="AccountSmall"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:display-name xml:lang="en-gb"&gt;Test&lt;/tizen:display-name&gt;<br>      &lt;tizen:capability&gt;http://tizen.org/account/capability/contact&lt;/tizen:capability&gt;<br>&lt;/tizen:account&gt;
+To use <em>add(), remove(), and update()</em> methods of AccountManager can be invoked only by account provider application.
+A web application is an account provider when its <em>config.xml</em> contains <a href="/application/tizen-studio/web-tools/config-editor#mw_account">Account provider section</a>. For example:<br>&lt;tizen:account multiple-account-support="true"&gt;<br>      &lt;tizen:icon section="Account"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:icon section="AccountSmall"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:display-name xml:lang="en-gb"&gt;Test&lt;/tizen:display-name&gt;<br>      &lt;tizen:capability&gt;http://tizen.org/account/capability/contact&lt;/tizen:capability&gt;<br>&lt;/tizen:account&gt;
         </p>
         <p>
 For more information about how to use Account API, see <a href="/application/web/guides/personal/account">Account Guide</a>.

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/account.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/account.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="wearable-optional emulator" title="Optional, Supported by Tizen Wearable emulator" src="wearable_s_w_optional.png"></div>
 <div class="title"><h1>Account API</h1></div>
 <div class="brief">
-  The Account API provides functionality for using existing configured
+ The Account API provides functionality for using existing configured
 online accounts and providers, and for creating accounts of known types.
         </div>
 <div class="description">
@@ -35,7 +35,7 @@ instance bound to the account.          </li>
         </ul>
         <p>
 To use <em>add(), remove(), and update()</em> methods of AccountManager can be invoked only
-by account provider application. A web application is an account provider when its <em>config.xml </em>contains <a href="/application/tizen-studio/web-tools/config-editor#mw_account">Account provider section</a>. For example:<br>&lt;tizen:account multiple-account-support="true"&gt;<br>      &lt;tizen:icon section="Account"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:icon section="AccountSmall"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:display-name xml:lang="en-gb"&gt;Test&lt;/tizen:display-name&gt;<br>      &lt;tizen:capability&gt;http://tizen.org/account/capability/contact&lt;/tizen:capability&gt;<br>&lt;/tizen:account&gt;
+by account provider application. A web application is an account provider when its <em>config.xml</em>contains <a href="/application/tizen-studio/web-tools/config-editor#mw_account">Account provider section</a>. For example:<br>&lt;tizen:account multiple-account-support="true"&gt;<br>      &lt;tizen:icon section="Account"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:icon section="AccountSmall"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:display-name xml:lang="en-gb"&gt;Test&lt;/tizen:display-name&gt;<br>      &lt;tizen:capability&gt;http://tizen.org/account/capability/contact&lt;/tizen:capability&gt;<br>&lt;/tizen:account&gt;
         </p>
         <p>
 For more information about how to use Account API, see <a href="/application/web/guides/personal/account">Account Guide</a>.

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/alarm.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/alarm.html
@@ -278,7 +278,7 @@ For more information about the application control, see <a href="application.htm
 <ul>
           <li class="param">
 <span class="name">alarm</span>:
- An alarm to add. It can be either <em>AlarmRelative</em>  or <em>AlarmAbsolute</em>.
+ An alarm to add. It can be either <em>AlarmRelative</em> or <em>AlarmAbsolute</em>.
                 </li>
           <li class="param">
 <span class="name">applicationId</span>:

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/alarm.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/alarm.html
@@ -157,8 +157,8 @@ For more information on the Alarm features, see <a href="/application/web/guides
 <div class="interface" id="AlarmManagerObject">
 <a class="backward-compatibility-anchor" name="::Alarm::AlarmManagerObject"></a><h3>2.1. AlarmManagerObject</h3>
 <div class="brief">
- The AlarmManagerObject interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
-The <em>tizen.alarm </em>object allows access to the functionality of the Alarm API.
+ The AlarmManagerObject interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
+The <em>tizen.alarm</em> object allows access to the functionality of the Alarm API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface AlarmManagerObject {
     readonly attribute <a href="#AlarmManager">AlarmManager</a> alarm;
@@ -278,7 +278,7 @@ For more information about the application control, see <a href="application.htm
 <ul>
           <li class="param">
 <span class="name">alarm</span>:
- An alarm to add. It can be either <em>AlarmRelative </em> or <em>AlarmAbsolute</em>.
+ An alarm to add. It can be either <em>AlarmRelative</em>  or <em>AlarmAbsolute</em>.
                 </li>
           <li class="param">
 <span class="name">applicationId</span>:

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/application.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/application.html
@@ -345,7 +345,7 @@ FREQUENTLY - Indicates most frequently used applications, in a descending order 
 <div class="interface" id="ApplicationManagerObject">
 <a class="backward-compatibility-anchor" name="::Application::ApplicationManagerObject"></a><h3>2.1. ApplicationManagerObject</h3>
 <div class="brief">
- This interface defines what is instantiated by the <em>Tizen </em>object on the Tizen Platform.
+ This interface defines what is instantiated by the <em>Tizen</em> object on the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface ApplicationManagerObject {
     readonly attribute <a href="#ApplicationManager">ApplicationManager</a> application;
@@ -356,7 +356,7 @@ FREQUENTLY - Indicates most frequently used applications, in a descending order 
           </p>
 <div class="description">
           <p>
-The <em>tizen.application </em>object allows access to the Application API's functionality.
+The <em>tizen.application</em> object allows access to the Application API's functionality.
           </p>
          </div>
 <div class="attributes">
@@ -416,7 +416,7 @@ The <em>tizen.application </em>object allows access to the Application API's fun
 </dt>
 <dd>
 <div class="brief">
- Gets the <em>Application </em>object defining the current application.
+ Gets the <em>Application</em> object defining the current application.
             </div>
 <div class="synopsis"><pre class="signature prettyprint"><a href="#Application">Application</a> getCurrentApplication();</pre></div>
 <p><span class="version">Since: </span>
@@ -626,10 +626,10 @@ to perform the requested application control, then launches the selected applica
             </p>
             <p>
 The application control request is passed to the newly launched application
-and it can be accessed by the <em>getRequestedAppControl() </em>method. The passed
+and it can be accessed by the <em>getRequestedAppControl()</em> method. The passed
 application control contains the reason the application has been launched and
 information about what the application is doing. The launched application
-can send a result to the caller application with the <em>replyResult() </em>method of the
+can send a result to the caller application with the <em>replyResult()</em> method of the
 <em>RequestedApplicationControl</em> interface.
             </p>
             <p>
@@ -663,7 +663,7 @@ Also, implicit launch requests are NOT delivered to service applications since 2
                 </li>
           <li class="param">
 <span class="name">id</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
- An identifier of the application to be launched. If the ID is <var>null </var>or not specified, then the system tries to find the application to be launched for the requested application control.
+ An identifier of the application to be launched. If the ID is <var>null</var> or not specified, then the system tries to find the application to be launched for the requested application control.
                 </li>
           <li class="param">
 <span class="name">successCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
@@ -883,7 +883,7 @@ tizen.application.getAppsContext(onRunningAppsContext);
 <dd>
 <div class="brief">
  Gets the application context for the specified application context ID.
-If the ID is set to<var> null</var> or is not set at all, the method returns the application context of the current application.
+If the ID is set to <var>null</var> or is not set at all, the method returns the application context of the current application.
 The list of running applications and their application IDs is obtained with <em>getAppsContext()</em>.
             </div>
 <div class="synopsis"><pre class="signature prettyprint"><a href="#ApplicationContext">ApplicationContext</a> getAppContext(optional <a href="#ApplicationContextId">ApplicationContextId</a>? contextId);</pre></div>
@@ -1049,23 +1049,23 @@ The certificate types are listed below:
             </p>
             <ul>
               <li>
- AUTHOR_ROOT - Author Root Certificate               </li>
+AUTHOR_ROOT - Author Root Certificate              </li>
               <li>
- AUTHOR_INTERMEDIATE - Author Intermediate Certificate               </li>
+AUTHOR_INTERMEDIATE - Author Intermediate Certificate              </li>
               <li>
- AUTHOR_SIGNER - Author Signer Certificate               </li>
+AUTHOR_SIGNER - Author Signer Certificate              </li>
               <li>
- DISTRIBUTOR_ROOT - Distributor Root Certificate               </li>
+DISTRIBUTOR_ROOT - Distributor Root Certificate              </li>
               <li>
- DISTRIBUTOR_INTERMEDIATE - Distributor Intermediate Certificate               </li>
+DISTRIBUTOR_INTERMEDIATE - Distributor Intermediate Certificate              </li>
               <li>
- DISTRIBUTOR_SIGNER - Distributor Signer Certificate               </li>
+DISTRIBUTOR_SIGNER - Distributor Signer Certificate              </li>
               <li>
- DISTRIBUTOR2_ROOT - Distributor2 Root Certificate               </li>
+DISTRIBUTOR2_ROOT - Distributor2 Root Certificate              </li>
               <li>
- DISTRIBUTOR2_INTERMEDIATE - Distributor2 Intermediate Certificate               </li>
+DISTRIBUTOR2_INTERMEDIATE - Distributor2 Intermediate Certificate              </li>
               <li>
- DISTRIBUTOR2_SIGNER - Distributor2 Signer Certificate               </li>
+DISTRIBUTOR2_SIGNER - Distributor2 Signer Certificate              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1589,7 +1589,7 @@ The maximum retention period is 90 days.
 <dd>
 <div class="brief">
  The attribute to store period of time, from which data is accumulated, in days.
-The  period of time begins <em>timeSpan</em> days ago and ends with current date.
+The period of time begins <em>timeSpan</em> days ago and ends with current date.
             </div>
 <div class="description">
             <p>
@@ -2292,7 +2292,7 @@ The attribute value scales from <var>0</var> to <var>1</var>, the higher value, 
 <a class="backward-compatibility-anchor" name="::Application::ApplicationControlData"></a><h3>2.9. ApplicationControlData</h3>
 <div class="brief">
  This interface defines a key/value pair used to pass data
-between applications through the <em>ApplicationControl </em>interface.
+between applications through the <em>ApplicationControl</em> interface.
           </div>
 <pre class="webidl prettyprint">  [Constructor(DOMString key, DOMString[] value)]
   interface ApplicationControlData {
@@ -2751,7 +2751,7 @@ This callback interface specifies a success method with an array of
 <div class="description">
           <p>
 This callback interface specifies a success method with an array of
-<em>ApplicationInformation </em>objects as an input parameter. It is used in <em>ApplicationManager.getAppsInfo()</em>.
+<em>ApplicationInformation</em> objects as an input parameter. It is used in <em>ApplicationManager.getAppsInfo()</em>.
           </p>
          </div>
 <div class="methods">
@@ -2807,7 +2807,7 @@ tizen.application.getAppsInfo(onListInstalledApps);
 <div class="description">
           <p>
 This callback interface specifies a success method with an array of
-<em>ApplicationInformation </em>objects and application control as an input parameter.
+<em>ApplicationInformation</em> objects and application control as an input parameter.
 It is used in <em>ApplicationManager.findAppControl()</em>.
           </p>
          </div>
@@ -2900,7 +2900,7 @@ tizen.application.findAppControl(appControl, successCB);
 <div class="description">
           <p>
 This callback interface specifies a success method with
-an array of <em>ApplicationContext </em>objects as an input parameter. It is used in <em>ApplicationManager.getAppsContext()</em>.
+an array of <em>ApplicationContext</em> objects as an input parameter. It is used in <em>ApplicationManager.getAppsContext()</em>.
           </p>
          </div>
 <div class="methods">
@@ -2911,7 +2911,7 @@ an array of <em>ApplicationContext </em>objects as an input parameter. It is use
 </dt>
 <dd>
 <div class="brief">
- Called when <em>ApplicationManager.getAppsContext() </em>completes successfully.
+ Called when <em>ApplicationManager.getAppsContext()</em> completes successfully.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void onsuccess(<a href="#ApplicationContext">ApplicationContext</a>[] contexts);</pre></div>
 <p><span class="version">Since: </span>
@@ -2948,9 +2948,9 @@ This callback interface specifies two methods:
           </p>
           <ul>
             <li>
- <em>onsuccess()</em> - Invoked if the callee application calls <em>RequestedApplicationControl.replyResult()</em>.            </li>
+<em>onsuccess()</em> - Invoked if the callee application calls <em>RequestedApplicationControl.replyResult()</em>.            </li>
             <li>
- <em>onfailure()</em> - Invoked if the callee application calls <em>RequestedApplicationControl.replyFailure()</em>.            </li>
+<em>onfailure()</em> - Invoked if the callee application calls <em>RequestedApplicationControl.replyFailure()</em>.            </li>
           </ul>
          </div>
 <div class="example">

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/archive.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/archive.html
@@ -393,7 +393,7 @@ Description                </th>
                 <td>
 r                </td>
                 <td>
-Use this mode for extracting or getting information about the contents of an archive file. <br><em>file</em> must exist. If the <em>file</em> does not exist, <em>onerror</em> will be invoked (<em>NotFoundError</em>).<br>When an archive file is opened in this mode, <em>add()</em> will not be available. (<em>IOError</em> will be thrown.)                 </td>
+Use this mode for extracting or getting information about the contents of an archive file. <br><em>file</em> must exist. If the <em>file</em> does not exist, <em>onerror</em> will be invoked (<em>NotFoundError</em>).<br>When an archive file is opened in this mode, <em>add()</em> will not be available. (<em>IOError</em> will be thrown.)                </td>
               </tr>
               <tr>
                 <td>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/calendar.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/calendar.html
@@ -19,7 +19,7 @@ Separate calendars can be implemented for group related events or tasks. For exa
 The Internet Calendaring and Scheduling Core Object Specification (iCalendar), defines a format for exchanging event items. Mapping to specified event/task attributes in this API is as per this specification. For details, see <a href="http://tools.ietf.org/html/rfc5545">RFC 5545</a>.
         </p>
         <p>
-This API provides functionality to read, create, delete, and update items in specific calendars. Calendars can be obtained using the <em>getCalendars() </em>method, which returns an array of Calendar objects.
+This API provides functionality to read, create, delete, and update items in specific calendars. Calendars can be obtained using the <em>getCalendars()</em> method, which returns an array of Calendar objects.
         </p>
         <p>
 For more information on the Calendar features, see <a href="/application/web/guides/personal/calendar">Calendar Guide</a>.
@@ -265,7 +265,7 @@ For more information on the Calendar features, see <a href="/application/web/gui
 <div class="typedef" id="CalendarItemId">
 <a class="backward-compatibility-anchor" name="::Calendar::CalendarItemId"></a><h3>1.3. CalendarItemId</h3>
 <div class="brief">
- The calendar item identifier, which can either be a <em>CalendarEventId </em>or a <em>CalendarTaskId</em>.
+ The calendar item identifier, which can either be a <em>CalendarEventId</em> or a <em>CalendarTaskId</em>.
           </div>
 <pre class="webidl prettyprint">  typedef (<a href="#CalendarEventId">CalendarEventId</a> or <a href="#CalendarTaskId">CalendarTaskId</a>) CalendarItemId;</pre>
 <p><span class="version">Since: </span>
@@ -593,7 +593,7 @@ CANCELLED -  if the task has been cancelled            </li>
 <div class="interface" id="CalendarManagerObject">
 <a class="backward-compatibility-anchor" name="::Calendar::CalendarManagerObject"></a><h3>2.1. CalendarManagerObject</h3>
 <div class="brief">
- The CalendarManagerObject interface gives access to the Calendar API from the <em>tizen.calendar </em>object.
+ The CalendarManagerObject interface gives access to the Calendar API from the <em>tizen.calendar</em> object.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface CalendarManagerObject {
     readonly attribute <a href="#CalendarManager">CalendarManager</a> calendar;
@@ -649,7 +649,7 @@ Once a calendar object is obtained, it is possible to add, remove, or update the
             </p>
 <div class="description">
             <p>
-If the operation completes successfully, the <em>successCallback() </em>must be invoked with all the calendars found and available. The first calendar in the list is always the default calendar.
+If the operation completes successfully, the <em>successCallback()</em> must be invoked with all the calendars found and available. The first calendar in the list is always the default calendar.
             </p>
             <p>
 If no Calendar object is available, the <em>successCallback()</em> is invoked with an empty array.
@@ -1207,15 +1207,15 @@ This interface offers the following methods to manage events in a calendar:
           </p>
           <ul>
             <li>
- Finding items using a key-value filter.            </li>
+Finding items using a key-value filter.            </li>
             <li>
- Adding items to a specific calendar using <em>add() </em>/ <em>addBatch() </em>methods.            </li>
+Adding items to a specific calendar using <em>add()</em> / <em>addBatch()</em> methods.            </li>
             <li>
- Updating existing items using <em>update() </em>/ <em>updateBatch()</em> methods.            </li>
+Updating existing items using <em>update()</em> / <em>updateBatch()</em> methods.            </li>
             <li>
- Deleting existing items using <em>remove()</em> / <em>removeBatch() </em>methods.            </li>
+Deleting existing items using <em>remove()</em> / <em>removeBatch()</em> methods.            </li>
             <li>
- Tracking calendar changes using <em>addChangeListener()</em> / <em>removeChangeListener() </em>methods.            </li>
+Tracking calendar changes using <em>addChangeListener()</em> / <em>removeChangeListener()</em> methods.            </li>
           </ul>
          </div>
 <div class="example">
@@ -1318,7 +1318,7 @@ console.log("The calendar name is " + calendar.name);
 <p><span class="return">Return value:</span></p>
 <ul>
 <span class="return">CalendarItem:</span>
- The matching <em>CalendarItem </em>object.
+ The matching <em>CalendarItem</em> object.
               </ul>
 </div>
 <div class="exceptionlist">
@@ -1373,10 +1373,10 @@ catch (err)
             </p>
 <div class="description">
             <p>
-If the item is successfully inserted in the calendar, the <em>CalendarItem </em>will have its identifier (id attribute) set when the method returns.
+If the item is successfully inserted in the calendar, the <em>CalendarItem</em> will have its identifier (id attribute) set when the method returns.
             </p>
             <p>
-To update an existing item, call the <em>update() </em>method instead. If you wish to add a copy of an existing <em>CalendarItem </em>object, call <em>CalendarItem.clone()</em> method first and pass the clone to the <em>add()</em> method.
+To update an existing item, call the <em>update()</em> method instead. If you wish to add a copy of an existing <em>CalendarItem</em> object, call <em>CalendarItem.clone()</em> method first and pass the clone to the <em>add()</em> method.
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1447,7 +1447,7 @@ console.log("Event added with uid " + ev.id.uid);
             </p>
 <div class="description">
             <p>
-If all the items are successfully added to the calendar, the success callback will be invoked, passing the list of <em>CalendarItem </em>objects that were added, with their identifier set (id attribute).
+If all the items are successfully added to the calendar, the success callback will be invoked, passing the list of <em>CalendarItem</em> objects that were added, with their identifier set (id attribute).
             </p>
             <p>
 The <em>ErrorCallback</em> method is launched with these error types:
@@ -1456,10 +1456,10 @@ The <em>ErrorCallback</em> method is launched with these error types:
               <li>
 InvalidValuesError - if any of the input parameters contain an invalid value, the item has any invalid value or the calendar has some restrictions that cause the attempted insertion of the calendar items to fail (for example, limitations in the size of text attributes).              </li>
               <li>
-UnknownError - if any other error occurs.               </li>
+UnknownError - if any other error occurs.              </li>
             </ul>
             <p>
-If you wish to update an existing item, call the <em>update() </em>method instead. If you wish to add a copy of an existing <em>CalendarItem </em>object, call CalendarItem.clone() method first and pass the clone to the add() method.
+If you wish to update an existing item, call the <em>update()</em> method instead. If you wish to add a copy of an existing <em>CalendarItem</em> object, call CalendarItem.clone() method first and pass the clone to the add() method.
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1651,11 +1651,11 @@ UnknownError - if any other error occurs.              </li>
                 </li>
           <li class="param">
 <span class="name">successCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
- Callback method that is invoked when the <em>updateEvents() </em>request succeeds.
+ Callback method that is invoked when the <em>updateEvents()</em> request succeeds.
                 </li>
           <li class="param">
 <span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
- Callback method that is invoked when the <em>updateEvents() </em>request fails.
+ Callback method that is invoked when the <em>updateEvents()</em> request fails.
                 </li>
           <li class="param">
 <span class="name">updateAllInstances</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
@@ -1805,7 +1805,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
-NotFoundError - if an identifier in the <em>ids </em>parameter does not correspond to the id attribute of an item in the calendar.              </li>
+NotFoundError - if an identifier in the <em>ids</em> parameter does not correspond to the id attribute of an item in the calendar.              </li>
               <li>
 InvalidValuesError - if any of the input parameters contain an invalid value.              </li>
               <li>
@@ -1826,7 +1826,7 @@ UnknownError - if any other error occurs.              </li>
 <ul>
           <li class="param">
 <span class="name">ids</span>:
- The identifiers (<em>id </em>attribute) of the items to delete.
+ The identifiers (<em>id</em> attribute) of the items to delete.
                 </li>
           <li class="param">
 <span class="name">successCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
@@ -1888,7 +1888,7 @@ myCalendar.find(eventSearchSuccessCallback, errorCallback);
 </dt>
 <dd>
 <div class="brief">
- Finds and fetches an array of <em>CalendarItem </em>objects for items stored in the calendar according to the supplied filter if it is valid else it will return all the items stored.
+ Finds and fetches an array of <em>CalendarItem</em> objects for items stored in the calendar according to the supplied filter if it is valid else it will return all the items stored.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void find(<a href="#CalendarItemArraySuccessCallback">CalendarItemArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter,
           optional <a href="tizen.html#SortMode">SortMode</a>? sortMode);</pre></div>
@@ -1897,9 +1897,9 @@ myCalendar.find(eventSearchSuccessCallback, errorCallback);
             </p>
 <div class="description">
             <p>
-If the filter is passed and contains valid values, only those values in the calendar that match the filter criteria as specified in the <em>AbstractFilter </em>interface will be returned in the <em>successCallback()</em>.
-If no filter is passed, or the filter contains any invalid value which is <var>null </var>or undefined, then the implementation must return the full list of items in the <em>successCallback()</em>.
-If no items are available in the calendar (it is empty) or no item matches the filter criteria, the <em>successCallback() </em>will be invoked with an empty array.
+If the filter is passed and contains valid values, only those values in the calendar that match the filter criteria as specified in the <em>AbstractFilter</em> interface will be returned in the <em>successCallback()</em>.
+If no filter is passed, or the filter contains any invalid value which is <var>null</var> or undefined, then the implementation must return the full list of items in the <em>successCallback()</em>.
+If no items are available in the calendar (it is empty) or no item matches the filter criteria, the <em>successCallback()</em> will be invoked with an empty array.
             </p>
             <p>
 The <em>ErrorCallback</em> method is launched with these error types:
@@ -1939,7 +1939,7 @@ If no recurrence ID is given, the filter will match both the parent event and al
                 </li>
           <li class="param">
 <span class="name">filter</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
- Supplied data used to filter the results of the <em>find() </em>method.
+ Supplied data used to filter the results of the <em>find()</em> method.
                 </li>
           <li class="param">
 <span class="name">sortMode</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
@@ -2085,8 +2085,8 @@ watcherId = calendar.addChangeListener(watcher);
             </p>
 <div class="description">
             <p>
-If the <em>watchId </em>argument is valid and corresponds to a subscription already in place, the watch process must immediately stop and no further callbacks must be invoked.
-If the <em>watchId </em>argument is not valid or does not correspond to a valid subscription, the method should return without any further action.
+If the <em>watchId</em> argument is valid and corresponds to a subscription already in place, the watch process must immediately stop and no further callbacks must be invoked.
+If the <em>watchId</em> argument is not valid or does not correspond to a valid subscription, the method should return without any further action.
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2196,7 +2196,7 @@ These attributes are shared by both calendar events and tasks.
           </p>
 <div class="description">
           <p>
-It also provides an interface for specifying task attributes upon task creation (in the <em>CalendarTask </em>constructor).
+It also provides an interface for specifying task attributes upon task creation (in the <em>CalendarTask</em> constructor).
           </p>
           <p>
 All the attributes are optional and are undefined by default.
@@ -2219,7 +2219,7 @@ All the attributes are optional and are undefined by default.
           </p>
 <div class="description">
           <p>
-Provides an interface for specifying event attributes upon event creation (in the <em>CalendarEvent </em>constructor).
+Provides an interface for specifying event attributes upon event creation (in the <em>CalendarEvent</em> constructor).
           </p>
           <p>
 All the attributes are optional and are undefined by default.
@@ -2351,7 +2351,7 @@ The default value is an empty string.
             </div>
 <div class="description">
             <p>
-If set to <var>true</var>, then the time and time zone of the <em>startDate </em>are to be ignored and are not guaranteed to be stored in the database. An all-day event always covers the whole day, regardless of which time zone it was defined in and what the current time zone is. The duration must be <var>n*60*24 </var>minutes for an event lasting <var>n</var> days.
+If set to <var>true</var>, then the time and time zone of the <em>startDate</em> are to be ignored and are not guaranteed to be stored in the database. An all-day event always covers the whole day, regardless of which time zone it was defined in and what the current time zone is. The duration must be <var>n*60*24</var>minutes for an event lasting <var>n</var> days.
             </p>
             <p>
 The default value for this attribute is <var>false</var>.
@@ -2506,7 +2506,7 @@ The default value for this attribute is <var>NONE</var>.
             </div>
 <div class="description">
             <p>
-The default value for this attribute is <var>NONE </var>priority.
+The default value for this attribute is <var>NONE</var> priority.
             </p>
             <p>
 If the native item database supports another priority schema (such as a range from 1 to 9), the implementation must convert those values to the supported values. For instance, RFC 5545 suggests the following mapping for a range from 1 to 9:
@@ -2674,7 +2674,7 @@ myCalendar.find(eventSearchSuccessCallback, errorCallback, filter);
 </dt>
 <dd>
 <div class="brief">
- Clones the <em>CalendarItem </em>object, detached from any calendar.
+ Clones the <em>CalendarItem</em> object, detached from any calendar.
             </div>
 <div class="synopsis"><pre class="signature prettyprint"><a href="#CalendarItem">CalendarItem</a> clone();</pre></div>
 <p><span class="version">Since: </span>
@@ -2682,7 +2682,7 @@ myCalendar.find(eventSearchSuccessCallback, errorCallback, filter);
             </p>
 <div class="description">
             <p>
-The <em>CalendarItem </em>object returned by the <em>clone()</em> method will have its identifier set to <var>null </var>and will be detached from any calendar.
+The <em>CalendarItem</em> object returned by the <em>clone()</em> method will have its identifier set to <var>null</var> and will be detached from any calendar.
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2695,7 +2695,7 @@ The <em>CalendarItem </em>object returned by the <em>clone()</em> method will ha
 <p><span class="return">Return value:</span></p>
 <ul>
 <span class="return">CalendarItem:</span>
- New clone of the <em>CalendarItem </em>object.
+ New clone of the <em>CalendarItem</em> object.
               </ul>
 </div>
 <div class="exceptionlist">
@@ -2737,7 +2737,7 @@ calendar.add(tizenseminar);
 <div class="interface" id="CalendarTask">
 <a class="backward-compatibility-anchor" name="::Calendar::CalendarTask"></a><h3>2.8. CalendarTask</h3>
 <div class="brief">
- This interface implements the <em>CalendarTask </em>object.
+ This interface implements the <em>CalendarTask</em> object.
           </div>
 <pre class="webidl prettyprint">  [Constructor(optional <a href="#CalendarTaskInit">CalendarTaskInit</a>? taskInitDict),
    Constructor(DOMString stringRepresentation, <a href="#CalendarTextFormat">CalendarTextFormat</a> format)]
@@ -2859,7 +2859,7 @@ The default value is <var>null</var>. If no value is provided, the task is not c
             </div>
 <div class="description">
             <p>
-The value is a positive integer between <var>0 </var>and <var>100</var>. A value of <var>0 </var>indicates the task has not been started yet. A value of <var>100 </var>indicates that the task has been completed.
+The value is a positive integer between <var>0</var>and <var>100</var>. A value of <var>0</var>indicates the task has not been started yet. A value of <var>100</var>indicates that the task has been completed.
             </p>
             <p>
 Integer values in between indicate the percent partially complete.
@@ -2883,7 +2883,7 @@ The default value is <var>0</var>, implies that the task has not been started.
 <div class="interface" id="CalendarEvent">
 <a class="backward-compatibility-anchor" name="::Calendar::CalendarEvent"></a><h3>2.9. CalendarEvent</h3>
 <div class="brief">
- This interface implements the <em>calendarEvent </em>object.
+ This interface implements the <em>calendarEvent</em> object.
           </div>
 <pre class="webidl prettyprint">  [Constructor(optional <a href="#CalendarEventInit">CalendarEventInit</a>? eventInitDict),
    Constructor(DOMString stringRepresentation, <a href="#CalendarTextFormat">CalendarTextFormat</a> format)]
@@ -3051,7 +3051,7 @@ event.recurrenceRule = rule;
 This method takes into consideration all the parameters of the event recurrence rule to generate the instances occurring in a given time interval.
             </p>
             <p>
-The call involves retrieving from the database detached instances of an event to replace their corresponding virtual instances in the returned list. The client can then use <em>CalendarEvent.isDetached </em>attribute to identify detached instances. If the event is not saved to a calendar yet, only virtual instances will be returned.
+The call involves retrieving from the database detached instances of an event to replace their corresponding virtual instances in the returned list. The client can then use <em>CalendarEvent.isDetached</em> attribute to identify detached instances. If the event is not saved to a calendar yet, only virtual instances will be returned.
             </p>
             <p>
 The <em>ErrorCallback</em> method is launched with these error types:
@@ -3156,14 +3156,14 @@ if (event.recurrenceRule != null)
           </p>
 <div class="description">
           <p>
-See <em>CalendarAttendee </em>interface for more information about the members.
+See <em>CalendarAttendee</em> interface for more information about the members.
           </p>
          </div>
 </div>
 <div class="interface" id="CalendarAttendee">
 <a class="backward-compatibility-anchor" name="::Calendar::CalendarAttendee"></a><h3>2.11. CalendarAttendee</h3>
 <div class="brief">
- The CalendarAttendee interface implements the <em>CalendarAttendee </em>object that contains information about an event attendee.
+ The CalendarAttendee interface implements the <em>CalendarAttendee</em> object that contains information about an event attendee.
           </div>
 <pre class="webidl prettyprint">  [Constructor(DOMString uri, optional <a href="#CalendarAttendeeInit">CalendarAttendeeInit</a>? attendeeInitDict)]
   interface CalendarAttendee {
@@ -3318,7 +3318,7 @@ The default value is <var>INDIVIDUAL</var>.
             </div>
 <div class="description">
             <p>
-If the contact is not resolved, this attribute will be set to<var> null</var>.
+If the contact is not resolved, this attribute will be set to <var>null</var>.
 For more information, see the <a href="contact.html">Contact API</a>.
             </p>
            </div>
@@ -3347,14 +3347,14 @@ For more information, see the <a href="contact.html">Contact API</a>.
           </p>
 <div class="description">
           <p>
-For more information about the members, see <em>CalendarRecurrenceRule </em>interface.
+For more information about the members, see <em>CalendarRecurrenceRule</em> interface.
           </p>
          </div>
 </div>
 <div class="interface" id="CalendarRecurrenceRule">
 <a class="backward-compatibility-anchor" name="::Calendar::CalendarRecurrenceRule"></a><h3>2.13. CalendarRecurrenceRule</h3>
 <div class="brief">
- The CalendarRecurrenceRule interface implements the<em> CalendarRecurrenceRule </em>object, which contains information about the recurrence of an event.
+ The CalendarRecurrenceRule interface implements the <em>CalendarRecurrenceRule</em> object, which contains information about the recurrence of an event.
 (See RFC 5545, Section 3.3.10.)
           </div>
 <pre class="webidl prettyprint">  [Constructor(<a href="#RecurrenceRuleFrequency">RecurrenceRuleFrequency</a> frequency, optional <a href="#CalendarRecurrenceRuleInit">CalendarRecurrenceRuleInit</a>? ruleInitDict)]
@@ -3407,13 +3407,13 @@ This property corresponds to <em>FREQ</em> in RFC 5545.
             </div>
 <div class="description">
             <p>
-This attribute is linked to the <em>frequency </em>attribute and for an interval of <var>n</var>, the event will recur every <var>n </var>of recurrence attribute.
+This attribute is linked to the <em>frequency</em> attribute and for an interval of <var>n</var>, the event will recur every <var>n</var> of recurrence attribute.
             </p>
             <p>
-For example, if the interval attribute is set to <var>2 </var>and <em>frequency </em>attribute is set to <var>WEEKLY</var>, then the event will recur every 2 weeks.
+For example, if the interval attribute is set to <var>2</var>and <em>frequency</em> attribute is set to <var>WEEKLY</var>, then the event will recur every 2 weeks.
             </p>
             <p>
-The default interval value is <var>1</var>, that is, every day if the <em>CalendarRecurrenceRule frequency</em> attribute is DAILY, every week if frequency is <var>WEEKLY</var>, every month if frequency is <var>MONTHLY </var>or every year if frequency is <var>YEARLY</var>.
+The default interval value is <var>1</var>, that is, every day if the <em>CalendarRecurrenceRule frequency</em> attribute is DAILY, every week if frequency is <var>WEEKLY</var>, every month if frequency is <var>MONTHLY</var> or every year if frequency is <var>YEARLY</var>.
             </p>
             <p>
 This property corresponds to <em>INTERVAL</em> in RFC 5545.
@@ -3425,11 +3425,11 @@ This property corresponds to <em>INTERVAL</em> in RFC 5545.
 </li>
 <li class="attribute" id="CalendarRecurrenceRule::untilDate">
 <span class="attrName"><span class="type">TZDate </span><span class="name">untilDate</span><span class="optional"> [nullable]</span></span><div class="brief">
- The end date of a recurrence duration of an event using either an end date (<em>untilDate </em>attribute) or a number of occurrences (<em>occurrenceCount </em>attribute).
+ The end date of a recurrence duration of an event using either an end date (<em>untilDate</em> attribute) or a number of occurrences (<em>occurrenceCount</em> attribute).
             </div>
 <div class="description">
             <p>
-By default, this attribute is set to <var>null</var>, meaning that the event recurs infinitely, unless <em>occurrenceCount </em>is set.
+By default, this attribute is set to <var>null</var>, meaning that the event recurs infinitely, unless <em>occurrenceCount</em> is set.
             </p>
             <p>
 This attribute is precise to the second. Milliseconds are ignored.
@@ -3451,10 +3451,10 @@ This property corresponds to <em>UNTIL</em> in RFC 5545.
             </div>
 <div class="description">
             <p>
-The recurrence duration of an event can be defined using either an end date (<em>untilDate </em>attribute) or a number of occurrences (<em>occurrenceCount </em>attribute).
+The recurrence duration of an event can be defined using either an end date (<em>untilDate</em> attribute) or a number of occurrences (<em>occurrenceCount</em> attribute).
             </p>
             <p>
-By default, this attribute is set to <var>-1</var>, meaning that the event recurs infinitely, unless <em>untilDate </em>is set.
+By default, this attribute is set to <var>-1</var>, meaning that the event recurs infinitely, unless <em>untilDate</em> is set.
             </p>
             <p>
 This property corresponds to <em>COUNT</em> in RFC 5545.
@@ -3494,7 +3494,7 @@ By default, this attribute is set to an empty array.
             </div>
 <div class="description">
             <p>
-For example, a yearly recurrence rule that has a <em>daysOfTheWeek </em>value that specifies Monday through Friday, and a <em>setPositions </em>array containing <var>2 </var>and <var>-1</var>, occurs only on the second weekday and last weekday of every year.
+For example, a yearly recurrence rule that has a <em>daysOfTheWeek</em> value that specifies Monday through Friday, and a <em>setPositions</em> array containing <var>2</var>and <var>-1</var>, occurs only on the second weekday and last weekday of every year.
             </p>
             <p>
 Values can be from 1 to 366 or -366 to -1.
@@ -3587,7 +3587,7 @@ This value is assigned by the platform when the <em>add()</em> method is success
 </li>
 <li class="attribute" id="CalendarEventId::rid">
 <span class="attrName"><span class="type">DOMString </span><span class="name">rid</span><span class="optional"> [nullable]</span></span><div class="brief">
- The recurrence ID of a <em>CalendarEvent </em>instance.
+ The recurrence ID of a <em>CalendarEvent</em> instance.
             </div>
 <div class="description">
             <p>
@@ -3654,7 +3654,7 @@ var alarm2 = new tizen.CalendarAlarm(new tizen.TimeDuration(1, "MINS"), "SOUND")
             </div>
 <div class="description">
             <p>
-<em>absoluteDate </em>and <em>before </em>are mutually exclusive.
+<em>absoluteDate</em> and <em>before</em> are mutually exclusive.
             </p>
             <p>
 This attribute is precise to the second. Milliseconds are ignored.
@@ -3673,7 +3673,7 @@ This attribute is precise to the second. Milliseconds are ignored.
 The duration should be positive.
             </p>
             <p>
-<em>absoluteDate </em>and <em>before </em>are mutually exclusive.
+<em>absoluteDate</em> and <em>before</em> are mutually exclusive.
             </p>
             <p>
 This attribute is precise to the second. Milliseconds are ignored.
@@ -3740,7 +3740,7 @@ The default value is an empty string.
 <ul>
           <li class="param">
 <span class="name">events</span>:
- Array of <em>CalendarEvent </em>objects.
+ Array of <em>CalendarEvent</em> objects.
                 </li>
         </ul>
 </div>
@@ -3804,7 +3804,7 @@ if (event.recurrenceRule != null)
 <ul>
           <li class="param">
 <span class="name">items</span>:
- Array of <em>CalendarItem </em>objects.
+ Array of <em>CalendarItem</em> objects.
                 </li>
         </ul>
 </div>
@@ -3859,7 +3859,7 @@ calendar.addBatch([ev], calendarItemArraySuccessCB, errorCallback);
 </dt>
 <dd>
 <div class="brief">
- Called when the array of <em>Calendar </em>objects is retrieved successfully.
+ Called when the array of <em>Calendar</em> objects is retrieved successfully.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void onsuccess(<a href="#Calendar">Calendar</a>[] calendars);</pre></div>
 <p><span class="version">Since: </span>
@@ -3870,7 +3870,7 @@ calendar.addBatch([ev], calendarItemArraySuccessCB, errorCallback);
 <ul>
           <li class="param">
 <span class="name">calendars</span>:
- Array of <em>Calendar </em>objects.
+ Array of <em>Calendar</em> objects.
                 </li>
         </ul>
 </div>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/calendar.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/calendar.html
@@ -2351,7 +2351,7 @@ The default value is an empty string.
             </div>
 <div class="description">
             <p>
-If set to <var>true</var>, then the time and time zone of the <em>startDate</em> are to be ignored and are not guaranteed to be stored in the database. An all-day event always covers the whole day, regardless of which time zone it was defined in and what the current time zone is. The duration must be <var>n*60*24</var>minutes for an event lasting <var>n</var> days.
+If set to <var>true</var>, then the time and time zone of the <em>startDate</em> are to be ignored and are not guaranteed to be stored in the database. An all-day event always covers the whole day, regardless of which time zone it was defined in and what the current time zone is. The duration must be <var>n*60*24</var> minutes for an event lasting <var>n</var> days.
             </p>
             <p>
 The default value for this attribute is <var>false</var>.
@@ -2859,7 +2859,7 @@ The default value is <var>null</var>. If no value is provided, the task is not c
             </div>
 <div class="description">
             <p>
-The value is a positive integer between <var>0</var>and <var>100</var>. A value of <var>0</var>indicates the task has not been started yet. A value of <var>100</var>indicates that the task has been completed.
+The value is a positive integer between <var>0</var> and <var>100</var>. A value of <var>0</var> indicates the task has not been started yet. A value of <var>100</var> indicates that the task has been completed.
             </p>
             <p>
 Integer values in between indicate the percent partially complete.
@@ -3410,7 +3410,7 @@ This property corresponds to <em>FREQ</em> in RFC 5545.
 This attribute is linked to the <em>frequency</em> attribute and for an interval of <var>n</var>, the event will recur every <var>n</var> of recurrence attribute.
             </p>
             <p>
-For example, if the interval attribute is set to <var>2</var>and <em>frequency</em> attribute is set to <var>WEEKLY</var>, then the event will recur every 2 weeks.
+For example, if the interval attribute is set to <var>2</var> and <em>frequency</em> attribute is set to <var>WEEKLY</var>, then the event will recur every 2 weeks.
             </p>
             <p>
 The default interval value is <var>1</var>, that is, every day if the <em>CalendarRecurrenceRule frequency</em> attribute is DAILY, every week if frequency is <var>WEEKLY</var>, every month if frequency is <var>MONTHLY</var> or every year if frequency is <var>YEARLY</var>.
@@ -3494,7 +3494,7 @@ By default, this attribute is set to an empty array.
             </div>
 <div class="description">
             <p>
-For example, a yearly recurrence rule that has a <em>daysOfTheWeek</em> value that specifies Monday through Friday, and a <em>setPositions</em> array containing <var>2</var>and <var>-1</var>, occurs only on the second weekday and last weekday of every year.
+For example, a yearly recurrence rule that has a <em>daysOfTheWeek</em> value that specifies Monday through Friday, and a <em>setPositions</em> array containing <var>2</var> and <var>-1</var>, occurs only on the second weekday and last weekday of every year.
             </p>
             <p>
 Values can be from 1 to 366 or -366 to -1.

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/contact.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/contact.html
@@ -22,7 +22,7 @@ e-mail addresses.
 <a href="http://www.ietf.org/rfc/rfc2426.txt"> RFC 2426 vCard MIME Directory Profile</a> defines a format for exchanging contacts. The Contact API refers to this specification to provide a mapping of the specified contact attributes.
         </p>
         <p>
-A <em>person </em>is a set of information that describes a person. Two different <em>contacts</em> that indicate the same person will have the same person ID. A person has a display contact ID that indicates a contact that represents information of the person. A person is automatically created when a new contact is added.
+A <em>person</em> is a set of information that describes a person. Two different <em>contacts</em> that indicate the same person will have the same person ID. A person has a display contact ID that indicates a contact that represents information of the person. A person is automatically created when a new contact is added.
         </p>
         <p>
 This API provides functionality to read, create, remove, and update contacts in specific address books. Address books can be obtained using the <em>getAddressBooks()</em> method, which returns an array of <em>AddressBook</em> objects.
@@ -439,7 +439,7 @@ CUSTOM - Custom relationship. The actual type can be set in the label.          
 <div class="enum" id="ContactInstantMessengerType">
 <a class="backward-compatibility-anchor" name="::Contact::ContactInstantMessengerType"></a><h3>1.8. ContactInstantMessengerType</h3>
 <div class="brief">
-  Specifies instant messenger types.
+ Specifies instant messenger types.
 The possible values are:
           </div>
 <pre class="webidl prettyprint">  enum ContactInstantMessengerType { "OTHER", "GOOGLE", "WLM", "YAHOO", "FACEBOOK", "ICQ", "AIM", "QQ", "JABBER", "SKYPE", "IRC",
@@ -479,7 +479,7 @@ CUSTOM - Custom IM service provider. The actual type can be set in the label.   
 <div class="enum" id="ContactUsageType">
 <a class="backward-compatibility-anchor" name="::Contact::ContactUsageType"></a><h3>1.9. ContactUsageType</h3>
 <div class="brief">
-  Specifies contact usage types.
+ Specifies contact usage types.
 The possible values are:
           </div>
 <pre class="webidl prettyprint">  enum ContactUsageType { "OUTGOING_CALL", "OUTGOING_MSG", "OUTGOING_EMAIL", "INCOMING_CALL", "INCOMING_MSG", "INCOMING_EMAIL",
@@ -518,7 +518,7 @@ BLOCKED_MSG - blocked message usage type            </li>
 <div class="interface" id="ContactManagerObject">
 <a class="backward-compatibility-anchor" name="::Contact::ContactManagerObject"></a><h3>2.1. ContactManagerObject</h3>
 <div class="brief">
- The ContactManagerObject interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
+ The ContactManagerObject interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface ContactManagerObject {
     readonly attribute <a href="#ContactManager">ContactManager</a> contact;
@@ -529,7 +529,7 @@ BLOCKED_MSG - blocked message usage type            </li>
           </p>
 <div class="description">
           <p>
-The <em>tizen.contact </em>object allows access to the Contact API functionality.
+The <em>tizen.contact</em> object allows access to the Contact API functionality.
           </p>
          </div>
 <div class="attributes">
@@ -1545,7 +1545,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
-NotFoundError - If an identifier in the <em>personIds </em>parameter does not correspond to the ID of any person in the contact DB. (Otherwise, the implementation will attempt to remove the contacts corresponding to these identifiers).              </li>
+NotFoundError - If an identifier in the <em>personIds</em> parameter does not correspond to the ID of any person in the contact DB. (Otherwise, the implementation will attempt to remove the contacts corresponding to these identifiers).              </li>
               <li>
 InvalidValuesError - If any of the input parameters contain an invalid value.              </li>
               <li>
@@ -1639,7 +1639,7 @@ catch (err)
 </dt>
 <dd>
 <div class="brief">
- Gets an array of all <em>Person </em>objects from the contact DB or the ones that match the optionally supplied filter.
+ Gets an array of all <em>Person</em> objects from the contact DB or the ones that match the optionally supplied filter.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void find(<a href="#PersonArraySuccessCallback">PersonArraySuccessCallback</a> successCallback, optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#AbstractFilter">AbstractFilter</a>? filter,
           optional <a href="tizen.html#SortMode">SortMode</a>? sortMode);</pre></div>
@@ -1651,7 +1651,7 @@ catch (err)
 If the filter is passed and contains valid values, only those values in the
 address book that match the filter criteria as specified in the AbstractFilter
 interface will be returned in the successCallback. If no filter is passed, the filter
-contains any invalid values, the filter is <var>null </var> or undefined, then
+contains any invalid values, the filter is <var>null</var> or undefined, then
 the implementation must return the full list of contact items
 in the successCallback. If no persons are available in the contact DB or no
 person matches the filter criteria, the successCallback will be invoked
@@ -1745,7 +1745,7 @@ catch (err)
 </dt>
 <dd>
 <div class="brief">
- Gets an array of <em>Person </em>objects from the contact DB which match the supplied filter. This method is for filtering usageCount property of Person objects.
+ Gets an array of <em>Person</em> objects from the contact DB which match the supplied filter. This method is for filtering usageCount property of Person objects.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void findByUsageCount(<a href="#ContactUsageCountFilter">ContactUsageCountFilter</a> filter, <a href="#PersonArraySuccessCallback">PersonArraySuccessCallback</a> successCallback,
                       optional <a href="tizen.html#ErrorCallback">ErrorCallback</a>? errorCallback, optional <a href="tizen.html#SortModeOrder">SortModeOrder</a>? sortModeOrder, optional unsigned long limit,
@@ -2074,32 +2074,32 @@ An address book is a collection of contacts and groups. This interface offers th
           </p>
           <ul>
             <li>
- <em>get()</em> - To get contacts that have a specific ID            </li>
+<em>get()</em> - To get contacts that have a specific ID            </li>
             <li>
- <em>find()</em> - To find contacts using filters            </li>
+<em>find()</em> - To find contacts using filters            </li>
             <li>
- <em>add() </em>or <em>addBatch()</em> - To add contacts to a specific address book            </li>
+<em>add()</em> or <em>addBatch()</em> - To add contacts to a specific address book            </li>
             <li>
- <em>update() </em>or <em>updateBatch()</em> - To update contacts in a specific address book            </li>
+<em>update()</em> or <em>updateBatch()</em> - To update contacts in a specific address book            </li>
             <li>
- <em>remove() </em>or <em>removeBatch() </em> - To remove existing contacts            </li>
+<em>remove()</em> or <em>removeBatch()</em>  - To remove existing contacts            </li>
             <li>
- <em>addChangeListener() </em>or <em>removeChangeListener() </em> - To watch for address book changes            </li>
+<em>addChangeListener()</em> or <em>removeChangeListener()</em>  - To watch for address book changes            </li>
           </ul>
           <p>
 This interface also offers the following methods to manipulate groups within the address book:
           </p>
           <ul>
             <li>
- <em>getGroup()</em> - To get a group having a specific ID            </li>
+<em>getGroup()</em> - To get a group having a specific ID            </li>
             <li>
- <em>getGroups()</em> - To get groups in a specific address book            </li>
+<em>getGroups()</em> - To get groups in a specific address book            </li>
             <li>
- <em>addGroup() </em> - To add groups to a specific address book             </li>
+<em>addGroup()</em>  - To add groups to a specific address book            </li>
             <li>
- <em>updateGroup() </em> - To update groups in a specific address book            </li>
+<em>updateGroup()</em>  - To update groups in a specific address book            </li>
             <li>
- <em>removeGroup() </em> - To remove existing groups            </li>
+<em>removeGroup()</em>  - To remove existing groups            </li>
           </ul>
          </div>
 <div class="example">
@@ -2142,7 +2142,7 @@ tizen.account.getAccounts(
             </div>
 <div class="description">
             <p>
-The value of this attribute is <var>null </var> if the address book
+The value of this attribute is <var>null</var> if the address book
 is the unified address book.
             </p>
            </div>
@@ -2586,7 +2586,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
-NotFoundError - If an identifier in the IDs parameter does not correspond to the <em>id </em>attribute of any contact in the address book.              </li>
+NotFoundError - If an identifier in the IDs parameter does not correspond to the <em>id</em> attribute of any contact in the address book.              </li>
               <li>
 InvalidValuesError - If any of the input parameters contain an invalid value.              </li>
               <li>
@@ -2805,7 +2805,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
-NotFoundError - If an identifier in the IDs parameter does not correspond to the <em>id </em>attribute of any contact in the address book (Otherwise, the implementation will attempt to remove the contacts that correspond to these identifiers).              </li>
+NotFoundError - If an identifier in the IDs parameter does not correspond to the <em>id</em> attribute of any contact in the address book (Otherwise, the implementation will attempt to remove the contacts that correspond to these identifiers).              </li>
               <li>
 InvalidValuesError - If any of the input parameters contain an invalid value.              </li>
               <li>
@@ -4080,7 +4080,7 @@ This dictionary is used to input parameters when contacts are created.
 <div class="interface" id="Contact">
 <a class="backward-compatibility-anchor" name="::Contact::Contact"></a><h3>2.6. Contact</h3>
 <div class="brief">
- The Contact interface is used to create a <em>Contact </em>object.
+ The Contact interface is used to create a <em>Contact</em> object.
           </div>
 <pre class="webidl prettyprint">  [Constructor(optional <a href="#ContactInit">ContactInit</a>? ContactInitDict),
    Constructor(DOMString stringRepresentation)]
@@ -5292,7 +5292,7 @@ By default, this attribute is set to HOMEPAGE.
 <div class="interface" id="ContactAnniversary">
 <a class="backward-compatibility-anchor" name="::Contact::ContactAnniversary"></a><h3>2.13. ContactAnniversary</h3>
 <div class="brief">
- The <em>ContactAnniversary </em>interface contains the date and description of an anniversary.
+ The <em>ContactAnniversary</em> interface contains the date and description of an anniversary.
           </div>
 <pre class="webidl prettyprint">  [Constructor(Date date, optional DOMString? label)]
   interface ContactAnniversary {
@@ -6014,7 +6014,7 @@ This attribute only contains a local file URI.
 </li>
 <li class="attribute" id="ContactGroup::photoURI">
 <span class="attrName"><span class="type">DOMString </span><span class="name">photoURI</span><span class="optional"> [nullable]</span></span><div class="brief">
- The URI that points to an image that can represent the<em> Group </em>object. This attribute only contains a local file URI.
+ The URI that points to an image that can represent the <em>Group</em> object. This attribute only contains a local file URI.
             </div>
 <div class="description">
             <p>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/contact.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/contact.html
@@ -1759,7 +1759,7 @@ If the filter is passed and contains valid value, only this value in the
 address book that match the filter criteria as specified in the ContactUsageCountFilter
 interface will be returned in the successCallback. If no persons are available in the contact DB or no
 person matches the filter criteria, the successCallback will be invoked
-with an empty array. The attributeName in filter must be one of <a href="#ContactUsageType">ContactUsageType</a>  value.
+with an empty array. The attributeName in filter must be one of <a href="#ContactUsageType">ContactUsageType</a> value.
             </p>
             <p>
 The <em>ErrorCallback</em> method is launched with these error types:
@@ -2082,9 +2082,9 @@ An address book is a collection of contacts and groups. This interface offers th
             <li>
 <em>update()</em> or <em>updateBatch()</em> - To update contacts in a specific address book            </li>
             <li>
-<em>remove()</em> or <em>removeBatch()</em>  - To remove existing contacts            </li>
+<em>remove()</em> or <em>removeBatch()</em> - To remove existing contacts            </li>
             <li>
-<em>addChangeListener()</em> or <em>removeChangeListener()</em>  - To watch for address book changes            </li>
+<em>addChangeListener()</em> or <em>removeChangeListener()</em> - To watch for address book changes            </li>
           </ul>
           <p>
 This interface also offers the following methods to manipulate groups within the address book:
@@ -2095,11 +2095,11 @@ This interface also offers the following methods to manipulate groups within the
             <li>
 <em>getGroups()</em> - To get groups in a specific address book            </li>
             <li>
-<em>addGroup()</em>  - To add groups to a specific address book            </li>
+<em>addGroup()</em> - To add groups to a specific address book            </li>
             <li>
-<em>updateGroup()</em>  - To update groups in a specific address book            </li>
+<em>updateGroup()</em> - To update groups in a specific address book            </li>
             <li>
-<em>removeGroup()</em>  - To remove existing groups            </li>
+<em>removeGroup()</em> - To remove existing groups            </li>
           </ul>
          </div>
 <div class="example">

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/content.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/content.html
@@ -365,7 +365,7 @@ ROTATE_270 - corresponds to rotate 270 degrees image content orientation.       
           </p>
 <div class="description">
           <p>
-The <em>tizen.content </em>object allows accessing the functionality of the Content module.
+The <em>tizen.content</em> object allows accessing the functionality of the Content module.
           </p>
          </div>
 <div class="attributes">
@@ -1543,7 +1543,7 @@ tizen.content.find(findCB);
 <ul>
           <li class="param">
 <span class="name">contents</span>:
- The array of <em>Content </em>objects.
+ The array of <em>Content</em> objects.
                 </li>
         </ul>
 </div>
@@ -1581,7 +1581,7 @@ tizen.content.find(findCB);
 <ul>
           <li class="param">
 <span class="name">directories</span>:
- The array of <em>ContentDirectory </em>objects.
+ The array of <em>ContentDirectory</em> objects.
                 </li>
         </ul>
 </div>
@@ -2010,7 +2010,7 @@ The attribute is marked as read-only since Tizen 5.5.
 </li>
 <li class="attribute" id="Content::isFavorite">
 <span class="attrName"><span class="type">boolean </span><span class="name">isFavorite</span></span><div class="brief">
-  Boolean value that indicates whether a content item is marked as a favorite.
+ Boolean value that indicates whether a content item is marked as a favorite.
             </div>
 <p><span class="version">Since: </span>
  2.3
@@ -2022,7 +2022,7 @@ The attribute is marked as read-only since Tizen 5.5.
 <div class="interface" id="VideoContent">
 <a class="backward-compatibility-anchor" name="::Content::VideoContent"></a><h3>2.9. VideoContent</h3>
 <div class="brief">
- The VideoContent interface extends a basic <em>Content </em>object with video-specific attributes.
+ The VideoContent interface extends a basic <em>Content</em> object with video-specific attributes.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface VideoContent : <a href="#Content">Content</a> {
     readonly attribute <a href="tizen.html#SimpleCoordinates">SimpleCoordinates</a>? geolocation;
@@ -2163,7 +2163,7 @@ If the lyrics are not synchronized, the array has only one member with full lyri
 <div class="interface" id="AudioContent">
 <a class="backward-compatibility-anchor" name="::Content::AudioContent"></a><h3>2.11. AudioContent</h3>
 <div class="brief">
- The AudioContent interface extends a basic <em>Content </em>object with audio-specific attributes.
+ The AudioContent interface extends a basic <em>Content</em> object with audio-specific attributes.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface AudioContent : <a href="#Content">Content</a> {
     readonly attribute DOMString? album;
@@ -2280,7 +2280,7 @@ If the lyrics are not synchronized, the array has only one member with full lyri
 <div class="interface" id="ImageContent">
 <a class="backward-compatibility-anchor" name="::Content::ImageContent"></a><h3>2.12. ImageContent</h3>
 <div class="brief">
- The ImageContent interface extends a basic <em>Content </em>object with image-specific attributes.
+ The ImageContent interface extends a basic <em>Content</em> object with image-specific attributes.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface ImageContent : <a href="#Content">Content</a> {
     readonly attribute <a href="tizen.html#SimpleCoordinates">SimpleCoordinates</a>? geolocation;

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/device-motion.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/device-motion.html
@@ -89,7 +89,7 @@ Original documentation: <a href="https://cordova.apache.org/docs/en/3.0.0/cordov
 <div class="interface" id="AccelerometerManagerObject">
 <a class="backward-compatibility-anchor" name="::DeviceMotion::AccelerometerManagerObject"></a><h3>1.1. AccelerometerManagerObject</h3>
 <div class="brief">
- The <em>navigator.accelerometer </em>object allows access to the functionality of the DeviceMotion API.
+ The <em>navigator.accelerometer</em> object allows access to the functionality of the DeviceMotion API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface AccelerometerManagerObject {
     readonly attribute <a href="#Accelerometer">Accelerometer</a> accelerometer;

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/device.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/device.html
@@ -60,7 +60,7 @@ Original documentation: <a href="https://cordova.apache.org/docs/en/3.0.0/cordov
 <div class="interface" id="DeviceManagerObject">
 <a class="backward-compatibility-anchor" name="::Device::DeviceManagerObject"></a><h3>1.1. DeviceManagerObject</h3>
 <div class="brief">
- The <em>window.device </em>object allows access to the functionality of the Device API.
+ The <em>window.device</em> object allows access to the functionality of the Device API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface DeviceManagerObject {
     readonly attribute <a href="#Device">Device</a> device;

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/file.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/cordova/file.html
@@ -347,7 +347,7 @@ See <a href="https://www.w3.org/TR/FileAPI/#blob-section">The Blob Interface and
     readonly attribute boolean lengthComputable;
     readonly attribute unsigned long long loaded;
     readonly attribute unsigned long long total;
-    readonly attribute  target;
+    readonly attribute EventTarget target;
   };</pre>
 <p><span class="version">Since: </span>
  3.0
@@ -512,7 +512,7 @@ var event = new ProgressEvent("submit", eventInit);
           </p>
 <div class="description">
           <p>
-There is a <em>cordova.file </em>object that allows accessing the functionality of the Filesystem API.
+There is a <em>cordova.file</em> object that allows accessing the functionality of the Filesystem API.
           </p>
          </div>
 </div>
@@ -735,7 +735,7 @@ This manager interface exposes the Filesystem base API constants.
 <li class="attribute" id="FileSystemManager::tempDirectory">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">DOMString </span><span class="name">tempDirectory</span><span class="optional"> [nullable]</span></span><div class="brief">
-  Temp directory that the OS can clear at will. Do not rely on the OS to clear this directory; your app should always remove files as applicable.
+ Temp directory that the OS can clear at will. Do not rely on the OS to clear this directory; your app should always remove files as applicable.
             </div>
 <p><span class="version">Since: </span>
  3.0
@@ -3499,7 +3499,7 @@ entry.createWriter(successCallback, errorCallback);
     readonly attribute boolean lengthComputable;
     readonly attribute unsigned long long loaded;
     readonly attribute unsigned long long total;
-    readonly attribute  target;
+    readonly attribute EventTarget target;
   };
   [NoInterfaceObject] interface FileSystemManagerObject {
     readonly attribute <a href="#FileSystemManager">FileSystemManager</a> file;

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/datacontrol.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/datacontrol.html
@@ -220,7 +220,7 @@ Data Control API.
 <div class="interface" id="DataControlManager">
 <a class="backward-compatibility-anchor" name="::DataControl::DataControlManager"></a><h3>2.2. DataControlManager</h3>
 <div class="brief">
- This interface provides access to the <em>DataControlManager </em>object.
+ This interface provides access to the <em>DataControlManager</em> object.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface DataControlManager {
     <a href="#DataControlConsumerObject">DataControlConsumerObject</a> getDataControlConsumer(DOMString providerId, DOMString dataId, <a href="#DataType">DataType</a> type) raises(<a href="tizen.html#WebAPIException">WebAPIException</a>);
@@ -628,7 +628,7 @@ removeChangeListener was invoked
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">insertionData</span>:
@@ -713,7 +713,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">updateData</span>:
@@ -802,7 +802,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">where</span>:
@@ -892,7 +892,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">columns</span>:
@@ -1037,7 +1037,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">key</span>:
@@ -1124,7 +1124,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation. <br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation. <br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">key</span>:
@@ -1214,7 +1214,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">key</span>:
@@ -1300,7 +1300,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">reqId</span>:
- A unique identifier for the current operation.<br>So a developer should increase the <em>reqId </em>value to ensure it is unique for each method.
+ A unique identifier for the current operation.<br>So a developer should increase the <em>reqId</em> value to ensure it is unique for each method.
                 </li>
           <li class="param">
 <span class="name">key</span>:

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/download.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/download.html
@@ -185,8 +185,8 @@ ALL - Indicates that the download operation is allowed in all network types.    
 <div class="interface" id="DownloadManagerObject">
 <a class="backward-compatibility-anchor" name="::Download::DownloadManagerObject"></a><h3>2.1. DownloadManagerObject</h3>
 <div class="brief">
- This interface defines the default download manager that is instantiated by the <em>Tizen </em>object.
-The <em>tizen.download </em>object allows access to the functionality of the Download API.
+ This interface defines the default download manager that is instantiated by the <em>Tizen</em> object.
+The <em>tizen.download</em> object allows access to the functionality of the Download API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface DownloadManagerObject {
     readonly attribute <a href="#DownloadManager">DownloadManager</a> download;
@@ -900,7 +900,7 @@ tizen.download.setListener(downloadId, listener);
 <dd>
 <div class="brief">
  Called when a download is successful and it is called multiple times as the download progresses.
-The interval between the <em>onprogress()</em> callback is platform-dependent. When the download is started, the <em>receivedSize </em>can be <var>0</var>.
+The interval between the <em>onprogress()</em> callback is platform-dependent. When the download is started, the <em>receivedSize</em> can be <var>0</var>.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void onprogress(long downloadId, unsigned long long receivedSize, unsigned long long totalSize);</pre></div>
 <p><span class="version">Since: </span>
@@ -929,7 +929,7 @@ The interval between the <em>onprogress()</em> callback is platform-dependent. W
 </dt>
 <dd>
 <div class="brief">
- Called when the download operation is paused by the <em>pause() </em>method.
+ Called when the download operation is paused by the <em>pause()</em> method.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void onpaused(long downloadId);</pre></div>
 <p><span class="version">Since: </span>
@@ -950,7 +950,7 @@ The interval between the <em>onprogress()</em> callback is platform-dependent. W
 </dt>
 <dd>
 <div class="brief">
- Called when the download operation is canceled by the <em>cancel() </em>method.
+ Called when the download operation is canceled by the <em>cancel()</em> method.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void oncanceled(long downloadId);</pre></div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/filesystem.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/filesystem.html
@@ -40,15 +40,15 @@ music - the location for sounds          </li>
           <li>
 documents - the location for documents          </li>
           <li>
-downloads - the location for downloaded items           </li>
+downloads - the location for downloaded items          </li>
           <li>
-ringtones - the location for ringtones (read-only location)           </li>
+ringtones - the location for ringtones (read-only location)          </li>
           <li>
-camera - the location for the pictures and videos taken by a device (supported since Tizen 2.3)           </li>
+camera - the location for the pictures and videos taken by a device (supported since Tizen 2.3)          </li>
           <li>
 wgt-package - the location for widget package which is read-only          </li>
           <li>
-wgt-private - the location for a widget's private storage           </li>
+wgt-private - the location for a widget's private storage          </li>
           <li>
 wgt-private-tmp - the location for a widget's private volatile storage          </li>
           <li>
@@ -417,7 +417,7 @@ END - End of the file.            </li>
           </p>
 <div class="description">
           <p>
-There is a <em>tizen.filesystem </em>object that allows accessing the functionality of the Filesystem API.
+There is a <em>tizen.filesystem</em> object that allows accessing the functionality of the Filesystem API.
           </p>
          </div>
 <div class="attributes">
@@ -1907,7 +1907,7 @@ Strips trailing '/', then breaks <em>path</em> into two components by last <em>p
             </p>
 <div class="description">
             <p>
-The <em>onsuccess </em>method receives the data structure as an input argument containing additional information about the drive.
+The <em>onsuccess</em> method receives the data structure as an input argument containing additional information about the drive.
             </p>
             <p>
 The ErrorCallback is launched with these error types:
@@ -1918,7 +1918,7 @@ InvalidValuesError - If any of the input parameters contains an invalid value.  
               <li>
 NotFoundError - If no drive was found with the given label.              </li>
               <li>
-UnknownError - If any other error occurs.               </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2134,7 +2134,7 @@ watchID = tizen.filesystem.addStorageStateChangeListener(onStorageStateChanged);
             </p>
 <div class="description">
             <p>
-If the <em>watchId </em>argument is valid and corresponds to a subscription already in place, the watch process will be stopped and no further callbacks will be invoked.
+If the <em>watchId</em> argument is valid and corresponds to a subscription already in place, the watch process will be stopped and no further callbacks will be invoked.
 Otherwise, the method call has no effect.
             </p>
            </div>
@@ -2399,7 +2399,7 @@ The <em>ErrorCallback</em> is launched with these error types:
             </p>
             <ul>
               <li>
-IOError, if any error related to file handle occurs.               </li>
+IOError, if any error related to file handle occurs.              </li>
             </ul>
             <p>
 Note, that current position indicator value, can be obtained in SeekSuccessCallback by calling <var>seekNonBlocking(0, "CURRENT")</var>.
@@ -2764,7 +2764,7 @@ Sets file handle position indicator at the end of written data.
                 </li>
           <li class="param">
 <span class="name">outputEncoding</span><span class="optional"> [optional]</span>:
-  Default value: UTF-8. Encoding to use for write operation on the file, at least the following encodings must be supported:<br>"<a href="http://www.ietf.org/rfc/rfc2279.txt">UTF-8</a>" default encoding<br>"<a href="http://en.wikipedia.org/wiki/ISO/IEC_8859-1">ISO-8859-1</a>" Latin-1 encoding<br>                </li>
+ Default value: UTF-8. Encoding to use for write operation on the file, at least the following encodings must be supported:<br>"<a href="http://www.ietf.org/rfc/rfc2279.txt">UTF-8</a>" default encoding<br>"<a href="http://en.wikipedia.org/wiki/ISO/IEC_8859-1">ISO-8859-1</a>" Latin-1 encoding<br>                </li>
         </ul>
 </div>
 <div class="returntype">
@@ -4154,12 +4154,12 @@ A file item only matches the <em>FileFilter</em> object if all of the defined fi
 (only matching values other than <var>undefined</var> or <var>null</var>). This is similar to a SQL's "AND" operation.
           </p>
           <p>
-An attribute of the file entry matches the <em>FileFilter </em>attribute value in accordance with the
+An attribute of the file entry matches the <em>FileFilter</em> attribute value in accordance with the
 following rules:
           </p>
           <ul>
             <li>
-For <em>FileFilter </em>attributes of type DOMString, an entry matches this value only if its corresponding attribute is an exact match. If the filter contains U+0025 "PERCENT SIGN" it is interpreted as a wildcard character and "%" matches any string of any length, including no length. If wildcards are used, the behavior is similar to the LIKE condition in SQL. To specify that a "PERCENT SIGN" character is to be considered literally instead of interpreting it as a wildcard, developers can escape it with the backslash character (\). Please, remember that the backslash character has to be escaped itself, to not to be removed from the string - proper escaping of the "PERCENT SIGN" in JavaScript string requires preceding it with double backslash ("\\%").
+For <em>FileFilter</em> attributes of type DOMString, an entry matches this value only if its corresponding attribute is an exact match. If the filter contains U+0025 "PERCENT SIGN" it is interpreted as a wildcard character and "%" matches any string of any length, including no length. If wildcards are used, the behavior is similar to the LIKE condition in SQL. To specify that a "PERCENT SIGN" character is to be considered literally instead of interpreting it as a wildcard, developers can escape it with the backslash character (\). Please, remember that the backslash character has to be escaped itself, to not to be removed from the string - proper escaping of the "PERCENT SIGN" in JavaScript string requires preceding it with double backslash ("\\%").
 The matching is not case sensitive, such as "FOO" matches a "foo" or an "f%" filter.            </li>
             <li>
 For File entry attributes of type Date, attributes start and end are included to allow filtering of File entries between two supplied dates. If either or both of these attributes are specified, the following rules apply:<br>A) If both start and end dates are specified (that is, other than <var>null</var>), a File entry matches the filter if its corresponding attribute is the same as either start or end or between the two supplied dates (that is, after start and before end).<br>B) If only the start attribute contains a value (other than <var>null</var>), a File entry matches the filter if its corresponding attribute is later than or equal to the start one.<br>C) If only the end date contains a value (other than <var>null</var>), a file matches the filter if its corresponding attribute is earlier than or equal to the end date.            </li>
@@ -4307,7 +4307,7 @@ It is used in asynchronous operations, such as FileSystemManager.listStorages().
 <div class="interface" id="FileSystemStorageSuccessCallback">
 <a class="backward-compatibility-anchor" name="::Filesystem::FileSystemStorageSuccessCallback"></a><h3>2.7. FileSystemStorageSuccessCallback</h3>
 <div class="brief">
- The FileSystemStorageSuccessCallback callback interface specifies a success callback with a <em>FileSystemStorage </em>object as input argument.
+ The FileSystemStorageSuccessCallback callback interface specifies a success callback with a <em>FileSystemStorage</em> object as input argument.
           </div>
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface FileSystemStorageSuccessCallback {
     void onsuccess(<a href="#FileSystemStorage">FileSystemStorage</a> storage);

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/humanactivitymonitor.html
@@ -383,7 +383,7 @@ The activity accuracy defined by this enumerator are:
           </p>
           <ul>
             <li>
-LOW - Low accuracy             </li>
+LOW - Low accuracy            </li>
             <li>
 MEDIUM - Medium accuracy            </li>
             <li>
@@ -579,7 +579,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError: If the <em>getHumanActivityData()</em> method is called without previously calling the <em>start()</em> method              </li>
+ServiceNotAvailableError: If the <em>getHumanActivityData()</em> method is called without previously calling the <em>start()</em> method              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -677,7 +677,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError - If the human activity service is not available. For the GPS type, if the GPS function is disabled by the user in the location settings, it is not possible to receive notifications when the GPS value changes.              </li>
+ServiceNotAvailableError - If the human activity service is not available. For the GPS type, if the GPS function is disabled by the user in the location settings, it is not possible to receive notifications when the GPS value changes.              </li>
             </ul>
            </div>
 <div class="description">
@@ -966,7 +966,7 @@ The <em>ErrorCallback</em> method is launched with this error type:
             </p>
             <ul>
               <li>
- AbortError: If the system operation was aborted.              </li>
+AbortError: If the system operation was aborted.              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1056,7 +1056,7 @@ The <em>ErrorCallback</em> method is launched with this error type:
             </p>
             <ul>
               <li>
- AbortError: If the system operation was aborted.              </li>
+AbortError: If the system operation was aborted.              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1419,7 +1419,7 @@ The <em>ErrorCallback</em> method is launched with this error type:
             </p>
             <ul>
               <li>
- AbortError: If the system operation was aborted.              </li>
+AbortError: If the system operation was aborted.              </li>
             </ul>
            </div>
 <div class="parameters">

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/iotcon.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/iotcon.html
@@ -317,7 +317,7 @@ The following values are supported:
           </p>
           <ul>
             <li>
-HIGH - for a high quality of service. acknowledgments are used to confirm delivery.             </li>
+HIGH - for a high quality of service. acknowledgments are used to confirm delivery.            </li>
             <li>
 LOW - for a low quality of service. packet delivery is best effort            </li>
           </ul>
@@ -415,7 +415,7 @@ The following values are supported:
           </p>
           <ul>
             <li>
-IP - Internet Protocol connectivity. IP includes all internet connectivity (UDP, TCP, IPV4, IPV6).             </li>
+IP - Internet Protocol connectivity. IP includes all internet connectivity (UDP, TCP, IPV4, IPV6).            </li>
             <li>
 PREFER_UDP - UDP is preferred            </li>
             <li>
@@ -492,7 +492,7 @@ The following values are supported:
           </p>
           <ul>
             <li>
-NO_TYPE - no action of observation             </li>
+NO_TYPE - no action of observation            </li>
             <li>
 REGISTER - action of registering observation            </li>
             <li>
@@ -692,7 +692,7 @@ catch (err)
 </dt>
 <dd>
 <div class="brief">
-  Returns the number of seconds set as the timeout threshold of asynchronous API.
+ Returns the number of seconds set as the timeout threshold of asynchronous API.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">long getTimeout();</pre></div>
 <p><span class="version">Since: </span>
@@ -902,9 +902,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  If any system error is invoked              </li>
+AbortError: If any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1174,9 +1174,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  If any system error is invoked              </li>
+AbortError: If any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1293,9 +1293,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  In any system error is invoked              </li>
+AbortError: In any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1858,7 +1858,7 @@ server.stopPresence();
 <li class="attribute" id="RemoteResource::isExplicitDiscoverable">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">boolean </span><span class="name">isExplicitDiscoverable</span></span><div class="brief">
- Indicates if the resource is  is allowed to be discovered only if discovery request contains an explicit query string or not
+ Indicates if the resource is allowed to be discovered only if discovery request contains an explicit query string or not
             </div>
 <p><span class="version">Since: </span>
  3.0
@@ -1933,9 +1933,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  In any system error is invoked              </li>
+AbortError: In any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2046,9 +2046,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  In any system error is invoked              </li>
+AbortError: In any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2165,9 +2165,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  In any system error is invoked              </li>
+AbortError: In any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2281,9 +2281,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- TimeoutError: If there is no resource or response within timeout value.              </li>
+TimeoutError: If there is no resource or response within timeout value.              </li>
               <li>
- AbortError:  In any system error is invoked              </li>
+AbortError: In any system error is invoked              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2964,7 +2964,7 @@ The default value is <var>false</var>            </p>
 <li class="attribute" id="Resource::isExplicitDiscoverable">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">boolean </span><span class="name">isExplicitDiscoverable</span></span><div class="brief">
- Indicates if the resource is  is allowed to be discovered only if discovery request contains an explicit query string or not
+ Indicates if the resource is allowed to be discovered only if discovery request contains an explicit query string or not
             </div>
 <p><span class="version">Since: </span>
  3.0
@@ -4514,7 +4514,7 @@ for <em>Client.findResource()</em>.
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#Client::addPresenceEventListener">addPresenceEventListener </a> code example.
+ Example of using can be find at <a href="iotcon.html#Client::addPresenceEventListener">addPresenceEventListener</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/keymanager.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/keymanager.html
@@ -98,13 +98,13 @@ For more information on the Key Manager features, see <a href="/application/web/
 <div class="description">
           <ul>
             <li>
- NONE - Clears or removes permissions             </li>
+NONE - Clears or removes permissions            </li>
             <li>
- READ - Permission to read data             </li>
+READ - Permission to read data            </li>
             <li>
- REMOVE - Permission to remove data             </li>
+REMOVE - Permission to remove data            </li>
             <li>
- READ_REMOVE - Permission to read and remove data             </li>
+READ_REMOVE - Permission to read and remove data            </li>
           </ul>
          </div>
 </div>
@@ -114,7 +114,7 @@ For more information on the Key Manager features, see <a href="/application/web/
 <div class="interface" id="KeyManagerObject">
 <a class="backward-compatibility-anchor" name="::KeyManager::KeyManagerObject"></a><h3>2.1. KeyManagerObject</h3>
 <div class="brief">
- The KeyManagerObject interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
+ The KeyManagerObject interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface KeyManagerObject {
     readonly attribute <a href="#KeyManager">KeyManager</a> keymanager;
@@ -125,7 +125,7 @@ For more information on the Key Manager features, see <a href="/application/web/
           </p>
 <div class="description">
           <p>
-The <em>tizen.keymanager </em>object allows access to the functionality of the Key Manager API.
+The <em>tizen.keymanager</em> object allows access to the functionality of the Key Manager API.
           </p>
          </div>
 <div class="attributes">

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/mediacontroller.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/mediacontroller.html
@@ -2515,7 +2515,7 @@ The ErrorCallback may be triggered for one of the following errors:
             </p>
             <ul>
               <li>
- UnknownError:  if any error prevents function from successful completion.               </li>
+UnknownError: if any error prevents function from successful completion.              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -9043,17 +9043,17 @@ Interface is used as a success method for:
           </p>
           <ul>
             <li>
- <em>MediaControllerServerInfo.sendCommand()</em>             </li>
+<em>MediaControllerServerInfo.sendCommand()</em>             </li>
             <li>
- <em>MediaControllerMode360Info.sendRequest()</em>             </li>
+<em>MediaControllerMode360Info.sendRequest()</em>             </li>
             <li>
- <em>MediaControllerSubtitlesInfo.sendRequest()</em>             </li>
+<em>MediaControllerSubtitlesInfo.sendRequest()</em>             </li>
             <li>
- <em>MediaControllerDisplayMode.sendRequest()</em>             </li>
+<em>MediaControllerDisplayMode.sendRequest()</em>             </li>
             <li>
- <em>MediaControllerDisplayRotationInfo.sendRequest()</em>             </li>
+<em>MediaControllerDisplayRotationInfo.sendRequest()</em>             </li>
             <li>
- <em>MediaControllerClientInfo.sendEvent()</em>             </li>
+<em>MediaControllerClientInfo.sendEvent()</em>             </li>
           </ul>
          </div>
 <div class="methods">
@@ -9075,7 +9075,7 @@ Interface is used as a success method for:
 <ul>
           <li class="param">
 <span class="name">data</span><span class="optional"> [nullable]</span>:
- Response data object sent by the command handler. This object is compatible with  <a href="tizen.html#Bundle">Bundle</a> object.
+ Response data object sent by the command handler. This object is compatible with <a href="tizen.html#Bundle">Bundle</a> object.
                 </li>
           <li class="param">
 <span class="name">code</span><span class="optional"> [optional]</span>:

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/mediakey.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/mediakey.html
@@ -87,21 +87,21 @@ For more information on the Media Key features, see <a href="/application/web/gu
 <div class="description">
           <ul>
             <li>
- MEDIA_PLAY - the Play media key             </li>
+MEDIA_PLAY - the Play media key            </li>
             <li>
- MEDIA_STOP - the Stop media key            </li>
+MEDIA_STOP - the Stop media key            </li>
             <li>
- MEDIA_PAUSE - the Pause media key            </li>
+MEDIA_PAUSE - the Pause media key            </li>
             <li>
- MEDIA_PREVIOUS - the Previous media key            </li>
+MEDIA_PREVIOUS - the Previous media key            </li>
             <li>
- MEDIA_NEXT - the Next media key            </li>
+MEDIA_NEXT - the Next media key            </li>
             <li>
- MEDIA_FAST_FORWARD - the Fast Forward media key            </li>
+MEDIA_FAST_FORWARD - the Fast Forward media key            </li>
             <li>
- MEDIA_REWIND - the Rewind media key            </li>
+MEDIA_REWIND - the Rewind media key            </li>
             <li>
- MEDIA_PLAY_PAUSE - the Play/Pause media key            </li>
+MEDIA_PLAY_PAUSE - the Play/Pause media key            </li>
           </ul>
          </div>
 </div>
@@ -189,7 +189,7 @@ There is a tizen.mediakey object that allows accessing the functionality of the 
 <span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">tizen.mediakey.setMediaKeyEventListener({
   onpressed: function(key)
   {
-    console.log("Pressed  key: " + key);
+    console.log("Pressed key: " + key);
   },
   onreleased: function(key)
   {

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/nfc.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/nfc.html
@@ -361,7 +361,7 @@ HCE - The HCE (Host Card Emulation) type. This allows a card to be emulated with
           </ul>
          </div>
 <p><span class="remark">Remark: </span>
- <em>HCE</em>  is supported since Tizen 2.3.1
+ <em>HCE</em> is supported since Tizen 2.3.1
           </p>
 </div>
 <div class="enum" id="CardEmulationCategoryType">

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/nfc.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/nfc.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="wearable-optional emulator" title="Optional, Supported by Tizen Wearable emulator" src="wearable_s_w_optional.png"></div>
 <div class="title"><h1>NFC API</h1></div>
 <div class="brief">
-  The NFC API provides a protocol for simple wireless interconnection of
+ The NFC API provides a protocol for simple wireless interconnection of
 closely coupled devices operating at 13.56 MHz using Near Field Communication (NFC),
 which is an international standard (ISO/IEC 18092).
 To know more, see <a href="https://nfc-forum.org/our-work/specifications-and-application-documents/specifications/nfc-forum-technical-specifications/">Technical Specifications</a>.
@@ -353,11 +353,11 @@ The following values are supported:
           </p>
           <ul>
             <li>
-ESE - The eSE (Embedded Secure Element) secure element type             </li>
+ESE - The eSE (Embedded Secure Element) secure element type            </li>
             <li>
-UICC - The UICC (Universal Integrated Circuit Card) secure element type             </li>
+UICC - The UICC (Universal Integrated Circuit Card) secure element type            </li>
             <li>
-HCE - The HCE (Host Card Emulation) type. This allows a card to be emulated without secure element             </li>
+HCE - The HCE (Host Card Emulation) type. This allows a card to be emulated without secure element            </li>
           </ul>
          </div>
 <p><span class="remark">Remark: </span>
@@ -379,9 +379,9 @@ The following values are supported:
           </p>
           <ul>
             <li>
-PAYMENT - Category used for NFC payment services              </li>
+PAYMENT - Category used for NFC payment services            </li>
             <li>
-OTHER - Category that can be used for all other cards             </li>
+OTHER - Category that can be used for all other cards            </li>
           </ul>
          </div>
 </div>
@@ -400,11 +400,11 @@ The following values are supported:
           </p>
           <ul>
             <li>
-DEACTIVATED - HCE deactivated              </li>
+DEACTIVATED - HCE deactivated            </li>
             <li>
-ACTIVATED - HCE activated             </li>
+ACTIVATED - HCE activated            </li>
             <li>
-APDU_RECEIVED - APDU (Application Protocol Data Unit) received             </li>
+APDU_RECEIVED - APDU (Application Protocol Data Unit) received            </li>
           </ul>
          </div>
 </div>
@@ -425,7 +425,7 @@ APDU_RECEIVED - APDU (Application Protocol Data Unit) received             </li>
 <a class="backward-compatibility-anchor" name="::NFC::NFCManagerObject"></a><h3>2.1. NFCManagerObject</h3>
 <div class="brief">
  The NFCManagerObject interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
-The <em>tizen.nfc </em>object allows access to the functionality of the NFC API.
+The <em>tizen.nfc</em> object allows access to the functionality of the NFC API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface NFCManagerObject {
     readonly attribute <a href="#NFCManager">NFCManager</a> nfc;
@@ -1664,7 +1664,7 @@ catch (err)
 {
   var onDetectedCB = function(event_data)
   {
-    console.log("HCE event type  is " + event_data.eventType);
+    console.log("HCE event type is " + event_data.eventType);
     console.log("APDU is " + event_data.apdu);
   };
   var listenerId = adapter.addHCEEventListener(onDetectedCB);
@@ -1751,9 +1751,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError - If the NFC service is not available.              </li>
+ServiceNotAvailableError - If the NFC service is not available.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1858,7 +1858,7 @@ catch (err)
 <ul>
           <li class="param">
 <span class="name">type</span>:
-  The secure element type.
+ The secure element type.
                 </li>
           <li class="param">
 <span class="name">aid</span>:
@@ -1988,7 +1988,7 @@ catch (err)
 </dt>
 <dd>
 <div class="brief">
-  Registers an AID for a specific category and secure element type.
+ Registers an AID for a specific category and secure element type.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void registerAID(<a href="#SecureElementType">SecureElementType</a> type, <a href="#AID">AID</a> aid, <a href="#CardEmulationCategoryType">CardEmulationCategoryType</a> category);</pre></div>
 <p><span class="version">Since: </span>
@@ -2017,7 +2017,7 @@ catch (err)
                 </li>
           <li class="param">
 <span class="name">category</span>:
-  The card emulation category type.
+ The card emulation category type.
                 </li>
         </ul>
 </div>
@@ -2086,7 +2086,7 @@ catch (err)
                 </li>
           <li class="param">
 <span class="name">category</span>:
-  The card emulation category type.
+ The card emulation category type.
                 </li>
         </ul>
 </div>
@@ -2139,9 +2139,9 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError - If the NFC service is not available.              </li>
+ServiceNotAvailableError - If the NFC service is not available.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2163,11 +2163,11 @@ The ErrorCallback is launched with these error types:
                 </li>
           <li class="param">
 <span class="name">category</span>:
-  The card emulation category type.
+ The card emulation category type.
                 </li>
           <li class="param">
 <span class="name">successCallback</span>:
- Invoked when the  AIDs are retrieved successfully.
+ Invoked when the AIDs are retrieved successfully.
                 </li>
           <li class="param">
 <span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
@@ -2465,11 +2465,11 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError - If the NFC service is not available.              </li>
+ServiceNotAvailableError - If the NFC service is not available.              </li>
               <li>
- InvalidValuesError - If the current Tag doesn't support the NDEF standard.              </li>
+InvalidValuesError - If the current Tag doesn't support the NDEF standard.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2552,11 +2552,11 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError: If any of the input parameters contain an invalid value or the current Tag does not support the NDEF standard.              </li>
+InvalidValuesError: If any of the input parameters contain an invalid value or the current Tag does not support the NDEF standard.              </li>
               <li>
- ServiceNotAvailableError: If the NFC service is not available.               </li>
+ServiceNotAvailableError: If the NFC service is not available.              </li>
               <li>
- UnknownError: In any other error case.               </li>
+UnknownError: In any other error case.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2642,11 +2642,11 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError - If any of the input parameters contain an invalid value.              </li>
+InvalidValuesError - If any of the input parameters contain an invalid value.              </li>
               <li>
- ServiceNotAvailableError - If the NFC service is not available.              </li>
+ServiceNotAvailableError - If the NFC service is not available.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -2889,11 +2889,11 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError: If any of the input parameters contain an invalid value.              </li>
+InvalidValuesError: If any of the input parameters contain an invalid value.              </li>
               <li>
- ServiceNotAvailableError: If the NFC service is not available.               </li>
+ServiceNotAvailableError: If the NFC service is not available.              </li>
               <li>
- UnknownError: In any other error case.               </li>
+UnknownError: In any other error case.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -3507,9 +3507,9 @@ This callback interface specifies two methods:
           </p>
           <ul>
             <li>
- onattach: Invoked when an NFC tag is detected            </li>
+onattach: Invoked when an NFC tag is detected            </li>
             <li>
- ondetach: Invoked when an NFC tag is lost            </li>
+ondetach: Invoked when an NFC tag is lost            </li>
           </ul>
           <p>
 It is used in NFCAdapter.setTagListener().
@@ -3617,9 +3617,9 @@ This callback interface specifies two methods:
           </p>
           <ul>
             <li>
- onattach: Invoked when an NFC peer-to-peer target is detected            </li>
+onattach: Invoked when an NFC peer-to-peer target is detected            </li>
             <li>
- ondetach: Invoked when an NFC peer-to-peer target is lost            </li>
+ondetach: Invoked when an NFC peer-to-peer target is lost            </li>
           </ul>
           <p>
 It is used in NFCAdapter.setPeerListener().

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/notification.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/notification.html
@@ -207,7 +207,7 @@ THUMBNAIL - The thumbnail user notification posts a thumbnail-format notificatio
 The thumbnail user notification is also removed by user selection.
             </li>
             <li>
-ONGOING - An user notification type that informs the user whether an application is running or not.             </li>
+ONGOING - An user notification type that informs the user whether an application is running or not.            </li>
             <li>
 PROGRESS - An user notification that displays information on the progress of a job. However, this user notification should be removed by the application that posted the notification.            </li>
           </ul>
@@ -228,9 +228,9 @@ The following notification progress types are supported:
           </p>
           <ul>
             <li>
- "BYTE" - The progress is indicated in bytes.            </li>
+"BYTE" - The progress is indicated in bytes.            </li>
             <li>
- "PERCENTAGE" -The progress is indicated in percentage.            </li>
+"PERCENTAGE" -The progress is indicated in percentage.            </li>
           </ul>
          </div>
 </div>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/package.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/package.html
@@ -125,7 +125,7 @@ For more information on the Package features, see <a href="/application/web/guid
 <div class="interface" id="PackageManagerObject">
 <a class="backward-compatibility-anchor" name="::Package::PackageManagerObject"></a><h3>2.1. PackageManagerObject</h3>
 <div class="brief">
- This interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
+ This interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface PackageManagerObject {
     readonly attribute <a href="#PackageManager">PackageManager</a> package;
@@ -136,7 +136,7 @@ For more information on the Package features, see <a href="/application/web/guid
           </p>
 <div class="description">
           <p>
-The <em>tizen.package </em>object allows access to Package API functionality.
+The <em>tizen.package</em> object allows access to Package API functionality.
           </p>
          </div>
 <div class="attributes">
@@ -190,7 +190,7 @@ The <em>tizen.package </em>object allows access to Package API functionality.
 This API provides a way to notify the progress and completion of an installation request through PackageProgressCallback.
             </p>
             <p>
-The <em>ErrorCallback() </em>is launched with these error types:
+The <em>ErrorCallback()</em> is launched with these error types:
             </p>
             <ul>
               <li>
@@ -286,7 +286,7 @@ tizen.filesystem.resolve("downloads/test.wgt",
 This API provides a way to notify about the progress and completion of an uninstallation request through PackageProgressCallback.
             </p>
             <p>
-The <em>ErrorCallback() </em>is launched with these error types:
+The <em>ErrorCallback()</em> is launched with these error types:
             </p>
             <ul>
               <li>
@@ -734,7 +734,7 @@ The relevant application is the one with the same
 <div class="interface" id="PackageInformationArraySuccessCallback">
 <a class="backward-compatibility-anchor" name="::Package::PackageInformationArraySuccessCallback"></a><h3>2.4. PackageInformationArraySuccessCallback</h3>
 <div class="brief">
- This interface invokes the success callback with an array of <em>PackageInformation </em>objects as an input parameter when the installed package list is retrieved.
+ This interface invokes the success callback with an array of <em>PackageInformation</em> objects as an input parameter when the installed package list is retrieved.
           </div>
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface PackageInformationArraySuccessCallback {
     void onsuccess(<a href="#PackageInformation">PackageInformation</a>[] informationArray);

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/playerutil.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/playerutil.html
@@ -90,8 +90,8 @@ HIGH - High audio latency mode.            </li>
 <div class="interface" id="PlayerUtilManagerObject">
 <a class="backward-compatibility-anchor" name="::PlayerUtil::PlayerUtilManagerObject"></a><h3>2.1. PlayerUtilManagerObject</h3>
 <div class="brief">
- The PlayerUtilManagerObject interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
-The <em>tizen.playerutil </em>object allows access to the functionality of the Player Util API.
+ The PlayerUtilManagerObject interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
+The <em>tizen.playerutil</em> object allows access to the functionality of the Player Util API.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface PlayerUtilManagerObject {
     readonly attribute <a href="#PlayerUtilManager">PlayerUtilManager</a> playerutil;

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/power.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/power.html
@@ -88,7 +88,7 @@ For more information on the Power features, see <a href="/application/web/guides
 <div class="enum" id="PowerResource">
 <a class="backward-compatibility-anchor" name="::Power::PowerResource"></a><h3>1.1. PowerResource</h3>
 <div class="brief">
- Specifies power resources with values aligned with <em>SystemInfo </em>property values.
+ Specifies power resources with values aligned with <em>SystemInfo</em> property values.
           </div>
 <pre class="webidl prettyprint">  enum PowerResource { "SCREEN", "CPU" };</pre>
 <p><span class="version">Since: </span>
@@ -182,7 +182,7 @@ It can be either a PowerScreenState or a PowerCpuState.
           </p>
 <div class="description">
           <p>
-There will be a <em>tizen.power </em>object that allows accessing of a functionality of the Power API.
+There will be a <em>tizen.power</em> object that allows accessing of a functionality of the Power API.
           </p>
          </div>
 <div class="attributes">
@@ -239,7 +239,7 @@ However, these requests can be overridden by the system. If the requests are ove
  public
             </p>
 <p><span class="privilege">Privilege: </span>
-      http://tizen.org/privilege/power
+ http://tizen.org/privilege/power
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/ppm.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/ppm.html
@@ -21,9 +21,9 @@ Privacy Privilege API allows:
         </p>
         <ul>
           <li>
- Checking if user granted permission for using a privacy-related privilege.          </li>
+Checking if user granted permission for using a privacy-related privilege.          </li>
           <li>
- Requesting pop-up about giving permission for using privacy-related privilege.          </li>
+Requesting pop-up about giving permission for using privacy-related privilege.          </li>
         </ul>
        </div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/preference.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/preference.html
@@ -419,7 +419,7 @@ console.log("The current value of the preference key1 is: " + currentValue);
 <p><span class="return">Return value:</span></p>
 <ul>
 <span class="return">boolean:</span>
- If <var>true</var> the key exists in the  application preference, otherwise <var>false</var>.
+ If <var>true</var> the key exists in the application preference, otherwise <var>false</var>.
               </ul>
 </div>
 <div class="exceptionlist">

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/push.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/push.html
@@ -158,7 +158,7 @@ UNREGISTERED - The application is not registered to the push server.            
 <div class="interface" id="PushManagerObject">
 <a class="backward-compatibility-anchor" name="::Push::PushManagerObject"></a><h3>2.1. PushManagerObject</h3>
 <div class="brief">
- The PushManagerObject interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
+ The PushManagerObject interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface PushManagerObject {
     readonly attribute <a href="#PushManager">PushManager</a> push;
@@ -169,7 +169,7 @@ UNREGISTERED - The application is not registered to the push server.            
           </p>
 <div class="description">
           <p>
-The <em>tizen.push </em>object allows access to the functionality of the Push API.
+The <em>tizen.push</em> object allows access to the functionality of the Push API.
           </p>
          </div>
 <div class="attributes">
@@ -525,7 +525,7 @@ tizen.push.disconnect();
 </dt>
 <dd>
 <div class="brief">
- Gets the push service registration ID for this application if the registration process is successful. <var>null </var>is returned if the application has not been registered yet.
+ Gets the push service registration ID for this application if the registration process is successful. <var>null</var> is returned if the application has not been registered yet.
             </div>
 <div class="synopsis"><pre class="signature prettyprint"><a href="#PushRegistrationId">PushRegistrationId</a> getRegistrationId();</pre></div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/se.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/se.html
@@ -196,7 +196,7 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- UnknownError - If any error occurs during retrieval.              </li>
+UnknownError - If any error occurs during retrieval.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -545,11 +545,11 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- IOError - An error occurred in communication with the Secure Element in this reader.              </li>
+IOError - An error occurred in communication with the Secure Element in this reader.              </li>
               <li>
- InvalidStateError - If a Secure Element is not present on this reader.              </li>
+InvalidStateError - If a Secure Element is not present on this reader.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -703,17 +703,17 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- IOError - If an error occurs while communicating with the Secure Element in the reader.              </li>
+IOError - If an error occurs while communicating with the Secure Element in the reader.              </li>
               <li>
- SecurityError - If access to this AID or the default application on this session is not allowed .              </li>
+SecurityError - If access to this AID or the default application on this session is not allowed .              </li>
               <li>
- InvalidStateError - If this session is closed.               </li>
+InvalidStateError - If this session is closed.              </li>
               <li>
- NotFoundError - If the application of the AID does not exist in the Secure Element.              </li>
+NotFoundError - If the application of the AID does not exist in the Secure Element.              </li>
               <li>
- NoChannelError - If basic channel is unavailable.              </li>
+NoChannelError - If basic channel is unavailable.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -814,17 +814,17 @@ The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- IOError - If an error occurs while communicating with the Secure Element in the reader.              </li>
+IOError - If an error occurs while communicating with the Secure Element in the reader.              </li>
               <li>
- SecurityError - If access to this AID or the default application in this session is not allowed.              </li>
+SecurityError - If access to this AID or the default application in this session is not allowed.              </li>
               <li>
- InvalidStateError - If this session is closed.              </li>
+InvalidStateError - If this session is closed.              </li>
               <li>
- NotFoundError - If the application of the AID does not exist in the Secure Element.              </li>
+NotFoundError - If the application of the AID does not exist in the Secure Element.              </li>
               <li>
- NoChannelError - If logical channel is unavailable.              </li>
+NoChannelError - If logical channel is unavailable.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1122,26 +1122,26 @@ Some commands that are not allowed to be sent are:
             </p>
             <ul>
               <li>
- MANAGE_CHANNEL commands.               </li>
+MANAGE_CHANNEL commands.              </li>
               <li>
- SELECT by DF Name (p1=04).               </li>
+SELECT by DF Name (p1=04).              </li>
               <li>
- The commands that CLA bytes with channel numbers are de-masked.               </li>
+The commands that CLA bytes with channel numbers are de-masked.              </li>
             </ul>
             <p>
 The ErrorCallback is launched with these error types:
             </p>
             <ul>
               <li>
- InvalidValuesError - If the command contain an invalid value.              </li>
+InvalidValuesError - If the command contain an invalid value.              </li>
               <li>
- IOError - An error occurred while communicating with the Secure Element in the reader.              </li>
+IOError - An error occurred while communicating with the Secure Element in the reader.              </li>
               <li>
- SecurityError - If the command is not allowed.              </li>
+SecurityError - If the command is not allowed.              </li>
               <li>
- InvalidStateError - If this channel is closed.              </li>
+InvalidStateError - If this channel is closed.              </li>
               <li>
- UnknownError - If any other error occurs.              </li>
+UnknownError - If any other error occurs.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1427,7 +1427,7 @@ It is used in asynchronous operations such as <em>Reader.openSession()</em>.
 <div class="description">
           <p>
 This callback interface specifies a success method with a <em>Channel</em> object as an input parameter.
-It is used in asynchronous operations such as <em>Session.openBasicChannel() </em>or <em>Session.openLogicalChannel()</em>.
+It is used in asynchronous operations such as <em>Session.openBasicChannel()</em> or <em>Session.openLogicalChannel()</em>.
           </p>
          </div>
 <div class="methods">
@@ -1460,7 +1460,7 @@ It is used in asynchronous operations such as <em>Session.openBasicChannel() </e
 <div class="interface" id="TransmitSuccessCallback">
 <a class="backward-compatibility-anchor" name="::SecureElement::TransmitSuccessCallback"></a><h3>1.10. TransmitSuccessCallback</h3>
 <div class="brief">
- The TransmitSuccessCallback interface specifies the success callback that is invoked when <em>Channel.transmit() </em>completes successfully.
+ The TransmitSuccessCallback interface specifies the success callback that is invoked when <em>Channel.transmit()</em> completes successfully.
           </div>
 <pre class="webidl prettyprint">  [Callback=FunctionOnly, NoInterfaceObject] interface TransmitSuccessCallback {
     void onsuccess(byte[] response);

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/sensor.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/sensor.html
@@ -489,7 +489,7 @@ ULTRAVIOLET - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/senso
  with error type NotSupportedError, if the given <var>type</var> is not supported on the device.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, this error is only thrown for <em>HRM_RAW</em>  sensor type when an application does not have http://tizen.org/privilege/healthinfo privilege in config.xml.
+ with error type SecurityError, this error is only thrown for <em>HRM_RAW</em> sensor type when an application does not have http://tizen.org/privilege/healthinfo privilege in config.xml.
                 </p></li>
 </ul>
 </li></ul>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/sensor.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/sensor.html
@@ -431,31 +431,31 @@ The supported sensor types are hardware-dependent. <br><br>To check if the given
             </p>
             <ul>
               <li>
- ACCELERATION - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.accelerometer"</em>)               </li>
+ACCELERATION - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.accelerometer"</em>)              </li>
               <li>
- GRAVITY     - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.gravity"</em>)               </li>
+GRAVITY     - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.gravity"</em>)              </li>
               <li>
- GYROSCOPE   - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.gyroscope"</em>)               </li>
+GYROSCOPE   - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.gyroscope"</em>)              </li>
               <li>
- GYROSCOPE_ROTATION_VECTOR - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.gyroscope_rotation_vector"</em>)               </li>
+GYROSCOPE_ROTATION_VECTOR - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.gyroscope_rotation_vector"</em>)              </li>
               <li>
- GYROSCOPE_UNCALIBRATED - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.gyroscope.uncalibrated"</em>)               </li>
+GYROSCOPE_UNCALIBRATED - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.gyroscope.uncalibrated"</em>)              </li>
               <li>
- HRM_RAW     - HRM_RAW is supported, if at least one HRM LED sensor type is supported:<br>tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.heart_rate_monitor.led_green"</em>),<br>tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.heart_rate_monitor.led_ir"</em>),<br>tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.heart_rate_monitor.led_red"</em>)               </li>
+HRM_RAW     - HRM_RAW is supported, if at least one HRM LED sensor type is supported:<br>tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.heart_rate_monitor.led_green"</em>),<br>tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.heart_rate_monitor.led_ir"</em>),<br>tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.heart_rate_monitor.led_red"</em>)              </li>
               <li>
- LIGHT       - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.photometer"</em>)               </li>
+LIGHT       - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.photometer"</em>)              </li>
               <li>
- LINEAR_ACCELERATION - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.linear_acceleration"</em>)               </li>
+LINEAR_ACCELERATION - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.linear_acceleration"</em>)              </li>
               <li>
- MAGNETIC    - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.magnetometer"</em>)               </li>
+MAGNETIC    - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.magnetometer"</em>)              </li>
               <li>
- MAGNETIC_UNCALIBRATED - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.magnetometer.uncalibrated"</em>)               </li>
+MAGNETIC_UNCALIBRATED - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.magnetometer.uncalibrated"</em>)              </li>
               <li>
- PRESSURE    - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.barometer"</em>)               </li>
+PRESSURE    - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.barometer"</em>)              </li>
               <li>
- PROXIMITY   - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.proximity"</em>)               </li>
+PROXIMITY   - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.proximity"</em>)              </li>
               <li>
- ULTRAVIOLET - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.ultraviolet"</em>)               </li>
+ULTRAVIOLET - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/sensor.ultraviolet"</em>)              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -489,7 +489,7 @@ The supported sensor types are hardware-dependent. <br><br>To check if the given
  with error type NotSupportedError, if the given <var>type</var> is not supported on the device.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, this error is only thrown for <em> HRM_RAW </em> sensor type when an application does not have http://tizen.org/privilege/healthinfo privilege in config.xml.
+ with error type SecurityError, this error is only thrown for <em>HRM_RAW</em>  sensor type when an application does not have http://tizen.org/privilege/healthinfo privilege in config.xml.
                 </p></li>
 </ul>
 </li></ul>
@@ -703,7 +703,7 @@ The start() method must be called to turn on the sensor, or the sensor data will
                 </li>
           <li class="param">
 <span class="name">batchLatency</span><span class="optional"> [optional]</span>:
- The batch latency time in milliseconds (ms) at which sensor events are stored or delivered when processor stay on sleep or suspend status since Tizen 3.0<br><em>batchLatency</em> has hardware dependency. You can calculate maximum batchLatency value using  <a href="#SensorHardwareInfo">maxBatchCount</a> (e.g. interval x maxBatchCount) . If maxBatchCount is zero, device doesn't support batch latency time.
+ The batch latency time in milliseconds (ms) at which sensor events are stored or delivered when processor stay on sleep or suspend status since Tizen 3.0<br><em>batchLatency</em> has hardware dependency. You can calculate maximum batchLatency value using <a href="#SensorHardwareInfo">maxBatchCount</a> (e.g. interval x maxBatchCount) . If maxBatchCount is zero, device doesn't support batch latency time.
                 </li>
         </ul>
 </div>
@@ -892,9 +892,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getAccelerationSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getAccelerationSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- AbortError : If the system operation was aborted              </li>
+AbortError : If the system operation was aborted              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -990,9 +990,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getGravitySensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getGravitySensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- AbortError : If the system operation was aborted              </li>
+AbortError : If the system operation was aborted              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1088,9 +1088,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getGyroscopeSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getGyroscopeSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- AbortError : If the system operation was aborted              </li>
+AbortError : If the system operation was aborted              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1186,9 +1186,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getGyroscopeRotationVectorSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getGyroscopeRotationVectorSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- AbortError : If the system operation was aborted              </li>
+AbortError : If the system operation was aborted              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1287,9 +1287,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getGyroscopeUncalibratedSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getGyroscopeUncalibratedSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- AbortError : If the system operation was aborted              </li>
+AbortError : If the system operation was aborted              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1379,9 +1379,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the getHRMRawSensorData method is called without calling the start method.              </li>
+ServiceNotAvailableError : If the getHRMRawSensorData method is called without calling the start method.              </li>
               <li>
- UnknownError  : An unknown error has occurred.              </li>
+UnknownError : An unknown error has occurred.              </li>
             </ul>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1479,9 +1479,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getLightSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getLightSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- UnknownError  : An unknown error has occurred              </li>
+UnknownError : An unknown error has occurred              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1566,9 +1566,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getLinearAccelerationSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getLinearAccelerationSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- AbortError : If the system operation was aborted              </li>
+AbortError : If the system operation was aborted              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1664,9 +1664,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getMagneticSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getMagneticSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- UnknownError  : An unknown error has occurred              </li>
+UnknownError : An unknown error has occurred              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1753,9 +1753,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getMagneticUncalibratedSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getMagneticUncalibratedSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- AbortError : If the system operation was aborted              </li>
+AbortError : If the system operation was aborted              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1846,9 +1846,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getPressureSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getPressureSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- UnknownError  : An unknown error has occurred              </li>
+UnknownError : An unknown error has occurred              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -1933,9 +1933,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getProximitySensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getProximitySensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- UnknownError  : An unknown error has occurred              </li>
+UnknownError : An unknown error has occurred              </li>
             </ul>
            </div>
 <div class="parameters">
@@ -2020,9 +2020,9 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
- ServiceNotAvailableError : If the <em>getUltravioletSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
+ServiceNotAvailableError : If the <em>getUltravioletSensorData()</em> method is called without first calling the <em>start()</em> method              </li>
               <li>
- UnknownError  : An unknown error has occurred              </li>
+UnknownError : An unknown error has occurred              </li>
             </ul>
            </div>
 <div class="parameters">

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/sound.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/sound.html
@@ -123,17 +123,17 @@ For more information on the Sound features, see <a href="/application/web/guides
 <div class="description">
           <ul>
             <li>
- SYSTEM - for system sounds            </li>
+SYSTEM - for system sounds            </li>
             <li>
- NOTIFICATION - for notifications            </li>
+NOTIFICATION - for notifications            </li>
             <li>
- ALARM - for alarm            </li>
+ALARM - for alarm            </li>
             <li>
- MEDIA - for media playback            </li>
+MEDIA - for media playback            </li>
             <li>
- VOICE - for voice            </li>
+VOICE - for voice            </li>
             <li>
- RINGTONE - for the phone ring            </li>
+RINGTONE - for the phone ring            </li>
           </ul>
          </div>
 <p><span class="remark">Remark: </span>
@@ -152,11 +152,11 @@ For more information on the Sound features, see <a href="/application/web/guides
 <div class="description">
           <ul>
             <li>
- SOUND - the sound mode            </li>
+SOUND - the sound mode            </li>
             <li>
- VIBRATE - the vibrate mode            </li>
+VIBRATE - the vibrate mode            </li>
             <li>
- MUTE - the mute mode            </li>
+MUTE - the mute mode            </li>
           </ul>
          </div>
 </div>
@@ -175,21 +175,21 @@ The possible types are:
           </p>
           <ul>
             <li>
- SPEAKER - For sound output using the built-in device speaker            </li>
+SPEAKER - For sound output using the built-in device speaker            </li>
             <li>
- RECEIVER - For sound output using the built-in device receiver            </li>
+RECEIVER - For sound output using the built-in device receiver            </li>
             <li>
- AUDIO_JACK - For sound input and/or output using the device audio jack which can be connected to a wired accessory such as a headset or headphone            </li>
+AUDIO_JACK - For sound input and/or output using the device audio jack which can be connected to a wired accessory such as a headset or headphone            </li>
             <li>
- BLUETOOTH - For sound input and/or output through a device that is connected by Bluetooth            </li>
+BLUETOOTH - For sound input and/or output through a device that is connected by Bluetooth            </li>
             <li>
- HDMI - For sound output through a device that is connected by HDMI            </li>
+HDMI - For sound output through a device that is connected by HDMI            </li>
             <li>
- MIRRORING - For sound output through a device that is connected by mirroring            </li>
+MIRRORING - For sound output through a device that is connected by mirroring            </li>
             <li>
- USB_AUDIO - For sound output through a device that is connected by USB            </li>
+USB_AUDIO - For sound output through a device that is connected by USB            </li>
             <li>
- MIC - For sound input using the built-in device microphone            </li>
+MIC - For sound input using the built-in device microphone            </li>
           </ul>
          </div>
 </div>
@@ -208,11 +208,11 @@ The possible types are:
           </p>
           <ul>
             <li>
- IN - For sound device type which <em>only support input</em>            </li>
+IN - For sound device type which <em>only support input</em>            </li>
             <li>
- OUT - For sound device type which <em>only support output</em>            </li>
+OUT - For sound device type which <em>only support output</em>            </li>
             <li>
- BOTH - For sound device type which <em>supports both input and output</em>            </li>
+BOTH - For sound device type which <em>supports both input and output</em>            </li>
           </ul>
          </div>
 </div>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/systeminfo.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/systeminfo.html
@@ -61,21 +61,21 @@ Not all above properties may be available on every Tizen device. For instance, a
         </p>
         <ul>
           <li>
- BATTERY          - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/battery"</em>)          </li>
+BATTERY          - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/battery"</em>)          </li>
           <li>
- CAMERA_FLASH     - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/camera.back.flash"</em>)          </li>
+CAMERA_FLASH     - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/camera.back.flash"</em>)          </li>
           <li>
- CELLULAR_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.telephony"</em>)          </li>
+CELLULAR_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.telephony"</em>)          </li>
           <li>
- DISPLAY          - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/screen"</em>)          </li>
+DISPLAY          - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/screen"</em>)          </li>
           <li>
- ETHERNET_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.ethernet"</em>)          </li>
+ETHERNET_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.ethernet"</em>)          </li>
           <li>
- NET_PROXY_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.net_proxy"</em>)          </li>
+NET_PROXY_NETWORK - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.net_proxy"</em>)          </li>
           <li>
- SIM              - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.telephony"</em>)          </li>
+SIM              - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.telephony"</em>)          </li>
           <li>
- WIFI_NETWORK     - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.wifi"</em>)          </li>
+WIFI_NETWORK     - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.wifi"</em>)          </li>
         </ul>
         <p>
 For more information on the System Information features, see <a href="/application/web/guides/device/system-information">System Information Guide</a>.
@@ -429,7 +429,7 @@ WARNING - indicating the remaining memory is insufficient. Low memory warnings m
 <div class="interface" id="SystemInfoObject">
 <a class="backward-compatibility-anchor" name="::SystemInfo::SystemInfoObject"></a><h3>2.1. SystemInfoObject</h3>
 <div class="brief">
- Defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
+ Defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface SystemInfoObject {
     readonly attribute <a href="#SystemInfo">SystemInfo</a> systeminfo;
@@ -1171,7 +1171,7 @@ This attribute has no effect on the <em>get()</em> method.
             </div>
 <div class="description">
             <p>
-If both <em>highThreshold </em>and <em>lowThreshold </em>parameters are specified, the <em>successCallback()</em> is triggered if and only if the property value is either lower than the value of <em>lowThreshold</em> or higher than the value of <em>highThreshold</em>.
+If both <em>highThreshold</em> and <em>lowThreshold</em> parameters are specified, the <em>successCallback()</em> is triggered if and only if the property value is either lower than the value of <em>lowThreshold</em> or higher than the value of <em>highThreshold</em>.
 This attribute has no effect on the get method.
             </p>
            </div>
@@ -1312,14 +1312,14 @@ Change listener registered on <var>BATTERY</var> property is triggered on
 <li class="attribute" id="SystemInfoBattery::level">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">level</span></span><div class="brief">
- An attribute to specify the remaining level of an internal battery, scaled from <var>0 </var>to <var>1</var>:
+ An attribute to specify the remaining level of an internal battery, scaled from <var>0</var>to <var>1</var>:
             </div>
 <div class="description">
             <ul>
               <li>
-<var>0 </var>indicates that the battery level is the lowest and the system is about to enter shutdown mode.              </li>
+<var>0</var>indicates that the battery level is the lowest and the system is about to enter shutdown mode.              </li>
               <li>
-<var>1 </var>indicates that the system's charge is maximum.              </li>
+<var>1</var>indicates that the system's charge is maximum.              </li>
             </ul>
             <p>
 Any threshold parameter used in a watch operation to monitor this property applies to this attribute.
@@ -1398,7 +1398,7 @@ This process may take up to few days.
 <ul><li class="attribute" id="SystemInfoCpu::load">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">load</span></span><div class="brief">
-  An attribute to indicate the current CPU load, as a number between <var>0.0 </var>and <var>1.0</var>, representing the minimum and maximum values allowed on this system.
+ An attribute to indicate the current CPU load, as a number between <var>0.0</var>and <var>1.0</var>, representing the minimum and maximum values allowed on this system.
             </div>
 <div class="description">
             <p>
@@ -1468,7 +1468,7 @@ The supported storage unit types are:
               <li>
 UNKNOWN              </li>
               <li>
-INTERNAL               </li>
+INTERNAL              </li>
               <li>
 USB_DEVICE              </li>
               <li>
@@ -1611,7 +1611,7 @@ Change listener registered on <var>DISPLAY</var> property is triggered on
 <li class="attribute" id="SystemInfoDisplay::brightness">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">brightness</span></span><div class="brief">
- The current brightness of a display ranging between <var>0 </var>to <var>1</var>.
+ The current brightness of a display ranging between <var>0</var>to <var>1</var>.
             </div>
 <p><span class="version">Since: </span>
  1.0

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/systeminfo.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/systeminfo.html
@@ -1312,14 +1312,14 @@ Change listener registered on <var>BATTERY</var> property is triggered on
 <li class="attribute" id="SystemInfoBattery::level">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">level</span></span><div class="brief">
- An attribute to specify the remaining level of an internal battery, scaled from <var>0</var>to <var>1</var>:
+ An attribute to specify the remaining level of an internal battery, scaled from <var>0</var> to <var>1</var>:
             </div>
 <div class="description">
             <ul>
               <li>
-<var>0</var>indicates that the battery level is the lowest and the system is about to enter shutdown mode.              </li>
+<var>0</var> indicates that the battery level is the lowest and the system is about to enter shutdown mode.              </li>
               <li>
-<var>1</var>indicates that the system's charge is maximum.              </li>
+<var>1</var> indicates that the system's charge is maximum.              </li>
             </ul>
             <p>
 Any threshold parameter used in a watch operation to monitor this property applies to this attribute.
@@ -1398,7 +1398,7 @@ This process may take up to few days.
 <ul><li class="attribute" id="SystemInfoCpu::load">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">load</span></span><div class="brief">
- An attribute to indicate the current CPU load, as a number between <var>0.0</var>and <var>1.0</var>, representing the minimum and maximum values allowed on this system.
+ An attribute to indicate the current CPU load, as a number between <var>0.0</var> and <var>1.0</var>, representing the minimum and maximum values allowed on this system.
             </div>
 <div class="description">
             <p>
@@ -1611,7 +1611,7 @@ Change listener registered on <var>DISPLAY</var> property is triggered on
 <li class="attribute" id="SystemInfoDisplay::brightness">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">double </span><span class="name">brightness</span></span><div class="brief">
- The current brightness of a display ranging between <var>0</var>to <var>1</var>.
+ The current brightness of a display ranging between <var>0</var> to <var>1</var>.
             </div>
 <p><span class="version">Since: </span>
  1.0

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/systemsetting.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/systemsetting.html
@@ -19,13 +19,13 @@ This API provides an interface and methods through features such as:
         </p>
         <ul>
           <li>
- HOME_SCREEN          </li>
+HOME_SCREEN          </li>
           <li>
- LOCK_SCREEN          </li>
+LOCK_SCREEN          </li>
           <li>
- INCOMING_CALL          </li>
+INCOMING_CALL          </li>
           <li>
- NOTIFICATION_EMAIL          </li>
+NOTIFICATION_EMAIL          </li>
         </ul>
         <p>
 System Setting API may not be provided in some devices.
@@ -36,13 +36,13 @@ In addition, not all the above properties may be available even though a device 
         </p>
         <ul>
           <li>
- HOME_SCREEN        - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/systemsetting.home_screen"</em>)          </li>
+HOME_SCREEN        - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/systemsetting.home_screen"</em>)          </li>
           <li>
- LOCK_SCREEN        - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/systemsetting.lock_screen"</em>)          </li>
+LOCK_SCREEN        - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/systemsetting.lock_screen"</em>)          </li>
           <li>
- INCOMING_CALL      - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/systemsetting.incoming_call"</em>)          </li>
+INCOMING_CALL      - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/systemsetting.incoming_call"</em>)          </li>
           <li>
- NOTIFICATION_EMAIL - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/systemsetting.notification_email"</em>)          </li>
+NOTIFICATION_EMAIL - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/systemsetting.notification_email"</em>)          </li>
         </ul>
         <p>
 <b id="StorageRemark">Remark:</b> In order to access files, a proper privilege has to be defined additionally:
@@ -145,7 +145,7 @@ The INCOMING_CALL and NOTIFICATION_EMAIL are supported for sound files.
 <div class="interface" id="SystemSettingObject">
 <a class="backward-compatibility-anchor" name="::SystemSetting::SystemSettingObject"></a><h3>2.1. SystemSettingObject</h3>
 <div class="brief">
- The SystemSettingObject interface defines what is instantiated by the <em>Tizen </em>object from the Tizen Platform.
+ The SystemSettingObject interface defines what is instantiated by the <em>Tizen</em> object from the Tizen Platform.
           </div>
 <pre class="webidl prettyprint">  [NoInterfaceObject] interface SystemSettingObject {
     readonly attribute <a href="#SystemSettingManager">SystemSettingManager</a> systemsetting;
@@ -156,7 +156,7 @@ The INCOMING_CALL and NOTIFICATION_EMAIL are supported for sound files.
           </p>
 <div class="description">
           <p>
-There will be a <em>tizen.systemsetting </em>object that allows accessing the functionality of the System Setting API.
+There will be a <em>tizen.systemsetting</em> object that allows accessing the functionality of the System Setting API.
           </p>
          </div>
 <div class="attributes">
@@ -212,7 +212,7 @@ The <em>ErrorCallback</em> method is launched with these error types:
               <li>
 InvalidValuesError - If any of the input parameters contain an invalid value              </li>
               <li>
-NotSupportedError - If the given <var>type</var> is not supported on the device               </li>
+NotSupportedError - If the given <var>type</var> is not supported on the device              </li>
               <li>
 UnknownError - If any other error occurs              </li>
             </ul>
@@ -322,15 +322,15 @@ The <em>ErrorCallback</em> method is launched with these error types:
             </p>
             <ul>
               <li>
-TypeMismatchError - If any input parameter is not compatible with the expected type for that parameter               </li>
+TypeMismatchError - If any input parameter is not compatible with the expected type for that parameter              </li>
               <li>
-InvalidValuesError - If any of the input parameters contain an invalid value               </li>
+InvalidValuesError - If any of the input parameters contain an invalid value              </li>
               <li>
-NotSupportedError - If the given <var>type</var> is not supported on the device               </li>
+NotSupportedError - If the given <var>type</var> is not supported on the device              </li>
               <li>
 SecurityError - If the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.              </li>
               <li>
-UnknownError - If any other error occurs               </li>
+UnknownError - If any other error occurs              </li>
             </ul>
            </div>
 <div class="parameters">

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/time.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/time.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="wearable-mandatory emulator" title="Mandatory, Supported by Tizen Wearable emulator" src="wearable_s_w.png"></div>
 <div class="title"><h1>Time API</h1></div>
 <div class="brief">
-  The Time API provides information regarding date/time and time zones.
+ The Time API provides information regarding date/time and time zones.
         </div>
 <div class="description">
         <p>
@@ -182,11 +182,11 @@ At least the following values must be supported:
             <li>
 MSECS - Indicates a duration in milliseconds            </li>
             <li>
-SECS - Indicates a duration in seconds             </li>
+SECS - Indicates a duration in seconds            </li>
             <li>
-MINS - Indicates a duration in minutes             </li>
+MINS - Indicates a duration in minutes            </li>
             <li>
-HOURS - Indicates a duration in hours             </li>
+HOURS - Indicates a duration in hours            </li>
             <li>
 DAYS - Indicates a duration in days            </li>
           </ul>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/tizen.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/tizen.html
@@ -292,7 +292,7 @@ BYTES_ARRAY - array of <a href="#ByteStream">ByteStream</a>            </li>
           </p>
 <div class="description">
           <p>
-The <em>Tizen</em> interface is always available within the <em>Window </em>object in the ECMAScript hierarchy.
+The <em>Tizen</em> interface is always available within the <em>Window</em> object in the ECMAScript hierarchy.
           </p>
          </div>
 <div class="attributes">

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/voicecontrol.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/voicecontrol.html
@@ -113,9 +113,9 @@ The result events defined by this enumeration are:
           </p>
           <ul>
             <li>
- SUCCESS - Successful result            </li>
+SUCCESS - Successful result            </li>
             <li>
- FAILURE - Rejected result by voice control service            </li>
+FAILURE - Rejected result by voice control service            </li>
           </ul>
          </div>
 </div>
@@ -134,7 +134,7 @@ The command type defined by this enumeration is:
           </p>
           <ul>
             <li>
- FOREGROUND - command type used when application is foreground            </li>
+FOREGROUND - command type used when application is foreground            </li>
           </ul>
          </div>
 </div>


### PR DESCRIPTION
This commit is about automatic formatting changes:
* removed duplicated spaces in some descriptions (two spaces in a row, except alignments)
* moved spaces outside 'formatting' tags as <em>, <var> etc.
e.g. "example<var> text </var>example" ---> "example <var>text</var> example"

Also one normal fix:
* fixed duplicated word issue in iotcon module
"Indicates if the resource is  is allowed" -> "Indicates if the resource is allowed"
