### PR TITLE
Change Sample URLs in .NET Samples

### DIFF
--- a/docs/application/dotnet/samples/appfw/overview.md
+++ b/docs/application/dotnet/samples/appfw/overview.md
@@ -50,7 +50,7 @@ for TD:
 			<p>This sample application demonstrates how to manage the application badge counter using <a href="https://samsung.github.io/TizenFX/latest/api/Tizen.Applications.html" target="_blank">Tizen.Applications</a>.</p>
 			<p>In addition, there is similar native sample application.<br>
 			<ul>
-				<li><a href="https://developer.tizen.org/development/sample/native/AppFW/Badges" target="_blank">Native version</a></li>
+				<li><a href="/development/sample/native/AppFW/Badges" target="_blank">Native version</a></li>
 			</ul></p>
 			</td>
 		</tr>
@@ -68,7 +68,7 @@ for TD:
 			<p>This sample application demonstrates how to store and retrieve application specific data and preferences using <a href="https://samsung.github.io/TizenFX/latest/api/Tizen.Applications.Preference.html" target="_blank">Tizen.Applications.Preference</a>.</p>
 			<p>In addition, there is similar native sample application.<br>
 			<ul>
-				<li><a href="https://developer.tizen.org/development/sample/native/AppFW/Preference" target="_blank">Native version</a></li>
+				<li><a href="/development/sample/native/AppFW/Preference" target="_blank">Native version</a></li>
 			</ul></p>
 			</td>
 		</tr>
@@ -86,8 +86,8 @@ for TD:
 			<p>This sample application demonstrates how to create and manage several alarms and save the alarm data. It also demonstrates how to create an application using Xamarin.Forms and <a href="https://samsung.github.io/Tizen.CircularUI/api/index.html" target="_blank">Tizen.Wearable.CircularUI</a>.</p>
 			<p>In addition, there are similar native and web sample applications.<br>
 			<ul>
-				<li><a href="https://developer.tizen.org/development/sample/native/UI/%28Circle%29_Alarm" target="_blank">Native version</a></li>
-				<li><a href="https://developer.tizen.org/development/sample/web/UI/Alarm_UI" target="_blank">Web version</a></li>
+				<li><a href="/development/sample/native/UI/%28Circle%29_Alarm" target="_blank">Native version</a></li>
+				<li><a href="/development/sample/web/UI/Alarm_UI" target="_blank">Web version</a></li>
 			</ul></p>
 			</td>
 		</tr>
@@ -108,8 +108,8 @@ for TD:
 			</ul></p>
 			<p>In addition, there are similar native and web sample applications.<br>
 			<ul>
-				<li><a href="https://developer.tizen.org/development/sample/native/AppFW/Application_control" target="_blank">Native version</a></li>
-				<li><a href="https://developer.tizen.org/development/sample/web/Application/App_Control" target="_blank">Web version</a>
+				<li><a href="/development/sample/native/AppFW/Application_control" target="_blank">Native version</a></li>
+				<li><a href="/development/sample/web/Application/App_Control" target="_blank">Web version</a>
 			</li></p>
 			</td>
 		</tr>
@@ -125,7 +125,7 @@ for TD:
 			</ul></p>
 			<p>In addition, there is similar native sample application.<br>
 			<ul>
-				<li><a href="https://developer.tizen.org/development/sample/native/AppFW/App-common" target="_blank">Native version</a></li>
+				<li><a href="/development/sample/native/AppFW/App-common" target="_blank">Native version</a></li>
 			</ul></p>
 			</td>
 		</tr>
@@ -136,7 +136,7 @@ for TD:
 			<p>This sample application demonstrates how to manage badge counter of the application using <a href="https://samsung.github.io/TizenFX/latest/api/Tizen.Applications.html" target="_blank">Tizen.Applications</a> and how to create circular UI using <a href="https://samsung.github.io/Tizen.CircularUI/api/index.html" target="_blank">Tizen.Wearable.CircularUI</a>.</p>
 			<p>In addition, there is similar web sample application.<br>
 			<ul>
-				<li><a href="https://developer.tizen.org/development/sample/web/Application/Badges" target="_blank">Web version</a></li>
+				<li><a href="/development/sample/web/Application/Badges" target="_blank">Web version</a></li>
 			</ul></p>
 			</td>
 		</tr>
@@ -171,7 +171,7 @@ for TD:
 			</ul></p>
 			<p>In addition, there is similar native sample application.<br>
 			<ul>
-				<li><a href="https://developer.tizen.org/development/sample/native/AppFW/%28Tutorial%29_Message_Port" target="_blank">Native version</a></li>
+				<li><a href="/development/sample/native/AppFW/%28Tutorial%29_Message_Port" target="_blank">Native version</a></li>
 			</ul></p>
 			</td>
 		</tr>
@@ -195,7 +195,7 @@ for TD:
 			</ul></p>
 			<p>In addition, there is similar native sample application.<br>
 			<ul>
-				<li><a href="https://developer.tizen.org/development/sample/native/AppFW/%28Tutorial%29_Service_Application" target="_blank">Native version</a></li>
+				<li><a href="/development/sample/native/AppFW/%28Tutorial%29_Service_Application" target="_blank">Native version</a></li>
 			</ul></p>
 			<table>
 				<tbody>
@@ -205,11 +205,11 @@ for TD:
 				</tr>
 				<tr>
 					<td>Native</td>
-					<td><a href="https://developer.tizen.org/development/guides/native-application/application-management/applications/service-application" target="_blank">Service Application</a></td>
+					<td><a href="../../../native/guides/applications/service-app.md" target="_blank">Service Application</a></td>
 				</tr>
 				<tr>
 					<td>Web</td>
-					<td><a href="https://developer.tizen.org/development/guides/web-application/application-management/applications/service-application" target="_blank">Service Application</a></td>
+					<td><a href="../../../web/guides/applications/service-app.md" target="_blank">Service Application</a></td>
 				</tr>
 				</tbody>
 			</table>

--- a/docs/application/dotnet/samples/general/overview.md
+++ b/docs/application/dotnet/samples/general/overview.md
@@ -88,8 +88,8 @@ for TD:
 			<p>The sample requires network connection (for example, Wi-Fi) at runtime.</p>
 			<p>In addition, there are similar native and web sample applications.<br>
 			<ul>
-				<li><a href="https://developer.tizen.org/development/sample/native/UI/%28Circle%29_Voice_Memo" target="_blank">Native version</a></li>
-				<li><a href="https://developer.tizen.org/development/sample/web/UI/Voice_Memo_UI" target="_blank">Web version</a></li>
+				<li><a href="/development/sample/native/UI/(Circle)_Voice_Memo" target="_blank">Native version</a></li>
+				<li><a href="/development/sample/web/UI/Voice_Memo_UI" target="_blank">Web version</a></li>
 			</ul></p>
 			</td>
 		</tr>

--- a/docs/application/dotnet/samples/ui/overview.md
+++ b/docs/application/dotnet/samples/ui/overview.md
@@ -44,7 +44,7 @@ for TD:
 			This sample follows the Portable Class Libraries (PCL) application model. It uses some of the Xamarin.Forms features such as XAML files for GUI, custom renderers for the image buttons, and subsystem ports using the dependency service.</p>
 			<p>In addition, there is similar web sample application.<br>
 			<ul>
-				<li><a href="https://developer.tizen.org/development/sample/web/General/Calculator" target="_blank">Web version</a></li>
+				<li><a href="/development/sample/web/General/Calculator_M" target="_blank">Web version</a></li>
 			</ul></p>
 			</td>
 		</tr>
@@ -110,8 +110,8 @@ for TD:
 			<p>This sample application demonstrates the regular calculator. This is using some Xamarin.Forms features such as XAML files for GUI and Custom Renderers for the image buttons.</p>
 			<p>In addition, there are similar native and web sample applications.<br>
 			<ul>
-				<li><a href="https://developer.tizen.org/development/sample/native/UI/%28Circle%29_Calculator" target="_blank">Native version</a></li>
-				<li><a href="https://developer.tizen.org/development/sample/web/General/Calculator_1" target="_blank">Web version</a></li>
+				<li><a href="/development/sample/native/UI/%28Circle%29_Calculator" target="_blank">Native version</a></li>
+				<li><a href="/development/sample/web/General/Calculator_W" target="_blank">Web version</a></li>
 			</ul></p>
 			</td>
 		</tr>
@@ -141,8 +141,8 @@ for TD:
 			<p>This sample application demonstrates how to use Rotary Bezel.</p>
 			<p>In addition, there are similar native and web sample applications.<br>
 			<ul>
-				<li><a href="https://developer.tizen.org/development/sample/native/UI/Rotary_Timer" target="_blank">Native version</a></li>
-				<li><a href="https://developer.tizen.org/development/sample/web/General/Rotary_Timer" target="_blank">Web version</a></li>
+				<li><a href="/development/sample/native/UI/Rotary_Timer" target="_blank">Native version</a></li>
+				<li><a href="/development/sample/web/General/Rotary_Timer" target="_blank">Web version</a></li>
 			</ul></p>
 			</td>
 		</tr>
@@ -178,7 +178,7 @@ for TD:
 			<p>This sample application demonstrates how to use a stopwatch and how to create circular UI using <a href="https://samsung.github.io/Tizen.CircularUI/api/index.html" target="_blank">Tizen.Wearable.CircularUI</a>.</p>
 			<p>In addition, there is similar native sample application.<br>
 			<ul>
-				<li><a href="https://developer.tizen.org/development/sample/native/UI/%28Circle%29_Stopwatch" target="_blank">Native version</a></li>
+				<li><a href="/development/sample/native/UI/%28Circle%29_Stopwatch" target="_blank">Native version</a></li>
 			</ul></p>
 			</td>
 		</tr>

--- a/docs/application/dotnet/samples/watch/overview.md
+++ b/docs/application/dotnet/samples/watch/overview.md
@@ -48,8 +48,8 @@ for TD:
 			To use the ambient mode, you must enable it in the application settings. Launch <strong>Settings</strong> > <strong>Watch faces and styles</strong> > <strong>Watch always on</strong> > enable it. After screen timeout, the wearable device turns into ambient mode. In addition, the ambient mode activates only if you are wearing the watch on your wrist.</p>
 			<p>In addition, there are similar native and web sample applications.<br>
 			<ul>
-				<li><a href="https://developer.tizen.org/development/sample/native/Watch/Ambient_Analog_Watch" target="_blank">Native version</a></li>
-				<li><a href="https://developer.tizen.org/development/sample/web/Watch/Ambient_Watch" target="_blank">Web version</a></li>
+				<li><a href="/development/sample/native/Watch/Ambient_Analog_Watch" target="_blank">Native version</a></li>
+				<li><a href="/development/sample/web/Watch/Ambient_Watch" target="_blank">Web version</a></li>
 			</ul></p>
 			</td>
 		</tr>
@@ -68,8 +68,8 @@ for TD:
             This sample application includes the watch and stopwatch functionality.</p>
 			<p>In addition, there are similar native and web sample applications.<br>
 			<ul>
-				<li><a href="https://developer.tizen.org/development/sample/native/Watch/Chronograph_Watch" target="_blank">Native version</a></li>
-				<li><a href="https://developer.tizen.org/development/sample/web/Watch/Chronograph_Watch" target="_blank">Web version</a></li>
+				<li><a href="/development/sample/native/Watch/Chronograph_Watchs" target="_blank">Native version</a></li>
+				<li><a href="/development/sample/web/Watch/Chronograph_Watch" target="_blank">Web version</a></li>
 			</ul></p>
 			</td>
 		</tr>
@@ -80,8 +80,8 @@ for TD:
 			<p>This sample application demonstrates how to create a circular watch face, which consists of moving hands. It also demonstrates how to use watch face API using <a href="https://samsung.github.io/Tizen.CircularUI/api/index.html" target="_blank">Tizen.Wearable.CircularUI</a>.</p>
 			<p>In addition, there are similar native and web sample applications.<br>
 			<ul>
-				<li><a href="https://developer.tizen.org/development/sample/native/Watch/Classic_Watch" target="_blank">Native version</a></li>
-				<li><a href="https://developer.tizen.org/development/sample/web/Watch/Classic_Watch" target="_blank">Web version</a></li>
+				<li><a href="/development/sample/native/Watch/Classic_Watch" target="_blank">Native version</a></li>
+				<li><a href="/development/sample/web/Watch/Classic_Watch" target="_blank">Web version</a></li>
 			</ul></p>
 			</td>
 		</tr>
@@ -108,8 +108,8 @@ for TD:
 			You can get detailed information from <a href="https://github.com/Samsung/Tizen-CSharp-Samples/blob/master/Wearable/WeatherWatch" target="_blank"><strong>readme file</strong> of WeatherWatch</a>.</p>
 			<p>In addition, there are similar native and web sample applications.<br>
 			<ul>
-				<li><a href="https://developer.tizen.org/development/sample/native/Watch/Weather_Watch" target="_blank">Native version</a></li>
-				<li><a href="https://developer.tizen.org/development/sample/web/Watch/Weather_Watch" target="_blank">Web version</a></li>
+				<li><a href="/development/sample/native/Watch/Weather_Watch" target="_blank">Native version</a></li>
+				<li><a href="/development/sample/web/Watch/Weather_Watch" target="_blank">Web version</a></li>
 			</ul></p>
 			</td>
 		</tr>

--- a/docs/application/dotnet/samples/watch/overview.md
+++ b/docs/application/dotnet/samples/watch/overview.md
@@ -68,7 +68,7 @@ for TD:
             This sample application includes the watch and stopwatch functionality.</p>
 			<p>In addition, there are similar native and web sample applications.<br>
 			<ul>
-				<li><a href="/development/sample/native/Watch/Chronograph_Watchs" target="_blank">Native version</a></li>
+				<li><a href="/development/sample/native/Watch/Chronograph_Watch" target="_blank">Native version</a></li>
 				<li><a href="/development/sample/web/Watch/Chronograph_Watch" target="_blank">Web version</a></li>
 			</ul></p>
 			</td>


### PR DESCRIPTION
Signed-off-by: Mijin, Cho <mijin85.cho@samsung.com>

### Change Description ###

Update the sample links in .NET samples from developer.tizen. to docs.tizen.


### Bugs Fixed ###

 - Issue https://github.com/Samsung/tizen-docs/issues/1269
