### PR TITLE
Add compulsory note to JDK to give clarity to readers.

### DIFF
--- a/docs/application/tizen-studio/setup/openjdk.md
+++ b/docs/application/tizen-studio/setup/openjdk.md
@@ -76,7 +76,7 @@ This section explains how to install the OpenJDK version 12 for Ubuntu:
     sudo update-alternatives --config java
     ```
     > [!NOTE]
-    > If there are multiple JDK installed, select the required java version by entering the selection number.
+    > If multiple versions of JDK are installed, select the required Java version by entering the selection number.
 
 5. Run the following command:
     ```

--- a/docs/application/tizen-studio/setup/openjdk.md
+++ b/docs/application/tizen-studio/setup/openjdk.md
@@ -1,4 +1,4 @@
-# OpenJDK 12 and OpenJFX Installation Guide
+# OpenJDK 12 and OpenJFX installation guide
 
 > [!NOTE]
 > It is highly recommended to use the latest version of Tizen Studio. Since Tizen Studio 3.7, the JDK installation is bundled with Tizen Studio installation. There is no need to explicitly install JDK or set the variable paths. The following procedure of installing the JDK and setting the JDK variables is applicable for Tizen Studio 3.6 or lower. 
@@ -33,11 +33,11 @@ This section explains how to install the OpenJDK version 12 for Windows:
 3. Click **Environment Variables...**. The **Environment Variables** window appears.
 
 4. Click **New...** in the **User variables for \<user name\>** section.
-    > **Note**
-    >
+    
+    > [!NOTE]
     > If your `JAVA_HOME` variable is already created, select it and click **Edit...**.
 
-5. Enter `JAVA_HOME` in the variable name field and the JDK directory path, for example, `C:\Users\user\Desktop\jdk-12.0.2`, in the Variable value field.
+5. Enter `JAVA_HOME` in the variable name field and the JDK directory path, for example, `C:\Users\user\Desktop\jdk-12.0.2\bin` in the Variable value field.
 
 6. Click **OK**. The Environment Variables window appears.
 
@@ -73,16 +73,14 @@ This section explains how to install the OpenJDK version 12 for Ubuntu:
     ```
     sudo update-alternatives --config java
     ```
-    > **Note**
-    >
+    > [!NOTE]
     > If there are multiple JDK installed, select the required java version by entering the selection number.
 
 5. Run the following command:
     ```
     sudo update-alternatives --config javac
     ```
-    > **Note**
-    >
+    > [!NOTE]
     > `javac` is for compilation. For more information on differences between java and javac, see https://docs.oracle.com.
 
 4. Select the required javac version as mentioned above.
@@ -92,7 +90,7 @@ This section explains how to install the OpenJDK version 12 for Ubuntu:
     java -version
     ```
 
-### Install OpenJDK for MacOS
+### Install OpenJDK for macOS
 
 This section explains how to install the OpenJDK version 12 for macOS:
 
@@ -108,8 +106,7 @@ This section explains how to install the OpenJDK version 12 for macOS:
     java -version
     ```
 
-    > **Note**
-    >
+    > [!NOTE]
     > If the OpenJDK version 12 is not installed, add the `export JAVA_HOME = /Library/Java/JavaVirtualMachines/jdk-12.jdk/Contents/Home` command in the `.profile` or `.bash_profile` file.
 
 
@@ -118,15 +115,15 @@ This section explains how to install the OpenJDK version 12 for macOS:
 After installing OpenJDK, install the OpenJFX:
 
 1. Download the OpenJFX version 11 from [https://gluonhq.com/products/javafx](https://gluonhq.com/products/javafx/).
-    > **Note**
-    >
+    
+    > [!NOTE]
     > Download the appropriate JavaFX product for your operating system.
 
 2. Extract the downloaded zip file.
 
 3. Copy all files in `lib` folder to `lib` folder of `JAVA_HOME`.
-   > **Note**
-   >
+   
+   > [!NOTE]
    > On Ubuntu, run the following command:
    > ```
    > cd javafx-sdk-11.0.1
@@ -134,7 +131,7 @@ After installing OpenJDK, install the OpenJFX:
    > ```
 
 4. Copy all files in `bin` folder to `bin` folder of `JAVA_HOME`.
-   > **Note**
+   > [!NOTE]
    >
    > This step is only required for Windows.
 

--- a/docs/application/tizen-studio/setup/openjdk.md
+++ b/docs/application/tizen-studio/setup/openjdk.md
@@ -1,5 +1,8 @@
 # OpenJDK 12 and OpenJFX Installation Guide
 
+> [!NOTE]
+> It is highly recommended to use the latest version of Tizen Studio. Since Tizen Studio 3.7, the JDK installation is bundled with Tizen Studio installation. There is no need to explicitly install JDK or set the variable paths. The following procedure of installing the JDK and setting the JDK variables is applicable for Tizen Studio 3.6 or lower. 
+
 Open Java Development Kit (OpenJDK) is an open source implementation of the Java Standard Edition (Java SE) platform with contribution from Oracle and the open Java community. For more information, see [OpenJDK](http://openjdk.java.net/).
 
 Open JavaFX (OpenJFX) is an open source, next generation client application platform for desktop, mobile and embedded systems built on Java. For more information, see [JavaFX](https://openjfx.io/).

--- a/docs/application/tizen-studio/setup/openjdk.md
+++ b/docs/application/tizen-studio/setup/openjdk.md
@@ -43,14 +43,16 @@ This section explains how to install the OpenJDK version 12 for Windows:
 
 7. If you cannot find `JAVA_HOME` in **System variables** section, add the variable by repeating the 4, 5, and 6 steps.
 
-12. Save and close the **Environment Variables** window.
+8. Save and close the **Environment Variables** window.
 
-11. Launch **Command Prompt**.
+9. Launch **Command Prompt**.
 
-12. Run the following command to verify whether the OpenJDK version 12 is installed:
+10. Run the following command to verify whether the OpenJDK version 12 is installed:
     ```
     java -version
     ```
+> [!NOTE]
+> If the JDK version other than the recommended is installed and selected as preferred on your system, the ability to deploy or debug may be affected.
 
 ### Install OpenJDK for Ubuntu
 

--- a/docs/application/tizen-studio/setup/openjdk.md
+++ b/docs/application/tizen-studio/setup/openjdk.md
@@ -52,7 +52,7 @@ This section explains how to install the OpenJDK version 12 for Windows:
     java -version
     ```
 > [!NOTE]
-> The ability to deploy or debug may be affected, if you have not installed and selected the recommended JDK as preferred on your system.
+> The ability to deploy or debug may be affected, if you have not installed and set the recommended JDK as default on your system.
 
 ### Install OpenJDK for Ubuntu
 

--- a/docs/application/tizen-studio/setup/openjdk.md
+++ b/docs/application/tizen-studio/setup/openjdk.md
@@ -1,7 +1,7 @@
 # OpenJDK 12 and OpenJFX installation guide
 
 > [!NOTE]
-> It is highly recommended to use the latest version of Tizen Studio. Since Tizen Studio 3.7, the JDK installation is bundled with Tizen Studio installation. There is no need to explicitly install JDK or set the variable paths. The following procedure of installing the JDK and setting the JDK variables is applicable for Tizen Studio 3.6 or lower. 
+> It is highly recommended to use the latest version of Tizen Studio. Since Tizen Studio 3.7, the JDK installation is bundled with Tizen Studio. There is no need to explicitly install JDK or set the variable paths. The following procedure of installing the JDK and setting the JDK variables is applicable for Tizen Studio 3.6 or lower. 
 
 Open Java Development Kit (OpenJDK) is an open source implementation of the Java Standard Edition (Java SE) platform with contribution from Oracle and the open Java community. For more information, see [OpenJDK](http://openjdk.java.net/).
 
@@ -52,7 +52,7 @@ This section explains how to install the OpenJDK version 12 for Windows:
     java -version
     ```
 > [!NOTE]
-> If the JDK version other than the recommended is installed and selected as preferred on your system, the ability to deploy or debug may be affected.
+> The ability to deploy or debug may be affected, if you have not installed and selected the recommended JDK as preferred on your system.
 
 ### Install OpenJDK for Ubuntu
 

--- a/docs/application/tizen-studio/setup/openjdk.md
+++ b/docs/application/tizen-studio/setup/openjdk.md
@@ -85,7 +85,7 @@ This section explains how to install the OpenJDK version 12 for Ubuntu:
     > [!NOTE]
     > `javac` is for compilation. For more information on differences between java and javac, see https://docs.oracle.com.
 
-4. Select the required javac version as mentioned above.
+4. Select the required `javac` version as mentioned in step 5.
 
 6. Run the following command to verify whether the OpenJDK version 12 is installed:
     ```


### PR DESCRIPTION
After user query, adding the note to help readers know that JAVA is managed and bundled with Tizen Studio 3.7 and onwards. 