### PR TITLE
Change the link to the tutorial page

### DIFF
--- a/docs/application/get-started/iot.md
+++ b/docs/application/get-started/iot.md
@@ -13,4 +13,4 @@ The following guide demonstrates how to create and run a basic Tizen .NET applic
 First, ensure that you have installed the latest version of Visual Studio Tools for Tizen. [**Learn more >**](../vstools/install.md)
 
 ## Hardware Setup for IoT Development
-To start developing Tizen IoT applications, follow the [guide](http://tizenschool.org/tutorial/137/) that demonstrates how to set up the Raspberry Pi board.
+To start developing Tizen IoT applications, follow the [Get Started guide](http://tizenschool.org/tutorial/191/) that demonstrates how to set up the Raspberry Pi 3 or 4 board.


### PR DESCRIPTION
### Change Description ###

Updated the link to the tutorial page for  'Getting started with Raspberry PI 3&4'.
(from http://tizenschool.org/tutorial/137 to http://tizenschool.org/tutorial/191)

For instance,
 - Fix broken links of native application docs.
 -  ...
