### PR TITLE
[6.5][NET] Fixed code snippets in app manager and app icon.

### DIFF
--- a/docs/application/dotnet/guides/app-management/app-icons.md
+++ b/docs/application/dotnet/guides/app-management/app-icons.md
@@ -36,7 +36,7 @@ To enable your application to use the application icon functionality:
 -   To handle badges:
     1.  To use the [Tizen.Applications.Badge](https://samsung.github.io/TizenFX/latest/api/Tizen.Applications.Badge.html) class, the application has to request permission by adding the following privilege to the `tizen-manifest.xml` file:
 
-        ```
+        ```XML
         <privileges>
            <privilege>http://tizen.org/privilege/notification</privilege>
         </privileges>
@@ -44,14 +44,14 @@ To enable your application to use the application icon functionality:
 
     2. To use the methods and properties of the Tizen.Applications.Badge class, include it in your application:
 
-        ```
+        ```csharp
         using Tizen.Applications.Badge;
         ```
 
 - To handle shortcuts:
     1.  To use the [Tizen.Applications.Shortcut](https://samsung.github.io/TizenFX/latest/api/Tizen.Applications.Shortcut.html) namespace, the application has to request permission by adding the following privilege to the `tizen-manifest.xml` file:
 
-        ```
+        ```XML
         <privileges>
            <privilege>http://tizen.org/privilege/shortcut</privilege>
         </privileges>
@@ -59,7 +59,7 @@ To enable your application to use the application icon functionality:
 
     2. To use the methods and properties of the Tizen.Applications.Shortcut namespace, include it in your application:
 
-        ```
+        ```csharp
         using Tizen.Application.Shortcut;
         ```
 
@@ -70,7 +70,7 @@ To create and remove badges:
 
 -   To create a badge for an application, create an instance of the [Tizen.Applications.Badge](https://samsung.github.io/TizenFX/latest/api/Tizen.Applications.Badge.html) class. The parameter defines the application for which the badge is added. If the application is adding a badge for itself, the parameter can be null.
 
-    ```
+    ```csharp
     Badge badge = new Badge(appId);
     BadgeControl.Add(badge);
     ```
@@ -81,7 +81,7 @@ To create and remove badges:
 
 - To remove the badge from the application, call the `Remove()` method. The only parameter is the ID of the application whose badge is to be removed.
 
-    ```
+    ```csharp
     BadgeControl.Remove(TEST_PKG);
     ```
 
@@ -94,7 +94,7 @@ To manage the badge:
 
     The badge count is displayed in the upper-right corner of the badge and the `count` property value must be an integer. The `visible` property value is of the `Bool` type.
 
-    ```
+    ```csharp
     uint count;
     bool visible;
 
@@ -106,7 +106,7 @@ To manage the badge:
 
 - Set the `count` and `visible` properties with the `Update()` method:
 
-    ```
+    ```csharp
     Badge badge = new Badge(TEST_PKG);
     BadgeControl.Add(badge);
 
@@ -128,7 +128,7 @@ To add a shortcut to the home screen:
     -   If you set the `Uri` property, clicking the shortcut opens the URI.
     -   If the `Uri` property is not set, clicking the shortcut launches the application that set the shortcut.
 
-    ```
+    ```csharp
     HomeShortcutInfo shortcut = new HomeShortcutInfo
     {
         ShortcutName = "Home",
@@ -140,7 +140,7 @@ To add a shortcut to the home screen:
 
 2. Add the shortcut using the `Add()` method of the [Tizen.Applications.Shortcut.ShortcutManager](https://samsung.github.io/TizenFX/latest/api/Tizen.Applications.Shortcut.ShortcutManager.html) class:
 
-    ```
+    ```csharp
     ShortcutManager.Add(shortcut);
     ```
 
@@ -152,7 +152,7 @@ To add a widget to the home screen:
 1.  Before adding a widget to the home screen, a widget application must be prepared.
 2. Define the widget details (such as its ID, size, and period) with the properties of the [Tizen.Applications.Shortcut.WidgetShortcutInfo](https://samsung.github.io/TizenFX/latest/api/Tizen.Applications.Shortcut.WidgetShortcutInfo.html) class:
 
-    ```
+    ```csharp
     WidgetShortcutInfo shortcut = new WidgetShortcutInfo
     {
         shortcutname = "samplewidget",
@@ -168,11 +168,9 @@ To add a widget to the home screen:
 
 3. Add the widget using the `Add()` method of the [Tizen.Applications.Shortcut.ShortcutManager](https://samsung.github.io/TizenFX/latest/api/Tizen.Applications.Shortcut.ShortcutManager.html) class:
 
-    ```
+    ```csharp
     ShortcutManager.Add(shortcut);
     ```
-
-
 
 ## Related Information
   * Dependencies

--- a/docs/application/dotnet/guides/app-management/app-manager.md
+++ b/docs/application/dotnet/guides/app-management/app-manager.md
@@ -26,13 +26,13 @@ To enable your application to use the application management functionality:
 
 1.  To use the methods and properties of the [Tizen.Applications.ApplicationManager](https://samsung.github.io/TizenFX/latest/api/Tizen.Applications.ApplicationManager.html), [Tizen.Applications.ApplicationRunningContext](https://samsung.github.io/TizenFX/latest/api/Tizen.Applications.ApplicationRunningContext.html), and [Tizen.Applications.ApplicationInfo](https://samsung.github.io/TizenFX/latest/api/Tizen.Applications.ApplicationInfo.html) classes, include the [Tizen.Applications](https://samsung.github.io/TizenFX/latest/api/Tizen.Applications.html) namespace in your application:
 
-    ```
+    ```csharp
     using Tizen.Applications;
     ```
 
 2.  To use the `Resume()` method of the `Tizen.Applications.ApplicationRunningContext` class, the application has to request permission by adding the following privilege to the `tizen-manifest.xml` file:
 
-    ```
+    ```XML
     <privileges>
        <privilege>http://tizen.org/privilege/appmanager.launch</privilege>
     </privileges>
@@ -48,20 +48,20 @@ To get the context, create an instance of the [Tizen.Applications.ApplicationRun
 
     If you do not have the application ID, you can retrieve it as:
 
-    ```
+    ```csharp
     string applicationId = ApplicationManager.GetAppId(Your PID);
     ```
 
     When an application is not running, it is impossible to get its context:
 
-    ```
+    ```csharp
     ApplicationRunningContext appRunningContext = new ApplicationRunningContext(Your App ID);
     ```
 
 2.  Operate on the application context:
     -   Get the application ID, package ID, and process ID from the context:
 
-        ```
+        ```csharp
         string applicationId = appRunningContext.ApplicationId;
         string packageId = appRunningContext.PackageId;
         int processId = appRunningContext.ProcessId;
@@ -69,7 +69,7 @@ To get the context, create an instance of the [Tizen.Applications.ApplicationRun
 
     -   Check the state of the application:
 
-        ```
+        ```csharp
         if (appRunningContext.State == ApplicationRunningContext.AppState.Foreground)
             /// UI application is running in the foreground
         else if (appRunningContext.State == ApplicationRunningContext.AppState.Background)
@@ -88,13 +88,13 @@ To get the context, create an instance of the [Tizen.Applications.ApplicationRun
 
     -   Resume the running application:
 
-        ```
+        ```csharp
         appRunningContext.Resume();
         ```
 
     -   Terminate the background application:
 
-        ```
+        ```csharp
         appRunningContext.TerminateBackgroundApplication();
         ```
 
@@ -105,19 +105,19 @@ To get information on filtered applications:
 
 1.  Create the filter as an instance of the [Tizen.Applications.ApplicationInfoFilter](https://samsung.github.io/TizenFX/latest/api/Tizen.Applications.ApplicationInfoFilter.html) class:
 
-    ```
+    ```csharp
     ApplicationInfoFilter appInfoFilter = new ApplicationInfoFilter();
     ```
 
 2.  Add filter rules:
 
-    ```
+    ```csharp
     appInfoFilter.Filter.Add(ApplicationInfoFilter.Keys.Type, "dotnet");
     ```
 
 3.  Call the `GetInstalledApplicationsAsync()` method of the [Tizen.Applications.ApplicationManager](https://samsung.github.io/TizenFX/latest/api/Tizen.Applications.ApplicationManager.html) class and retrieve all filtered applications and print their information:
 
-    ```
+    ```csharp
     IEnumerable<ApplicationInfo> appInfoList = await ApplicationManager.GetInstalledApplicationsAsync(appinfoFilter);
 
     foreach (ApplicationInfo appInfo in appInfoList)
@@ -142,26 +142,26 @@ To get information on the current application, follow these steps:
 
 1.  Call the `Current` property of the [Tizen.Applications](https://samsung.github.io/TizenFX/latest/api/Tizen.Applications.Application.html) class:
 
-    ```
+    ```csharp
     Application application = Application.Current;
     ```
 
 2.  Operate on the application information:
     -   Get the application directory information:
 
-        ```
+        ```csharp
         DirectoryInfo directory = application.DirectoryInfo;
         ```
 
     -   Get the application name:
 
-        ```
+        ```csharp
         string name = application.Name;
         ```
 
     -   Get the application version:
 
-        ```
+        ```csharp
         string version = application.Version;
         ```
 


### PR DESCRIPTION
To keep documentation consistency code snippets uses same tags.
