### PR TITLE
Fixing headers format issue in topics (docs/platform/developing)

### DIFF
--- a/docs/platform/developing/building-all.md
+++ b/docs/platform/developing/building-all.md
@@ -1,4 +1,4 @@
-# Building All Packages Locally with GBS
+# Build all packages locally with GBS
 
 You can perform a build for all Tizen packages using the Git Build System (GBS).
 
@@ -13,7 +13,7 @@ Before performing the build, study the following instructions:
 > - To understand the local full build commands, see [GBS Build Concepts](#gbs-build-concepts).
 > - To speed up the build process when hardware allows, see [Speeding up a Local Build](building.md#speeding-up-a-local-build).
 
-## Cloning All Tizen Projects
+## Clone all Tizen projects
 
 You can clone all Tizen projects over SSH or HTTPS.
 
@@ -21,7 +21,7 @@ You can clone all Tizen projects over SSH or HTTPS.
 >
 > Procedures to clone all projects over SSH and HTTPS are almost identical, the only difference being the Git cloning protocol. However, you can only contribute code to Tizen using the SSH method.
 
-### Cloning All Projects over SSH
+### Clone all projects over SSH
 You can clone the source of all projects over SSH, including the latest source and the snapshot source.
 
 > [!NOTE]
@@ -109,7 +109,7 @@ To clone the latest sources of all projects over SSH:
    > ```
    > you can control jobs number using `-j` option.
 
-### Cloning All Projects over HTTPS
+### Clone all projects over HTTPS
 
 You can clone the source of all projects over HTTPS, including the latest source and the snapshot source.
 
@@ -168,7 +168,7 @@ To clone the latest sources of all projects over HTTPS:
    $ repo sync
    ```
 
-## Building All Packages
+## Build all packages
 
 Build all packages by executing the following commands:
 
@@ -193,7 +193,7 @@ $ gbs build -A armv7l --threads=4 --clean-once
 >
 > For information on increasing the build speed, see [Development Tips](./tips.md).
 
-## GBS Build Concepts
+## GBS build concepts
 The following build concepts help you understand the full build commands:
 
 - **Dependency cycles**

--- a/docs/platform/developing/building.md
+++ b/docs/platform/developing/building.md
@@ -1,4 +1,4 @@
-# Building Packages Locally with GBS
+# Build packages locally with GBS
 
 You can perform local builds using the Git Build System (GBS).
 
@@ -29,7 +29,7 @@ To build a package for a specific project:
    ```
 5. Take follow-up actions, if necessary. For more information, see [Performing Another Build](#performing-another-build) or [gbs build document](../reference/gbs/gbs-build.md).
 
-## Build Tips
+## Build tips
 
 The build tips for local builds include:
 
@@ -37,7 +37,7 @@ The build tips for local builds include:
 - How to [speed up a local build](#speeding-up-a-local-build).
 - How to [perform another build](#performing-another-build).
 
-### Excluding Specific Packages
+### Exclude specific packages
 
 To exclude specific packages when building locally with GBS, you can either list them in the `--exclude` argument of the `gbs build` command, or list them in the `.gbs.conf` file:
 
@@ -53,7 +53,7 @@ To exclude specific packages when building locally with GBS, you can either list
   exclude_packages=aaa,bbb,ccc,ddd,eee,fff
   ```
 
-### Speeding up a Local Build
+### Speed up a local build
 
 If the size of your RAM and swap file are both larger than 8 GB, you can speed up building by creating a GBS `BUILD-ROOTS` directory and mounting it as a RAM disk:
 
@@ -62,7 +62,7 @@ $ mkdir -p ~/GBS-ROOT/local/BUILD-ROOTS
 $ sudo mount -t tmpfs -o size=16G tmpfs ~/GBS-ROOT/local/BUILD-ROOTS
 ```
 
-### Performing Another Build
+### Perform another build
 
 When the result of the first build is unsatisfactory, perform another build by executing 1 of the following commands, as appropriate:
 

--- a/docs/platform/developing/cloning.md
+++ b/docs/platform/developing/cloning.md
@@ -1,4 +1,4 @@
-# Cloning Tizen Source Files
+# Clone Tizen source files
 
 You can clone Tizen source files over SSH or HTTPS.
 
@@ -11,7 +11,7 @@ Before cloning source files, study the following instructions:
 - [Setting up the Development Environment](setting-up.md)
 - [Installing Development Tools](installing.md)
 
-## Cloning over SSH
+## Clone over SSH
 
 You can clone source files over SSH, either for a specific project or for all Tizen projects.
 
@@ -38,7 +38,7 @@ To clone all Tizen projects over SSH, see [Cloning All Projects over SSH](buildi
 > $ ssh review.tizen.org gerrit ls-projects
 > ```
 
-## Cloning over HTTPS
+## Clone over HTTPS
 
 You can clone source files over HTTPS, either for a specific project or for all Tizen projects.
 

--- a/docs/platform/developing/contributing.md
+++ b/docs/platform/developing/contributing.md
@@ -1,14 +1,14 @@
-# Contributing Code to Tizen
+# Contribute code to Tizen
 
 This topic describes how you can contribute code to Tizen.
 
 For more information about the whole work process, see [Tizen Development Workflow](../get-started/work-flow.md).
 
-## Cloning Source Files over SSH
+## Clone source files over SSH
 
 To clone source files for a specific project, see [Cloning Tizen Source Files](cloning.md).
 
-## Submitting a Patch to Gerrit
+## Submit a patch to Gerrit
 
 You can perform patch submission and review on Gerrit.
 
@@ -37,7 +37,7 @@ To submit a patch to Gerrit:
 
 For more information, see [Gerrit Documentation](https://review.tizen.org/gerrit/Documentation/index.html).
 
-## Reviewing a Patch on Gerrit
+## Review a patch on Gerrit
 
 To review a patch in the Gerrit Web UI, publish the comments and vote for the patch.
 
@@ -52,11 +52,11 @@ The patch is merged or discarded depending on the voting results.The merge is pe
 
 When a patch meets the above criteria, privileged users can submit to merge the patch to the Git repository.
 
-## Submitting Packages to the Build System
+## Submit packages to the build system
 
 You can submit a single package or a group of packages.
 
-### Submitting a Single Package
+### Submit a single package
 
 To submit a package to the build system, execute the following command:
 
@@ -76,7 +76,7 @@ If the code change has already been merged in Gerrit, a merge request is created
 >
 > If the patch has not been merged in Gerrit, the backend services abort the operation and send an email to the patch owner, to notify that the patch needs to be re-submitted after it is merged.
 
-### Submitting a Group of Packages
+### Submit a group of packages
 
 If multiple changed packages have mutual dependencies, they must be submitted as a group. This means that all of the packages must be submitted with 1 unified identification, through a process known as **group submission**.
 
@@ -108,7 +108,7 @@ submit/$Tizen_Version/$(%Y%m%d.%H%M%S).N (N is a number you can choose freely)
 
 Tizen backend services take care of all submissions with the same tag, and build them together.
 
-## Reviewing a Package on the Build Server
+## Review a package on the build server
 
 If you are a release engineer, you can review and accept changes on the build system side.
 

--- a/docs/platform/developing/creating.md
+++ b/docs/platform/developing/creating.md
@@ -1,4 +1,4 @@
-# Creating Tizen Images with MIC
+# Create Tizen images with MIC
 
 This topic provides information on how to create a Tizen image.
 
@@ -20,7 +20,7 @@ The tool offers three major functions as follows:
 
 For more information on the tool and its functions, see [MIC Image Creator](../reference/mic/mic-overview.md).
 
-## Prepare the Kickstart File
+## Prepare the kickstart file
 
 Image creation requires a kickstart file that describes how to create an image. To prepare the kickstart file:
 

--- a/docs/platform/developing/flashing-rpi.md
+++ b/docs/platform/developing/flashing-rpi.md
@@ -1,4 +1,4 @@
-# Flashing an Image to RPI
+# Flash an image to RPI
 
 This topic describes how to flash Tizen on SD card with or without IoT Setup Manager and setting up Raspberry Pi 3 or 4.
 
@@ -122,7 +122,7 @@ During installation, the Package Manager creates shortcuts for IoT Setup Manager
 
 IoT Setup Manager window appears.
 
-###  IoT setup manager features
+###  IoT Setup Manager features
 
 ![IoT Setup Manager Main](media/setup_manager_main_window.png)
 

--- a/docs/platform/developing/flashing.md
+++ b/docs/platform/developing/flashing.md
@@ -1,4 +1,4 @@
-# Flashing an Image to Device
+# Flash an image to device
 
 The instructions for flashing depend on the type of device you are using. Instructions are available for the following devices:
 - TM1 reference device

--- a/docs/platform/developing/installing.md
+++ b/docs/platform/developing/installing.md
@@ -1,4 +1,4 @@
-# Installing Development Tools
+# Install development tools
 
 Tizen SCM tools support the following Linux distribution versions:
 
@@ -21,7 +21,7 @@ You can install a variety of development tools, including:
 >
 > GBS and MIC are used as examples because they are mandatory development tools for Tizen developers.
 
-## Installing Development Tools in Ubuntu or Debian
+## Install development tools in Ubuntu or Debian
 
 To install a development tool in Ubuntu or Debian:
 
@@ -71,7 +71,7 @@ To install a development tool in Ubuntu or Debian:
    sudo apt-get update && sudo apt-get install gbs mic
    ```
 
-## Installing Development Tools in openSUSE
+## Install development tools in openSUSE
 
 To install a development tool in openSUSE:
 

--- a/docs/platform/developing/setting-up.md
+++ b/docs/platform/developing/setting-up.md
@@ -1,8 +1,8 @@
-# Setting up the Development Environment
+# Set up the development environment
 
 This topic provides information on how to set up a development environment.
 
-## Setting Up Gerrit Access
+## Set up Gerrit access
 
 You can set up access to [Tizen Gerrit](http://review.tizen.org/gerrit/) through the following steps:
 
@@ -10,7 +10,7 @@ You can set up access to [Tizen Gerrit](http://review.tizen.org/gerrit/) through
 2. Configure Secure Shell (SSH) for Gerrit access.
 3. Configure Git for Gerrit access.
 
-### Registering a User Account
+### Register a user account
 
 To register a user account to gain access to tizen.org:
 
@@ -27,7 +27,7 @@ To register a user account to gain access to tizen.org:
 
 At this point, the prerequisites for accessing Gerrit are ready. Move on to the next section to enable Gerrit access.
 
-### Configuring SSH for Gerrit Access
+### Configure SSH for Gerrit access
 
 To configure SSH for Gerrit access:
 
@@ -100,7 +100,7 @@ To configure SSH for Gerrit access:
    **** Welcome to Gerrit Code Review ****
    ```
 
-### Configuring Git for Gerrit Access
+### Configure Git for Gerrit access
 
 Git must know the user's name and email address to determine the author of each commit. If the user name or email address is not set up in a way that Git can find it, the user can encounter some odd warnings.
 
@@ -121,11 +121,11 @@ To configure Git for Gerrit access:
 >
 > Using the `GIT_AUTHOR_NAME` and `GIT_AUTHOR_EMAIL` environment variables is an alternative solution. These variables override all configuration settings once set.
 
-## Setting Up the GBS Configuration
+## Set up the GBS configuration
 
 You can set up the GBS configuration through editing the `.gbs.conf` file.
 
-### Setting Up the Default GBS Configuration File
+### Set up the default GBS configuration file
 
 The default GBS configuration file is located in `~/.gbs.conf`:
 
@@ -193,7 +193,7 @@ profile = profile.unified_standard
 > - Profile: unified
 > - Repository: standard
 
-### Setting Up a Specific Profile in the `.gbs.conf` File
+### Set up a specific profile in the `.gbs.conf` file
 
 To build using a non-default Tizen version, profile, or repository, select 1 of the profiles specified in the `.gbs.conf` file and set that profile in the `[general]` section, using the following format:
 
@@ -229,7 +229,7 @@ Each `profile` entry in the `.gbs.conf` file specifies multiple `repo` entries, 
 
 For more information on `.gbs.conf`, see [GBS Configuration](../reference/gbs/gbs.conf.md).
 
-## Setting Up the Repo Tool
+## Set up the repo tool
 
 Repo is a repository management tool built on top of Git.  Multiple Git repositories can be downloaded with a single repo command.
 
@@ -265,7 +265,7 @@ To install and set up the repo tool:
    $ sudo chmod a+x ~/bin/repo
    ```
 
-## Working through a Network Proxy
+## Work through a network proxy
 
 You can set up your development environment to work through a network proxy.
 
@@ -273,7 +273,7 @@ You can set up your development environment to work through a network proxy.
 >
 > A network proxy is particularly useful if you also track other Git repositories for which you do not already have a dedicated `ProxyCommand` in your `~/.ssh/config`, or which use "git://" or "http://".
 
-### Configuring a Proxy
+### Configure a proxy
 
 To configure a proxy through the Linux shell prompt:
 
@@ -296,7 +296,7 @@ To configure a proxy through the Linux shell prompt:
    > Replace "=" with "+=" if other `env_keep` settings already exist in `/etc/sudoers`.
 
 
-### Configuring Git Access through the Proxy
+### Configure Git access through the proxy
 
 To allow Git access through the proxy:
 

--- a/docs/platform/developing/tips.md
+++ b/docs/platform/developing/tips.md
@@ -1,4 +1,4 @@
-# Development Tips
+# Development tips
 
 - **SSH configuration file content**
 


### PR DESCRIPTION
Since headers in these topics/files were written in title case and gerund forms, I have updated the headers as per Tizen writing style guidelines.