### PR TITLE
Fix the order of RequestReply attributes

### DIFF
--- a/docs/application/web/guides/multimedia/media-controller.md
+++ b/docs/application/web/guides/multimedia/media-controller.md
@@ -391,7 +391,7 @@ To receive and handle search request on the server, follow these steps:
 
         // You can return RequestReply object, which will be sent to the client
         // who can handle it in search request reply callback.
-        return new tizen.mediacontroller.RequestReply(123, {"someData": "someValue"});
+        return new tizen.mediacontroller.RequestReply({"someData": "someValue"}, 123);
     }
     ```
 


### PR DESCRIPTION
The order of RequestReply attributes was incorrect in one of code examples. This commit fixes this issue.