### PR TITLE
[Security] Remove removed API's description

### DIFF
--- a/docs/application/native/guides/security/privilege.md
+++ b/docs/application/native/guides/security/privilege.md
@@ -89,7 +89,7 @@ To get various privilege information:
                                                      &return_result);
     ```
 
-These functions return a `privilege_info_error_e` enum value (in [mobile](../../api/mobile/latest/group__CAPI__SECURITY__FRAMEWORK__PRIVILEGE__INFO__MODULE.html#gae50b814d4efe1b1d7218b6d68cdcadd6) and [wearable](../../api/wearable/latest/group__CAPI__SECURITY__FRAMEWORK__PRIVILEGE__INFO__MODULE.html#gae50b814d4efe1b1d7218b6d68cdcadd6) applications), which indicates the value of retrieval result. These functions also store the requested privilege display name or description and privacy display in their last parameter.
+These functions return a `privilege_info_error_e` enum value (in [mobile](../../api/mobile/latest/group__CAPI__SECURITY__FRAMEWORK__PRIVILEGE__INFO__MODULE.html#gae50b814d4efe1b1d7218b6d68cdcadd6) and [wearable](../../api/wearable/latest/group__CAPI__SECURITY__FRAMEWORK__PRIVILEGE__INFO__MODULE.html#gae50b814d4efe1b1d7218b6d68cdcadd6) applications), which indicates the value of retrieval result. These functions also store the requested privilege display name or description, and privacy display in their last parameter.
 
 ## Related Information
 - Dependencies

--- a/docs/application/native/guides/security/privilege.md
+++ b/docs/application/native/guides/security/privilege.md
@@ -11,7 +11,7 @@ With the Privilege Info API, you can [retrieve the following privilege informati
 
 Since Tizen 3.0, some privileges are categorized as privacy-related. The user can switch those privileges on and off as needed by changing certain privileges' status to allow or deny them at runtime. This means that the application calling a privileged API can be prevented from using it even if the required privilege is declared in its manifest file. Specific APIs can be used to check the privacy-related privilege's current status and get the display name of the privacy that includes the privilege. For example, you can use the APIs to check the privilege's current status before entering a function that requires the privilege, and if the status is off, display a guide message to the user to ask them to go to the device settings and switch the required privacy on.
 
-> **Note**  
+> [!NOTE]
 > Since Tizen 4.0, the status of privacy-related privileges can be [resolved at runtime](privacy-related-permissions.md) using the Privacy Privilege Manager API (in [mobile](../../api/mobile/latest/group__CAPI__PRIVACY__PRIVILEGE__MANAGER__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__PRIVACY__PRIVILEGE__MANAGER__MODULE.html) applications).
 
 ## Prerequisites
@@ -89,7 +89,7 @@ To get various privilege information:
                                                      &return_result);
     ```
 
-These functions return a `privilege_info_error_e` enum value (in [mobile](../../api/mobile/latest/group__CAPI__SECURITY__FRAMEWORK__PRIVILEGE__INFO__MODULE.html#gae50b814d4efe1b1d7218b6d68cdcadd6) and [wearable](../../api/wearable/latest/group__CAPI__SECURITY__FRAMEWORK__PRIVILEGE__INFO__MODULE.html#gae50b814d4efe1b1d7218b6d68cdcadd6) applications), which indicates the value of retrieval result. These functions also store the requested privilege display name or description, privacy display, and privacy privilege status in their last parameter.
+These functions return a `privilege_info_error_e` enum value (in [mobile](../../api/mobile/latest/group__CAPI__SECURITY__FRAMEWORK__PRIVILEGE__INFO__MODULE.html#gae50b814d4efe1b1d7218b6d68cdcadd6) and [wearable](../../api/wearable/latest/group__CAPI__SECURITY__FRAMEWORK__PRIVILEGE__INFO__MODULE.html#gae50b814d4efe1b1d7218b6d68cdcadd6) applications), which indicates the value of retrieval result. These functions also store the requested privilege display name or description and privacy display in their last parameter.
 
 ## Related Information
 - Dependencies


### PR DESCRIPTION
### Change Description ###

- Remove privacy privilege status related description.
  privilege-info API to get privacy privilege status was removed by ACR-1555.

