### PR TITLE
[tts][ACR-1685] Add description for tts_prepare_sync()

### DIFF
--- a/docs/application/native/guides/text-input/tts.md
+++ b/docs/application/native/guides/text-input/tts.md
@@ -352,7 +352,7 @@ To obtain the current state, the supported voice list, and the current voice:
 
 - Get the default voice using the `tts_get_default_voice()` function.
 
-    The TTS synthesizes the text using the default voice, if you do not set the language and the voice type as parameters of the `tts_add_text()` function:
+    TTS synthesizes the text using the default voice if you do not set the language and the voice type as parameters of the `tts_add_text()` function:
 
     ```cpp
     void

--- a/docs/application/native/guides/text-input/tts.md
+++ b/docs/application/native/guides/text-input/tts.md
@@ -26,9 +26,9 @@ Using TTS, you can:
 
 - Create a handle and register callback functions.
   - Create a TTS handle which is used for distinguishing your application from other applications also using the TTS.
-  - To get notifications about state changes, language changes, starting or finishing utterances, and errors, [register callback functions](#set).
+  - To get notifications about state changes, language changes, starting or finishing utterances, and errors, we should [register callback functions](#set).
 - Add text and set the mode.
-  - [Add the text](#text) that you want to read out by the TTS module. The requested text is handled as an utterance. You can add several texts, and they are managed using a queue.
+  - [Add the text](#text) that you want the TTS module to read out. The requested text is handled as an utterance. You can add several texts, and they are managed using a queue.
   - There is a limit on the maximum text length for one utterance, and the time spent for synthesizing is dependent on the text length.
   - [Get and set the TTS mode](#mode) to manage audio mixing with other sources.
 - Play, pause, and stop playback.
@@ -48,7 +48,7 @@ You can set the following parameters about TTS:
 
 - Credential
 
-  The credential is a key to verify the authorization about using the TTS engine. The necessity of the credential depends on the TTS engine. If the TTS engine requests the credential, you can set it using the `tts_set_credential()` function.
+  The credential is a key used to verify the authorization when using the TTS engine. The necessity of the credential depends on the TTS engine. If the TTS engine requests the credential, you can set it using the `tts_set_credential()` function.
 
 - Private data
 
@@ -119,7 +119,7 @@ The enum values, as well as the parameter details, for the callback parameters a
 
 To set and unset callbacks:
 
-1. The TTS provides various callbacks to get information, such as the state changes and start or completion of an utterance.
+1. TTS provides various callbacks to get information, such as the state changes and start or completion of an utterance.
 
    Set the callbacks in the `TTS_STATE_CREATED` state.
 
@@ -531,7 +531,7 @@ To set and get the options about the TTS engine:
 <a name="text"></a>
 ## Add text
 
-There are defined values, `TTS_VOICE_TYPE_AUTO` and `TTS_VOICE_SPEED_AUTO` for following the default TTS setting. Those values and the minimum and maximum limits for the speed, are defined in the `tts.h` header file.
+There are defined values, `TTS_VOICE_TYPE_AUTO` and `TTS_VOICE_SPEED_AUTO`, for following the default TTS setting. Those values and the minimum and maximum limits for the speed, are defined in the `tts.h` header file.
 
 To add text:
 

--- a/docs/application/native/guides/text-input/tts.md
+++ b/docs/application/native/guides/text-input/tts.md
@@ -1,7 +1,7 @@
 # Text-to-speech
 
 
-The TTS (text-to-speech) features include synthesizing text into sound data as utterances and playing them. It is also possible to pause and stop playing.
+TTS (text-to-speech) features include synthesizing text into sound data as utterances and playing them. It is also possible to pause and stop playback.
 
 When your application creates a handle and prepares the TTS service by the API, the TTS daemon is invoked and connected for background work. This daemon and your application communicate as the server and the client, respectively.
 
@@ -44,7 +44,7 @@ The TTS life-cycle is described in the following figure.
 <a name="parameter_tts"></a>
 ## TTS parameters
 
-You can set the following parameters about the TTS:
+You can set the following parameters about TTS:
 
 - Credential
 
@@ -57,12 +57,12 @@ You can set the following parameters about the TTS:
 <a name="info_tts"></a>
 ## TTS information retrieval
 
-You can get the following information about the TTS:
+You can get the following information about TTS:
 
-- [Get the current state](#get) of the TTS. The state is also applied as a precondition for each function.
-- Get the default voice.
-  - In the TTS, the voice is defined as a combination of the language and the type, such as male or female.
-  - You can request the synthesis of the text with your own voice option by the parameter of the add text function. However, if you do not set a specific option, the TTS synthesizes the text with the default voice.
+- [Get the current state](#get) of TTS. The state is also applied as a precondition for each function.
+- Get the default voice:
+  - In TTS, the voice is defined as a combination of the language and the type, such as male or female.
+  - You can request the synthesis of the text with your own voice option by the parameter of the [`tts_add_text()`](#text) function. However, if you do not set a specific option, the TTS synthesizes the text with the default voice.
   - The user can change the default voice in the device settings by modifying the display language or the TTS default language status. If the display language is changed to a non-supported language, the TTS language is changed to UK English.
 - Get a list of supported voices to check whether the language and voice type you want are supported.
 - Get the error message when the error callback is invoked.
@@ -79,7 +79,7 @@ To enable your application to use the TTS functionality:
 
 2. To use the TTS library, create a TTS handle.
 
-   The TTS handle is used in other TTS functions as a parameter. After the handle creation, the TTS state changes to `TTS_STATE_CREATED`.
+   The TTS handle is used in other TTS functions as a parameter. After the handle creation, the TTS state changes to `TTS_STATE_CREATED`:
 
    > [!NOTE]
    > TTS is not thread-safe and depends on the Ecore main loop. Implement TTS within the Ecore main loop and do not use it in a thread.
@@ -194,7 +194,7 @@ To set and unset callbacks:
 
    - Engine changed
 
-     If you set the engine change callback for the TTS, it is invoked when the engine is changed by the TTS:
+     If you set the engine change callback for TTS, it is invoked when the engine is changed by the TTS:
 
      ```cpp
      /* Callback */
@@ -228,7 +228,7 @@ To set and unset callbacks:
 
    - Utterance started or completed
 
-     If you add text in the TTS, that text is handled as an utterance and it obtains its own ID. After you request the TTS process to start, the text is synthesized by an engine and played out. To get a notification when an utterance is started or completed, set the respective callbacks:
+     If you add text in TTS, that text is handled as an utterance and it obtains its own ID. After you request the TTS process to start, the text is synthesized by an engine and played out. To get a notification when an utterance is started or completed, set the respective callbacks:
 
      ```cpp
      /* Started callback */
@@ -434,7 +434,7 @@ get_mode(tts_h tts)
 <a name="prepare"></a>
 ## Connect and disconnect TTS
 
-To operate the TTS:
+To operate TTS:
 
 1. After you create the TTS handle, connect the background TTS daemon with the `tts_prepare()` function.
 
@@ -456,7 +456,7 @@ To operate the TTS:
 
 2. If you want to connect the daemon synchronously, use the `tts_prepare_sync()` function.
 
-   If the function returns no error, connection succeeds and the TTS state changes to `TTS_STATE_READY` immediately:
+   If the function returns no error, the connection succeeds and the TTS state changes to `TTS_STATE_READY` immediately:
 
    ```cpp
    void
@@ -488,7 +488,7 @@ To set and get the options about the TTS engine:
 
 - Set the credential.
 
-  The credential is a key to verify the authorization about using the TTS engine. The necessity of the credential depends on the engine. If the engine requests the credential, you can set it using the `tts_set_credential()` function:
+  The credential is a key used to verify the authorization when using the TTS engine. The necessity of the credential depends on the engine. If the engine requests the credential, you can set it using the `tts_set_credential()` function:
 
   ```cpp
   void
@@ -503,7 +503,7 @@ To set and get the options about the TTS engine:
 
 - Set and get the private data.
 
-  The private data is a setting parameter for applying keys provided by the TTS engine. Using the `tts_set_private_data()` function, you can set the private data and use the corresponding key of the engine. To get the private data which corresponds to a specific key from the engine, use the `tts_get_private_data()` function.
+  The private data is a setting parameter for applying keys provided by the TTS engine. Using the `tts_set_private_data()` function, you can set the private data and use the corresponding key of the engine. To get the private data that corresponds to a specific key from the engine, use the `tts_get_private_data()` function:
 
   > [!NOTE]
   > The key and data are determined by the TTS engine. To set and get the private data, see the engine instructions.
@@ -531,7 +531,7 @@ To set and get the options about the TTS engine:
 <a name="text"></a>
 ## Add text
 
-There are defined values, `TTS_VOICE_TYPE_AUTO` and `TTS_VOICE_SPEED_AUTO` for following the default TTS setting. Those values, and the minimum and maximum limits for the speed, are defined in the `tts.h` header file.
+There are defined values, `TTS_VOICE_TYPE_AUTO` and `TTS_VOICE_SPEED_AUTO` for following the default TTS setting. Those values and the minimum and maximum limits for the speed, are defined in the `tts.h` header file.
 
 To add text:
 
@@ -586,7 +586,7 @@ To start, pause, and stop the playback:
 
   The state is changed to `TTS_STATE_PLAYING`, and the playback continues until you call the `tts_stop()` or the `tts_pause()` function.
 
-  If there is no text in the queue, TTS stays in the `TTS_STATE_PLAYING` state for text to be added. In that case, when text is added, TTS starts synthesizing and playing it immediately. There is no need to change the state to `TTS_STATE_READY` by using the `tts_stop()` function even when there is no text in the queue. It will continue to stay in the `TTS_STATE_PLAYING` state.
+  If there is no text in the queue, TTS stays in the `TTS_STATE_PLAYING` state for text to be added. In that case, when text is added, TTS starts synthesizing and playing it immediately. There is no need to change the state to `TTS_STATE_READY` by using the `tts_stop()` function even when there is no text in the queue. It will continue to stay in the `TTS_STATE_PLAYING` state:
 
   > [!NOTE]
   > If the TTS state changed callback is invoked, state change can occur without any controlling functions being called. In this case, the state change takes place only when other applications request TTS play, the audio session requests TTS pause, or the TTS engine changes.
@@ -632,7 +632,7 @@ To start, pause, and stop the playback:
   }
   ```
 
-## Related Information
+## Related information
 - Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/native/guides/text-input/tts.md
+++ b/docs/application/native/guides/text-input/tts.md
@@ -3,7 +3,7 @@
 
 The TTS (text-to-speech) features include synthesizing text into sound data as utterances and playing them. It is also possible to pause and stop playing.
 
-When your application creates a handle and prepares the TTS service by the API, the TTS daemon is invoked and connected for background work. This daemon and your application communicate as the server and the client.
+When your application creates a handle and prepares the TTS service by the API, the TTS daemon is invoked and connected for background work. This daemon and your application communicate as the server and the client, respectively.
 
 The main features of the TTS API include:
 
@@ -20,7 +20,7 @@ The main features of the TTS API include:
   You can [get information](#info_tts) on the supported voice, and the current state and voice.
 
 <a name="basic_tts"></a>
-## Basic TTS Processes
+## Basic TTS processes
 
 Using TTS, you can:
 
@@ -42,7 +42,7 @@ The TTS life-cycle is described in the following figure.
 ![TTS life-cycle](./media/tts_lifecycle.png)
 
 <a name="parameter_tts"></a>
-## TTS Parameters
+## TTS parameters
 
 You can set the following parameters about the TTS:
 
@@ -55,7 +55,7 @@ You can set the following parameters about the TTS:
   The private data is a setting parameter for applying keys provided by the TTS engine. Using the `tts_set_private_data()` function, you can set the private data as the corresponding key of the TTS engine.
 
 <a name="info_tts"></a>
-## TTS Information Retrieval
+## TTS information retrieval
 
 You can get the following information about the TTS:
 
@@ -63,7 +63,7 @@ You can get the following information about the TTS:
 - Get the default voice.
   - In the TTS, the voice is defined as a combination of the language and the type, such as male or female.
   - You can request the synthesis of the text with your own voice option by the parameter of the add text function. However, if you do not set a specific option, the TTS synthesizes the text with the default voice.
-  - The default voice can be changed by the TTS setting an application or by the display language changing. If the display language is changed to a non-supported language, the language of the TTS is changed to UK English.
+  - The user can change the default voice in the device settings by modifying the display language or the TTS default language status. If the display language is changed to a non-supported language, the TTS language is changed to UK English.
 - Get a list of supported voices to check whether the language and voice type you want are supported.
 - Get the error message when the error callback is invoked.
 - Get private data from the TTS engine.
@@ -73,7 +73,7 @@ You can get the following information about the TTS:
 To enable your application to use the TTS functionality:
 
 1. To use the functions and data types of the TTS (text-to-speech) API (in [mobile](../../api/mobile/latest/group__CAPI__UIX__TTS__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__UIX__TTS__MODULE.html) applications), include the `<tts.h>` header file in your application:
-   ```
+   ```cpp
    #include <tts.h>
    ```
 
@@ -81,11 +81,10 @@ To enable your application to use the TTS functionality:
 
    The TTS handle is used in other TTS functions as a parameter. After the handle creation, the TTS state changes to `TTS_STATE_CREATED`.
 
-   > **Note**
-   >
+   > [!NOTE]
    > TTS is not thread-safe and depends on the Ecore main loop. Implement TTS within the Ecore main loop and do not use it in a thread.
 
-   ```
+   ```cpp
    void
    create_tts_handle()
    {
@@ -99,7 +98,7 @@ To enable your application to use the TTS functionality:
 
 3. When you no longer need the TTS library, destroy the TTS handle using the `tts_destroy()` function:
 
-   ```
+   ```cpp
    void
    destroy_tts_handle(tts_h tts)
    {
@@ -110,12 +109,11 @@ To enable your application to use the TTS functionality:
    }
    ```
 
-   > **Note**
-   >
+   > [!NOTE]
    > Do not use the `tts_destroy()` function in a callback function. Within a callback, the `tts_destroy()` function fails and returns `TTS_ERROR_OPERATION_FAILED`.
 
 <a name="set"></a>
-## Setting and Unsetting Callbacks
+## Set and unset callbacks
 
 The enum values, as well as the parameter details, for the callback parameters are defined in the `tts.h` header file.
 
@@ -129,9 +127,9 @@ To set and unset callbacks:
 
    - State changed
 
-     If you set the state change callback, it is invoked when the TTS state changes.
+     If you set the state change callback, it is invoked when the TTS state changes:
 
-     ```
+     ```cpp
      /* Callback */
      void
      state_changed_cb(tts_h tts, tts_state_e previous, tts_state_e current, void* user_data)
@@ -164,7 +162,7 @@ To set and unset callbacks:
 
      In the TTS library, the voice includes the language used and the voice type, such as male or female. The default voice of the TTS is changed either when the system language is changed, or through the TTS settings. To get a notification of a voice change, set the default voice changed callback:
 
-     ```
+     ```cpp
      /* Callback */
      void
      default_voice_changed_cb(tts_h tts, const char* previous_language, int previous_voice_type,
@@ -198,7 +196,7 @@ To set and unset callbacks:
 
      If you set the engine change callback for the TTS, it is invoked when the engine is changed by the TTS:
 
-     ```
+     ```cpp
      /* Callback */
      void
      engine_changed_cb(tts_h tts, const char* engine_id, const char* language,
@@ -232,7 +230,7 @@ To set and unset callbacks:
 
      If you add text in the TTS, that text is handled as an utterance and it obtains its own ID. After you request the TTS process to start, the text is synthesized by an engine and played out. To get a notification when an utterance is started or completed, set the respective callbacks:
 
-     ```
+     ```cpp
      /* Started callback */
      void
      utterance_started_cb(tts_h tts, int utt_id, void* user_data)
@@ -279,7 +277,7 @@ To set and unset callbacks:
 
      When an error occurs, the TTS library sends a message using a callback:
 
-     ```
+     ```cpp
      /* Callback */
      void
      error_cb(tts_h tts, int utt_id, tts_error_e reason, void* user_data)
@@ -309,15 +307,15 @@ To set and unset callbacks:
      ```
 
 <a name="get"></a>
-## Getting Information
+## Get information
 
 To obtain the current state, the supported voice list, and the current voice:
 
 - Get the current state using the `tts_get_state()` function.
 
-    The TTS state is changed by various TTS functions, and it is applied as a precondition of each function.
+    The TTS state is changed by various TTS functions, and it is applied as a precondition of each function:
 
-    ```
+    ```cpp
     void
     get_state(tts_h tts)
     {
@@ -331,9 +329,9 @@ To obtain the current state, the supported voice list, and the current voice:
 
 - Obtain a list of voices supported by the TTS using the `tts_foreach_supported_voices()` function.
 
-    The foreach function triggers a separate callback for each supported voice. As long as the callback returns `true`, the foreach function continues to loop over the supported voices.
+    The foreach function triggers a separate callback for each supported voice. As long as the callback returns `true`, the foreach function continues to loop over the supported voices:
 
-    ```
+    ```cpp
     bool
     supported_voice_cb(tts_h tts, const char* language, int voice_type, void* user_data)
     {
@@ -354,9 +352,9 @@ To obtain the current state, the supported voice list, and the current voice:
 
 - Get the default voice using the `tts_get_default_voice()` function.
 
-    The TTS synthesizes the text using the default voice, if you do not set the language and the voice type as parameters of the `tts_add_text()` function.
+    The TTS synthesizes the text using the default voice, if you do not set the language and the voice type as parameters of the `tts_add_text()` function:
 
-    ```
+    ```cpp
     void
     get_default_voice(tts_h tts)
     {
@@ -373,9 +371,9 @@ To obtain the current state, the supported voice list, and the current voice:
 
 - Get the error message.
 
-  Call this function during the TTS error callback. If not, the error as an operation failure is returned. If the function succeeds, the error message must be released using the `free()` function, when it is no longer required.
+  Call this function during the TTS error callback. If not, the error as an operation failure is returned. If the function succeeds, the error message must be released using the `free()` function, when it is no longer required:
 
-  ```
+  ```cpp
   void
   error_cb(tts_h tts, int utt_id, tts_error_e reason, void* user_data)
   {
@@ -402,17 +400,16 @@ To obtain the current state, the supported voice list, and the current voice:
   ```
 
 <a name="mode"></a>
-## Getting and Setting the Mode
+## Get and set the mode
 
 There are 3 different TTS modes available. The main difference is audio mixing with other sources. The default mode is `TTS_MODE_DEFAULT`, used for normal applications such as eBooks. If you set this mode and play your text, it can be interrupted when other sounds, such as ringtone or other TTS sounds, are played.
 
-> **Note**
->
+> [!NOTE]
 > The `TTS_MODE_NOTIFICATION` and `TTS_MODE_SCREEN_READER` modes are mixed with other sound sources, but they are used only for platform-specific features. Do not use them for normal applications.
 
 Get and set the mode in the `TTS_STATE_CREATED` state:
 
-```
+```cpp
 void
 set_mode(tts_h tts)
 {
@@ -435,15 +432,15 @@ get_mode(tts_h tts)
 ```
 
 <a name="prepare"></a>
-## Connecting and Disconnecting TTS
+## Connect and disconnect TTS
 
 To operate the TTS:
 
 1. After you create the TTS handle, connect the background TTS daemon with the `tts_prepare()` function.
 
-   The daemon synthesizes the text with the engine and plays the resulting sound data. The function is asynchronous and the TTS state changes to `TTS_STATE_READY`.
+   The daemon synthesizes the text with the engine and plays the resulting sound data. The function is asynchronous and the TTS state changes to `TTS_STATE_READY`:
 
-   ```
+   ```cpp
    void
    prepare_for_tts(tts_h tts)
    {
@@ -454,13 +451,27 @@ To operate the TTS:
    }
    ```
 
-   > **Note**
-   >
+   > [!NOTE]
    > If you get the error callback after calling the `tts_prepare()` function, TTS is not available.
 
-2. When the connection is no longer needed, use the `tts_unprepare()` function to disconnect the TTS and change the state to `TTS_STATE_CREATED`:
+2. If you want to connect the daemon synchronously, use the `tts_prepare_sync()` function.
 
+   If the function returns no error, connection succeeds and the TTS state changes to `TTS_STATE_READY` immediately:
+
+   ```cpp
+   void
+   prepare_sync_for_tts(tts_h tts)
+   {
+       int ret;
+       ret = tts_prepare_sync(tts);
+       if (TTS_ERROR_NONE != ret)
+           /* Error handling */
+   }
    ```
+
+3. When the connection is no longer needed, use the `tts_unprepare()` function to disconnect the TTS and change the state to `TTS_STATE_CREATED`:
+
+   ```cpp
    void
    unprepared_for_tts(tts_h tts)
    {
@@ -471,7 +482,7 @@ To operate the TTS:
    }
    ```
 
-## Setting and Getting Options about the TTS Engine
+## Set and get options about the TTS engine
 
 To set and get the options about the TTS engine:
 
@@ -479,7 +490,7 @@ To set and get the options about the TTS engine:
 
   The credential is a key to verify the authorization about using the TTS engine. The necessity of the credential depends on the engine. If the engine requests the credential, you can set it using the `tts_set_credential()` function:
 
-  ```
+  ```cpp
   void
   set_credential(tts_h tts, const char* credential)
   {
@@ -494,11 +505,10 @@ To set and get the options about the TTS engine:
 
   The private data is a setting parameter for applying keys provided by the TTS engine. Using the `tts_set_private_data()` function, you can set the private data and use the corresponding key of the engine. To get the private data which corresponds to a specific key from the engine, use the `tts_get_private_data()` function.
 
-  > **Note**
-  >
+  > [!NOTE]
   > The key and data are determined by the TTS engine. To set and get the private data, see the engine instructions.
 
-  ```
+  ```cpp
   void
   set_private_data(tts_h tts, const char* key, const char* data)
   {
@@ -519,7 +529,7 @@ To set and get the options about the TTS engine:
   ```
 
 <a name="text"></a>
-## Adding Text
+## Add text
 
 There are defined values, `TTS_VOICE_TYPE_AUTO` and `TTS_VOICE_SPEED_AUTO` for following the default TTS setting. Those values, and the minimum and maximum limits for the speed, are defined in the `tts.h` header file.
 
@@ -527,15 +537,14 @@ To add text:
 
 - You can request the TTS library to read your own text using the `tts_add_text()` function. The TTS library manages added text using queues, so it is possible to add several texts simultaneously. Each obtained text receives an utterance ID, which is used for synthesizing and playing the sound data.
 
-  > **Note**
-  >
+  > [!NOTE]
   > If the added text is too long, some engines need a long time for synthesis. It is recommended to only use proper length text clips.
 
   When you do not set the language and use `NULL` for it, the default language is used for synthesizing text.
 
-  You can add text at any point after the `tts_prepare()` function changes the state to `TTS_STATE_READY`.
+  You can add text at any point after the `tts_prepare()` function changes the state to `TTS_STATE_READY`:
 
-  ```
+  ```cpp
   void
   add_text(tts_h tts)
   {
@@ -556,7 +565,7 @@ To add text:
 
   To retrieve the maximum value, use the `tts_get_max_text_size()` function in the `TTS_STATE_READY` state:
 
-  ```
+  ```cpp
   void
   get_maximum_text_size(tts_h tts)
   {
@@ -569,7 +578,7 @@ To add text:
   ```
 
 <a name="control"></a>
-## Controlling the Playback
+## Control playback
 
 To start, pause, and stop the playback:
 
@@ -577,13 +586,12 @@ To start, pause, and stop the playback:
 
   The state is changed to `TTS_STATE_PLAYING`, and the playback continues until you call the `tts_stop()` or the `tts_pause()` function.
 
-  If there is no text in the queue, the TTS waits for text to be added in the `TTS_STATE_PLAYING` state. In that case, when you add text, the TTS starts synthesizing and playing it immediately. The TTS state need not change to `TTS_STATE_READY` state before using the `tts_stop()` function.
+  If there is no text in the queue, TTS stays in the `TTS_STATE_PLAYING` state for text to be added. In that case, when text is added, TTS starts synthesizing and playing it immediately. There is no need to change the state to `TTS_STATE_READY` by using the `tts_stop()` function even when there is no text in the queue. It will continue to stay in the `TTS_STATE_PLAYING` state.
 
-  > **Note**
-  >
-  > If you get the TTS state changed callback in the `TTS_STATE_PLAYING` state without a TTS function call, prepare the TTS state. The TTS state can change if other applications request TTS play, the audio session requests TTS pause, or the TTS engine changes.
+  > [!NOTE]
+  > If the TTS state changed callback is invoked, state change can occur without any controlling functions being called. In this case, the state change takes place only when other applications request TTS play, the audio session requests TTS pause, or the TTS engine changes.
 
-  ```
+  ```cpp
   void
   start(tts_h tts)
   {
@@ -596,9 +604,9 @@ To start, pause, and stop the playback:
 
 - To pause the playback, use the `tts_pause()` function.
 
-  The state is changed to `TTS_STATE_PAUSED`. To resume playback, use the `tts_play()` function.
+  The state is changed to `TTS_STATE_PAUSED`. To resume playback, use the `tts_play()` function:
 
-  ```
+  ```cpp
   void
   pause(tts_h tts)
   {
@@ -611,9 +619,9 @@ To start, pause, and stop the playback:
 
 - To stop the playback, use the `tts_stop()` function.
 
-  All the texts in the queue are removed, and the state is changed to `TTS_STATE_READY`.
+  All the texts in the queue are removed, and the state is changed to `TTS_STATE_READY`:
 
-  ```
+  ```cpp
   void
   stop(tts_h tts)
   {
@@ -625,6 +633,6 @@ To start, pause, and stop the playback:
   ```
 
 ## Related Information
-* Dependencies
+- Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable


### PR DESCRIPTION
Signed-off-by: Suyeon Hwang <stom.hwang@samsung.com>

### Change Description ###
Add description for `tts_prepare_sync()`
Fix some contents to fit style guide and description of dotnet
> This PR does not include description for `ttse_terminate()` because there is no guide for tts engine API.

### API Changes ###

 - ACR: ACR-1685

