### PR TITLE
[NUI][TCSACR-349] Add and deprecate Button EventArgs classes

### DIFF
--- a/docs/application/dotnet/guides/nui/nui-components/Button.md
+++ b/docs/application/dotnet/guides/nui/nui-components/Button.md
@@ -136,18 +136,18 @@ Following output is generated when the Button is created using the defined style
 
 ![ButtonProperty](./media/ButtonProperty.PNG)
 
-## Responding to ClickEvent
+## Responding to Clicked
 
-When you click a Button, the Button instance receives a click event.
-You can declare the click event handler as follows:
+When you click a Button, the Button instance receives a clicked event.
+You can declare the clicked event handler as follows:
 
 ```cs
 Button button = new Button();
-button.ClickEvent += OnClick;
+button.Clicked += OnClicked;
 ```
 
 ```cs
-private void OnClick(object sender, Button.ClickEventArgs e)
+private void OnClicked(object sender, ClickedEventArgs e)
 {
     // Do something in response to button click
 }

--- a/docs/application/dotnet/guides/nui/nui-components/CheckBox.md
+++ b/docs/application/dotnet/guides/nui/nui-components/CheckBox.md
@@ -41,17 +41,17 @@ Following output is generated when a checkbox is created using style:
 ![CheckBox2](./media/CheckBox2.png)
 
 
-## Responding to ClickEvent
-When you click a CheckBox, the CheckBox instance receives a click event.
-You can declare the click event handler as follows:
+## Responding to Clicked
+When you click a CheckBox, the CheckBox instance receives a clicked event.
+You can declare the clicked event handler as follows:
 
 ```cs
 CheckBox ck = new CheckBox();
-ck.ClickEvent += OnClick;
+ck.Clicked += OnClicked;
 ```
 
 ```cs
-private void OnClick(object sender, Button.ClickEventArgs e)
+private void OnClicked(object sender, ClickedEventArgs e)
 {
     // Do something in response to CheckBox click
 }

--- a/docs/application/dotnet/guides/nui/nui-components/RadioButton.md
+++ b/docs/application/dotnet/guides/nui/nui-components/RadioButton.md
@@ -41,17 +41,17 @@ Following output is generated when a radio button is created using style:
 ![RadioButton2](./media/RadioButton2.png)
 
 
-## Responding to ClickEvent
-When you click a radio button, the radio button instance receives a click event.
-You can declare the click event handler as follows:
+## Responding to Clicked
+When you click a radio button, the radio button instance receives a clicked event.
+You can declare the clicked event handler as follows:
 
 ```cs
 RadioButton button = new RadioButton();
-button.ClickEvent += OnClick;
+button.Clicked += OnClicked;
 ```
 
 ```cs
-private void OnClick(object sender, Button.ClickEventArgs e)
+private void OnClicked(object sender, ClickedEventArgs e)
 {
     // Do something in response to RadioButton click
 }


### PR DESCRIPTION
Add ClickedEventArgs class.
Deprecate Button.ClickEventArgs class.

### Change Description ###

Describe your changes here.

For instance,
 - Fix broken links of native application docs.
 -  ...

### Bugs Fixed ###

Provide links to bugs here

For instance,

 - Issue #265

### API Changes ###

In case of ACR, put the link of ACR

For instance,

 - ACR: ACR-1120

