### PR TITLE
Change some guides for decoding an image

### DIFF
--- a/docs/application/native/guides/multimedia/face-detection.md
+++ b/docs/application/native/guides/multimedia/face-detection.md
@@ -107,10 +107,11 @@ To detect faces:
     ```
     /* For details, see the Image Util API Reference */
     unsigned char *dataBuffer = NULL;
-    unsigned long long bufferSize = 0;
-    unsigned long width = 0;
-    unsigned long height = 0;
+    size_t long bufferSize = 0;
+    unsigned int width = 0;
+    unsigned int height = 0;
     image_util_decode_h imageDecoder = NULL;
+    image_util_image_h decodedImage = NULL;
 
     error_code = image_util_decode_create(&imageDecoder);
     if (error_code != IMAGE_UTIL_ERROR_NONE)
@@ -124,11 +125,11 @@ To detect faces:
     if (error_code != IMAGE_UTIL_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-    error_code = image_util_decode_set_output_buffer(imageDecoder, &dataBuffer);
+    error_code = image_util_decode_run2(imageDecoder, &decodedImage);
     if (error_code != IMAGE_UTIL_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-    error_code = image_util_decode_run(imageDecoder, &width, &height, &bufferSize);
+    error_code = image_util_get_image(decodedImage, &width, &height, NULL, &dataBuffer, &bufferSize);
     if (error_code != IMAGE_UTIL_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
@@ -138,12 +139,14 @@ To detect faces:
 
     /* Fill the dataBuffer to g_source */
     error_code = mv_source_fill_by_buffer(facedata.g_source, dataBuffer, (unsigned int)bufferSize,
-                                          (unsigned int)width, (unsigned int)height, MEDIA_VISION_COLORSPACE_RGB888);
+                                          width, height, MEDIA_VISION_COLORSPACE_RGB888);
     if (error_code != MEDIA_VISION_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-    free(dataBuffer);
-    dataBuffer = NULL;
+    error_code = image_util_destroy_image(decodedImage);
+    if (error_code != IMAGE_UTIL_ERROR_NONE)
+        dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
+    decodedImage = NULL;
     ```
 
 3. Create the media vision engine using the `mv_create_engine_config()` function. The function creates the `g_engine_config` engine configuration handle and configures it with default attributes.
@@ -241,16 +244,13 @@ To recognize faces:
 
    char filePath[1024];
    unsigned char *dataBuffer = NULL;
-   unsigned long long bufferSize = 0;
-   unsigned long width = 0;
-   unsigned long height = 0;
+   size_t bufferSize = 0;
+   unsigned int width = 0;
+   unsigned int height = 0;
    image_util_decode_h imageDecoder = NULL;
+   image_util_image_h decodedImage = NULL;
 
     error_code = image_util_decode_create(&imageDecoder);
-    if (error_code != IMAGE_UTIL_ERROR_NONE)
-        dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
-
-    error_code = image_util_decode_set_colorspace(imageDecoder, IMAGE_UTIL_COLORSPACE_RGB888);
     if (error_code != IMAGE_UTIL_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
@@ -261,11 +261,15 @@ To recognize faces:
        if (error_code != IMAGE_UTIL_ERROR_NONE)
            dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-       error_code = image_util_decode_set_output_buffer(imageDecoder, &dataBuffer);
+       error_code = image_util_decode_set_colorspace(imageDecoder, IMAGE_UTIL_COLORSPACE_RGB888);
        if (error_code != IMAGE_UTIL_ERROR_NONE)
            dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-       error_code = image_util_decode_run(imageDecoder, &width, &height, &bufferSize);
+       error_code = image_util_decode_run2(imageDecoder, &decodedImage);
+       if (error_code != IMAGE_UTIL_ERROR_NONE)
+           dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
+
+       error_code = image_util_get_image(decodedImage, &width, &height, NULL, &dataBuffer, &bufferSize);
        if (error_code != IMAGE_UTIL_ERROR_NONE)
            dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
@@ -277,12 +281,14 @@ To recognize faces:
            dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
        error_code = mv_source_fill_by_buffer(facedata.g_source, dataBuffer, (unsigned int)bufferSize,
-                                             (unsigned int)width, (unsigned int)height, MEDIA_VISION_COLORSPACE_RGB888);
+                                             width, height, MEDIA_VISION_COLORSPACE_RGB888);
        if (error_code != MEDIA_VISION_ERROR_NONE)
            dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-       free(dataBuffer);
-       dataBuffer = NULL;
+       error_code = image_util_destroy_image(decodedImage);
+       if (error_code != IMAGE_UTIL_ERROR_NONE)
+           dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
+       decodedImage = NULL;
 
        error_code = mv_face_recognition_model_add(facedata.g_source,
                                                   facedata.g_face_recog_model, &roi, face_label);
@@ -312,6 +318,7 @@ To recognize faces:
     /* Decode the image and fill the image data to g_source handle */
     snprintf(filePath, 1024, "%s/whos_face.jpg", mydir);
     image_util_decode_h imageDecoder = NULL;
+    image_util_image_h decodedImage = NULL;
 
     error_code = image_util_decode_create(&imageDecoder);
     if (error_code != IMAGE_UTIL_ERROR_NONE)
@@ -325,14 +332,14 @@ To recognize faces:
     if (error_code != IMAGE_UTIL_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-    error_code = image_util_decode_set_output_buffer(imageDecoder, &dataBuffer);
+    error_code = image_util_decode_run2(imageDecoder, &decodedImage);
     if (error_code != IMAGE_UTIL_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-    error_code = image_util_decode_run(imageDecoder, &width, &height, &bufferSize);
+    error_code = image_util_get_image(decodedImage, &width, &height, NULL, &dataBuffer, &bufferSize);
     if (error_code != IMAGE_UTIL_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
-
+    
     error_code = image_util_decode_destroy(imageDecoder);
     if (error_code != IMAGE_UTIL_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
@@ -346,8 +353,10 @@ To recognize faces:
     if (error_code != MEDIA_VISION_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code= %d", error_code);
 
-    free(dataBuffer);
-    dataBuffer = NULL;
+    error_code = image_util_destroy_image(decodedImage);
+    if (error_code != IMAGE_UTIL_ERROR_NONE)
+        dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
+    decodedImage = NULL;
 
     error_code = mv_face_recognize(facedata.g_source, facedata.g_face_recog_model, facedata.g_engine_config,
                                    NULL, _on_face_recognized_cb, NULL);

--- a/docs/application/native/guides/multimedia/face-recognition.md
+++ b/docs/application/native/guides/multimedia/face-recognition.md
@@ -42,11 +42,12 @@ To register a new face image with a given label, follow these steps:
    ```
    char filePath[1024];
    unsigned char *dataBuffer = NULL;
-   unsigned long long bufferSize = 0;
-   unsigned long width = 0;
-   unsigned long height = 0;
+   size_t bufferSize = 0;
+   unsigned int width = 0;
+   unsigned int height = 0;
    image_util_decode_h imageDecoder = NULL;
    mv_source_h mv_source = NULL;
+   image_util_image_h decodedImage = NULL;
 
    ret = mv_create_source(&mv_source);
    if (ret != MEDIA_VISION_ERROR_NONE) {
@@ -58,11 +59,6 @@ To register a new face image with a given label, follow these steps:
        // handle an error.
    }
 
-   ret = image_util_decode_set_colorspace(imageDecoder, IMAGE_UTIL_COLORSPACE_RGB888);
-   if (ret != IMAGE_UTIL_ERROR_NONE) {
-       // handle an error.
-   }
-
    /* Decode image and fill the image data to mv_source handle */
    snprintf(filePath, 1024, "/path/to/face_image.jpg");
    ret = image_util_decode_set_input_path(imageDecoder, filePath);
@@ -70,18 +66,23 @@ To register a new face image with a given label, follow these steps:
        // handle an error.
    }
 
-   ret = image_util_decode_set_output_buffer(imageDecoder, &dataBuffer);
+   ret = image_util_decode_set_colorspace(imageDecoder, IMAGE_UTIL_COLORSPACE_RGB888);
    if (ret != IMAGE_UTIL_ERROR_NONE) {
        // handle an error.
    }
 
-   ret = image_util_decode_run(imageDecoder, &width, &height, &bufferSize);
+   ret = image_util_decode_run2(imageDecoder, &decodedImage);
+   if (ret != IMAGE_UTIL_ERROR_NONE) {
+       // handle an error.
+   }
+
+   ret = image_util_get_image(decodedImage, &width, &height, NULL, &dataBuffer, &bufferSize);
    if (ret != IMAGE_UTIL_ERROR_NONE) {
        // handle an error.
    }
 
    ret = mv_source_fill_by_buffer(mv_source, dataBuffer, (unsigned int)bufferSize,
-                                 (unsigned int)width, (unsigned int)height, MEDIA_VISION_COLORSPACE_RGB888);
+                                 width, height, MEDIA_VISION_COLORSPACE_RGB888);
    if (ret != MEDIA_VISION_ERROR_NONE) {
       free(dataBuffer);
 	  // handle an error.
@@ -92,7 +93,10 @@ To register a new face image with a given label, follow these steps:
        // handle an error.
    }
 
-   free(dataBuffer);
+   ret = image_util_destroy_image(decodedImage);
+   if (ret != IMAGE_UTIL_ERROR_NONE) {
+       // handle an error.
+   }
    ```
 
 3. Now, we are ready for using the face recognition main features. There are three face recognition features - register, unregister and recognize. You can use any one of them.

--- a/docs/application/native/guides/multimedia/image-classification.md
+++ b/docs/application/native/guides/multimedia/image-classification.md
@@ -61,10 +61,11 @@ To classify an image, follow these steps:
     ```c
     /* For details, see the Image Util API Reference */
     unsigned char *dataBuffer = NULL;
-    unsigned long long bufferSize = 0;
-    unsigned long width = 0;
-    unsigned long height = 0;
+    size_t bufferSize = 0;
+    unsigned int width = 0;
+    unsigned int height = 0;
     image_util_decode_h imageDecoder = NULL;
+    image_util_image_h decodedImage = NULL;
 
     error_code = image_util_decode_create(&imageDecoder);
     if (error_code != IMAGE_UTIL_ERROR_NONE)
@@ -78,11 +79,11 @@ To classify an image, follow these steps:
     if (error_code != IMAGE_UTIL_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-    error_code = image_util_decode_set_output_buffer(imageDecoder, &dataBuffer);
+    error_code = image_util_decode_run2(imageDecoder, &decodedImage);
     if (error_code != IMAGE_UTIL_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-    error_code = image_util_decode_run(imageDecoder, &width, &height, &bufferSize);
+    error_code = image_util_get_image(decodedImage, &width, &height, NULL, &dataBuffer, &bufferSize);
     if (error_code != IMAGE_UTIL_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
@@ -92,12 +93,14 @@ To classify an image, follow these steps:
 
     /* Fill the dataBuffer to g_source */
     error_code = mv_source_fill_by_buffer(imagedata.g_source, dataBuffer, (unsigned int)bufferSize,
-                                          (unsigned int)width, (unsigned int)height, MEDIA_VISION_COLORSPACE_RGB888);
+                                          width, height, MEDIA_VISION_COLORSPACE_RGB888);
     if (error_code != MEDIA_VISION_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-    free(dataBuffer);
-    dataBuffer = NULL;
+    error_code = image_util_destroy_image(decodedImage);
+    if (error_code != IMAGE_UTIL_ERROR_NONE)
+        dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
+    decodedImage = NULL;
     ```
 
 3. To classify the `sample.jpg` image, create a `g_inference` media vision inference handle:

--- a/docs/application/native/guides/multimedia/image-recognition.md
+++ b/docs/application/native/guides/multimedia/image-recognition.md
@@ -94,10 +94,11 @@ To recognize images:
     ```
     /* For details, see the Image Util API Reference */
     unsigned char *dataBuffer = NULL;
-    unsigned long long bufferSize = 0;
-    unsigned long width = 0;
-    unsigned long height = 0;
+    size_t bufferSize = 0;
+    unsigned int width = 0;
+    unsigned int height = 0;
     image_util_decode_h imageDecoder = NULL;
+    image_util_image_h decodedImage = NULL;
 
     error_code = image_util_decode_create(&imageDecoder);
     if (error_code != IMAGE_UTIL_ERROR_NONE)
@@ -111,11 +112,11 @@ To recognize images:
     if (error_code != IMAGE_UTIL_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-    error_code = image_util_decode_set_output_buffer(imageDecoder, &dataBuffer);
+    error_code = image_util_decode_run2(imageDecoder, &decodedImage);
     if (error_code != IMAGE_UTIL_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-    error_code = image_util_decode_run(imageDecoder, &width, &height, &bufferSize);
+    error_code = image_util_get_image(decodedImage, &width, &height, NULL, &dataBuffer, &bufferSize);
     if (error_code != IMAGE_UTIL_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
@@ -125,12 +126,14 @@ To recognize images:
 
     /* Fill the dataBuffer to g_source */
     error_code = mv_source_fill_by_buffer(imagedata.g_source, dataBuffer, (unsigned int)bufferSize,
-                                          (unsigned int)width, (unsigned int)height, MEDIA_VISION_COLORSPACE_RGB888);
+                                          width, height, MEDIA_VISION_COLORSPACE_RGB888);
     if (error_code != MEDIA_VISION_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-    free(dataBuffer);
-    dataBuffer = NULL;
+    error_code = image_util_destroy_image(decodedImage);
+    if (error_code != IMAGE_UTIL_ERROR_NONE)
+        dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
+    decodedImage = NULL;
     ```
 
 3. To recognize the `sample.jpg` image from others, create a `g_image_object` media vision image object handle and set a label.
@@ -175,11 +178,11 @@ To recognize images:
     if (error_code != IMAGE_UTIL_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-    error_code = image_util_decode_set_output_buffer(imageDecoder, &dataBuffer);
+    error_code = image_util_decode_run2(imageDecoder, &decodedImage);
     if (error_code != IMAGE_UTIL_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-    error_code = image_util_decode_run(imageDecoder, &width, &height, &bufferSize);
+    error_code = image_util_get_image(decodedImage, &width, &height, NULL, &dataBuffer, &bufferSize);
     if (error_code != IMAGE_UTIL_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
@@ -197,8 +200,10 @@ To recognize images:
     if (error_code != MEDIA_VISION_ERROR_NONE)
         dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-    free(dataBuffer);
-    dataBuffer = NULL;
+    error_code = image_util_destroy_image(decodedImage);
+    if (error_code != IMAGE_UTIL_ERROR_NONE)
+        dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
+    decodedImage = NULL;
 
     error_code = mv_image_recognize(imagedata.g_source, &imagedata.g_image_object, 1,
                                     imagedata.g_engine_config, _on_image_recognized_cb, NULL);

--- a/docs/application/native/guides/multimedia/pose-detection.md
+++ b/docs/application/native/guides/multimedia/pose-detection.md
@@ -142,10 +142,11 @@ To detect human pose from an image, follow the steps below:
    ```c
    /* For details, see the Image Util API Reference */
    unsigned char *dataBuffer = NULL;
-   unsigned long long bufferSize = 0;
-   unsigned long width = 0;
-   unsigned long height = 0;
+   size_t bufferSize = 0;
+   unsigned int width = 0;
+   unsigned int height = 0;
    image_util_decode_h imageDecoder = NULL;
+   image_util_image_h decodedImage = NULL;
 
    error_code = image_util_decode_create(&imageDecoder);
    if (error_code != IMAGE_UTIL_ERROR_NONE)
@@ -159,11 +160,11 @@ To detect human pose from an image, follow the steps below:
    if (error_code != IMAGE_UTIL_ERROR_NONE)
        dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-   error_code = image_util_decode_set_output_buffer(imageDecoder, &dataBuffer);
+   error_code = image_util_decode_run2(imageDecoder, &decodedImage);
    if (error_code != IMAGE_UTIL_ERROR_NONE)
        dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-   error_code = image_util_decode_run(imageDecoder, &width, &height, &bufferSize);
+   error_code = image_util_get_image(decodedImage, &width, &height, NULL, &dataBuffer, &bufferSize);
    if (error_code != IMAGE_UTIL_ERROR_NONE)
        dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
@@ -173,12 +174,14 @@ To detect human pose from an image, follow the steps below:
 
    /* Fill the dataBuffer to g_source */
    error_code = mv_source_fill_by_buffer(imagedata.g_source, dataBuffer, (unsigned int)bufferSize,
-                                         (unsigned int)width, (unsigned int)height, MEDIA_VISION_COLORSPACE_RGB888);
+                                         width, height, MEDIA_VISION_COLORSPACE_RGB888);
    if (error_code != MEDIA_VISION_ERROR_NONE)
        dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
 
-   free(dataBuffer);
-   dataBuffer = NULL;
+   error_code = image_util_destroy_image(decodedImage);
+   if (error_code != IMAGE_UTIL_ERROR_NONE)
+       dlog_print(DLOG_ERROR, LOG_TAG, "error code = %d", error_code);
+   decodedImage = NULL;
    ```
 3. To detect landmark of the pose from the `sample.jpg` image, create a `g_inference` media vision inference handle:
 


### PR DESCRIPTION
Some guides are using old APIs for decoding an image. It has been deprecated since Tizen 5.5.
So I modify the parts that use deprecated APIs.

Deprecated APIs
-  [image_util_decode_set_output_buffer](https://docs.tizen.org/application/native/api/iot-headed/5.5/group__CAPI__MEDIA__IMAGE__UTIL__ENCODE__DECODE__MODULE.html#gac5be85e5c3176c61ed0a16562f21cf3b)
- [image_util_decode_run](https://docs.tizen.org/application/native/api/iot-headed/5.5/group__CAPI__MEDIA__IMAGE__UTIL__ENCODE__DECODE__MODULE.html#gaa04997e8a94ae9c5c2d20b32fb6945cd)