### PR TITLE
Adds newly removed enums of Curl

### DIFF
--- a/docs/application/native/tutorials/details/native-removed-history.md
+++ b/docs/application/native/tutorials/details/native-removed-history.md
@@ -296,6 +296,8 @@ The following table provides detailed information regarding removed functions an
 | Network - Wi-Fi | wifi_tdls_set_state_changed_cb() | Mobile, Wearable | Since 3.0 | 5.5 | Better alternative | wifi_manager_tdls_set_state_changed_cb() |
 | Network - Wi-Fi | wifi_tdls_unset_state_changed_cb() | Mobile, Wearable | Since 3.0 | 5.5 | Better alternative | wifi_manager_tdls_unset_state_changed_cb() |
 | Security - Privilege Info | privilege_info_get_privacy_privilege_status() | Mobile, Wearable | Since 5.0 | 6.0 | Better alternative | ppm_check_permission() |
+| Network - Curl | CURLE_SSL_CACERT | Mobile, Wearable | Since 5.0 | 5.5 | Security | CURLE_PEER_FAILED_VERIFICATION |
+| Network - Curl | CURLOPT_DNS_USE_GLOBAL_CACHE | Mobile, Wearable | Since 5.0 | 5.5 | Security | CURLOPT_SHARE |
 
 ## Related information
 


### PR DESCRIPTION
Following enums are newly removed.
- CURLE_SSL_CACERT
- CURLOPT_DNS_USE_GLOBAL_CACHE