### PR TITLE
Change http:// to https:// in the tizen-docs repo URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ On a certain cadence, we push all commits from master branch into the live branc
 
 ### How to PR
 
-1. Fork form the original repository, http://github.com/Samsung/tizen-docs.git.
+1. Fork form the original repository, https://github.com/Samsung/tizen-docs.
    (Ref. https://help.github.com/articles/fork-a-repo/)
 
 2. Type `git clone`, and then paste the URL you copied in 1. It will look like this, with your GitHub username instead of `YOUR-USERNAME`:
@@ -101,7 +101,7 @@ On a certain cadence, we push all commits from master branch into the live branc
 3. Set to synchronize the original repository and the forked repository.
    ```bash
    $ git remote -v
-   $ git remote add upstream http://github.com/Samsung/tizen-docs.git
+   $ git remote add upstream https://github.com/Samsung/tizen-docs.git
    $ git remote -v
    ```
 4. Create a new branch on the forked repository or the local repository,
@@ -119,7 +119,7 @@ On a certain cadence, we push all commits from master branch into the live branc
    ```bash
    $ git push origin <new branch name>
    ```
-7. Open a pull request on http://github.com/Samsung/tizen-docs.git.
+7. Open a pull request on https://github.com/Samsung/tizen-docs.
 
 
 ## DOs and DON'Ts


### PR DESCRIPTION
### Change Description ###

I changed http:// to https:// in the tizen-docs repo URL to push commit without warning message.
We can open the URL without `.git` on any web browser. I removed it to reduce typing.