### PR TITLE
[Web API][Iotcon] Add NotSupportedError to initialize()

### DIFF
--- a/docs/application/web/api/6.5/device_api/mobile/tizen/iotcon.html
+++ b/docs/application/web/api/6.5/device_api/mobile/tizen/iotcon.html
@@ -602,6 +602,9 @@ There is a <em>tizen.iotcon</em> object that allows access to the Iotcon API.
  with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
+ with error type NotSupportedError, if this feature is not supported.
+                </p></li>
+<li class="list"><p>
  with error type AbortError, if the operation has been stopped.
                 </p></li>
 </ul>

--- a/docs/application/web/api/6.5/device_api/tv/tizen/iotcon.html
+++ b/docs/application/web/api/6.5/device_api/tv/tizen/iotcon.html
@@ -600,6 +600,9 @@ There is a <em>tizen.iotcon</em> object that allows access to the Iotcon API.
  with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
+ with error type NotSupportedError, if this feature is not supported.
+                </p></li>
+<li class="list"><p>
  with error type AbortError, if the operation has been stopped.
                 </p></li>
 </ul>

--- a/docs/application/web/api/6.5/device_api/wearable/tizen/iotcon.html
+++ b/docs/application/web/api/6.5/device_api/wearable/tizen/iotcon.html
@@ -602,6 +602,9 @@ There is a <em>tizen.iotcon</em> object that allows access to the Iotcon API.
  with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
+ with error type NotSupportedError, if this feature is not supported.
+                </p></li>
+<li class="list"><p>
  with error type AbortError, if the operation has been stopped.
                 </p></li>
 </ul>


### PR DESCRIPTION
ACR: TWDAPI-279

A new exception is added to tizen.iotcon.initialize()

Signed-off-by: Pawel Wasowski <p.wasowski2@samsung.com>


- ACR: https://code.sec.samsung.net/jira/browse/TWDAPI-279
