### PR TITLE
[fix] Remove items (and it's descriptions) deprecated 2+ versions earlier

### DIFF
--- a/docs/application/web/api/2.3.2/device_api/wearable/tizen/alarm.html
+++ b/docs/application/web/api/2.3.2/device_api/wearable/tizen/alarm.html
@@ -546,11 +546,6 @@ console.log(alarms.length + " alarms present in the storage.");
 This alarm triggers after a duration mentioned in the <em>delay</em> attribute from the moment the alarm is added.
 If a <em>period</em> is provided, the alarm keeps triggering for the given interval.
           </p>
-          <p>
-the operating system decides when this alarm is going to be fired and what is the period between subsequent executions.
-It is guaranteed that this alarm will be fired after at least <em>delay</em> seconds.
-If <em>period</em> is provided, it will be adjusted by the operating system, however this value will not be lower than <var>600</var> seconds.
-          </p>
          </div>
 <div class="example">
 <span class="example"><p>Code example:</p></span><pre name="code" class="examplecode prettyprint">/* Gets the current application ID. */
@@ -670,7 +665,8 @@ console.log("remaining time is " + sec);
           </p>
 <div class="description">
           <p>
-If a <em>period</em> is provided, the alarm keeps triggering for the given interval. If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
+If a <em>period</em> is provided, the alarm keeps triggering for the given interval.
+If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
           </p>
          </div>
 <div class="example">

--- a/docs/application/web/api/2.3.2/device_api/wearable/tizen/push.html
+++ b/docs/application/web/api/2.3.2/device_api/wearable/tizen/push.html
@@ -505,7 +505,7 @@ if (registrationId != null)
 </dt>
 <dd>
 <div class="brief">
- Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications..
+ Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void getUnreadNotifications();</pre></div>
 <p><span class="version">Since: </span>
@@ -514,7 +514,7 @@ if (registrationId != null)
 <div class="description">
             <p>
 The connectService() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
-If connectService is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
+If connectService() is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
 For instance, if there are 10 unread messages, the <var>PushNotificationCallback</var> will be invoked 10 times.<br><br>If an application receives unread messages, the messages are removed from the system.
             </p>
             <p>

--- a/docs/application/web/api/2.4/device_api/mobile/tizen/alarm.html
+++ b/docs/application/web/api/2.4/device_api/mobile/tizen/alarm.html
@@ -548,7 +548,7 @@ If a <em>period</em> is provided, the alarm keeps triggering for the given inter
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Since Tizen 2.4 behaviour of this alarm has changed. In order to decrease the power consumption,
+ Since Tizen 2.4 behavior of this alarm has changed. In order to decrease the power consumption,
 the operating system decides when this alarm is going to be fired and what is the period between subsequent executions.
 It is guaranteed that this alarm will be fired after at least <em>delay</em> seconds.
 If <em>period</em> is provided, it will be adjusted by the operating system, however this value will not be lower than <var>600</var> seconds.
@@ -674,7 +674,8 @@ console.log("remaining time is " + sec);
           </p>
 <div class="description">
           <p>
-If a <em>period</em> is provided, the alarm keeps triggering for the given interval. If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
+If a <em>period</em> is provided, the alarm keeps triggering for the given interval.
+If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
           </p>
          </div>
 <div class="example">

--- a/docs/application/web/api/2.4/device_api/mobile/tizen/push.html
+++ b/docs/application/web/api/2.4/device_api/mobile/tizen/push.html
@@ -505,7 +505,7 @@ if (registrationId != null)
 </dt>
 <dd>
 <div class="brief">
- Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications..
+ Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void getUnreadNotifications();</pre></div>
 <p><span class="version">Since: </span>
@@ -514,7 +514,7 @@ if (registrationId != null)
 <div class="description">
             <p>
 The connectService() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
-If connectService is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
+If connectService() is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
 For instance, if there are 10 unread messages, the <var>PushNotificationCallback</var> will be invoked 10 times.<br><br>If an application receives unread messages, the messages are removed from the system.
             </p>
             <p>

--- a/docs/application/web/api/3.0/device_api/mobile/tizen/alarm.html
+++ b/docs/application/web/api/3.0/device_api/mobile/tizen/alarm.html
@@ -548,7 +548,7 @@ If a <em>period</em> is provided, the alarm keeps triggering for the given inter
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Since Tizen 2.4 behaviour of this alarm has changed. In order to decrease the power consumption,
+ Since Tizen 2.4 behavior of this alarm has changed. In order to decrease the power consumption,
 the operating system decides when this alarm is going to be fired and what is the period between subsequent executions.
 It is guaranteed that this alarm will be fired after at least <em>delay</em> seconds.
 If <em>period</em> is provided, it will be adjusted by the operating system, however this value will not be lower than <var>600</var> seconds.
@@ -674,7 +674,8 @@ console.log("remaining time is " + sec);
           </p>
 <div class="description">
           <p>
-If a <em>period</em> is provided, the alarm keeps triggering for the given interval. If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
+If a <em>period</em> is provided, the alarm keeps triggering for the given interval.
+If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
           </p>
          </div>
 <div class="example">

--- a/docs/application/web/api/3.0/device_api/mobile/tizen/push.html
+++ b/docs/application/web/api/3.0/device_api/mobile/tizen/push.html
@@ -890,7 +890,7 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
 </dt>
 <dd>
 <div class="brief">
- Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications..
+ Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void getUnreadNotifications();</pre></div>
 <p><span class="version">Since: </span>
@@ -899,7 +899,7 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
 <div class="description">
             <p>
 The connectService() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
-If connectService is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
+If connectService() is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
 For instance, if there are 10 unread messages, the <var>PushNotificationCallback</var> will be invoked 10 times.<br><br>If an application receives unread messages, the messages are removed from the system.
             </p>
             <p>

--- a/docs/application/web/api/3.0/device_api/tv/tizen/alarm.html
+++ b/docs/application/web/api/3.0/device_api/tv/tizen/alarm.html
@@ -548,7 +548,7 @@ If a <em>period</em> is provided, the alarm keeps triggering for the given inter
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Since Tizen 2.4 behaviour of this alarm has changed. In order to decrease the power consumption,
+ Since Tizen 2.4 behavior of this alarm has changed. In order to decrease the power consumption,
 the operating system decides when this alarm is going to be fired and what is the period between subsequent executions.
 It is guaranteed that this alarm will be fired after at least <em>delay</em> seconds.
 If <em>period</em> is provided, it will be adjusted by the operating system, however this value will not be lower than <var>600</var> seconds.
@@ -674,7 +674,8 @@ console.log("remaining time is " + sec);
           </p>
 <div class="description">
           <p>
-If a <em>period</em> is provided, the alarm keeps triggering for the given interval. If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
+If a <em>period</em> is provided, the alarm keeps triggering for the given interval.
+If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
           </p>
          </div>
 <div class="example">

--- a/docs/application/web/api/3.0/device_api/tv/tizen/push.html
+++ b/docs/application/web/api/3.0/device_api/tv/tizen/push.html
@@ -595,7 +595,7 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
 </dt>
 <dd>
 <div class="brief">
- Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications..
+ Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void getUnreadNotifications();</pre></div>
 <p><span class="version">Since: </span>
@@ -604,7 +604,7 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
 <div class="description">
             <p>
 The connectService() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
-If connectService is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
+If connectService() is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
 For instance, if there are 10 unread messages, the <var>PushNotificationCallback</var> will be invoked 10 times.<br><br>If an application receives unread messages, the messages are removed from the system.
             </p>
             <p>

--- a/docs/application/web/api/3.0/device_api/wearable/tizen/alarm.html
+++ b/docs/application/web/api/3.0/device_api/wearable/tizen/alarm.html
@@ -548,7 +548,7 @@ If a <em>period</em> is provided, the alarm keeps triggering for the given inter
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Since Tizen 2.4 behaviour of this alarm has changed. In order to decrease the power consumption,
+ Since Tizen 2.4 behavior of this alarm has changed. In order to decrease the power consumption,
 the operating system decides when this alarm is going to be fired and what is the period between subsequent executions.
 It is guaranteed that this alarm will be fired after at least <em>delay</em> seconds.
 If <em>period</em> is provided, it will be adjusted by the operating system, however this value will not be lower than <var>600</var> seconds.
@@ -674,7 +674,8 @@ console.log("remaining time is " + sec);
           </p>
 <div class="description">
           <p>
-If a <em>period</em> is provided, the alarm keeps triggering for the given interval. If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
+If a <em>period</em> is provided, the alarm keeps triggering for the given interval.
+If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
           </p>
          </div>
 <div class="example">

--- a/docs/application/web/api/3.0/device_api/wearable/tizen/push.html
+++ b/docs/application/web/api/3.0/device_api/wearable/tizen/push.html
@@ -890,7 +890,7 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
 </dt>
 <dd>
 <div class="brief">
- Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications..
+ Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void getUnreadNotifications();</pre></div>
 <p><span class="version">Since: </span>
@@ -899,7 +899,7 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
 <div class="description">
             <p>
 The connectService() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
-If connectService is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
+If connectService() is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
 For instance, if there are 10 unread messages, the <var>PushNotificationCallback</var> will be invoked 10 times.<br><br>If an application receives unread messages, the messages are removed from the system.
             </p>
             <p>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/alarm.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/alarm.html
@@ -712,7 +712,7 @@ If a <em>period</em> is provided, the alarm keeps triggering for the given inter
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Since Tizen 2.4 behaviour of this alarm has changed. In order to decrease the power consumption,
+ Since Tizen 2.4 behavior of this alarm has changed. In order to decrease the power consumption,
 the operating system decides when this alarm is going to be fired and what is the period between subsequent executions.
 It is guaranteed that this alarm will be fired after at least <em>delay</em> seconds.
 If <em>period</em> is provided, it will be adjusted by the operating system, however this value will not be lower than <var>600</var> seconds.
@@ -838,7 +838,8 @@ console.log("remaining time is " + sec);
           </p>
 <div class="description">
           <p>
-If a <em>period</em> is provided, the alarm keeps triggering for the given interval. If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
+If a <em>period</em> is provided, the alarm keeps triggering for the given interval.
+If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
           </p>
          </div>
 <div class="example">

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/push.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/push.html
@@ -890,7 +890,7 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
 </dt>
 <dd>
 <div class="brief">
- Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications..
+ Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the <a href="push.html#PushManager::connect">connect()</a> method will be invoked to retrieve the notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void getUnreadNotifications();</pre></div>
 <p><span class="version">Since: </span>
@@ -898,8 +898,8 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
             </p>
 <div class="description">
             <p>
-The connectService() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
-If connectService is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
+The connect() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
+If connect() is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connect().
 For instance, if there are 10 unread messages, the <var>PushNotificationCallback</var> will be invoked 10 times.<br><br>If an application receives unread messages, the messages are removed from the system.
             </p>
             <p>

--- a/docs/application/web/api/4.0/device_api/tv/tizen/alarm.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/alarm.html
@@ -548,7 +548,7 @@ If a <em>period</em> is provided, the alarm keeps triggering for the given inter
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Since Tizen 2.4 behaviour of this alarm has changed. In order to decrease the power consumption,
+ Since Tizen 2.4 behavior of this alarm has changed. In order to decrease the power consumption,
 the operating system decides when this alarm is going to be fired and what is the period between subsequent executions.
 It is guaranteed that this alarm will be fired after at least <em>delay</em> seconds.
 If <em>period</em> is provided, it will be adjusted by the operating system, however this value will not be lower than <var>600</var> seconds.
@@ -674,7 +674,8 @@ console.log("remaining time is " + sec);
           </p>
 <div class="description">
           <p>
-If a <em>period</em> is provided, the alarm keeps triggering for the given interval. If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
+If a <em>period</em> is provided, the alarm keeps triggering for the given interval.
+If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
           </p>
          </div>
 <div class="example">

--- a/docs/application/web/api/4.0/device_api/tv/tizen/push.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/push.html
@@ -595,7 +595,7 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
 </dt>
 <dd>
 <div class="brief">
- Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications..
+ Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the <a href="push.html#PushManager::connect">connect()</a> method will be invoked to retrieve the notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void getUnreadNotifications();</pre></div>
 <p><span class="version">Since: </span>
@@ -603,8 +603,8 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
             </p>
 <div class="description">
             <p>
-The connectService() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
-If connectService is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
+The connect() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
+If connect() is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connect().
 For instance, if there are 10 unread messages, the <var>PushNotificationCallback</var> will be invoked 10 times.<br><br>If an application receives unread messages, the messages are removed from the system.
             </p>
             <p>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/alarm.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/alarm.html
@@ -725,7 +725,7 @@ If a <em>period</em> is provided, the alarm keeps triggering for the given inter
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Since Tizen 2.4 behaviour of this alarm has changed. In order to decrease the power consumption,
+ Since Tizen 2.4 behavior of this alarm has changed. In order to decrease the power consumption,
 the operating system decides when this alarm is going to be fired and what is the period between subsequent executions.
 It is guaranteed that this alarm will be fired after at least <em>delay</em> seconds.
 If <em>period</em> is provided, it will be adjusted by the operating system, however this value will not be lower than <var>600</var> seconds.
@@ -851,7 +851,8 @@ console.log("remaining time is " + sec);
           </p>
 <div class="description">
           <p>
-If a <em>period</em> is provided, the alarm keeps triggering for the given interval. If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
+If a <em>period</em> is provided, the alarm keeps triggering for the given interval.
+If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
           </p>
          </div>
 <div class="example">

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/push.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/push.html
@@ -890,7 +890,7 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
 </dt>
 <dd>
 <div class="brief">
- Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications..
+ Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the <a href="push.html#PushManager::connect">connect()</a> method will be invoked to retrieve the notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void getUnreadNotifications();</pre></div>
 <p><span class="version">Since: </span>
@@ -898,8 +898,8 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
             </p>
 <div class="description">
             <p>
-The connectService() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
-If connectService is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
+The connect() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
+If connect() is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connect().
 For instance, if there are 10 unread messages, the <var>PushNotificationCallback</var> will be invoked 10 times.<br><br>If an application receives unread messages, the messages are removed from the system.
             </p>
             <p>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/alarm.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/alarm.html
@@ -725,7 +725,7 @@ If a <em>period</em> is provided, the alarm keeps triggering for the given inter
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Since Tizen 2.4 behaviour of this alarm has changed. In order to decrease the power consumption,
+ Since Tizen 2.4 behavior of this alarm has changed. In order to decrease the power consumption,
 the operating system decides when this alarm is going to be fired and what is the period between subsequent executions.
 It is guaranteed that this alarm will be fired after at least <em>delay</em> seconds.
 If <em>period</em> is provided, it will be adjusted by the operating system, however this value will not be lower than <var>600</var> seconds.
@@ -851,7 +851,8 @@ console.log("remaining time is " + sec);
           </p>
 <div class="description">
           <p>
-If a <em>period</em> is provided, the alarm keeps triggering for the given interval. If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
+If a <em>period</em> is provided, the alarm keeps triggering for the given interval.
+If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
           </p>
          </div>
 <div class="example">

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/push.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/push.html
@@ -595,7 +595,7 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
 </dt>
 <dd>
 <div class="brief">
- Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications..
+ Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the <a href="push.html#PushManager::connect">connect()</a> method will be invoked to retrieve the notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void getUnreadNotifications();</pre></div>
 <p><span class="version">Since: </span>
@@ -603,8 +603,8 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
             </p>
 <div class="description">
             <p>
-The connectService() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
-If connectService is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
+The connect() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
+If connect() is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connect().
 For instance, if there are 10 unread messages, the <var>PushNotificationCallback</var> will be invoked 10 times.<br><br>If an application receives unread messages, the messages are removed from the system.
             </p>
             <p>

--- a/docs/application/web/api/5.0/device_api/tv/tizen/alarm.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/alarm.html
@@ -559,7 +559,7 @@ If a <em>period</em> is provided, the alarm keeps triggering for the given inter
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Since Tizen 2.4 behaviour of this alarm has changed. In order to decrease the power consumption,
+ Since Tizen 2.4 behavior of this alarm has changed. In order to decrease the power consumption,
 the operating system decides when this alarm is going to be fired and what is the period between subsequent executions.
 It is guaranteed that this alarm will be fired after at least <em>delay</em> seconds.
 If <em>period</em> is provided, it will be adjusted by the operating system, however this value will not be lower than <var>600</var> seconds.
@@ -685,7 +685,8 @@ console.log("remaining time is " + sec);
           </p>
 <div class="description">
           <p>
-If a <em>period</em> is provided, the alarm keeps triggering for the given interval. If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
+If a <em>period</em> is provided, the alarm keeps triggering for the given interval.
+If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
           </p>
          </div>
 <div class="example">

--- a/docs/application/web/api/5.0/device_api/tv/tizen/push.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/push.html
@@ -595,7 +595,7 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
 </dt>
 <dd>
 <div class="brief">
- Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications..
+ Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the <a href="push.html#PushManager::connect">connect()</a> method will be invoked to retrieve the notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void getUnreadNotifications();</pre></div>
 <p><span class="version">Since: </span>
@@ -603,8 +603,8 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
             </p>
 <div class="description">
             <p>
-The connectService() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
-If connectService is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
+The connect() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
+If connect() is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connect().
 For instance, if there are 10 unread messages, the <var>PushNotificationCallback</var> will be invoked 10 times.<br><br>If an application receives unread messages, the messages are removed from the system.
             </p>
             <p>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/alarm.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/alarm.html
@@ -725,7 +725,7 @@ If a <em>period</em> is provided, the alarm keeps triggering for the given inter
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Since Tizen 2.4 behaviour of this alarm has changed. In order to decrease the power consumption,
+ Since Tizen 2.4 behavior of this alarm has changed. In order to decrease the power consumption,
 the operating system decides when this alarm is going to be fired and what is the period between subsequent executions.
 It is guaranteed that this alarm will be fired after at least <em>delay</em> seconds.
 If <em>period</em> is provided, it will be adjusted by the operating system, however this value will not be lower than <var>600</var> seconds.
@@ -851,7 +851,8 @@ console.log("remaining time is " + sec);
           </p>
 <div class="description">
           <p>
-If a <em>period</em> is provided, the alarm keeps triggering for the given interval. If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
+If a <em>period</em> is provided, the alarm keeps triggering for the given interval.
+If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
           </p>
          </div>
 <div class="example">

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/push.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/push.html
@@ -595,7 +595,7 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
 </dt>
 <dd>
 <div class="brief">
- Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications..
+ Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the <a href="push.html#PushManager::connect">connect()</a> method will be invoked to retrieve the notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void getUnreadNotifications();</pre></div>
 <p><span class="version">Since: </span>
@@ -603,8 +603,8 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
             </p>
 <div class="description">
             <p>
-The connectService() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
-If connectService is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
+The connect() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
+If connect() is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connect().
 For instance, if there are 10 unread messages, the <var>PushNotificationCallback</var> will be invoked 10 times.<br><br>If an application receives unread messages, the messages are removed from the system.
             </p>
             <p>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/alarm.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/alarm.html
@@ -718,7 +718,7 @@ If a <em>period</em> is provided, the alarm keeps triggering for the given inter
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Since Tizen 2.4 behaviour of this alarm has changed. In order to decrease the power consumption,
+ Since Tizen 2.4 behavior of this alarm has changed. In order to decrease the power consumption,
 the operating system decides when this alarm is going to be fired and what is the period between subsequent executions.
 It is guaranteed that this alarm will be fired after at least <em>delay</em> seconds.
 If <em>period</em> is provided, it will be adjusted by the operating system, however this value will not be lower than <var>600</var> seconds.
@@ -842,7 +842,7 @@ console.log("remaining time is " + sec);
           </p>
 <div class="description">
           <p>
-If a <em>period</em> is provided, the alarm keeps triggering for the given interval. If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
+If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
           </p>
          </div>
 <div class="example">
@@ -899,7 +899,6 @@ This attribute is precise to the second. Milliseconds will be ignored.
 <div class="description">
             <p>
 By default, this attribute is set to an empty array.
-The <em>period</em> and <em>daysOfTheWeek</em> attributes are mutually exclusive.
             </p>
            </div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/humanactivitymonitor.html
@@ -273,8 +273,6 @@ The human activity monitor types defined by this enumerator are:
             <li>
 PEDOMETER - Pedometer data            </li>
             <li>
-WRIST_UP - Wrist up gesture            </li>
-            <li>
 HRM - Heart rate monitor (Heart rate and RR interval)            </li>
             <li>
 GPS - GPS information (latitude, longitude and speed)            </li>
@@ -686,9 +684,6 @@ ServiceNotAvailableError - If the human activity service is not available. For t
             </p>
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/healthinfo
-            </p>
-<p><span class="remark">Remark: </span>
- When the CPU is in the power saving mode, the WRIST_UP event might not occur even though &lt;tizen:setting background-support="enable" /&gt; is declared in the <em>config.xml</em> file.
             </p>
 <p><span class="remark">Remark: </span>
  The <b>"http://tizen.org/privilege/location"</b> privilege is required for only the <a href="#HumanActivityType">GPS</a> type.
@@ -2987,8 +2982,7 @@ It's a <a href="https://www.researchgate.net/publication/313837778_Microcontroll
 <ul>
           <li class="param">
 <span class="name">humanactivitydata</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
- New human activity data<br>Note that <var>null</var> is passed for the WRIST_UP type.
-                </li>
+ New human activity data<br>                </li>
         </ul>
 </div>
 </dd>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/push.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/push.html
@@ -595,7 +595,7 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
 </dt>
 <dd>
 <div class="brief">
- Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications..
+ Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the <a href="push.html#PushManager::connect">connect()</a> method will be invoked to retrieve the notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void getUnreadNotifications();</pre></div>
 <p><span class="version">Since: </span>
@@ -603,8 +603,8 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
             </p>
 <div class="description">
             <p>
-The connectService() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
-If connectService is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
+The connect() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
+If connect() is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connect().
 For instance, if there are 10 unread messages, the <var>PushNotificationCallback</var> will be invoked 10 times.<br><br>If an application receives unread messages, the messages are removed from the system.
             </p>
             <p>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/alarm.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/alarm.html
@@ -559,7 +559,7 @@ If a <em>period</em> is provided, the alarm keeps triggering for the given inter
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Since Tizen 2.4 behaviour of this alarm has changed. In order to decrease the power consumption,
+ Since Tizen 2.4 behavior of this alarm has changed. In order to decrease the power consumption,
 the operating system decides when this alarm is going to be fired and what is the period between subsequent executions.
 It is guaranteed that this alarm will be fired after at least <em>delay</em> seconds.
 If <em>period</em> is provided, it will be adjusted by the operating system, however this value will not be lower than <var>600</var> seconds.
@@ -683,7 +683,7 @@ console.log("remaining time is " + sec);
           </p>
 <div class="description">
           <p>
-If a <em>period</em> is provided, the alarm keeps triggering for the given interval. If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
+If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
           </p>
          </div>
 <div class="example">
@@ -740,7 +740,6 @@ This attribute is precise to the second. Milliseconds will be ignored.
 <div class="description">
             <p>
 By default, this attribute is set to an empty array.
-The <em>period</em> and <em>daysOfTheWeek</em> attributes are mutually exclusive.
             </p>
            </div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/push.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/push.html
@@ -595,7 +595,7 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
 </dt>
 <dd>
 <div class="brief">
- Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications..
+ Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the <a href="push.html#PushManager::connect">connect()</a> method will be invoked to retrieve the notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void getUnreadNotifications();</pre></div>
 <p><span class="version">Since: </span>
@@ -603,8 +603,8 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
             </p>
 <div class="description">
             <p>
-The connectService() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
-If connectService is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
+The connect() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
+If connect() is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connect().
 For instance, if there are 10 unread messages, the <var>PushNotificationCallback</var> will be invoked 10 times.<br><br>If an application receives unread messages, the messages are removed from the system.
             </p>
             <p>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/alarm.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/alarm.html
@@ -718,7 +718,7 @@ If a <em>period</em> is provided, the alarm keeps triggering for the given inter
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Since Tizen 2.4 behaviour of this alarm has changed. In order to decrease the power consumption,
+ Since Tizen 2.4 behavior of this alarm has changed. In order to decrease the power consumption,
 the operating system decides when this alarm is going to be fired and what is the period between subsequent executions.
 It is guaranteed that this alarm will be fired after at least <em>delay</em> seconds.
 If <em>period</em> is provided, it will be adjusted by the operating system, however this value will not be lower than <var>600</var> seconds.
@@ -842,7 +842,7 @@ console.log("remaining time is " + sec);
           </p>
 <div class="description">
           <p>
-If a <em>period</em> is provided, the alarm keeps triggering for the given interval. If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
+If the <em>daysOfTheWeek</em> array is not empty, the alarm triggers every week, for the given days, at the time defined by the <em>date</em> attribute.
           </p>
          </div>
 <div class="example">
@@ -899,7 +899,6 @@ This attribute is precise to the second. Milliseconds will be ignored.
 <div class="description">
             <p>
 By default, this attribute is set to an empty array.
-The <em>period</em> and <em>daysOfTheWeek</em> attributes are mutually exclusive.
             </p>
            </div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/humanactivitymonitor.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/humanactivitymonitor.html
@@ -273,8 +273,6 @@ The human activity monitor types defined by this enumerator are:
             <li>
 PEDOMETER - Pedometer data            </li>
             <li>
-WRIST_UP - Wrist up gesture            </li>
-            <li>
 HRM - Heart rate monitor (Heart rate and RR interval)            </li>
             <li>
 GPS - GPS information (latitude, longitude and speed)            </li>
@@ -686,9 +684,6 @@ ServiceNotAvailableError - If the human activity service is not available. For t
             </p>
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/healthinfo
-            </p>
-<p><span class="remark">Remark: </span>
- When the CPU is in the power saving mode, the WRIST_UP event might not occur even though &lt;tizen:setting background-support="enable" /&gt; is declared in the <em>config.xml</em> file.
             </p>
 <p><span class="remark">Remark: </span>
  The <b>"http://tizen.org/privilege/location"</b> privilege is required for only the <a href="#HumanActivityType">GPS</a> type.
@@ -2987,8 +2982,7 @@ It's a <a href="https://www.researchgate.net/publication/313837778_Microcontroll
 <ul>
           <li class="param">
 <span class="name">humanactivitydata</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
- New human activity data<br>Note that <var>null</var> is passed for the WRIST_UP type.
-                </li>
+ New human activity data<br>                </li>
         </ul>
 </div>
 </dd>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/push.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/push.html
@@ -595,7 +595,7 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
 </dt>
 <dd>
 <div class="brief">
- Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the connectService() method will be invoked to retrieve the notifications..
+ Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the <a href="push.html#PushManager::connect">connect()</a> method will be invoked to retrieve the notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void getUnreadNotifications();</pre></div>
 <p><span class="version">Since: </span>
@@ -603,8 +603,8 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
             </p>
 <div class="description">
             <p>
-The connectService() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
-If connectService is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connectService().
+The connect() method must be called to connect to Tizen push server and receive push notifications before calling the getUnreadNotifications() method.
+If connect() is not called, <var>ServiceNotAvailableError</var> occurs.<br>If any unread message exists, you will get unread push notification message through <var>PushNotificationCallback</var> of connect().
 For instance, if there are 10 unread messages, the <var>PushNotificationCallback</var> will be invoked 10 times.<br><br>If an application receives unread messages, the messages are removed from the system.
             </p>
             <p>


### PR DESCRIPTION
Some items are deprecated 2 or earlier version since generated html
but are still in the documentation.
This commit removes these items and its descriptions.
Also fixes some minor issues

