### PR TITLE
Update event.md

### DIFF
--- a/docs/application/native/guides/app-management/event.md
+++ b/docs/application/native/guides/app-management/event.md
@@ -113,7 +113,7 @@ To subscribe to a predefined system event or user-defined event:
 
          /* event_data is the event data, its type is bundle */
          char *battery_level_status = NULL;
-         battery_level_status = bundle_get_val(event_data, EVENT_KEY_BATTERY_LEVEL_STATUS);
+         bundle_get_str(event_data, EVENT_KEY_BATTERY_LEVEL_STATUS, &battery_level_status);
      }
 
      event_handler_h handler;


### PR DESCRIPTION
bundle_get_val() is not available in bundle.h (anymore?), but in this example it is a string value, so the change should do it.

### Change Description ###

Describe your changes here.

For instance,
 - Fix broken links of native application docs.
 -  ...

### Bugs Fixed ###

Provide links to bugs here

For instance,

 - Issue #265

### API Changes ###

In case of ACR, put the link of ACR

For instance,

 - ACR: ACR-1120

