### PR TITLE
[NUI] Window system

### DIFF
--- a/docs/application/dotnet/guides/nui/tizenshell.md
+++ b/docs/application/dotnet/guides/nui/tizenshell.md
@@ -10,9 +10,9 @@ To support each system GUI service in Tizen, TZSH provides the following library
 Most applications do not need to use the TZSH’s functionalities. However, in some cases, certain applications may require to perform manipulation of system GUI service window. For example, media player application needs to close the Quickpanel window during playback of video. In this case, you can use the Quickpanel client library.
 
 ## Prerequisites
-To use the functions and structures of the [TZSH API](https://samsung.github.io/TizenFX/latest/api/Tizen.NUI.WindowSystem.Shell.TizenShell.html), use `Tizen.NUI.WindowSystem` in your application:
+To use the functions and structures of the [TZSH API](https://samsung.github.io/TizenFX/latest/api/Tizen.NUI.WindowSystem.Shell.TizenShell.html), use `Tizen.NUI.WindowSystem.Shell` in your application:
 ```
-using Tizen.NUI.WindowSystem;
+using Tizen.NUI.WindowSystem.Shell;
 ```
 
 ## Create TizenShell handle
@@ -23,7 +23,7 @@ public void TizenShell_INIT()
     try
     {
         /* Create tzsh handler */
-        Shell.TizenShell tzsh = new Shell.TizenShell();
+        TizenShell tzsh = new TizenShell();
     }
     catch (NotSupportedException e)
     {
@@ -41,3 +41,4 @@ public void TizenShell_INIT()
 ## Related information
 - Dependencies
   - Tizen 6.0 and Higher
+  - Tizen dotnet SDK 1.1.5 and Higer

--- a/docs/application/dotnet/guides/nui/tizenshell.md
+++ b/docs/application/dotnet/guides/nui/tizenshell.md
@@ -41,4 +41,4 @@ public void TizenShell_INIT()
 ## Related information
 - Dependencies
   - Tizen 6.0 and Higher
-  - Tizen .NET SDK 1.1.5 and Higer
+  - Tizen .NET SDK 1.1.5 and Higher

--- a/docs/application/dotnet/guides/nui/tizenshell.md
+++ b/docs/application/dotnet/guides/nui/tizenshell.md
@@ -41,4 +41,4 @@ public void TizenShell_INIT()
 ## Related information
 - Dependencies
   - Tizen 6.0 and Higher
-  - Tizen dotnet SDK 1.1.5 and Higer
+  - Tizen .NET SDK 1.1.5 and Higer


### PR DESCRIPTION
Changes:
```
using Tizen.NUI.WindowSystem;
Shell.TizenShell tzsh = new Shell.TizenShell();
```
produces compilation error: 
The type or namespace name 'Shell' could not be found (are you missing a using directive or an assembly reference?) [NUI_tzsh]csharp(CS0246)