### PR TITLE
[WebAPI][Bluetooth] Added remark about BT stack business

### DIFF
--- a/docs/application/web/api/2.3.2/device_api/wearable/tizen/bluetooth.html
+++ b/docs/application/web/api/2.3.2/device_api/wearable/tizen/bluetooth.html
@@ -4086,7 +4086,7 @@ UnknownError - If any other error occurs              </li>
  http://tizen.org/privilege/bluetooth.admin
             </p>
 <p><span class="remark">Remark: </span>
- Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+ Establishing a connection can make device's Bluetooth stack busy. With the result, some of the operations, such as <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a> can fail until <em>connect()</em>'s callback such as <em>successCallback()</em> or <em>errorCallback()</em> is triggered.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/2.3.2/device_api/wearable/tizen/bluetooth.html
+++ b/docs/application/web/api/2.3.2/device_api/wearable/tizen/bluetooth.html
@@ -4085,6 +4085,9 @@ UnknownError - If any other error occurs              </li>
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/bluetooth.admin
             </p>
+<p><span class="remark">Remark: </span>
+ Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/2.4/device_api/mobile/tizen/bluetooth.html
+++ b/docs/application/web/api/2.4/device_api/mobile/tizen/bluetooth.html
@@ -4433,7 +4433,7 @@ UnknownError - If any other error occurs              </li>
 Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
             </p>
 <p><span class="remark">Remark: </span>
- Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+ Establishing a connection can make device's Bluetooth stack busy. With the result, some of the operations, such as <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a> can fail until <em>connect()</em>'s callback such as <em>successCallback()</em> or <em>errorCallback()</em> is triggered.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/2.4/device_api/mobile/tizen/bluetooth.html
+++ b/docs/application/web/api/2.4/device_api/mobile/tizen/bluetooth.html
@@ -4432,6 +4432,9 @@ UnknownError - If any other error occurs              </li>
  <em>http://tizen.org/privilege/bluetooth.admin</em> <em>(public level)</em> has been deprecated since 2.4.
 Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
             </p>
+<p><span class="remark">Remark: </span>
+ Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/3.0/device_api/mobile/tizen/bluetooth.html
+++ b/docs/application/web/api/3.0/device_api/mobile/tizen/bluetooth.html
@@ -4464,6 +4464,9 @@ UnknownError - If any other error occurs              </li>
  <em>http://tizen.org/privilege/bluetooth.admin</em> <em>(public level)</em> has been deprecated since 2.4.
 Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
             </p>
+<p><span class="remark">Remark: </span>
+ Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/3.0/device_api/mobile/tizen/bluetooth.html
+++ b/docs/application/web/api/3.0/device_api/mobile/tizen/bluetooth.html
@@ -4465,7 +4465,7 @@ UnknownError - If any other error occurs              </li>
 Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
             </p>
 <p><span class="remark">Remark: </span>
- Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+ Establishing a connection can make device's Bluetooth stack busy. With the result, some of the operations, such as <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a> can fail until <em>connect()</em>'s callback such as <em>successCallback()</em> or <em>errorCallback()</em> is triggered.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/3.0/device_api/wearable/tizen/bluetooth.html
+++ b/docs/application/web/api/3.0/device_api/wearable/tizen/bluetooth.html
@@ -4202,7 +4202,7 @@ UnknownError - If any other error occurs              </li>
 Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
             </p>
 <p><span class="remark">Remark: </span>
- Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+ Establishing a connection can make device's Bluetooth stack busy. With the result, some of the operations, such as <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a> can fail until <em>connect()</em>'s callback such as <em>successCallback()</em> or <em>errorCallback()</em> is triggered.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/3.0/device_api/wearable/tizen/bluetooth.html
+++ b/docs/application/web/api/3.0/device_api/wearable/tizen/bluetooth.html
@@ -4201,6 +4201,9 @@ UnknownError - If any other error occurs              </li>
  <em>http://tizen.org/privilege/bluetooth.admin</em> <em>(public level)</em> has been deprecated since 3.0.
 Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
             </p>
+<p><span class="remark">Remark: </span>
+ Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/bluetooth.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/bluetooth.html
@@ -4110,7 +4110,7 @@ UnknownError - If any other error occurs              </li>
  http://tizen.org/privilege/bluetooth
             </p>
 <p><span class="remark">Remark: </span>
- Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+ Establishing a connection can make device's Bluetooth stack busy. With the result, some of the operations, such as <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a> can fail until <em>connect()</em>'s callback such as <em>successCallback()</em> or <em>errorCallback()</em> is triggered.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/bluetooth.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/bluetooth.html
@@ -4109,6 +4109,9 @@ UnknownError - If any other error occurs              </li>
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/bluetooth
             </p>
+<p><span class="remark">Remark: </span>
+ Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/bluetooth.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/bluetooth.html
@@ -4193,6 +4193,9 @@ UnknownError - If any other error occurs              </li>
  <em>http://tizen.org/privilege/bluetooth.admin</em> <em>(public level)</em> has been deprecated since 3.0.
 Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
             </p>
+<p><span class="remark">Remark: </span>
+ Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/bluetooth.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/bluetooth.html
@@ -4194,7 +4194,7 @@ UnknownError - If any other error occurs              </li>
 Instead, use <em>http://tizen.org/privilege/bluetooth</em>.
             </p>
 <p><span class="remark">Remark: </span>
- Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+ Establishing a connection can make device's Bluetooth stack busy. With the result, some of the operations, such as <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a> can fail until <em>connect()</em>'s callback such as <em>successCallback()</em> or <em>errorCallback()</em> is triggered.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/bluetooth.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/bluetooth.html
@@ -4110,7 +4110,7 @@ UnknownError - If any other error occurs              </li>
  http://tizen.org/privilege/bluetooth
             </p>
 <p><span class="remark">Remark: </span>
- Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+ Establishing a connection can make device's Bluetooth stack busy. With the result, some of the operations, such as <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a> can fail until <em>connect()</em>'s callback such as <em>successCallback()</em> or <em>errorCallback()</em> is triggered.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/bluetooth.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/bluetooth.html
@@ -4109,6 +4109,9 @@ UnknownError - If any other error occurs              </li>
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/bluetooth
             </p>
+<p><span class="remark">Remark: </span>
+ Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/bluetooth.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/bluetooth.html
@@ -4110,7 +4110,7 @@ UnknownError - If any other error occurs              </li>
  http://tizen.org/privilege/bluetooth
             </p>
 <p><span class="remark">Remark: </span>
- Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+ Establishing a connection can make device's Bluetooth stack busy. With the result, some of the operations, such as <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a> can fail until <em>connect()</em>'s callback such as <em>successCallback()</em> or <em>errorCallback()</em> is triggered.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/bluetooth.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/bluetooth.html
@@ -4109,6 +4109,9 @@ UnknownError - If any other error occurs              </li>
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/bluetooth
             </p>
+<p><span class="remark">Remark: </span>
+ Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/bluetooth.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/bluetooth.html
@@ -4077,6 +4077,9 @@ UnknownError - If any other error occurs              </li>
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/bluetooth
             </p>
+<p><span class="remark">Remark: </span>
+ Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/bluetooth.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/bluetooth.html
@@ -4078,7 +4078,7 @@ UnknownError - If any other error occurs              </li>
  http://tizen.org/privilege/bluetooth
             </p>
 <p><span class="remark">Remark: </span>
- Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+ Establishing a connection can make device's Bluetooth stack busy. With the result, some of the operations, such as <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a> can fail until <em>connect()</em>'s callback such as <em>successCallback()</em> or <em>errorCallback()</em> is triggered.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/bluetooth.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/bluetooth.html
@@ -4077,6 +4077,9 @@ UnknownError - If any other error occurs              </li>
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/bluetooth
             </p>
+<p><span class="remark">Remark: </span>
+ Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/bluetooth.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/bluetooth.html
@@ -4078,7 +4078,7 @@ UnknownError - If any other error occurs              </li>
  http://tizen.org/privilege/bluetooth
             </p>
 <p><span class="remark">Remark: </span>
- Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+ Establishing a connection can make device's Bluetooth stack busy. With the result, some of the operations, such as <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a> can fail until <em>connect()</em>'s callback such as <em>successCallback()</em> or <em>errorCallback()</em> is triggered.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/bluetooth.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/bluetooth.html
@@ -6776,6 +6776,9 @@ UnknownError - If any other error occurs              </li>
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/bluetooth
             </p>
+<p><span class="remark">Remark: </span>
+ Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/bluetooth.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/bluetooth.html
@@ -6777,7 +6777,7 @@ UnknownError - If any other error occurs              </li>
  http://tizen.org/privilege/bluetooth
             </p>
 <p><span class="remark">Remark: </span>
- Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+ Establishing a connection can make device's Bluetooth stack busy. With the result, some of the operations, such as <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a> can fail until <em>connect()</em>'s callback such as <em>successCallback()</em> or <em>errorCallback()</em> is triggered.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/bluetooth.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/bluetooth.html
@@ -6612,6 +6612,9 @@ UnknownError - If any other error occurs              </li>
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/bluetooth
             </p>
+<p><span class="remark">Remark: </span>
+ Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/bluetooth.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/bluetooth.html
@@ -6613,7 +6613,7 @@ UnknownError - If any other error occurs              </li>
  http://tizen.org/privilege/bluetooth
             </p>
 <p><span class="remark">Remark: </span>
- Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+ Establishing a connection can make device's Bluetooth stack busy. With the result, some of the operations, such as <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a> can fail until <em>connect()</em>'s callback such as <em>successCallback()</em> or <em>errorCallback()</em> is triggered.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/bluetooth.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/bluetooth.html
@@ -6776,6 +6776,9 @@ UnknownError - If any other error occurs              </li>
 <p><span class="privilege">Privilege: </span>
  http://tizen.org/privilege/bluetooth
             </p>
+<p><span class="remark">Remark: </span>
+ Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+            </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/bluetooth.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/bluetooth.html
@@ -6777,7 +6777,7 @@ UnknownError - If any other error occurs              </li>
  http://tizen.org/privilege/bluetooth
             </p>
 <p><span class="remark">Remark: </span>
- Establishing a connection can make device's Bluetooth stack busy. Some operations, for example <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a>, may fail before <em>connect()</em>'s <em>successCallback()</em> or <em>errorCallback()</em> is called.
+ Establishing a connection can make device's Bluetooth stack busy. With the result, some of the operations, such as <a href="#BluetoothLEAdapter::stopScan">BluetoothLEAdapter::stopScan()</a> can fail until <em>connect()</em>'s callback such as <em>successCallback()</em> or <em>errorCallback()</em> is triggered.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>


### PR DESCRIPTION
Some functions may fail when a connection with a remote GATT server is being established. This commit adds a
remark about it.