### PR TITLE
[TV] Fixed descriptions for TV modules

### DIFF
--- a/docs/application/web/api/3.0/device_api/tv/index.html
+++ b/docs/application/web/api/3.0/device_api/tv/index.html
@@ -167,19 +167,19 @@ table.api-list span.mandatory::after { content: "*"; font-weight: normal; }
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinfo.html">TV Information</a></td>
-<td>This API allows receiving key events generated when the user presses a key of an Input Device (for example a TV remote control).</td>
+<td>This API provides interfaces and methods for getting information about TV settings.</td>
 <td>2.4</td>
 <td>Optional</td>
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinputdevice.html">TV Input Device</a></td>
-<td>This API provides interfaces and methods for control of TV Window (e.g. main window, PIP window).</td>
+<td>This API allows receiving key events generated when the user presses a key of an Input Device (for example a TV remote control).</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>Yes</td>
 </tr>
 <tr><td><a href="tizen/tvwindow.html">TV Window</a></td>
-<td>This API provides interfaces and methods for getting information about TV setting.</td>
+<td>This API provides interfaces and methods for control of TV Window (e.g. main window, PIP window).</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>No</td>

--- a/docs/application/web/api/3.0/device_api/tv/index.html
+++ b/docs/application/web/api/3.0/device_api/tv/index.html
@@ -161,25 +161,25 @@ table.api-list span.mandatory::after { content: "*"; font-weight: normal; }
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvdisplaycontrol.html">TV Display Control</a></td>
-<td>This API provides interfaces and methods for getting information about the effects of stereoscopy (3D mode).</td>
+<td>This API provides interfaces and methods to get information about the effects of stereoscopy (3D mode).</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinfo.html">TV Information</a></td>
-<td>This API provides interfaces and methods for getting information about TV settings.</td>
+<td>This API provides interfaces and methods to get information about the TV settings.</td>
 <td>2.4</td>
 <td>Optional</td>
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinputdevice.html">TV Input Device</a></td>
-<td>This API allows receiving key events generated when the user presses a key of an Input Device (for example a TV remote control).</td>
+<td>This API allows to receive the key events generated from an input device. For example, when a user presses a key of the TV remote control.</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>Yes</td>
 </tr>
 <tr><td><a href="tizen/tvwindow.html">TV Window</a></td>
-<td>This API provides interfaces and methods for control of TV Window (e.g. main window, PIP window).</td>
+<td>This API provides interfaces and methods to control the TV Window. For example, the main window and PIP window.</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>No</td>

--- a/docs/application/web/api/3.0/device_api/tv/tizen/tvinfo.html
+++ b/docs/application/web/api/3.0/device_api/tv/tizen/tvinfo.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="tv-optional" title="Optional, Not supported by Tizen Tv emulator" src="tv_s_w_optional.png"></div>
 <div class="title"><h1>TVInfo API</h1></div>
 <div class="brief">
- The TVInfo API provides interfaces and methods for getting information about TV settings.
+ The TVInfo API provides interfaces and methods to get information about the TV settings.
         </div>
 <p><span class="version">Since: </span>
  2.4

--- a/docs/application/web/api/3.0/device_api/tv/tizen/tvinfo.html
+++ b/docs/application/web/api/3.0/device_api/tv/tizen/tvinfo.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="tv-optional" title="Optional, Not supported by Tizen Tv emulator" src="tv_s_w_optional.png"></div>
 <div class="title"><h1>TVInfo API</h1></div>
 <div class="brief">
- The TVInfo API provides functions to get settings values that are provided by the Tizen TV.
+ The TVInfo API provides interfaces and methods for getting information about TV settings.
         </div>
 <p><span class="version">Since: </span>
  2.4

--- a/docs/application/web/api/4.0/device_api/tv/index.html
+++ b/docs/application/web/api/4.0/device_api/tv/index.html
@@ -176,19 +176,19 @@ table.api-list span.mandatory::after { content: "*"; font-weight: normal; }
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinfo.html">TV Information</a></td>
-<td>This API allows receiving key events generated when the user presses a key of an Input Device (for example a TV remote control).</td>
+<td>This API provides interfaces and methods for getting information about TV settings.</td>
 <td>2.4</td>
 <td>Optional</td>
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinputdevice.html">TV Input Device</a></td>
-<td>This API provides interfaces and methods for control of TV Window (e.g. main window, PIP window).</td>
+<td>This API allows receiving key events generated when the user presses a key of an Input Device (for example a TV remote control).</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>Yes</td>
 </tr>
 <tr><td><a href="tizen/tvwindow.html">TV Window</a></td>
-<td>This API provides interfaces and methods for getting information about TV setting.</td>
+<td>This API provides interfaces and methods for control of TV Window (e.g. main window, PIP window).</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>No</td>

--- a/docs/application/web/api/4.0/device_api/tv/index.html
+++ b/docs/application/web/api/4.0/device_api/tv/index.html
@@ -170,25 +170,25 @@ table.api-list span.mandatory::after { content: "*"; font-weight: normal; }
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvdisplaycontrol.html">TV Display Control</a></td>
-<td>This API provides interfaces and methods for getting information about the effects of stereoscopy (3D mode).</td>
+<td>This API provides interfaces and methods to get information about the effects of stereoscopy (3D mode).</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinfo.html">TV Information</a></td>
-<td>This API provides interfaces and methods for getting information about TV settings.</td>
+<td>This API provides interfaces and methods to get information about the TV settings.</td>
 <td>2.4</td>
 <td>Optional</td>
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinputdevice.html">TV Input Device</a></td>
-<td>This API allows receiving key events generated when the user presses a key of an Input Device (for example a TV remote control).</td>
+<td>This API allows to receive the key events generated from an input device. For example, when a user presses a key of the TV remote control.</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>Yes</td>
 </tr>
 <tr><td><a href="tizen/tvwindow.html">TV Window</a></td>
-<td>This API provides interfaces and methods for control of TV Window (e.g. main window, PIP window).</td>
+<td>This API provides interfaces and methods to control the TV Window. For example, the main window and PIP window.</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>No</td>

--- a/docs/application/web/api/4.0/device_api/tv/tizen/tvinfo.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/tvinfo.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="tv-optional" title="Optional, Not supported by Tizen Tv emulator" src="tv_s_w_optional.png"></div>
 <div class="title"><h1>TVInfo API</h1></div>
 <div class="brief">
- The TVInfo API provides interfaces and methods for getting information about TV settings.
+ The TVInfo API provides interfaces and methods to get information about the TV settings.
         </div>
 <p><span class="version">Since: </span>
  2.4

--- a/docs/application/web/api/4.0/device_api/tv/tizen/tvinfo.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/tvinfo.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="tv-optional" title="Optional, Not supported by Tizen Tv emulator" src="tv_s_w_optional.png"></div>
 <div class="title"><h1>TVInfo API</h1></div>
 <div class="brief">
- The TVInfo API provides functions to get settings values that are provided by the Tizen TV.
+ The TVInfo API provides interfaces and methods for getting information about TV settings.
         </div>
 <p><span class="version">Since: </span>
  2.4

--- a/docs/application/web/api/5.0/device_api/tv/index.html
+++ b/docs/application/web/api/5.0/device_api/tv/index.html
@@ -185,25 +185,25 @@ table.api-list span.mandatory::after { content: "*"; font-weight: normal; }
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvdisplaycontrol.html">TV Display Control</a></td>
-<td>This API provides interfaces and methods for getting information about the effects of stereoscopy (3D mode).</td>
+<td>This API provides interfaces and methods to get information about the effects of stereoscopy (3D mode).</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinfo.html">TV Information</a></td>
-<td>This API provides interfaces and methods for getting information about TV settings.</td>
+<td>This API provides interfaces and methods to get information about the TV settings.</td>
 <td>2.4</td>
 <td>Optional</td>
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinputdevice.html">TV Input Device</a></td>
-<td>This API allows receiving key events generated when the user presses a key of an Input Device (for example a TV remote control).</td>
+<td>This API allows to receive the key events generated from an input device. For example, when a user presses a key of the TV remote control.</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>Yes</td>
 </tr>
 <tr><td><a href="tizen/tvwindow.html">TV Window</a></td>
-<td>This API provides interfaces and methods for control of TV Window (e.g. main window, PIP window).</td>
+<td>This API provides interfaces and methods to control the TV Window. For example, the main window and PIP window.</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>No</td>

--- a/docs/application/web/api/5.0/device_api/tv/index.html
+++ b/docs/application/web/api/5.0/device_api/tv/index.html
@@ -191,19 +191,19 @@ table.api-list span.mandatory::after { content: "*"; font-weight: normal; }
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinfo.html">TV Information</a></td>
-<td>This API allows receiving key events generated when the user presses a key of an Input Device (for example a TV remote control).</td>
+<td>This API provides interfaces and methods for getting information about TV settings.</td>
 <td>2.4</td>
 <td>Optional</td>
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinputdevice.html">TV Input Device</a></td>
-<td>This API provides interfaces and methods for control of TV Window (e.g. main window, PIP window).</td>
+<td>This API allows receiving key events generated when the user presses a key of an Input Device (for example a TV remote control).</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>Yes</td>
 </tr>
 <tr><td><a href="tizen/tvwindow.html">TV Window</a></td>
-<td>This API provides interfaces and methods for getting information about TV setting.</td>
+<td>This API provides interfaces and methods for control of TV Window (e.g. main window, PIP window).</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>No</td>

--- a/docs/application/web/api/5.0/device_api/tv/tizen/tvinfo.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/tvinfo.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="tv-optional" title="Optional, Not supported by Tizen Tv emulator" src="tv_s_w_optional.png"></div>
 <div class="title"><h1>TVInfo API</h1></div>
 <div class="brief">
- The TVInfo API provides interfaces and methods for getting information about TV settings.
+ The TVInfo API provides interfaces and methods to get information about the TV settings.
         </div>
 <p><span class="version">Since: </span>
  2.4

--- a/docs/application/web/api/5.0/device_api/tv/tizen/tvinfo.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/tvinfo.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="tv-optional" title="Optional, Not supported by Tizen Tv emulator" src="tv_s_w_optional.png"></div>
 <div class="title"><h1>TVInfo API</h1></div>
 <div class="brief">
- The TVInfo API provides functions to get settings values that are provided by the Tizen TV.
+ The TVInfo API provides interfaces and methods for getting information about TV settings.
         </div>
 <p><span class="version">Since: </span>
  2.4

--- a/docs/application/web/api/5.5/device_api/tv/index.html
+++ b/docs/application/web/api/5.5/device_api/tv/index.html
@@ -185,25 +185,25 @@ table.api-list span.mandatory::after { content: "*"; font-weight: normal; }
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvdisplaycontrol.html">TV Display Control</a></td>
-<td>This API provides interfaces and methods for getting information about the effects of stereoscopy (3D mode).</td>
+<td>This API provides interfaces and methods to get information about the effects of stereoscopy (3D mode).</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinfo.html">TV Information</a></td>
-<td>This API provides interfaces and methods for getting information about TV settings.</td>
+<td>This API provides interfaces and methods to get information about the TV settings.</td>
 <td>2.4</td>
 <td>Optional</td>
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinputdevice.html">TV Input Device</a></td>
-<td>This API allows receiving key events generated when the user presses a key of an Input Device (for example a TV remote control).</td>
+<td>This API allows to receive the key events generated from an input device. For example, when a user presses a key of the TV remote control.</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>Yes</td>
 </tr>
 <tr><td><a href="tizen/tvwindow.html">TV Window</a></td>
-<td>This API provides interfaces and methods for control of TV Window (e.g. main window, PIP window).</td>
+<td>This API provides interfaces and methods to control the TV Window. For example, the main window and PIP window.</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>No</td>

--- a/docs/application/web/api/5.5/device_api/tv/index.html
+++ b/docs/application/web/api/5.5/device_api/tv/index.html
@@ -191,19 +191,19 @@ table.api-list span.mandatory::after { content: "*"; font-weight: normal; }
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinfo.html">TV Information</a></td>
-<td>This API allows receiving key events generated when the user presses a key of an Input Device (for example a TV remote control).</td>
+<td>This API provides interfaces and methods for getting information about TV settings.</td>
 <td>2.4</td>
 <td>Optional</td>
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinputdevice.html">TV Input Device</a></td>
-<td>This API provides interfaces and methods for control of TV Window (e.g. main window, PIP window).</td>
+<td>This API allows receiving key events generated when the user presses a key of an Input Device (for example a TV remote control).</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>Yes</td>
 </tr>
 <tr><td><a href="tizen/tvwindow.html">TV Window</a></td>
-<td>This API provides interfaces and methods for getting information about TV setting.</td>
+<td>This API provides interfaces and methods for control of TV Window (e.g. main window, PIP window).</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>No</td>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tvinfo.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tvinfo.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="tv-optional" title="Optional, Not supported by Tizen Tv emulator" src="tv_s_w_optional.png"></div>
 <div class="title"><h1>TVInfo API</h1></div>
 <div class="brief">
- The TVInfo API provides interfaces and methods for getting information about TV settings.
+ The TVInfo API provides interfaces and methods to get information about the TV settings.
         </div>
 <p><span class="version">Since: </span>
  2.4

--- a/docs/application/web/api/5.5/device_api/tv/tizen/tvinfo.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/tvinfo.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="tv-optional" title="Optional, Not supported by Tizen Tv emulator" src="tv_s_w_optional.png"></div>
 <div class="title"><h1>TVInfo API</h1></div>
 <div class="brief">
- The TVInfo API provides functions to get settings values that are provided by the Tizen TV.
+ The TVInfo API provides interfaces and methods for getting information about TV settings.
         </div>
 <p><span class="version">Since: </span>
  2.4

--- a/docs/application/web/api/6.0/device_api/tv/index.html
+++ b/docs/application/web/api/6.0/device_api/tv/index.html
@@ -197,25 +197,25 @@ table.api-list span.mandatory::after { content: "*"; font-weight: normal; }
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvdisplaycontrol.html">TV Display Control</a></td>
-<td>This API provides interfaces and methods for getting information about the effects of stereoscopy (3D mode).</td>
+<td>This API provides interfaces and methods to get information about the effects of stereoscopy (3D mode).</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinfo.html">TV Information</a></td>
-<td>This API provides interfaces and methods for getting information about TV settings.</td>
+<td>This API provides interfaces and methods to get information about the TV settings.</td>
 <td>2.4</td>
 <td>Optional</td>
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinputdevice.html">TV Input Device</a></td>
-<td>This API allows receiving key events generated when the user presses a key of an Input Device (for example a TV remote control).</td>
+<td>This API allows to receive the key events generated from an input device. For example, when a user presses a key of the TV remote control.</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>Yes</td>
 </tr>
 <tr><td><a href="tizen/tvwindow.html">TV Window</a></td>
-<td>This API provides interfaces and methods for control of TV Window (e.g. main window, PIP window).</td>
+<td>This API provides interfaces and methods to control the TV Window. For example, the main window and PIP window.</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>No</td>

--- a/docs/application/web/api/6.0/device_api/tv/index.html
+++ b/docs/application/web/api/6.0/device_api/tv/index.html
@@ -203,19 +203,19 @@ table.api-list span.mandatory::after { content: "*"; font-weight: normal; }
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinfo.html">TV Information</a></td>
-<td>This API allows receiving key events generated when the user presses a key of an Input Device (for example a TV remote control).</td>
+<td>This API provides interfaces and methods for getting information about TV settings.</td>
 <td>2.4</td>
 <td>Optional</td>
 <td>No</td>
 </tr>
 <tr><td><a href="tizen/tvinputdevice.html">TV Input Device</a></td>
-<td>This API provides interfaces and methods for control of TV Window (e.g. main window, PIP window).</td>
+<td>This API allows receiving key events generated when the user presses a key of an Input Device (for example a TV remote control).</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>Yes</td>
 </tr>
 <tr><td><a href="tizen/tvwindow.html">TV Window</a></td>
-<td>This API provides interfaces and methods for getting information about TV setting.</td>
+<td>This API provides interfaces and methods for control of TV Window (e.g. main window, PIP window).</td>
 <td>2.3</td>
 <td>Optional</td>
 <td>No</td>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/tvinfo.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/tvinfo.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="tv-optional" title="Optional, Not supported by Tizen Tv emulator" src="tv_s_w_optional.png"></div>
 <div class="title"><h1>TVInfo API</h1></div>
 <div class="brief">
- The TVInfo API provides interfaces and methods for getting information about TV settings.
+ The TVInfo API provides interfaces and methods to get information about the TV settings.
         </div>
 <p><span class="version">Since: </span>
  2.4

--- a/docs/application/web/api/6.0/device_api/tv/tizen/tvinfo.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/tvinfo.html
@@ -11,7 +11,7 @@
 <div class="supported-platforms"><img class="tv-optional" title="Optional, Not supported by Tizen Tv emulator" src="tv_s_w_optional.png"></div>
 <div class="title"><h1>TVInfo API</h1></div>
 <div class="brief">
- The TVInfo API provides functions to get settings values that are provided by the Tizen TV.
+ The TVInfo API provides interfaces and methods for getting information about TV settings.
         </div>
 <p><span class="version">Since: </span>
  2.4


### PR DESCRIPTION
Issue: https://github.com/Samsung/tizen-docs/issues/1335

Fixed descriptions of TV modules - they were mixed up.