### PR TITLE
Remove guides related to auto-restart and on-boot

### DIFF
--- a/docs/application/native/guides/app-management/data-control.md
+++ b/docs/application/native/guides/app-management/data-control.md
@@ -59,8 +59,7 @@ To enable your application to use the data control functionality:
       <description>datacontrolprovider</description>
       <service-application appid="org.tizen.datacontrolprovider"
                       exec="datacontrolprovider"
-                      nodisplay="true" multiple="false" type="capp" taskmanage="true"
-                      auto-restart="false" on-boot="false">
+                      nodisplay="true" multiple="false" type="capp" taskmanage="true">
           <datacontrol providerid = "Your Provider ID" access="ReadWrite" type="Sql" trusted="True">
              <privilege>http://tizen.org/privilege/contact.read</privilege>
              <privilege>http://tizen.org/privilege/email</privilege>

--- a/docs/application/native/guides/applications/service-app.md
+++ b/docs/application/native/guides/applications/service-app.md
@@ -84,35 +84,6 @@ Describe your service application attributes in the manifest file. The attribute
 </manifest>
 ```
 
-Pay specific attention to the following attributes:
-
-- `auto-restart`
-
-  If set to `true`, the application restarts whenever it terminates abnormally. If the application is running, it is launched after installing or updating the package.
-
-  > **Note**
-  >
-  > This attribute is not supported on Tizen wearable devices. Since Tizen 2.4, this attribute is not supported on all Tizen devices. Because of this, the `auto-restart` attribute used in a lower API version package than 2.4 is ignored on devices with the Tizen platform version 2.4 and higher.
-
-- `on-boot`
-
-  If set to `true`, the application launches on boot time, and after installing or updating the package. The application does not start if this attribute is removed after updating the package.
-
-  > **Note**
-  >
-  > This attribute is not supported on Tizen wearable devices. Since Tizen 2.4, this attribute is not supported on all Tizen devices. Because of this, the `on-boot` attribute used in a lower API version package than 2.4 is ignored on devices with the Tizen platform version 2.4 and higher.
-
-The following table defines the behaviors resulting from the attribute combinations:
-
-**Table: Attribute combinations**
-
-| `auto-restart` | `on-boot` | After normal termination   | On forced close            | On Reboot                           | After package installation | After package update       |
-|----------------|-----------|----------------------------|----------------------------|-------------------------------------|----------------------------|----------------------------|
-| `FALSE`        | `FALSE`   | Not launched automatically | Not launched automatically | Not launched after reboot           | Not launched               | Not launched automatically |
-| `FALSE`        | `TRUE`    | Not launched automatically | Not launched automatically | Launched automatically after reboot | Launched                   | Launched automatically     |
-| `TRUE`         | `FALSE`   | Launched automatically     | Launched automatically     | Not launched after reboot           | Not launched               | Launched automatically     |
-| `TRUE`         | `TRUE`    | Launched automatically     | Launched automatically     | Launched automatically after reboot | Launched                   | Launched automatically     |
-
 ## Prerequisites
 
 To use the functions and data types of the Service Application API (in [mobile](../../api/mobile/latest/group__CAPI__SERVICE__APP__MODULE.html) and [wearable](../../api/wearable/latest/group__CAPI__SERVICE__APP__MODULE.html) applications), include the `<service_app.h>` header file in your application:

--- a/docs/application/tizen-studio/native-tools/manifest-text-editor.md
+++ b/docs/application/tizen-studio/native-tools/manifest-text-editor.md
@@ -379,16 +379,6 @@ For more information on the relationship between the elements, see the [element 
 
   This can be used for launching or terminating the application explicitly.
 
-- `auto-restart`
-
-  Indicates whether the application is relaunched automatically if it is terminated abnormally (available values: `true`, `false`)
-
-  If the value is not defined, `false` is used.
-
-  > **Note**
-  >
-  > This attribute is not supported on Tizen wearable devices. Since Tizen 2.4, this attribute is not supported on all Tizen devices.
-
 - `exec`
 
   Application executable file path (string)
@@ -400,16 +390,6 @@ For more information on the relationship between the elements, see the [element 
   > **Note**
   >
   > This attribute is read-only. Do not attempt to modify it.
-
-- `on-boot`
-
-  Indicates whether the application is launched automatically on device boot or application installation (available values: `true`, `false`)
-
-  If the value is not defined, `false` is used.
-
-  > **Note**
-  >
-  > This attribute is not supported on Tizen wearable devices. Since Tizen 2.4, this attribute is not supported on all Tizen devices.
 
 - `taskmanage`
 
@@ -426,8 +406,8 @@ For more information on the relationship between the elements, see the [element 
 **For example:**
 
 ```xml
-<service-application appid="org.tizen.servicenew" auto-restart="false" exec="servicenew"
-                     multiple="false" on-boot="true" taskmanage="false" type="capp">
+<service-application appid="org.tizen.servicenew" exec="servicenew"
+                     multiple="false" taskmanage="false" type="capp">
    <label>servicenew</label>
    <label xml:lang="en-gb">testlabel</label>
    <icon>servicenew.png</icon>

--- a/docs/application/tizen-studio/web-tools/config-editor.md
+++ b/docs/application/tizen-studio/web-tools/config-editor.md
@@ -2099,19 +2099,9 @@ The following sections show additional configuration elements used in the `confi
 				<p>Mandatory; Tizen service ID, which is a combination of the Tizen wearable package ID and service name.</p>
 				<p>The service ID is a set of characters (0~9, a~z, A~Z) and unique among service applications on the device. The minimum value is 1 byte and the maximum value is 52 bytes.</p>
 				</li>
-				<li><code>on-boot</code>
-				<p>Optional; sets whether the service application is launched automatically on device boot (available values: <code>true</code>, <code>false</code> (default))</p>
-				<blockquote><p><strong>Note</strong><br>
-                This attribute is not supported on Tizen wearable devices. Since Tizen 2.4, this attribute is not supported on all Tizen devices.</p></blockquote>
-				</li>
-				<li><code>auto-restart</code>
-				<p>Optional; sets whether the service application is relaunched automatically when it is terminated (available values: <code>true</code>, <code>false</code> (default))</p>
-				<blockquote><p><strong>Note</strong><br>
-                This attribute is not supported on Tizen wearable devices. Since Tizen 2.4, this attribute is not supported on all Tizen devices.</p></blockquote>
-				</li>
 			</ul>
 			<p><strong>Example:</strong></p>
-			<pre><code>&lt;tizen:service id="webService.application" auto-restart="true" on-boot="false"&gt;
+			<pre><code>&lt;tizen:service id="webService.application"&gt;
    &lt;tizen:content src="service/service.js"/&gt;
    &lt;tizen:name&gt;WebService&lt;/tizen:name&gt;
    &lt;tizen:icon src="service-icon.png"/&gt;


### PR DESCRIPTION
### Change Description ###

The auto-restart and on-boot options are not supported since Tizen 2.4.
This PR removes related guides.

Signed-off-by: Hwankyu Jhun <h.jhun@samsung.com>