### PR TITLE
[NUI] WindowSystem - fixed examples

### DIFF
--- a/docs/application/dotnet/guides/nui/quickpanelclient.md
+++ b/docs/application/dotnet/guides/nui/quickpanelclient.md
@@ -103,4 +103,5 @@ public void afterQPClientCreated()
 ## Related information
 - Dependencies
   - Tizen 6.0 and Higher
-  - Tizen dotnet SDK 1.1.5 and Higher 
+  - Tizen .NET SDK 1.1.5 and Higher
+

--- a/docs/application/dotnet/guides/nui/quickpanelclient.md
+++ b/docs/application/dotnet/guides/nui/quickpanelclient.md
@@ -3,9 +3,9 @@
 Quickpanel is a library to control the Quickpanel service window that shows notifications and system setup widgets. You can use Quickpanel client to get various information from the Quickpanel service window and change the values on purposes. For example, media player application needs to close the Quickpanel service window during playback of video. In this case, you can use the media player as the Quickpanel client.
 
 ## Prerequisites
-To use the methods of the [Quickpanel API](https://samsung.github.io/TizenFX/latest/api/Tizen.NUI.WindowSystem.Shell.QuickPanelClient.html), use `Tizen.NUI.WindowSystem` in your application:
+To use the methods of the [Quickpanel API](https://samsung.github.io/TizenFX/latest/api/Tizen.NUI.WindowSystem.Shell.QuickPanelClient.html), use `Tizen.NUI.WindowSystem.Shell` in your application:
 ```
-using Tizen.NUI.WindowSystem;
+using Tizen.NUI.WindowSystem.Shell;
 ```
 
 ## Create QuickPanel handle
@@ -14,8 +14,8 @@ After you have created the main window of your application, call `QuickPanelClie
 private void onInitialize()
 {
     Window window = NUIApplication.GetDefaultWindow();
-    Shell.TizenShell tzShell = new Shell.TizenShell();
-    Shell.QuickPanelClient qpClient = new Shell.QuickPanelClient(tzShell, window, Shell.QuickPanelClient.Types.SystemDefault);
+    TizenShell tzShell = new TizenShell();
+    QuickPanelClient qpClient = new QuickPanelClient(tzShell, window, QuickPanelClient.Types.SystemDefault);
 
     // Do something with qpClient
 }
@@ -27,8 +27,8 @@ To show or hide the Quickpanel service window when your application’s window i
 public void qpShowHide()
 {
     Window window = NUIApplication.GetDefaultWindow();
-    Shell.TizenShell tzShell = new Shell.TizenShell();
-    Shell.QuickPanelClient qpClient = new Shell.QuickPanelClient(tzShell, window, Shell.QuickPanelClient.Types.SystemDefault);
+    TizenShell tzShell = new TizenShell();
+    QuickPanelClient qpClient = new QuickPanelClient(tzShell, window, QuickPanelClient.Types.SystemDefault);
 
     qpClient.Hide();
 
@@ -62,12 +62,12 @@ Quickpanel client window can control scrollable state of the Quickpanel service 
 
 ```
 // To Unset the Scrollable state after creating qpClient
-qpClient.Scrollable = Shell.QuickPanelClient.ScrollableState.Unset;
+qpClient.Scrollable = QuickPanelClient.ScrollableState.Unset;
 
 // Do something with Quickpanel that not scrollable
 
 // To Set the Scrollable state
-qpClient.Scrollable = Shell.QuickPanelClient.ScrollableState.Set;
+qpClient.Scrollable = QuickPanelClient.ScrollableState.Set;
 ```
 
 ## Register a changed event for Quickpanel window
@@ -75,7 +75,7 @@ To get notified about the state changes, implement the `VisibleChanged` or `Orie
 ### VisibleChanged
 If you want to change your application’s behavior to match the visibility of the Quickpanel service window, you need to handle the state change event. To handle the state change event, use the following code:
 ```
-public void OnVisibleEvent(object sender, Shell.QuickPanelClient.VisibleState visibleState)
+public void OnVisibleEvent(object sender, QuickPanelClient.VisibleState visibleState)
 {
     // Do something with visibleState
 }
@@ -103,3 +103,4 @@ public void afterQPClientCreated()
 ## Related information
 - Dependencies
   - Tizen 6.0 and Higher
+  - Tizen dotnet SDK 1.1.5 and Higher 


### PR DESCRIPTION
Code examples don't work on Visual Studio Code (Ubuntu). Shell namespace is not accessible.