### PR TITLE
[Web API] Fix typing/spelling mistakes in notifications API

### DIFF
--- a/docs/application/web/api/2.4/device_api/mobile/tizen/notification.html
+++ b/docs/application/web/api/2.4/device_api/mobile/tizen/notification.html
@@ -180,9 +180,9 @@ The following notification progress types are supported:
           </p>
           <ul>
             <li>
-"BYTE" - The progress is indicated in bytes.            </li>
+BYTE - The progress is indicated in bytes.            </li>
             <li>
-"PERCENTAGE" -The progress is indicated in percentage.            </li>
+PERCENTAGE - The progress is indicated in percentage.            </li>
           </ul>
          </div>
 </div>
@@ -190,7 +190,7 @@ The following notification progress types are supported:
 <a class="backward-compatibility-anchor" name="::Notification::LEDCustomFlags"></a><h3>1.5. LEDCustomFlags</h3>
 <div class="brief">
  Specifies custom LED flags.
-The following values are supported in this release :
+The following values are supported in this release:
           </div>
 <pre class="webidl prettyprint">  enum LEDCustomFlags { "LED_CUSTOM_DUTY_ON", "LED_CUSTOM_DEFAULT" };</pre>
 <p><span class="version">Since: </span>
@@ -199,9 +199,9 @@ The following values are supported in this release :
 <div class="description">
           <ul>
             <li>
-LED_CUSTOM_DUTY_ON, blink LED            </li>
+LED_CUSTOM_DUTY_ON - blink LED            </li>
             <li>
-LED_CUSTOM_DEFAULT, default flag            </li>
+LED_CUSTOM_DEFAULT - default flag            </li>
           </ul>
          </div>
 </div>
@@ -612,7 +612,7 @@ catch (err)
             <p>
 Given parameters consist of timeOn and timeOff in milliseconds, RGBA color and LEDCustomFlags combination.
 For the color first three bytes are RGB values. The last byte is opacity. For example "#FFFF0080". There is also another possibility when the last byte
-is not given (in this case alpha is assumed to have value 0xff). In this case only RGB values are given. For example: "#ff0000" that is equivalent of "#ff0000ff".
+is not given (in this case alpha is assumed to have a value of 0xff). In this case only RGB values are given. For example: "#ff0000" that is equivalent of "#ff0000ff".
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1061,7 +1061,7 @@ the saved value in the notification status tray would be different from
 the exact progress value.
             </p>
             <p>
-Range of <em>progressValue</em>: percent (0 to 100).
+The range of <em>progressValue</em>: percent (0 to 100).
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1166,7 +1166,7 @@ By default, this attribute is set to <var>null</var>.
                     <div class="def-api-feature">
 <p><div class="description">
             <p>
-If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has a led:
+If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has an LED:
             </p>
            </div></p>
 <li class="feature">http://tizen.org/feature/led</li>

--- a/docs/application/web/api/3.0/device_api/mobile/tizen/notification.html
+++ b/docs/application/web/api/3.0/device_api/mobile/tizen/notification.html
@@ -180,9 +180,9 @@ The following notification progress types are supported:
           </p>
           <ul>
             <li>
-"BYTE" - The progress is indicated in bytes.            </li>
+BYTE - The progress is indicated in bytes.            </li>
             <li>
-"PERCENTAGE" -The progress is indicated in percentage.            </li>
+PERCENTAGE - The progress is indicated in percentage.            </li>
           </ul>
          </div>
 </div>
@@ -190,7 +190,7 @@ The following notification progress types are supported:
 <a class="backward-compatibility-anchor" name="::Notification::LEDCustomFlags"></a><h3>1.5. LEDCustomFlags</h3>
 <div class="brief">
  Specifies custom LED flags.
-The following values are supported in this release :
+The following values are supported in this release:
           </div>
 <pre class="webidl prettyprint">  enum LEDCustomFlags { "LED_CUSTOM_DUTY_ON", "LED_CUSTOM_DEFAULT" };</pre>
 <p><span class="version">Since: </span>
@@ -199,9 +199,9 @@ The following values are supported in this release :
 <div class="description">
           <ul>
             <li>
-LED_CUSTOM_DUTY_ON, blink LED            </li>
+LED_CUSTOM_DUTY_ON - blink LED            </li>
             <li>
-LED_CUSTOM_DEFAULT, default flag            </li>
+LED_CUSTOM_DEFAULT - default flag            </li>
           </ul>
          </div>
 </div>
@@ -612,7 +612,7 @@ catch (err)
             <p>
 Given parameters consist of timeOn and timeOff in milliseconds, RGBA color and LEDCustomFlags combination.
 For the color first three bytes are RGB values. The last byte is opacity. For example "#FFFF0080". There is also another possibility when the last byte
-is not given (in this case alpha is assumed to have value 0xff). In this case only RGB values are given. For example: "#ff0000" that is equivalent of "#ff0000ff".
+is not given (in this case alpha is assumed to have a value of 0xff). In this case only RGB values are given. For example: "#ff0000" that is equivalent of "#ff0000ff".
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1061,7 +1061,7 @@ the saved value in the notification status tray would be different from
 the exact progress value.
             </p>
             <p>
-Range of <em>progressValue</em>: percent (0 to 100).
+The range of <em>progressValue</em>: percent (0 to 100).
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1166,7 +1166,7 @@ By default, this attribute is set to <var>null</var>.
                     <div class="def-api-feature">
 <p><div class="description">
             <p>
-If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has a led:
+If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has an LED:
             </p>
            </div></p>
 <li class="feature">http://tizen.org/feature/led</li>

--- a/docs/application/web/api/3.0/device_api/wearable/tizen/notification.html
+++ b/docs/application/web/api/3.0/device_api/wearable/tizen/notification.html
@@ -176,9 +176,9 @@ The following notification progress types are supported:
           </p>
           <ul>
             <li>
-"BYTE" - The progress is indicated in bytes.            </li>
+BYTE - The progress is indicated in bytes.            </li>
             <li>
-"PERCENTAGE" -The progress is indicated in percentage.            </li>
+PERCENTAGE - The progress is indicated in percentage.            </li>
           </ul>
          </div>
 </div>
@@ -914,7 +914,7 @@ the saved value in the notification status tray would be different from
 the exact progress value.
             </p>
             <p>
-Range of <em>progressValue</em>: percent (0 to 100).
+The range of <em>progressValue</em>: percent (0 to 100).
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1019,7 +1019,7 @@ By default, this attribute is set to <var>null</var>.
                     <div class="def-api-feature">
 <p><div class="description">
             <p>
-If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has a led:
+If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has an LED:
             </p>
            </div></p>
 <li class="feature">http://tizen.org/feature/led</li>

--- a/docs/application/web/api/4.0/device_api/mobile/tizen/notification.html
+++ b/docs/application/web/api/4.0/device_api/mobile/tizen/notification.html
@@ -256,9 +256,9 @@ The following notification progress types are supported:
           </p>
           <ul>
             <li>
-"BYTE" - The progress is indicated in bytes.            </li>
+BYTE - The progress is indicated in bytes.            </li>
             <li>
-"PERCENTAGE" -The progress is indicated in percentage.            </li>
+PERCENTAGE - The progress is indicated in percentage.            </li>
           </ul>
          </div>
 </div>
@@ -266,7 +266,7 @@ The following notification progress types are supported:
 <a class="backward-compatibility-anchor" name="::Notification::LEDCustomFlags"></a><h3>1.6. LEDCustomFlags</h3>
 <div class="brief">
  Specifies custom LED flags.
-The following values are supported in this release :
+The following values are supported in this release:
           </div>
 <pre class="webidl prettyprint">  enum LEDCustomFlags { "LED_CUSTOM_DUTY_ON", "LED_CUSTOM_DEFAULT" };</pre>
 <p><span class="version">Since: </span>
@@ -275,9 +275,9 @@ The following values are supported in this release :
 <div class="description">
           <ul>
             <li>
-LED_CUSTOM_DUTY_ON, blink LED            </li>
+LED_CUSTOM_DUTY_ON - blink LED            </li>
             <li>
-LED_CUSTOM_DEFAULT, default flag            </li>
+LED_CUSTOM_DEFAULT - default flag            </li>
           </ul>
          </div>
 </div>
@@ -874,7 +874,7 @@ catch (err)
             <p>
 Given parameters consist of timeOn and timeOff in milliseconds, RGBA color and LEDCustomFlags combination.
 For the color first three bytes are RGB values. The last byte is opacity. For example "#FFFF0080". There is also another possibility when the last byte
-is not given (in this case alpha is assumed to have value 0xff). In this case only RGB values are given. For example: "#ff0000" that is equivalent of "#ff0000ff".
+is not given (in this case alpha is assumed to have a value of 0xff). In this case only RGB values are given. For example: "#ff0000" that is equivalent of "#ff0000ff".
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1114,7 +1114,7 @@ An application can load only templates that it has saved.
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type NotFoundError, if the method cannot find a template with given name.
+ with error type NotFoundError, if the method cannot find a template with a given name.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if the method cannot be completed because of any error.
@@ -1256,7 +1256,7 @@ For detailed descriptions of properties, please refer to <a href="#Notification"
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Some of the specified options might be ignored if the device does not support related feature (e.g. LED notification settings).
+ Some of the specified options might be ignored if the device does not support the related features (e.g. LED notification settings).
           </p>
 </div>
 <div class="dictionary" id="NotificationTextContentInfo">
@@ -1294,7 +1294,8 @@ By default, this attribute is set to <em>PERCENTAGE</em>.
 <dt class="member" id="NotificationTextContentInfo::progressValue"><span class="attrName">unsigned long? progressValue</span></dt>
 <dd>
 <div class="brief">
- Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>            </div>
+ Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>.
+            </div>
 <div class="description">
             <p>
 If <em>progressValue</em> is set, the progressbar will be displayed in the notification. The <em>progressValue</em> can change the amount of progress as it moves forward or backward. It gets the progress value of the current notification.
@@ -1302,12 +1303,12 @@ If 0, the indeterminate progressbar will be shown.
 This attribute only affects for <em>UserNotification</em> of type <em>PROGRESS</em>.
             </p>
             <p>
-Applications should keep the progress value for its job because
+Applications should keep the progress value for their job because
 the saved value in the notification status tray can be different from
 the exact progress value.
             </p>
             <p>
-Range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
+The range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1381,7 +1382,7 @@ The maximum number of detail information elements in the array is 2.
 <dt class="member" id="NotificationTextContentInfo::contentForOff"><span class="attrName">DOMString? contentForOff</span></dt>
 <dd>
 <div class="brief">
- The content to show when the option to display content is off in the Settings.
+ The content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1624,7 +1625,7 @@ The maximum number of thumbnail path elements in the array is 4.
 <dt class="member" id="NotificationGroupContentInfo::groupContentForOff"><span class="attrName">DOMString? groupContentForOff</span></dt>
 <dd>
 <div class="brief">
- The group content to show when the option to display content is off in the Settings.
+ The group content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1663,7 +1664,7 @@ by exactly six hexadecimal characters(0-9, A-F). The color format is case-insens
             <p>
 The LED indicator color will show that it's a close approximation.
 LED will only light on when the screen is off. To turn the LED off, set "#000000" or null to ledColor.
-This method has effects when the device has notification LED.
+This method has effects when the device has a notification LED.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1948,7 +1949,7 @@ the saved value in the notification status tray would be different from
 the exact progress value.
             </p>
             <p>
-Range of <em>progressValue</em>: percent (0 to 100).
+The range of <em>progressValue</em>: percent (0 to 100).
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -2111,7 +2112,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::thumbnails">
 <span class="attrName"><span class="type">NotificationThumbnailInfo </span><span class="name">thumbnails</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional thumbnails-related settings of a notification.
+ Defines additional thumbnail-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -2146,7 +2147,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::actions">
 <span class="attrName"><span class="type">NotificationActionInfo </span><span class="name">actions</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional actions-related settings of a notification.
+ Defines additional action-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -2318,7 +2319,7 @@ By default, this attribute is set to <var>null</var>.
                     <div class="def-api-feature">
 <p><div class="description">
             <p>
-If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has a led:
+If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has an LED:
             </p>
            </div></p>
 <li class="feature">http://tizen.org/feature/led</li>

--- a/docs/application/web/api/4.0/device_api/wearable/tizen/notification.html
+++ b/docs/application/web/api/4.0/device_api/wearable/tizen/notification.html
@@ -26,7 +26,7 @@ for accessing only external storage using this API, a privilege <a href="http://
           <li>
 for accessing internal and external storage using this API, privileges (<a href="http://tizen.org/privilege/mediastorage">http://tizen.org/privilege/mediastorage</a> and <a href="http://tizen.org/privilege/externalstorage">http://tizen.org/privilege/externalstorage</a>) must be provided.          </li>
           <li>
-Storage privileges are privacy-related privileges and there is a need of asking user directly with proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
+Storage privileges are privacy-related privileges and there is a need of asking the user directly with the proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
         </ul>
         <p>
 For more information on the Notification features, see <a href="/application/web/guides/notification/notification">Notification Guide</a>.
@@ -265,9 +265,9 @@ The following notification progress types are supported:
           </p>
           <ul>
             <li>
-"BYTE" - The progress is indicated in bytes.            </li>
+BYTE - The progress is indicated in bytes.            </li>
             <li>
-"PERCENTAGE" -The progress is indicated in percentage.            </li>
+PERCENTAGE - The progress is indicated in percentage.            </li>
           </ul>
          </div>
 </div>
@@ -980,7 +980,7 @@ An application can load only templates that it has saved.
  with error type SecurityError, if the application does not have the privilege to call this method.
                 </p></li>
 <li class="list"><p>
- with error type NotFoundError, if the method cannot find a template with given name.
+ with error type NotFoundError, if the method cannot find a template with a given name.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if the method cannot be completed because of any error.
@@ -1122,7 +1122,7 @@ For detailed descriptions of properties, please refer to <a href="#Notification"
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Some of the specified options might be ignored if the device does not support related feature (e.g. LED notification settings).
+ Some of the specified options might be ignored if the device does not support the related features (e.g. LED notification settings).
           </p>
 </div>
 <div class="dictionary" id="NotificationTextContentInfo">
@@ -1160,7 +1160,8 @@ By default, this attribute is set to <em>PERCENTAGE</em>.
 <dt class="member" id="NotificationTextContentInfo::progressValue"><span class="attrName">unsigned long? progressValue</span></dt>
 <dd>
 <div class="brief">
- Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>            </div>
+ Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>.
+            </div>
 <div class="description">
             <p>
 If <em>progressValue</em> is set, the progressbar will be displayed in the notification. The <em>progressValue</em> can change the amount of progress as it moves forward or backward. It gets the progress value of the current notification.
@@ -1168,12 +1169,12 @@ If 0, the indeterminate progressbar will be shown.
 This attribute only affects for <em>UserNotification</em> of type <em>PROGRESS</em>.
             </p>
             <p>
-Applications should keep the progress value for its job because
+Applications should keep the progress value for their job because
 the saved value in the notification status tray can be different from
 the exact progress value.
             </p>
             <p>
-Range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
+The range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1247,7 +1248,7 @@ The maximum number of detail information elements in the array is 2.
 <dt class="member" id="NotificationTextContentInfo::contentForOff"><span class="attrName">DOMString? contentForOff</span></dt>
 <dd>
 <div class="brief">
- The content to show when the option to display content is off in the Settings.
+ The content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1490,7 +1491,7 @@ The maximum number of thumbnail path elements in the array is 4.
 <dt class="member" id="NotificationGroupContentInfo::groupContentForOff"><span class="attrName">DOMString? groupContentForOff</span></dt>
 <dd>
 <div class="brief">
- The group content to show when the option to display content is off in the Settings.
+ The group content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1529,7 +1530,7 @@ by exactly six hexadecimal characters(0-9, A-F). The color format is case-insens
             <p>
 The LED indicator color will show that it's a close approximation.
 LED will only light on when the screen is off. To turn the LED off, set "#000000" or null to ledColor.
-This method has effects when the device has notification LED.
+This method has effects when the device has a notification LED.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1814,7 +1815,7 @@ the saved value in the notification status tray would be different from
 the exact progress value.
             </p>
             <p>
-Range of <em>progressValue</em>: percent (0 to 100).
+The range of <em>progressValue</em>: percent (0 to 100).
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1977,7 +1978,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::thumbnails">
 <span class="attrName"><span class="type">NotificationThumbnailInfo </span><span class="name">thumbnails</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional thumbnails-related settings of a notification.
+ Defines additional thumbnail-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -2012,7 +2013,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::actions">
 <span class="attrName"><span class="type">NotificationActionInfo </span><span class="name">actions</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional actions-related settings of a notification.
+ Defines additional action-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -2184,7 +2185,7 @@ By default, this attribute is set to <var>null</var>.
                     <div class="def-api-feature">
 <p><div class="description">
             <p>
-If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has a led:
+If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has an LED:
             </p>
            </div></p>
 <li class="feature">http://tizen.org/feature/led</li>

--- a/docs/application/web/api/5.0/device_api/mobile/tizen/notification.html
+++ b/docs/application/web/api/5.0/device_api/mobile/tizen/notification.html
@@ -25,7 +25,7 @@ for accessing only external storage using this API, a privilege <a href="http://
           <li>
 for accessing internal and external storage using this API, privileges (<a href="http://tizen.org/privilege/mediastorage">http://tizen.org/privilege/mediastorage</a> and <a href="http://tizen.org/privilege/externalstorage">http://tizen.org/privilege/externalstorage</a>) must be provided.          </li>
           <li>
-Storage privileges are privacy-related privileges and there is a need of asking user directly with proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
+Storage privileges are privacy-related privileges and there is a need of asking the user directly with the proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
         </ul>
         <p>
 For more information on the Notification features, see <a href="/application/web/guides/notification/notification">Notification Guide</a>.
@@ -269,9 +269,9 @@ The following notification progress types are supported:
           </p>
           <ul>
             <li>
-"BYTE" - The progress is indicated in bytes.            </li>
+BYTE - The progress is indicated in bytes.            </li>
             <li>
-"PERCENTAGE" -The progress is indicated in percentage.            </li>
+PERCENTAGE - The progress is indicated in percentage.            </li>
           </ul>
          </div>
 </div>
@@ -279,7 +279,7 @@ The following notification progress types are supported:
 <a class="backward-compatibility-anchor" name="::Notification::LEDCustomFlags"></a><h3>1.6. LEDCustomFlags</h3>
 <div class="brief">
  Specifies custom LED flags.
-The following values are supported in this release :
+The following values are supported in this release:
           </div>
 <pre class="webidl prettyprint">  enum LEDCustomFlags { "LED_CUSTOM_DUTY_ON", "LED_CUSTOM_DEFAULT" };</pre>
 <p><span class="version">Since: </span>
@@ -288,9 +288,9 @@ The following values are supported in this release :
 <div class="description">
           <ul>
             <li>
-LED_CUSTOM_DUTY_ON, blink LED            </li>
+LED_CUSTOM_DUTY_ON - blink LED            </li>
             <li>
-LED_CUSTOM_DEFAULT, default flag            </li>
+LED_CUSTOM_DEFAULT - default flag            </li>
           </ul>
          </div>
 </div>
@@ -392,7 +392,7 @@ The NotificationManager interface provides access to the notification object.
 parameters contain an invalid value.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
@@ -522,7 +522,7 @@ catch (err)
 parameters contain an invalid value.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
@@ -684,7 +684,7 @@ catch (err)
  with error type NotFoundError, if NotificationId is not found in the previously posted notifications.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type UnknownError, if any other error occurs.
@@ -745,7 +745,7 @@ catch (err)
  with error type NotFoundError, if NotificationId is not found in the previously posted notifications.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if any other error occurs.
@@ -796,7 +796,7 @@ catch (err)
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type UnknownError, if any other error occurs.
@@ -858,7 +858,7 @@ catch (err)
  with error type AbortError, if any error occurs.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 </ul>
 </li></ul>
@@ -903,7 +903,7 @@ catch (err)
             <p>
 Given parameters consist of timeOn and timeOff in milliseconds, RGBA color and LEDCustomFlags combination.
 For the color first three bytes are RGB values. The last byte is opacity. For example "#FFFF0080". There is also another possibility when the last byte
-is not given (in this case alpha is assumed to have value 0xff). In this case only RGB values are given. For example: "#ff0000" that is equivalent of "#ff0000ff".
+is not given (in this case alpha is assumed to have a value of 0xff). In this case only RGB values are given. For example: "#ff0000" that is equivalent of "#ff0000ff".
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -1060,7 +1060,7 @@ All templates are removed when the application package is uninstalled.
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type QuotaExceededError, if the allowed number of templates is exceeded.
@@ -1140,10 +1140,10 @@ An application can load only templates that it has saved.
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
- with error type NotFoundError, if the method cannot find a template with given name.
+ with error type NotFoundError, if the method cannot find a template with a given name.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if the method cannot be completed because of any error.
@@ -1285,7 +1285,7 @@ For detailed descriptions of properties, please refer to <a href="#Notification"
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Some of the specified options might be ignored if the device does not support related feature (e.g. LED notification settings).
+ Some of the specified options might be ignored if the device does not support the related features (e.g. LED notification settings).
           </p>
 </div>
 <div class="dictionary" id="NotificationTextContentInfo">
@@ -1323,7 +1323,8 @@ By default, this attribute is set to <em>PERCENTAGE</em>.
 <dt class="member" id="NotificationTextContentInfo::progressValue"><span class="attrName">unsigned long? progressValue</span></dt>
 <dd>
 <div class="brief">
- Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>            </div>
+ Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>.
+            </div>
 <div class="description">
             <p>
 If <em>progressValue</em> is set, the progressbar will be displayed in the notification. The <em>progressValue</em> can change the amount of progress as it moves forward or backward. It gets the progress value of the current notification.
@@ -1331,12 +1332,12 @@ If 0, the indeterminate progressbar will be shown.
 This attribute only affects for <em>UserNotification</em> of type <em>PROGRESS</em>.
             </p>
             <p>
-Applications should keep the progress value for its job because
+Applications should keep the progress value for their job because
 the saved value in the notification status tray can be different from
 the exact progress value.
             </p>
             <p>
-Range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
+The range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1410,7 +1411,7 @@ The maximum number of detail information elements in the array is 2.
 <dt class="member" id="NotificationTextContentInfo::contentForOff"><span class="attrName">DOMString? contentForOff</span></dt>
 <dd>
 <div class="brief">
- The content to show when the option to display content is off in the Settings.
+ The content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1653,7 +1654,7 @@ The maximum number of thumbnail path elements in the array is 4.
 <dt class="member" id="NotificationGroupContentInfo::groupContentForOff"><span class="attrName">DOMString? groupContentForOff</span></dt>
 <dd>
 <div class="brief">
- The group content to show when the option to display content is off in the Settings.
+ The group content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1692,7 +1693,7 @@ by exactly six hexadecimal characters(0-9, A-F). The color format is case-insens
             <p>
 The LED indicator color will show that it's a close approximation.
 LED will only light on when the screen is off. To turn the LED off, set "#000000" or null to ledColor.
-This method has effects when the device has notification LED.
+This method has effects when the device has a notification LED.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1977,7 +1978,7 @@ the saved value in the notification status tray would be different from
 the exact progress value.
             </p>
             <p>
-Range of <em>progressValue</em>: percent (0 to 100).
+The range of <em>progressValue</em>: percent (0 to 100).
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -2140,7 +2141,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::thumbnails">
 <span class="attrName"><span class="type">NotificationThumbnailInfo </span><span class="name">thumbnails</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional thumbnails-related settings of a notification.
+ Defines additional thumbnail-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -2175,7 +2176,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::actions">
 <span class="attrName"><span class="type">NotificationActionInfo </span><span class="name">actions</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional actions-related settings of a notification.
+ Defines additional action-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -2347,7 +2348,7 @@ By default, this attribute is set to <var>null</var>.
                     <div class="def-api-feature">
 <p><div class="description">
             <p>
-If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has a led:
+If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has an LED:
             </p>
            </div></p>
 <li class="feature">http://tizen.org/feature/led</li>

--- a/docs/application/web/api/5.0/device_api/wearable/tizen/notification.html
+++ b/docs/application/web/api/5.0/device_api/wearable/tizen/notification.html
@@ -26,7 +26,7 @@ for accessing only external storage using this API, a privilege <a href="http://
           <li>
 for accessing internal and external storage using this API, privileges (<a href="http://tizen.org/privilege/mediastorage">http://tizen.org/privilege/mediastorage</a> and <a href="http://tizen.org/privilege/externalstorage">http://tizen.org/privilege/externalstorage</a>) must be provided.          </li>
           <li>
-Storage privileges are privacy-related privileges and there is a need of asking user directly with proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
+Storage privileges are privacy-related privileges and there is a need of asking the user directly with the proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
         </ul>
         <p>
 For more information on the Notification features, see <a href="/application/web/guides/notification/notification">Notification Guide</a>.
@@ -265,9 +265,9 @@ The following notification progress types are supported:
           </p>
           <ul>
             <li>
-"BYTE" - The progress is indicated in bytes.            </li>
+BYTE - The progress is indicated in bytes.            </li>
             <li>
-"PERCENTAGE" -The progress is indicated in percentage.            </li>
+PERCENTAGE - The progress is indicated in percentage.            </li>
           </ul>
          </div>
 </div>
@@ -367,7 +367,7 @@ The NotificationManager interface provides access to the notification object.
 parameters contain an invalid value.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
@@ -497,7 +497,7 @@ catch (err)
 parameters contain an invalid value.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
@@ -659,7 +659,7 @@ catch (err)
  with error type NotFoundError, if NotificationId is not found in the previously posted notifications.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type UnknownError, if any other error occurs.
@@ -720,7 +720,7 @@ catch (err)
  with error type NotFoundError, if NotificationId is not found in the previously posted notifications.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if any other error occurs.
@@ -771,7 +771,7 @@ catch (err)
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type UnknownError, if any other error occurs.
@@ -833,7 +833,7 @@ catch (err)
  with error type AbortError, if any error occurs.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 </ul>
 </li></ul>
@@ -913,7 +913,7 @@ All templates are removed when the application package is uninstalled.
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type QuotaExceededError, if the allowed number of templates is exceeded.
@@ -993,10 +993,10 @@ An application can load only templates that it has saved.
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
- with error type NotFoundError, if the method cannot find a template with given name.
+ with error type NotFoundError, if the method cannot find a template with a given name.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if the method cannot be completed because of any error.
@@ -1138,7 +1138,7 @@ For detailed descriptions of properties, please refer to <a href="#Notification"
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Some of the specified options might be ignored if the device does not support related feature (e.g. LED notification settings).
+ Some of the specified options might be ignored if the device does not support the related features (e.g. LED notification settings).
           </p>
 </div>
 <div class="dictionary" id="NotificationTextContentInfo">
@@ -1176,7 +1176,8 @@ By default, this attribute is set to <em>PERCENTAGE</em>.
 <dt class="member" id="NotificationTextContentInfo::progressValue"><span class="attrName">unsigned long? progressValue</span></dt>
 <dd>
 <div class="brief">
- Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>            </div>
+ Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>.
+            </div>
 <div class="description">
             <p>
 If <em>progressValue</em> is set, the progressbar will be displayed in the notification. The <em>progressValue</em> can change the amount of progress as it moves forward or backward. It gets the progress value of the current notification.
@@ -1184,12 +1185,12 @@ If 0, the indeterminate progressbar will be shown.
 This attribute only affects for <em>UserNotification</em> of type <em>PROGRESS</em>.
             </p>
             <p>
-Applications should keep the progress value for its job because
+Applications should keep the progress value for their job because
 the saved value in the notification status tray can be different from
 the exact progress value.
             </p>
             <p>
-Range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
+The range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1263,7 +1264,7 @@ The maximum number of detail information elements in the array is 2.
 <dt class="member" id="NotificationTextContentInfo::contentForOff"><span class="attrName">DOMString? contentForOff</span></dt>
 <dd>
 <div class="brief">
- The content to show when the option to display content is off in the Settings.
+ The content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1506,7 +1507,7 @@ The maximum number of thumbnail path elements in the array is 4.
 <dt class="member" id="NotificationGroupContentInfo::groupContentForOff"><span class="attrName">DOMString? groupContentForOff</span></dt>
 <dd>
 <div class="brief">
- The group content to show when the option to display content is off in the Settings.
+ The group content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1545,7 +1546,7 @@ by exactly six hexadecimal characters(0-9, A-F). The color format is case-insens
             <p>
 The LED indicator color will show that it's a close approximation.
 LED will only light on when the screen is off. To turn the LED off, set "#000000" or null to ledColor.
-This method has effects when the device has notification LED.
+This method has effects when the device has a notification LED.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1830,7 +1831,7 @@ the saved value in the notification status tray would be different from
 the exact progress value.
             </p>
             <p>
-Range of <em>progressValue</em>: percent (0 to 100).
+The range of <em>progressValue</em>: percent (0 to 100).
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1993,7 +1994,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::thumbnails">
 <span class="attrName"><span class="type">NotificationThumbnailInfo </span><span class="name">thumbnails</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional thumbnails-related settings of a notification.
+ Defines additional thumbnail-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -2028,7 +2029,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::actions">
 <span class="attrName"><span class="type">NotificationActionInfo </span><span class="name">actions</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional actions-related settings of a notification.
+ Defines additional action-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -2200,7 +2201,7 @@ By default, this attribute is set to <var>null</var>.
                     <div class="def-api-feature">
 <p><div class="description">
             <p>
-If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has a led:
+If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has an LED:
             </p>
            </div></p>
 <li class="feature">http://tizen.org/feature/led</li>

--- a/docs/application/web/api/5.5/device_api/mobile/tizen/notification.html
+++ b/docs/application/web/api/5.5/device_api/mobile/tizen/notification.html
@@ -25,7 +25,7 @@ for accessing only external storage using this API, a privilege <a href="http://
           <li>
 for accessing internal and external storage using this API, privileges (<a href="http://tizen.org/privilege/mediastorage">http://tizen.org/privilege/mediastorage</a> and <a href="http://tizen.org/privilege/externalstorage">http://tizen.org/privilege/externalstorage</a>) must be provided.          </li>
           <li>
-Storage privileges are privacy-related privileges and there is a need of asking user directly with proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
+Storage privileges are privacy-related privileges and there is a need of asking the user directly with the proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
         </ul>
         <p>
 For more information on the Notification features, see <a href="/application/web/guides/notification/notification">Notification Guide</a>.
@@ -232,9 +232,9 @@ The following notification progress types are supported:
           </p>
           <ul>
             <li>
-"BYTE" - The progress is indicated in bytes.            </li>
+BYTE - The progress is indicated in bytes.            </li>
             <li>
-"PERCENTAGE" -The progress is indicated in percentage.            </li>
+PERCENTAGE - The progress is indicated in percentage.            </li>
           </ul>
          </div>
 </div>
@@ -242,7 +242,7 @@ The following notification progress types are supported:
 <a class="backward-compatibility-anchor" name="::Notification::LEDCustomFlags"></a><h3>1.5. LEDCustomFlags</h3>
 <div class="brief">
  Specifies custom LED flags.
-The following values are supported in this release :
+The following values are supported in this release:
           </div>
 <pre class="webidl prettyprint">  enum LEDCustomFlags { "LED_CUSTOM_DUTY_ON", "LED_CUSTOM_DEFAULT" };</pre>
 <p><span class="version">Since: </span>
@@ -251,9 +251,9 @@ The following values are supported in this release :
 <div class="description">
           <ul>
             <li>
-LED_CUSTOM_DUTY_ON, blink LED            </li>
+LED_CUSTOM_DUTY_ON - blink LED            </li>
             <li>
-LED_CUSTOM_DEFAULT, default flag            </li>
+LED_CUSTOM_DEFAULT - default flag            </li>
           </ul>
          </div>
 </div>
@@ -353,7 +353,7 @@ The NotificationManager interface provides access to the notification object.
 parameters contain an invalid value.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
@@ -483,7 +483,7 @@ catch (err)
 parameters contain an invalid value.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
@@ -640,7 +640,7 @@ catch (err)
  with error type NotFoundError, if NotificationId is not found in the previously posted notifications.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if any other error occurs.
@@ -689,7 +689,7 @@ catch (err)
  with error type AbortError, if any error occurs.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 </ul>
 </li></ul>
@@ -734,7 +734,7 @@ catch (err)
             <p>
 Given parameters consist of timeOn and timeOff in milliseconds, RGBA color and LEDCustomFlags combination.
 For the color first three bytes are RGB values. The last byte is opacity. For example "#FFFF0080". There is also another possibility when the last byte
-is not given (in this case alpha is assumed to have value 0xff). In this case only RGB values are given. For example: "#ff0000" that is equivalent of "#ff0000ff".
+is not given (in this case alpha is assumed to have a value of 0xff). In this case only RGB values are given. For example: "#ff0000" that is equivalent of "#ff0000ff".
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -891,7 +891,7 @@ All templates are removed when the application package is uninstalled.
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type QuotaExceededError, if the allowed number of templates is exceeded.
@@ -968,10 +968,10 @@ An application can load only templates that it has saved.
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
- with error type NotFoundError, if the method cannot find a template with given name.
+ with error type NotFoundError, if the method cannot find a template with a given name.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if the method cannot be completed because of any error.
@@ -1083,7 +1083,7 @@ For detailed descriptions of properties, please refer to <a href="#Notification"
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Some of the specified options might be ignored if the device does not support related feature (e.g. LED notification settings).
+ Some of the specified options might be ignored if the device does not support the related features (e.g. LED notification settings).
           </p>
 </div>
 <div class="dictionary" id="NotificationTextContentInfo">
@@ -1121,7 +1121,8 @@ By default, this attribute is set to <em>PERCENTAGE</em>.
 <dt class="member" id="NotificationTextContentInfo::progressValue"><span class="attrName">unsigned long? progressValue</span></dt>
 <dd>
 <div class="brief">
- Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>            </div>
+ Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>.
+            </div>
 <div class="description">
             <p>
 If <em>progressValue</em> is set, the progressbar will be displayed in the notification. The <em>progressValue</em> can change the amount of progress as it moves forward or backward. It gets the progress value of the current notification.
@@ -1129,12 +1130,12 @@ If 0, the indeterminate progressbar will be shown.
 This attribute only affects for <em>UserNotification</em> of type <em>PROGRESS</em>.
             </p>
             <p>
-Applications should keep the progress value for its job because
+Applications should keep the progress value for their job because
 the saved value in the notification status tray can be different from
 the exact progress value.
             </p>
             <p>
-Range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
+The range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1208,7 +1209,7 @@ The maximum number of detail information elements in the array is 2.
 <dt class="member" id="NotificationTextContentInfo::contentForOff"><span class="attrName">DOMString? contentForOff</span></dt>
 <dd>
 <div class="brief">
- The content to show when the option to display content is off in the Settings.
+ The content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1451,7 +1452,7 @@ The maximum number of thumbnail path elements in the array is 4.
 <dt class="member" id="NotificationGroupContentInfo::groupContentForOff"><span class="attrName">DOMString? groupContentForOff</span></dt>
 <dd>
 <div class="brief">
- The group content to show when the option to display content is off in the Settings.
+ The group content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1490,7 +1491,7 @@ by exactly six hexadecimal characters(0-9, A-F). The color format is case-insens
             <p>
 The LED indicator color will show that it's a close approximation.
 LED will only light on when the screen is off. To turn the LED off, set "#000000" or null to ledColor.
-This method has effects when the device has notification LED.
+This method has effects when the device has a notification LED.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1643,7 +1644,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::thumbnails">
 <span class="attrName"><span class="type">NotificationThumbnailInfo </span><span class="name">thumbnails</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional thumbnails-related settings of a notification.
+ Defines additional thumbnail-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -1678,7 +1679,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::actions">
 <span class="attrName"><span class="type">NotificationActionInfo </span><span class="name">actions</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional actions-related settings of a notification.
+ Defines additional action-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -1850,7 +1851,7 @@ By default, this attribute is set to <var>null</var>.
                     <div class="def-api-feature">
 <p><div class="description">
             <p>
-If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has a led:
+If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has an LED:
             </p>
            </div></p>
 <li class="feature">http://tizen.org/feature/led</li>

--- a/docs/application/web/api/5.5/device_api/wearable/tizen/notification.html
+++ b/docs/application/web/api/5.5/device_api/wearable/tizen/notification.html
@@ -26,7 +26,7 @@ for accessing only external storage using this API, a privilege <a href="http://
           <li>
 for accessing internal and external storage using this API, privileges (<a href="http://tizen.org/privilege/mediastorage">http://tizen.org/privilege/mediastorage</a> and <a href="http://tizen.org/privilege/externalstorage">http://tizen.org/privilege/externalstorage</a>) must be provided.          </li>
           <li>
-Storage privileges are privacy-related privileges and there is a need of asking user directly with proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
+Storage privileges are privacy-related privileges and there is a need of asking the user directly with the proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
         </ul>
         <p>
 For more information on the Notification features, see <a href="/application/web/guides/notification/notification">Notification Guide</a>.
@@ -228,9 +228,9 @@ The following notification progress types are supported:
           </p>
           <ul>
             <li>
-"BYTE" - The progress is indicated in bytes.            </li>
+BYTE - The progress is indicated in bytes.            </li>
             <li>
-"PERCENTAGE" -The progress is indicated in percentage.            </li>
+PERCENTAGE - The progress is indicated in percentage.            </li>
           </ul>
          </div>
 </div>
@@ -328,7 +328,7 @@ The NotificationManager interface provides access to the notification object.
 parameters contain an invalid value.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
@@ -458,7 +458,7 @@ catch (err)
 parameters contain an invalid value.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
@@ -615,7 +615,7 @@ catch (err)
  with error type NotFoundError, if NotificationId is not found in the previously posted notifications.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if any other error occurs.
@@ -664,7 +664,7 @@ catch (err)
  with error type AbortError, if any error occurs.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 </ul>
 </li></ul>
@@ -744,7 +744,7 @@ All templates are removed when the application package is uninstalled.
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type QuotaExceededError, if the allowed number of templates is exceeded.
@@ -821,10 +821,10 @@ An application can load only templates that it has saved.
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
- with error type NotFoundError, if the method cannot find a template with given name.
+ with error type NotFoundError, if the method cannot find a template with a given name.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if the method cannot be completed because of any error.
@@ -936,7 +936,7 @@ For detailed descriptions of properties, please refer to <a href="#Notification"
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Some of the specified options might be ignored if the device does not support related feature (e.g. LED notification settings).
+ Some of the specified options might be ignored if the device does not support the related features (e.g. LED notification settings).
           </p>
 </div>
 <div class="dictionary" id="NotificationTextContentInfo">
@@ -974,7 +974,8 @@ By default, this attribute is set to <em>PERCENTAGE</em>.
 <dt class="member" id="NotificationTextContentInfo::progressValue"><span class="attrName">unsigned long? progressValue</span></dt>
 <dd>
 <div class="brief">
- Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>            </div>
+ Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>.
+            </div>
 <div class="description">
             <p>
 If <em>progressValue</em> is set, the progressbar will be displayed in the notification. The <em>progressValue</em> can change the amount of progress as it moves forward or backward. It gets the progress value of the current notification.
@@ -982,12 +983,12 @@ If 0, the indeterminate progressbar will be shown.
 This attribute only affects for <em>UserNotification</em> of type <em>PROGRESS</em>.
             </p>
             <p>
-Applications should keep the progress value for its job because
+Applications should keep the progress value for their job because
 the saved value in the notification status tray can be different from
 the exact progress value.
             </p>
             <p>
-Range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
+The range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1061,7 +1062,7 @@ The maximum number of detail information elements in the array is 2.
 <dt class="member" id="NotificationTextContentInfo::contentForOff"><span class="attrName">DOMString? contentForOff</span></dt>
 <dd>
 <div class="brief">
- The content to show when the option to display content is off in the Settings.
+ The content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1304,7 +1305,7 @@ The maximum number of thumbnail path elements in the array is 4.
 <dt class="member" id="NotificationGroupContentInfo::groupContentForOff"><span class="attrName">DOMString? groupContentForOff</span></dt>
 <dd>
 <div class="brief">
- The group content to show when the option to display content is off in the Settings.
+ The group content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1343,7 +1344,7 @@ by exactly six hexadecimal characters(0-9, A-F). The color format is case-insens
             <p>
 The LED indicator color will show that it's a close approximation.
 LED will only light on when the screen is off. To turn the LED off, set "#000000" or null to ledColor.
-This method has effects when the device has notification LED.
+This method has effects when the device has a notification LED.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1496,7 +1497,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::thumbnails">
 <span class="attrName"><span class="type">NotificationThumbnailInfo </span><span class="name">thumbnails</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional thumbnails-related settings of a notification.
+ Defines additional thumbnail-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -1531,7 +1532,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::actions">
 <span class="attrName"><span class="type">NotificationActionInfo </span><span class="name">actions</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional actions-related settings of a notification.
+ Defines additional action-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -1703,7 +1704,7 @@ By default, this attribute is set to <var>null</var>.
                     <div class="def-api-feature">
 <p><div class="description">
             <p>
-If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has a led:
+If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has an LED:
             </p>
            </div></p>
 <li class="feature">http://tizen.org/feature/led</li>

--- a/docs/application/web/api/6.0/device_api/mobile/tizen/notification.html
+++ b/docs/application/web/api/6.0/device_api/mobile/tizen/notification.html
@@ -25,7 +25,7 @@ for accessing only external storage using this API, a privilege <a href="http://
           <li>
 for accessing internal and external storage using this API, privileges (<a href="http://tizen.org/privilege/mediastorage">http://tizen.org/privilege/mediastorage</a> and <a href="http://tizen.org/privilege/externalstorage">http://tizen.org/privilege/externalstorage</a>) must be provided.          </li>
           <li>
-Storage privileges are privacy-related privileges and there is a need of asking user directly with proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
+Storage privileges are privacy-related privileges and there is a need of asking the user directly with the proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
         </ul>
         <p>
 For more information on the Notification features, see <a href="/application/web/guides/notification/notification">Notification Guide</a>.
@@ -232,9 +232,9 @@ The following notification progress types are supported:
           </p>
           <ul>
             <li>
-"BYTE" - The progress is indicated in bytes.            </li>
+BYTE - The progress is indicated in bytes.            </li>
             <li>
-"PERCENTAGE" -The progress is indicated in percentage.            </li>
+PERCENTAGE - The progress is indicated in percentage.            </li>
           </ul>
          </div>
 </div>
@@ -242,7 +242,7 @@ The following notification progress types are supported:
 <a class="backward-compatibility-anchor" name="::Notification::LEDCustomFlags"></a><h3>1.5. LEDCustomFlags</h3>
 <div class="brief">
  Specifies custom LED flags.
-The following values are supported in this release :
+The following values are supported in this release:
           </div>
 <pre class="webidl prettyprint">  enum LEDCustomFlags { "LED_CUSTOM_DUTY_ON", "LED_CUSTOM_DEFAULT" };</pre>
 <p><span class="version">Since: </span>
@@ -251,9 +251,9 @@ The following values are supported in this release :
 <div class="description">
           <ul>
             <li>
-LED_CUSTOM_DUTY_ON, blink LED            </li>
+LED_CUSTOM_DUTY_ON - blink LED            </li>
             <li>
-LED_CUSTOM_DEFAULT, default flag            </li>
+LED_CUSTOM_DEFAULT - default flag            </li>
           </ul>
          </div>
 </div>
@@ -353,7 +353,7 @@ The NotificationManager interface provides access to the notification object.
 parameters contain an invalid value.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
@@ -483,7 +483,7 @@ catch (err)
 parameters contain an invalid value.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
@@ -640,7 +640,7 @@ catch (err)
  with error type NotFoundError, if NotificationId is not found in the previously posted notifications.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if any other error occurs.
@@ -689,7 +689,7 @@ catch (err)
  with error type AbortError, if any error occurs.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 </ul>
 </li></ul>
@@ -734,7 +734,7 @@ catch (err)
             <p>
 Given parameters consist of timeOn and timeOff in milliseconds, RGBA color and LEDCustomFlags combination.
 For the color first three bytes are RGB values. The last byte is opacity. For example "#FFFF0080". There is also another possibility when the last byte
-is not given (in this case alpha is assumed to have value 0xff). In this case only RGB values are given. For example: "#ff0000" that is equivalent of "#ff0000ff".
+is not given (in this case alpha is assumed to have a value of 0xff). In this case only RGB values are given. For example: "#ff0000" that is equivalent of "#ff0000ff".
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -891,7 +891,7 @@ All templates are removed when the application package is uninstalled.
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type QuotaExceededError, if the allowed number of templates is exceeded.
@@ -968,10 +968,10 @@ An application can load only templates that it has saved.
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
- with error type NotFoundError, if the method cannot find a template with given name.
+ with error type NotFoundError, if the method cannot find a template with a given name.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if the method cannot be completed because of any error.
@@ -1083,7 +1083,7 @@ For detailed descriptions of properties, please refer to <a href="#Notification"
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Some of the specified options might be ignored if the device does not support related feature (e.g. LED notification settings).
+ Some of the specified options might be ignored if the device does not support the related features (e.g. LED notification settings).
           </p>
 </div>
 <div class="dictionary" id="NotificationTextContentInfo">
@@ -1121,7 +1121,8 @@ By default, this attribute is set to <em>PERCENTAGE</em>.
 <dt class="member" id="NotificationTextContentInfo::progressValue"><span class="attrName">unsigned long? progressValue</span></dt>
 <dd>
 <div class="brief">
- Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>            </div>
+ Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>.
+            </div>
 <div class="description">
             <p>
 If <em>progressValue</em> is set, the progressbar will be displayed in the notification. The <em>progressValue</em> can change the amount of progress as it moves forward or backward. It gets the progress value of the current notification.
@@ -1129,12 +1130,12 @@ If 0, the indeterminate progressbar will be shown.
 This attribute only affects for <em>UserNotification</em> of type <em>PROGRESS</em>.
             </p>
             <p>
-Applications should keep the progress value for its job because
+Applications should keep the progress value for their job because
 the saved value in the notification status tray can be different from
 the exact progress value.
             </p>
             <p>
-Range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
+The range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1208,7 +1209,7 @@ The maximum number of detail information elements in the array is 2.
 <dt class="member" id="NotificationTextContentInfo::contentForOff"><span class="attrName">DOMString? contentForOff</span></dt>
 <dd>
 <div class="brief">
- The content to show when the option to display content is off in the Settings.
+ The content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1451,7 +1452,7 @@ The maximum number of thumbnail path elements in the array is 4.
 <dt class="member" id="NotificationGroupContentInfo::groupContentForOff"><span class="attrName">DOMString? groupContentForOff</span></dt>
 <dd>
 <div class="brief">
- The group content to show when the option to display content is off in the Settings.
+ The group content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1490,7 +1491,7 @@ by exactly six hexadecimal characters(0-9, A-F). The color format is case-insens
             <p>
 The LED indicator color will show that it's a close approximation.
 LED will only light on when the screen is off. To turn the LED off, set "#000000" or null to ledColor.
-This method has effects when the device has notification LED.
+This method has effects when the device has a notification LED.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1643,7 +1644,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::thumbnails">
 <span class="attrName"><span class="type">NotificationThumbnailInfo </span><span class="name">thumbnails</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional thumbnails-related settings of a notification.
+ Defines additional thumbnail-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -1678,7 +1679,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::actions">
 <span class="attrName"><span class="type">NotificationActionInfo </span><span class="name">actions</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional actions-related settings of a notification.
+ Defines additional action-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -1850,7 +1851,7 @@ By default, this attribute is set to <var>null</var>.
                     <div class="def-api-feature">
 <p><div class="description">
             <p>
-If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has a led:
+If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has an LED:
             </p>
            </div></p>
 <li class="feature">http://tizen.org/feature/led</li>

--- a/docs/application/web/api/6.0/device_api/wearable/tizen/notification.html
+++ b/docs/application/web/api/6.0/device_api/wearable/tizen/notification.html
@@ -26,7 +26,7 @@ for accessing only external storage using this API, a privilege <a href="http://
           <li>
 for accessing internal and external storage using this API, privileges (<a href="http://tizen.org/privilege/mediastorage">http://tizen.org/privilege/mediastorage</a> and <a href="http://tizen.org/privilege/externalstorage">http://tizen.org/privilege/externalstorage</a>) must be provided.          </li>
           <li>
-Storage privileges are privacy-related privileges and there is a need of asking user directly with proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
+Storage privileges are privacy-related privileges and there is a need of asking the user directly with the proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
         </ul>
         <p>
 For more information on the Notification features, see <a href="/application/web/guides/notification/notification">Notification Guide</a>.
@@ -228,9 +228,9 @@ The following notification progress types are supported:
           </p>
           <ul>
             <li>
-"BYTE" - The progress is indicated in bytes.            </li>
+BYTE - The progress is indicated in bytes.            </li>
             <li>
-"PERCENTAGE" -The progress is indicated in percentage.            </li>
+PERCENTAGE - The progress is indicated in percentage.            </li>
           </ul>
          </div>
 </div>
@@ -328,7 +328,7 @@ The NotificationManager interface provides access to the notification object.
 parameters contain an invalid value.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
@@ -458,7 +458,7 @@ catch (err)
 parameters contain an invalid value.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
@@ -615,7 +615,7 @@ catch (err)
  with error type NotFoundError, if NotificationId is not found in the previously posted notifications.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if any other error occurs.
@@ -664,7 +664,7 @@ catch (err)
  with error type AbortError, if any error occurs.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 </ul>
 </li></ul>
@@ -744,7 +744,7 @@ All templates are removed when the application package is uninstalled.
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type QuotaExceededError, if the allowed number of templates is exceeded.
@@ -821,10 +821,10 @@ An application can load only templates that it has saved.
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
- with error type NotFoundError, if the method cannot find a template with given name.
+ with error type NotFoundError, if the method cannot find a template with a given name.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if the method cannot be completed because of any error.
@@ -936,7 +936,7 @@ For detailed descriptions of properties, please refer to <a href="#Notification"
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Some of the specified options might be ignored if the device does not support related feature (e.g. LED notification settings).
+ Some of the specified options might be ignored if the device does not support the related features (e.g. LED notification settings).
           </p>
 </div>
 <div class="dictionary" id="NotificationTextContentInfo">
@@ -974,7 +974,8 @@ By default, this attribute is set to <em>PERCENTAGE</em>.
 <dt class="member" id="NotificationTextContentInfo::progressValue"><span class="attrName">unsigned long? progressValue</span></dt>
 <dd>
 <div class="brief">
- Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>            </div>
+ Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>.
+            </div>
 <div class="description">
             <p>
 If <em>progressValue</em> is set, the progressbar will be displayed in the notification. The <em>progressValue</em> can change the amount of progress as it moves forward or backward. It gets the progress value of the current notification.
@@ -982,12 +983,12 @@ If 0, the indeterminate progressbar will be shown.
 This attribute only affects for <em>UserNotification</em> of type <em>PROGRESS</em>.
             </p>
             <p>
-Applications should keep the progress value for its job because
+Applications should keep the progress value for their job because
 the saved value in the notification status tray can be different from
 the exact progress value.
             </p>
             <p>
-Range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
+The range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1061,7 +1062,7 @@ The maximum number of detail information elements in the array is 2.
 <dt class="member" id="NotificationTextContentInfo::contentForOff"><span class="attrName">DOMString? contentForOff</span></dt>
 <dd>
 <div class="brief">
- The content to show when the option to display content is off in the Settings.
+ The content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1304,7 +1305,7 @@ The maximum number of thumbnail path elements in the array is 4.
 <dt class="member" id="NotificationGroupContentInfo::groupContentForOff"><span class="attrName">DOMString? groupContentForOff</span></dt>
 <dd>
 <div class="brief">
- The group content to show when the option to display content is off in the Settings.
+ The group content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1343,7 +1344,7 @@ by exactly six hexadecimal characters(0-9, A-F). The color format is case-insens
             <p>
 The LED indicator color will show that it's a close approximation.
 LED will only light on when the screen is off. To turn the LED off, set "#000000" or null to ledColor.
-This method has effects when the device has notification LED.
+This method has effects when the device has a notification LED.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1496,7 +1497,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::thumbnails">
 <span class="attrName"><span class="type">NotificationThumbnailInfo </span><span class="name">thumbnails</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional thumbnails-related settings of a notification.
+ Defines additional thumbnail-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -1531,7 +1532,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::actions">
 <span class="attrName"><span class="type">NotificationActionInfo </span><span class="name">actions</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional actions-related settings of a notification.
+ Defines additional action-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -1703,7 +1704,7 @@ By default, this attribute is set to <var>null</var>.
                     <div class="def-api-feature">
 <p><div class="description">
             <p>
-If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has a led:
+If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has an LED:
             </p>
            </div></p>
 <li class="feature">http://tizen.org/feature/led</li>

--- a/docs/application/web/api/6.5/device_api/mobile/tizen/notification.html
+++ b/docs/application/web/api/6.5/device_api/mobile/tizen/notification.html
@@ -25,7 +25,7 @@ for accessing only external storage using this API, a privilege <a href="http://
           <li>
 for accessing internal and external storage using this API, privileges (<a href="http://tizen.org/privilege/mediastorage">http://tizen.org/privilege/mediastorage</a> and <a href="http://tizen.org/privilege/externalstorage">http://tizen.org/privilege/externalstorage</a>) must be provided.          </li>
           <li>
-Storage privileges are privacy-related privileges and there is a need of asking user directly with proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
+Storage privileges are privacy-related privileges and there is a need of asking the user directly with the proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
         </ul>
         <p>
 For more information on the Notification features, see <a href="/application/web/guides/notification/notification">Notification Guide</a>.
@@ -232,9 +232,9 @@ The following notification progress types are supported:
           </p>
           <ul>
             <li>
-"BYTE" - The progress is indicated in bytes.            </li>
+BYTE - The progress is indicated in bytes.            </li>
             <li>
-"PERCENTAGE" -The progress is indicated in percentage.            </li>
+PERCENTAGE - The progress is indicated in percentage.            </li>
           </ul>
          </div>
 </div>
@@ -242,7 +242,7 @@ The following notification progress types are supported:
 <a class="backward-compatibility-anchor" name="::Notification::LEDCustomFlags"></a><h3>1.5. LEDCustomFlags</h3>
 <div class="brief">
  Specifies custom LED flags.
-The following values are supported in this release :
+The following values are supported in this release:
           </div>
 <pre class="webidl prettyprint">  enum LEDCustomFlags { "LED_CUSTOM_DUTY_ON", "LED_CUSTOM_DEFAULT" };</pre>
 <p><span class="version">Since: </span>
@@ -251,9 +251,9 @@ The following values are supported in this release :
 <div class="description">
           <ul>
             <li>
-LED_CUSTOM_DUTY_ON, blink LED            </li>
+LED_CUSTOM_DUTY_ON - blink LED            </li>
             <li>
-LED_CUSTOM_DEFAULT, default flag            </li>
+LED_CUSTOM_DEFAULT - default flag            </li>
           </ul>
          </div>
 </div>
@@ -353,7 +353,7 @@ The NotificationManager interface provides access to the notification object.
 parameters contain an invalid value.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
@@ -483,7 +483,7 @@ catch (err)
 parameters contain an invalid value.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
@@ -640,7 +640,7 @@ catch (err)
  with error type NotFoundError, if NotificationId is not found in the previously posted notifications.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if any other error occurs.
@@ -689,7 +689,7 @@ catch (err)
  with error type AbortError, if any error occurs.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 </ul>
 </li></ul>
@@ -734,7 +734,7 @@ catch (err)
             <p>
 Given parameters consist of timeOn and timeOff in milliseconds, RGBA color and LEDCustomFlags combination.
 For the color first three bytes are RGB values. The last byte is opacity. For example "#FFFF0080". There is also another possibility when the last byte
-is not given (in this case alpha is assumed to have value 0xff). In this case only RGB values are given. For example: "#ff0000" that is equivalent of "#ff0000ff".
+is not given (in this case alpha is assumed to have a value of 0xff). In this case only RGB values are given. For example: "#ff0000" that is equivalent of "#ff0000ff".
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
@@ -891,7 +891,7 @@ All templates are removed when the application package is uninstalled.
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type QuotaExceededError, if the allowed number of templates is exceeded.
@@ -968,10 +968,10 @@ An application can load only templates that it has saved.
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
- with error type NotFoundError, if the method cannot find a template with given name.
+ with error type NotFoundError, if the method cannot find a template with a given name.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if the method cannot be completed because of any error.
@@ -1083,7 +1083,7 @@ For detailed descriptions of properties, please refer to <a href="#Notification"
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Some of the specified options might be ignored if the device does not support related feature (e.g. LED notification settings).
+ Some of the specified options might be ignored if the device does not support the related features (e.g. LED notification settings).
           </p>
 </div>
 <div class="dictionary" id="NotificationTextContentInfo">
@@ -1121,7 +1121,8 @@ By default, this attribute is set to <em>PERCENTAGE</em>.
 <dt class="member" id="NotificationTextContentInfo::progressValue"><span class="attrName">unsigned long? progressValue</span></dt>
 <dd>
 <div class="brief">
- Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>            </div>
+ Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>.
+            </div>
 <div class="description">
             <p>
 If <em>progressValue</em> is set, the progressbar will be displayed in the notification. The <em>progressValue</em> can change the amount of progress as it moves forward or backward. It gets the progress value of the current notification.
@@ -1129,12 +1130,12 @@ If 0, the indeterminate progressbar will be shown.
 This attribute only affects for <em>UserNotification</em> of type <em>PROGRESS</em>.
             </p>
             <p>
-Applications should keep the progress value for its job because
+Applications should keep the progress value for their job because
 the saved value in the notification status tray can be different from
 the exact progress value.
             </p>
             <p>
-Range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
+The range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1208,7 +1209,7 @@ The maximum number of detail information elements in the array is 2.
 <dt class="member" id="NotificationTextContentInfo::contentForOff"><span class="attrName">DOMString? contentForOff</span></dt>
 <dd>
 <div class="brief">
- The content to show when the option to display content is off in the Settings.
+ The content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1451,7 +1452,7 @@ The maximum number of thumbnail path elements in the array is 4.
 <dt class="member" id="NotificationGroupContentInfo::groupContentForOff"><span class="attrName">DOMString? groupContentForOff</span></dt>
 <dd>
 <div class="brief">
- The group content to show when the option to display content is off in the Settings.
+ The group content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1490,7 +1491,7 @@ by exactly six hexadecimal characters(0-9, A-F). The color format is case-insens
             <p>
 The LED indicator color will show that it's a close approximation.
 LED will only light on when the screen is off. To turn the LED off, set "#000000" or null to ledColor.
-This method has effects when the device has notification LED.
+This method has effects when the device has a notification LED.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1643,7 +1644,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::thumbnails">
 <span class="attrName"><span class="type">NotificationThumbnailInfo </span><span class="name">thumbnails</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional thumbnails-related settings of a notification.
+ Defines additional thumbnail-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -1678,7 +1679,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::actions">
 <span class="attrName"><span class="type">NotificationActionInfo </span><span class="name">actions</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional actions-related settings of a notification.
+ Defines additional action-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -1850,7 +1851,7 @@ By default, this attribute is set to <var>null</var>.
                     <div class="def-api-feature">
 <p><div class="description">
             <p>
-If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has a led:
+If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has an LED:
             </p>
            </div></p>
 <li class="feature">http://tizen.org/feature/led</li>

--- a/docs/application/web/api/6.5/device_api/wearable/tizen/notification.html
+++ b/docs/application/web/api/6.5/device_api/wearable/tizen/notification.html
@@ -26,7 +26,7 @@ for accessing only external storage using this API, a privilege <a href="http://
           <li>
 for accessing internal and external storage using this API, privileges (<a href="http://tizen.org/privilege/mediastorage">http://tizen.org/privilege/mediastorage</a> and <a href="http://tizen.org/privilege/externalstorage">http://tizen.org/privilege/externalstorage</a>) must be provided.          </li>
           <li>
-Storage privileges are privacy-related privileges and there is a need of asking user directly with proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
+Storage privileges are privacy-related privileges and there is a need of asking the user directly with the proper pop-up. Please refer to <a href="ppm.html">Privacy Privilege API</a> for more details.          </li>
         </ul>
         <p>
 For more information on the Notification features, see <a href="/application/web/guides/notification/notification">Notification Guide</a>.
@@ -228,9 +228,9 @@ The following notification progress types are supported:
           </p>
           <ul>
             <li>
-"BYTE" - The progress is indicated in bytes.            </li>
+BYTE - The progress is indicated in bytes.            </li>
             <li>
-"PERCENTAGE" -The progress is indicated in percentage.            </li>
+PERCENTAGE - The progress is indicated in percentage.            </li>
           </ul>
          </div>
 </div>
@@ -328,7 +328,7 @@ The NotificationManager interface provides access to the notification object.
 parameters contain an invalid value.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
@@ -458,7 +458,7 @@ catch (err)
 parameters contain an invalid value.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
@@ -615,7 +615,7 @@ catch (err)
  with error type NotFoundError, if NotificationId is not found in the previously posted notifications.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if any other error occurs.
@@ -664,7 +664,7 @@ catch (err)
  with error type AbortError, if any error occurs.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 </ul>
 </li></ul>
@@ -744,7 +744,7 @@ All templates are removed when the application package is uninstalled.
  with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
                 </p></li>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
  with error type QuotaExceededError, if the allowed number of templates is exceeded.
@@ -821,10 +821,10 @@ An application can load only templates that it has saved.
 <p><span class="except">Exceptions:</span></p>
           <ul class="exception"><li>WebAPIException<ul>
 <li class="list"><p>
- with error type SecurityError, if the application does not have the privilege to call this method or the application does not have privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
+ with error type SecurityError, if the application does not have the privilege to call this method or the application does not have the privilege to access the storage. For more information, see <a href="#StorageRemark">Storage privileges</a>.
                 </p></li>
 <li class="list"><p>
- with error type NotFoundError, if the method cannot find a template with given name.
+ with error type NotFoundError, if the method cannot find a template with a given name.
                 </p></li>
 <li class="list"><p>
  with error type AbortError, if the method cannot be completed because of any error.
@@ -936,7 +936,7 @@ For detailed descriptions of properties, please refer to <a href="#Notification"
           </p>
          </div>
 <p><span class="remark">Remark: </span>
- Some of the specified options might be ignored if the device does not support related feature (e.g. LED notification settings).
+ Some of the specified options might be ignored if the device does not support the related features (e.g. LED notification settings).
           </p>
 </div>
 <div class="dictionary" id="NotificationTextContentInfo">
@@ -974,7 +974,8 @@ By default, this attribute is set to <em>PERCENTAGE</em>.
 <dt class="member" id="NotificationTextContentInfo::progressValue"><span class="attrName">unsigned long? progressValue</span></dt>
 <dd>
 <div class="brief">
- Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>            </div>
+ Defines the current notification progress value (<em>PERCENTAGE</em> or <em>BYTE</em>), depending on the <em>progressType</em>.
+            </div>
 <div class="description">
             <p>
 If <em>progressValue</em> is set, the progressbar will be displayed in the notification. The <em>progressValue</em> can change the amount of progress as it moves forward or backward. It gets the progress value of the current notification.
@@ -982,12 +983,12 @@ If 0, the indeterminate progressbar will be shown.
 This attribute only affects for <em>UserNotification</em> of type <em>PROGRESS</em>.
             </p>
             <p>
-Applications should keep the progress value for its job because
+Applications should keep the progress value for their job because
 the saved value in the notification status tray can be different from
 the exact progress value.
             </p>
             <p>
-Range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
+The range of <em>progressValue</em> for <em>PERCENTAGE</em> <em>progressType</em> is from 0 to 100.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1061,7 +1062,7 @@ The maximum number of detail information elements in the array is 2.
 <dt class="member" id="NotificationTextContentInfo::contentForOff"><span class="attrName">DOMString? contentForOff</span></dt>
 <dd>
 <div class="brief">
- The content to show when the option to display content is off in the Settings.
+ The content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1304,7 +1305,7 @@ The maximum number of thumbnail path elements in the array is 4.
 <dt class="member" id="NotificationGroupContentInfo::groupContentForOff"><span class="attrName">DOMString? groupContentForOff</span></dt>
 <dd>
 <div class="brief">
- The group content to show when the option to display content is off in the Settings.
+ The group content to show when the option to display content is off in the settings.
             </div>
 <p><span class="version">Since: </span>
  4.0
@@ -1343,7 +1344,7 @@ by exactly six hexadecimal characters(0-9, A-F). The color format is case-insens
             <p>
 The LED indicator color will show that it's a close approximation.
 LED will only light on when the screen is off. To turn the LED off, set "#000000" or null to ledColor.
-This method has effects when the device has notification LED.
+This method has effects when the device has a notification LED.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1496,7 +1497,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::thumbnails">
 <span class="attrName"><span class="type">NotificationThumbnailInfo </span><span class="name">thumbnails</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional thumbnails-related settings of a notification.
+ Defines additional thumbnail-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -1531,7 +1532,7 @@ catch (err)
 </li>
 <li class="attribute" id="UserNotification::actions">
 <span class="attrName"><span class="type">NotificationActionInfo </span><span class="name">actions</span><span class="optional"> [nullable]</span></span><div class="brief">
- Defines additional actions-related settings of a notification.
+ Defines additional action-related settings of a notification.
             </div>
 <div class="description">
             <p>
@@ -1703,7 +1704,7 @@ By default, this attribute is set to <var>null</var>.
                     <div class="def-api-feature">
 <p><div class="description">
             <p>
-If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has a led:
+If an application uses playLEDCustomEffect() or stopLEDCustomEffect(), declare the following feature requirements in the config file to guarantee the running of this application on a device which has an LED:
             </p>
            </div></p>
 <li class="feature">http://tizen.org/feature/led</li>


### PR DESCRIPTION
Apply changes from #1622 to all versions.

### Change Description ###

 - fix typing/spelling mistakes (missing articles, missing commas, etc.)

### Bugs Fixed ###

N/A

### API Changes ###

N/A

