### PR TITLE
Change Version Info in Tizen Studio setup

### DIFF
--- a/docs/application/tizen-studio/setup/prerequisites.md
+++ b/docs/application/tizen-studio/setup/prerequisites.md
@@ -148,7 +148,7 @@ The following table lists the CPU, screen resolution, graphic card, driver, and 
 <td>Check and install the necessary drivers in the <strong>Control Panel &gt; System and Security &gt; Windows Update</strong>.</td>
 <td>-</td>
 <td>For more information on driver upgrades, see the <a href="https://help.ubuntu.com/community/BinaryDriverHowto/" target="_blank">Ubuntu Web site</a>. Check and install the necessary drivers in the <strong>System Settings &gt; Software &amp; Updates &gt; Additional Drivers</strong>.</p>
-<p>In 16.04, the Intel driver version must be 8.0.1 or higher.</p>
+<p>In 16.04 and 18.04, the Intel driver version must be 8.0.1 or higher.</p>
 </td>
 </tr>
 <tr>

--- a/docs/application/tizen-studio/setup/prerequisites.md
+++ b/docs/application/tizen-studio/setup/prerequisites.md
@@ -148,7 +148,7 @@ The following table lists the CPU, screen resolution, graphic card, driver, and 
 <td>Check and install the necessary drivers in the <strong>Control Panel &gt; System and Security &gt; Windows Update</strong>.</td>
 <td>-</td>
 <td>For more information on driver upgrades, see the <a href="https://help.ubuntu.com/community/BinaryDriverHowto/" target="_blank">Ubuntu Web site</a>. Check and install the necessary drivers in the <strong>System Settings &gt; Software &amp; Updates &gt; Additional Drivers</strong>.</p>
-<p>In 16.04 and 14.04, the Intel driver version must be 8.0.1 or higher.</p>
+<p>In 16.04, the Intel driver version must be 8.0.1 or higher.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Signed-off-by: Mijin, Cho <mijin85.cho@samsung.com>

### Change Description ###

According to "OS and System Requirements"
the at least supported version for Ubuntu is 16.04.
So I remove the 14.04 description in "Driver".

### Bugs Fixed ###

- https://github.com/Samsung/tizen-docs/issues/1291

