### PR TITLE
Fix the parameter on preference_set_changed_cb

### DIFF
--- a/docs/application/native/guides/app-management/app-preferences.md
+++ b/docs/application/native/guides/app-management/app-preferences.md
@@ -70,9 +70,7 @@ To manage preferences:
   You can set a different callback function to each variable. The callback function is invoked each time the variable is changed.
 
   ```
-  int previous_value;
-
-  preference_set_changed_cb(integer_key, preference_changed_cb_impl, &previous_value);
+  preference_set_changed_cb(integer_key, preference_changed_cb_impl, user_data);
   ```
 
   Pass custom parameters to the callback function in the `user_data` field.


### PR DESCRIPTION
Parameter "previous_value" is wrong. The user data is passed.
So the code snippet is edited.

### Change Description ###

Describe your changes here.

For instance,
 - Fix broken links of native application docs.
 -  ...

### Bugs Fixed ###

Provide links to bugs here

For instance,

 - Issue #265

### API Changes ###

In case of ACR, put the link of ACR

For instance,

 - ACR: ACR-1120

