### PR TITLE
Replace "Common Tools" with "Tizen SDK Tools"

### DIFF
--- a/docs/application/toc_all.md
+++ b/docs/application/toc_all.md
@@ -1298,7 +1298,7 @@
 #### [1.0.1 (Oct 28, 2016)](/application/tizen-studio/release-notes/1-0-1-release-notes.md)
 #### [1.0 (Sep 1, 2016)](/application/tizen-studio/release-notes/1-0-release-notes.md)
 
-## Common Tools
+## Tizen SDK Tools
 ### [Tizen-Core CLI](/application/tizen-studio/tizen-core/tizen-core-cli.md)
 ### [CLI](/application/tizen-studio/common-tools/command-line-interface.md)
 ### [SDB](/application/tizen-studio/common-tools/smart-development-bridge.md)


### PR DESCRIPTION
Signed-off-by: Dongkyun Son <dongkyun.s@samsung.com>

### Change Description ###

#### `Tizen SDK Tools` is appropriated which includes 
- `Baseline SDK` (`.NET CLI`, `Certificate Manager`, `Emulator Manager`)
- `Native CLI`
- `Native IDE`
- `Native Toolchain`
- `Web CLI`
- `Web IDE`

**Captured by `Package Manager` :**
![image](https://user-images.githubusercontent.com/17193661/166133059-6328b34e-56d7-4898-9754-4abf5779ce7b.png)

