### PR TITLE
.NET application site fix (Part - 5)

### DIFF
--- a/docs/application/dotnet/guides/app-management/app-icons.md
+++ b/docs/application/dotnet/guides/app-management/app-icons.md
@@ -62,7 +62,7 @@ To enable your application to use the application icon functionality, follow the
         ```
 
 <a name="create"></a>
-## Create and Remove a badge
+## Create and remove a badge
 
 To create and remove badges, follow these steps:
 

--- a/docs/application/dotnet/guides/app-management/app-icons.md
+++ b/docs/application/dotnet/guides/app-management/app-icons.md
@@ -3,13 +3,11 @@
 
 You can show the application icon as a shortcut on the home screen to allow the user to easily launch the application. In the device application list, you can show a badge with the application icon to provide additional information about the application state or notifications to the user.
 
-The main application icon features include:
+The main application icon features include the following:
 
 -   Creating and removing a badge
 
-    You can use badges in your application to inform the user about notifications and events. A badge is an image displayed on the application icon.
-
-    You can [create a badge for an application](#create) and remove it.
+    You can use badges in your application to inform the user about notifications and events. A badge is an image displayed on the application icon. You can [create a badge for an application](#create) and remove it.
 
 - Managing the badge
 
@@ -31,9 +29,9 @@ The main application icon features include:
 ## Prerequisites
 
 
-To enable your application to use the application icon functionality:
+To enable your application to use the application icon functionality, follow these steps:
 
--   To handle badges:
+-   To handle badges, follow the steps below:
     1.  To use the [Tizen.Applications.Badge](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.Badge.html) class, the application has to request permission by adding the following privilege to the `tizen-manifest.xml` file:
 
         ```XML
@@ -48,7 +46,7 @@ To enable your application to use the application icon functionality:
         using Tizen.Applications.Badge;
         ```
 
-- To handle shortcuts:
+- To handle shortcuts, follow the steps below:
     1.  To use the [Tizen.Applications.Shortcut](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.Shortcut.html) namespace, the application has to request permission by adding the following privilege to the `tizen-manifest.xml` file:
 
         ```XML
@@ -64,11 +62,11 @@ To enable your application to use the application icon functionality:
         ```
 
 <a name="create"></a>
-## Creating and Removing a Badge
+## Create and Remove a badge
 
-To create and remove badges:
+To create and remove badges, follow these steps:
 
--   To create a badge for an application, create an instance of the [Tizen.Applications.Badge](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.Badge.html) class. The parameter defines the application for which the badge is added. If the application is adding a badge for itself, the parameter can be null.
+-   To create a badge for an application, create an instance of the [Tizen.Applications.Badge](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.Badge.html) class. The parameter defines the application for which the badge is added. If the application is adding a badge for itself, the parameter can be null:
 
     ```csharp
     Badge badge = new Badge(appId);
@@ -79,20 +77,20 @@ To create and remove badges:
 
     If an application not signed with the same certificate must be allowed to [manage a badge](#manage), use the `Add()` method of the [Tizen.Applications.BadgeControl](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.BadgeControl.html) class with a writable application ID. The writable application ID enables another application to control your application to manage the badge. You can also configure your application to handle the badge itself.
 
-- To remove the badge from the application, call the `Remove()` method. The only parameter is the ID of the application whose badge is to be removed.
+- To remove the badge from the application, call the `Remove()` method. The only parameter is the ID of the application whose badge is to be removed:
 
     ```csharp
     BadgeControl.Remove(TEST_PKG);
     ```
 
 <a name="manage"></a>
-## Managing the Badge
+## Manage the badge
 
-To manage the badge:
+To manage the badge, follow these steps:
 
 -   Retrieve the badge count and visibility with the `Find()` method of the [Tizen.Applications.BadgeControl](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.BadgeControl.html) class. The values are stored in the `count` and `visible` properties of the [Tizen.Applications.Badge](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.Badge.html) class.
 
-    The badge count is displayed in the upper-right corner of the badge and the `count` property value must be an integer. The `visible` property value is of the `Bool` type.
+    The badge count is displayed in the upper-right corner of the badge and the `count` property value must be an integer. The `visible` property value is of the `Bool` type:
 
     ```csharp
     uint count;
@@ -117,16 +115,16 @@ To manage the badge:
     ```
 
 <a name="add"></a>
-## Adding a Shortcut
+## Add a shortcut
 
-To add a shortcut to the home screen:
+To add a shortcut to the home screen, follow these steps:
 
 1.  Define the shortcut details (such as its name, icon path, and whether duplicates are allowed) with the properties of the [Tizen.Applications.Shortcut.HomeShortcutInfo](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.Shortcut.HomeShortcutInfo.html) class.
 
-    You can create 2 types of shortcuts:
+    You can create 2 types of shortcuts, they are:
 
     -   If you set the `Uri` property, clicking the shortcut opens the URI.
-    -   If the `Uri` property is not set, clicking the shortcut launches the application that set the shortcut.
+    -   If the `Uri` property is not set, clicking the shortcut launches the application that set the shortcut:
 
     ```csharp
     HomeShortcutInfo shortcut = new HomeShortcutInfo
@@ -145,9 +143,9 @@ To add a shortcut to the home screen:
     ```
 
 <a name="add_widget"></a>
-## Adding a Widget
+## Add a widget
 
-To add a widget to the home screen:
+To add a widget to the home screen, follow these steps:
 
 1.  Before adding a widget to the home screen, a widget application must be prepared.
 2. Define the widget details (such as its ID, size, and period) with the properties of the [Tizen.Applications.Shortcut.WidgetShortcutInfo](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.Shortcut.WidgetShortcutInfo.html) class:
@@ -172,6 +170,6 @@ To add a widget to the home screen:
     ShortcutManager.Add(shortcut);
     ```
 
-## Related Information
+## Related information
   * Dependencies
     -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/app-management/app-manager.md
+++ b/docs/application/dotnet/guides/app-management/app-manager.md
@@ -3,7 +3,7 @@
 
 The application manager provides information about installed and running applications. It provides functions for obtaining the application name and absolute path to share files among all applications.
 
-The main features of the `Tizen.Applications.ApplicationManager` class include:
+The main features of the `Tizen.Applications.ApplicationManager` class include the following:
 
 -   Managing the application running context
 
@@ -22,7 +22,7 @@ Iterator methods are used to travel through a list of applications. The `GetRunn
 
 ## Prerequisites
 
-To enable your application to use the application management functionality:
+To enable your application to use the application management functionality, follow these steps:
 
 1.  To use the methods and properties of the [Tizen.Applications.ApplicationManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ApplicationManager.html), [Tizen.Applications.ApplicationRunningContext](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ApplicationRunningContext.html), and [Tizen.Applications.ApplicationInfo](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ApplicationInfo.html) classes, include the [Tizen.Applications](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.html) namespace in your application:
 
@@ -39,7 +39,7 @@ To enable your application to use the application management functionality:
     ```
 
 <a name="manage_context"></a>
-## Managing Application Running Context
+## Manage application running context
 
 To manage the context of the currently running application, follow these steps:
 
@@ -99,9 +99,9 @@ To get the context, create an instance of the [Tizen.Applications.ApplicationRun
         ```
 
 <a name="filter"></a>
-## Getting Information on Filtered Applications
+## Get information on filtered applications
 
-To get information on filtered applications:
+To get information on filtered applications, follow these steps:
 
 1.  Create the filter as an instance of the [Tizen.Applications.ApplicationInfoFilter](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ApplicationInfoFilter.html) class:
 
@@ -136,7 +136,7 @@ To get information on filtered applications:
     ```
 
 <a name="manage_current"></a>
-## Getting Information on Current Application
+## Get information on current application
 
 To get information on the current application, follow these steps:
 
@@ -166,6 +166,6 @@ To get information on the current application, follow these steps:
         ```
 
 
-## Related Information
+## Related information
   - Dependencies
     -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/app-management/application-launcher.md
+++ b/docs/application/dotnet/guides/app-management/application-launcher.md
@@ -108,7 +108,7 @@ The following steps illustrate how to implement the simple application launcher 
     - Set `AppId` and `OriginSize`.
     - Create view components: `Label` which is used to show an application name and `Icon` which load resource from `path` string and show loaded image.
     - Create `Layout` of the `ApplicationIcon`. In this case, the vertical linear layout is used.
-    - Setup the `TouchEvent` handler:
+    - Setup the `TouchEvent` handler.
 
 
     ```csharp

--- a/docs/application/dotnet/guides/app-management/application-launcher.md
+++ b/docs/application/dotnet/guides/app-management/application-launcher.md
@@ -3,8 +3,8 @@
 This guide explains how to create a basic application launcher. The application launcher is the main application that normally starts after the system boots. This app is commonly replaced in the platform adjustment process. It is easy to use the .NET APIs in the application launcher implementation.
 
 Every application launcher must be able to do the following tasks:
- - List installed and runnable applications.
- - Run selected application by the user.
+ - List installed and runnable applications
+ - Run applications selected by the user
 
 You can also implement advanced functionalities such as the following:
  - Grouping installed applications into folders.

--- a/docs/application/dotnet/guides/app-management/application-launcher.md
+++ b/docs/application/dotnet/guides/app-management/application-launcher.md
@@ -1,6 +1,6 @@
 # Application Launcher
 
-This guide explains how to create a basic application launcher. The application launcher is the main application that normally starts after system boot. This app is commonly replaced in the platform adjustment process. It is easy to use the .NET APIs in the application launcher implementation.
+This guide explains how to create a basic application launcher. The application launcher is the main application that normally starts after the system boots. This app is commonly replaced in the platform adjustment process. It is easy to use the .NET APIs in the application launcher implementation.
 
 Every application launcher must be able to do the following tasks:
  - List installed and runnable applications.
@@ -105,7 +105,7 @@ The following steps illustrate how to implement the simple application launcher 
     ```
 
 5. The `ApplicationIcon` constructor is responsible for the following:
-    - Set `AppId` and `OriginSize`
+    - Set `AppId` and `OriginSize`.
     - Create view components: `Label` which is used to show an application name and `Icon` which load resource from `path` string and show loaded image.
     - Create `Layout` of the `ApplicationIcon`. In this case, the vertical linear layout is used.
     - Setup the `TouchEvent` handler:

--- a/docs/application/dotnet/guides/app-management/application-launcher.md
+++ b/docs/application/dotnet/guides/app-management/application-launcher.md
@@ -7,11 +7,11 @@ Every application launcher must be able to do the following tasks:
  - Run applications selected by the user
 
 You can also implement advanced functionalities such as the following:
- - Grouping installed applications into folders.
- - Removing applications.
- - Rearrangement of icons.
- - Viewing notifications.
- - Viewing widgets.
+ - Grouping installed applications into folders
+ - Removing applications
+ - Rearrangement of icons
+ - Viewing notifications
+ - Viewing widgets
 
 ## Prerequisites
 

--- a/docs/application/dotnet/guides/app-management/application-launcher.md
+++ b/docs/application/dotnet/guides/app-management/application-launcher.md
@@ -6,7 +6,7 @@ Every application launcher must be able to do the following tasks:
  - List installed and runnable applications.
  - Run selected application by the user.
 
-You can also implement advanced functionalities such as:
+You can also implement advanced functionalities such as the following:
  - Grouping installed applications into folders.
  - Removing applications.
  - Rearrangement of icons.
@@ -28,7 +28,7 @@ To list the installed applications and launch them, the launcher app must have d
   </privileges>
 ```
 
-## Managing app launcher
+## Manage app launcher
 
 The following steps illustrate how to implement the simple application launcher using:
  - [NUI](/application/dotnet/api/TizenFX/latest/api/Tizen.NUI.html) for the view implementation
@@ -39,7 +39,7 @@ The following steps illustrate how to implement the simple application launcher 
 
 ![Application launcher](./media/application_launcher_animation.gif)
 
-1. To use mentioned API's following namespaces have to be included:
+1. To use mentioned API's, the following namespaces have to be included:
 
     ```csharp
     using System;
@@ -51,7 +51,7 @@ The following steps illustrate how to implement the simple application launcher 
     using Tizen.NUI.BaseComponents;
     ```
 
-2. To group application launcher responsibilities, three classes in the `NUIApplicationLauncher` namespace are defined which represents the main application structure:
+2. To group application launcher responsibilities, three classes in the `NUIApplicationLauncher` namespace are defined which represent the main application structure:
 
     ```csharp
     namespace NUIApplicationLauncher
@@ -76,7 +76,7 @@ The following steps illustrate how to implement the simple application launcher 
     }
     ```
 
-3. To add an application id field, create the event arguments derived class. The application id is used by `AppControl` to launch the application:
+3. To add an application ID field, create the event arguments derived class. The application ID is used by `AppControl` to launch the application:
 
     ```csharp
     partial class ApplicationIconClickedEventArgs : EventArgs
@@ -90,7 +90,7 @@ The following steps illustrate how to implement the simple application launcher 
     }
     ```
 
-4. The `ApplicationIcon` class stores  the application id. The `Icon` component and `OriginSize` are used to resize `Icon` when it is in the pressed state. The `ApplicationIconClicked` is invoked when touch changes its state to finished:
+4. The `ApplicationIcon` class stores  the application ID. The `Icon` component and `OriginSize` are used to resize `Icon` when it is in the pressed state. The `ApplicationIconClicked` is invoked when touch changes its state to finished:
 
     ```csharp
     class ApplicationIcon : View
@@ -148,7 +148,7 @@ The following steps illustrate how to implement the simple application launcher 
     }
     ```
 
-    **Figure: Application Icons**
+    **Figure: Application icons**
 
     ![Application Icons](./media/application_launcher_icons.png)
 

--- a/docs/application/dotnet/guides/app-management/application-preference.md
+++ b/docs/application/dotnet/guides/app-management/application-preference.md
@@ -56,14 +56,14 @@ To remove all records, use the following function:
 
 ## Manage application preferences
 
-Following code snippet shows how to store counter value, when application is closed using [Tizen.Applications.Preference](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.Preference.html) module.
+The following code snippet shows how to store counter value when the application is closed using [Tizen.Applications.Preference](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.Preference.html) module.
 
 **Figure: Preference Application Screenshot**
 
 ![Screenshot](./media/preferences.png)
 
 The clicked counter is stored as a pair of key-value data. When the application starts it tries to read this value and inserts it in the label component.
-To use NUI components and Preference module following namespaces are included:
+To use NUI components and Preference module, the following namespaces are included:
 
 ```csharp
 using System;
@@ -75,7 +75,7 @@ using Tizen.NUI.Components;
 using Tizen.Applications;
 ```
 
-The `ClickedPreferenceKey` key is used to store counter value. Declared as a class member to use it in button callbacks. Also, the `TextLabel` has to be a class member to show and update the counter value:
+The `ClickedPreferenceKey` key is used to store counter value. It has to be declared as a class member for it to be used in button callbacks. Also, the `TextLabel` has to be a class member to show and update the counter value:
 
 ```csharp
 namespace NUIPreference

--- a/docs/application/dotnet/guides/app-management/application-preference.md
+++ b/docs/application/dotnet/guides/app-management/application-preference.md
@@ -1,6 +1,6 @@
 # Application Preferences
 
-Many applications require to save data in the persistent memory and read them in the next session in a safe way. Saved data can be sensitive, so in many cases access to the saved preference should be restricted. Preference API allows you to share stored preference data among applications in the same package.
+Many applications are required to save data in the persistent memory and read them in the next session in a safe way. Saved data can be sensitive, so in many cases access to the saved preference should be restricted. Preference API allows you to share stored preference data among applications in the same package.
 
 ## Store and retrieve records
 

--- a/docs/application/dotnet/guides/app-management/application-preference.md
+++ b/docs/application/dotnet/guides/app-management/application-preference.md
@@ -6,7 +6,7 @@ Many applications require to save data in the persistent memory and read them in
 
 To store a variable, you must create a key-value pair. Use the following function to create a preference for a specific simple type: `Preference.Set(string key, value)`.
 
-Before storing or retrieving a variable, check whether it exists using the `Preference.Contains(string key)` function. Use the following function to retrieve a stored variable: `Preference.Get<T>()`.
+Before storing or retrieving a variable, check whether it exists using the `Preference.Contains(string key)` function. Use the following function to retrieve a stored variable: `Preference.Get<T>()`:
 
   ```csharp
   //set/get integer value
@@ -25,7 +25,7 @@ To store and retrieve string variables, use the following functions:
 
 ## List records 
 
-To list all records, use `Keys` collection: `Preference.Keys()`
+To list all records, use `Keys` collection `Preference.Keys()`:
 
   ```csharp
     Preference.Set("Option_enabled", true);
@@ -42,7 +42,7 @@ To list all records, use `Keys` collection: `Preference.Keys()`
 
 ## Remove records
 
-To safely remove records, use: `Preference.Remove(string key)`;
+To safely remove records, use `Preference.Remove(string key)`:
 
 ```csharp
     if (Preference.Contains("key"))
@@ -51,10 +51,10 @@ To safely remove records, use: `Preference.Remove(string key)`;
     }
 ```
 
-To remove all records, use:
+To remove all records, use the following function:
   - `Preference.RemoveAll()`
 
-## Managing application preferences
+## Manage application preferences
 
 Following code snippet shows how to store counter value, when application is closed using [Tizen.Applications.Preference](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.Preference.html) module.
 
@@ -62,7 +62,7 @@ Following code snippet shows how to store counter value, when application is clo
 
 ![Screenshot](./media/preferences.png)
 
-Clicked counter is stored as a pair of key - value data. When the application starts it tries to read this value and inserts it in the label component.
+The clicked counter is stored as a pair of key-value data. When the application starts it tries to read this value and inserts it in the label component.
 To use NUI components and Preference module following namespaces are included:
 
 ```csharp
@@ -75,7 +75,7 @@ using Tizen.NUI.Components;
 using Tizen.Applications;
 ```
 
-The `ClickedPreferenceKey` key is used to store counter value. Declared as a class member to use it in buttons callbacks. Also the `TextLabel` have to be a class member to show and update counter value:
+The `ClickedPreferenceKey` key is used to store counter value. Declared as a class member to use it in button callbacks. Also, the `TextLabel` has to be a class member to show and update the counter value:
 
 ```csharp
 namespace NUIPreference
@@ -94,7 +94,7 @@ namespace NUIPreference
 }
 ```
 
-The `OnCreate()` handler tries to read value from the `Preference` module. Try / Catch block is useful when `ClickedPreferenceKey` is not set previously:
+The `OnCreate()` handler tries to read value from the `Preference` module. Try/Catch block is useful when `ClickedPreferenceKey` is not set previously:
 
 ```csharp
 protected override void OnCreate()
@@ -112,7 +112,7 @@ protected override void OnCreate()
 }
 ```
 
-In `OnTerminate()` method you can save key - value pairs:
+In `OnTerminate()` method you can save key-value pairs:
 
 ```csharp
 protected override void OnTerminate()
@@ -125,7 +125,7 @@ protected override void OnTerminate()
 The `CreateButtons()` method is a helper function. It is responsible for the following:
 - Creating buttons layout,
 - Creating buttons,
-- Setup callbacks.
+- Setup callbacks:
 
 ```csharp
 private View CreateButtons()

--- a/docs/application/dotnet/guides/app-management/cion.md
+++ b/docs/application/dotnet/guides/app-management/cion.md
@@ -2,15 +2,15 @@
 
 The Cion API provides functionality to communicate with other devices.
 
-The main features of the `Tizen.Applications.Cion` class include:
+The main features of the `Tizen.Applications.Cion` class includes the following:
 
-- Communicating with other applications in server-client style.
+-   Communicating with other applications in server-client style.
 
-  You can communicate with other applications in [server-client](#server_client) style.
+    You can communicate with other applications in [server-client](#server_client) style.
 
-- Communicating with other applications in group style.
+-   Communicating with other applications in group style.
 
-  You can communicate with other applications in [group](#group) style.
+    You can communicate with other applications in [group](#group) style.
 
 And, you can generate communication code using [TIDL](#tidl).
 
@@ -157,7 +157,7 @@ To communicate with the server, use the [Tizen.Applications.Cion.ClientBase](/ap
     ```
 
 The Cion server can listen to the request from the client; If a connection request comes from the client, the server can accept it.
-After connection is accepted, the server can receive data and payload.
+After the connection is accepted, the server can receive data and payload.
 
 To communicate with the client, use the [Tizen.Applications.Cion.ServerBase](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.Cion.ServerBase.html) class as follows:
 

--- a/docs/application/dotnet/guides/app-management/cion.md
+++ b/docs/application/dotnet/guides/app-management/cion.md
@@ -12,7 +12,7 @@ The main features of the `Tizen.Applications.Cion` class includes the following:
 
     You can communicate with other applications in [group](#group) style.
 
-And, you can generate communication code using [TIDL](#tidl).
+And, you can also generate communication code using [TIDL](#tidl).
 
 ## Prerequisites
 

--- a/docs/application/dotnet/guides/app-management/component-manager.md
+++ b/docs/application/dotnet/guides/app-management/component-manager.md
@@ -1,6 +1,6 @@
 # Component Manager
 
-Component manager provides information about installed and running components.
+The Component manager provides information about installed and running components.
 
 The main features of the `Tizen.Applications.ComponentBased.ComponentManager` class includes the following:
 
@@ -85,7 +85,7 @@ To get the running component context and its details, and to operate on the cont
 
 To get the installed information and its details, and to operate on the information, follow these steps:
 
-1.  Get the information of the currently-installed component by creating an instance of the [Tizen.Applications.ComponentBased.ComponentInfo](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ComponentBased.ComponentInfo.html) class, with the ID of information obtained component as a parameter.
+1.  Get the information of the currently-installed component by creating an instance of the [Tizen.Applications.ComponentBased.ComponentInfo](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ComponentBased.ComponentInfo.html) class, with the ID information obtained from a component as a parameter.
 
     To get a component's information, the component must be installed:
 

--- a/docs/application/dotnet/guides/app-management/component-manager.md
+++ b/docs/application/dotnet/guides/app-management/component-manager.md
@@ -2,7 +2,7 @@
 
 Component manager provides information about installed and running components.
 
-The main features of the `Tizen.Applications.ComponentBased.ComponentManager` class include:
+The main features of the `Tizen.Applications.ComponentBased.ComponentManager` class includes the following:
 
 -   Managing running component context
 
@@ -16,7 +16,7 @@ Iterator methods are used to travel through a list of components. The `GetRunnin
 
 ## Prerequisites
 
-To enable your application to use the component management functionality:
+To enable your application to use the component management functionality, follow these steps:
 
 1.  To use classes and methods, the application has to request permission by adding the following privilege to the `tizen-manifest.xml` file:
 
@@ -34,13 +34,13 @@ To enable your application to use the component management functionality:
     ```
 
 <a name="manage_context"></a>
-## Managing Running Component Context
+## Manage running component context
 
-To get the running component context and its details, and to operate on the context:
+To get the running component context and its details, and to operate on the context, follow these steps:
 
 1.  Get the context of the currently running component by creating an instance of the [Tizen.Applications.ComponentBased.ComponentRunningContext](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ComponentBased.ComponentRunningContext.html) class, with the ID of the context obtained component as a parameter.
 
-    To get a component's context, the component must be running.
+    To get a component's context, the component must be running:
 
     ```csharp
     ComponentRunningContext compoRunningContext = new ComponentRunningContext(Your Component ID);
@@ -81,13 +81,13 @@ To get the running component context and its details, and to operate on the cont
         ```
 
 <a name="filter"></a>
-## Managing Component Information
+## Manage component information
 
-To get the installed information and its details, and to operate on the information:
+To get the installed information and its details, and to operate on the information, follow these steps:
 
 1.  Get the information of the currently-installed component by creating an instance of the [Tizen.Applications.ComponentBased.ComponentInfo](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ComponentBased.ComponentInfo.html) class, with the ID of information obtained component as a parameter.
 
-    To get a component's information, the component must be installed.
+    To get a component's information, the component must be installed:
 
     ```csharp
     ComponentInfo compoInfo = new ComponentInfo(Your Component ID);
@@ -136,6 +136,6 @@ To get the installed information and its details, and to operate on the informat
     ```
 
 
-## Related Information
+## Related information
   * Dependencies
     -   Tizen 5.5 and Higher

--- a/docs/application/dotnet/guides/app-management/component-manager.md
+++ b/docs/application/dotnet/guides/app-management/component-manager.md
@@ -1,6 +1,6 @@
 # Component Manager
 
-The Component manager provides information about installed and running components.
+The component manager provides information about installed and running components.
 
 The main features of the `Tizen.Applications.ComponentBased.ComponentManager` class includes the following:
 

--- a/docs/application/dotnet/guides/app-management/component-port.md
+++ b/docs/application/dotnet/guides/app-management/component-port.md
@@ -2,30 +2,31 @@
 
 Tizen components of the component-based applications can communicate with each other using component ports. Components can send and receive serializable objects through component port communication.
 
-The main feature of the `Tizen.Applications.ComponentBased.ComponentPort` class include:
-- Managing component port
+The main feature of the `Tizen.Applications.ComponentBased.ComponentPort` class includes the following:
 
-  You can set up the component ports to [send and receive requests](#port) between components of component-based application with the `Tizen.Applications.ComponentBased.ComponentPort` class.
+-   Managing component port
 
-- Using component task
+    You can set up the component ports to [send and receive requests](#port) between components of component-based applications with the `Tizen.Applications.ComponentBased.ComponentPort` class.
 
-  You can set up the component tasks to [run tasks](#task) and wait for events from other components with the `Tizen.Applications.ComponentBased.ComponentTask` class.
+-   Using component task
+
+    You can set up the component tasks to [run tasks](#task) and wait for events from other components with the `Tizen.Applications.ComponentBased.ComponentTask` class.
 
 ## Prerequisites
 
-To enable your component to use the component port functionality:
+To enable your component to use the component port functionality, follow these steps:
 
 1.  You need two components to communicate with each other through the component port.
-2.  To use the methods and properties of the [Tizen.Applications.ComponentBased.ComponentPort](https://samsung.github.io/TizenFX/API9/api/Tizen.Applications.ComponentBased.ComponentPort.html) and [Tizen.Applications.ComponentBased.ComponentTask](https://samsung.github.io/TizenFX/API9/api/Tizen.Applications.ComponentBased.ComponentPort.html) classes, include the [Tizen.Applications.ComponentBased](https://samsung.github.io/TizenFX/API9/api/Tizen.Applications.ComponentBased.html) namespace in your component:
+2.  To use the methods and properties of the [Tizen.Applications.ComponentBased.ComponentPort](https://samsung.github.io/TizenFX/API9/api/Tizen.Applications.ComponentBased.ComponentPort.html){:target="_blank"} and [Tizen.Applications.ComponentBased.ComponentTask](https://samsung.github.io/TizenFX/API9/api/Tizen.Applications.ComponentBased.ComponentPort.html){:target="_blank"} classes, include the [Tizen.Applications.ComponentBased](https://samsung.github.io/TizenFX/API9/api/Tizen.Applications.ComponentBased.html){:target="_blank"} namespace in your component:
 
     ```csharp
     using Tizen.Applications.ComponentBased;
     ```
 
-<a name="local"></a>
-## Managing component port
+<a name="port"></a>
+## Manage component port
 
-To send a request from one component `ClientService.Tizen` to another `ServerService.Tizen` component, use the [Tizen.Applications.ComponentBased.ComponentPort](https://samsung.github.io/TizenFX/API9/api/Tizen.Applications.ComponentBased.ComponentPort.html) class as follows:
+To send a request from one component `ClientService.Tizen` to another `ServerService.Tizen` component, use the [Tizen.Applications.ComponentBased.ComponentPort](https://samsung.github.io/TizenFX/API9/api/Tizen.Applications.ComponentBased.ComponentPort.html){:target="_blank"} class as follows:
 
 1.  Create a component port instance for sending component `ClientService.Tizen` as follows:
 
@@ -239,7 +240,7 @@ To send a request from one component `ClientService.Tizen` to another `ServerSer
     }
     ```
 
-3.  Set up the receiving thread of the component.
+3.  Set up the receiving thread of the component by following these steps:
 
     1. To have the receiving thread of the component wait for incoming requests, call `WaitForEvent()` of the `Tizen.Applications.ComponentBased.ComponentPort` class.
     2. If `WaitForEvent()` is called in the main thread, then `WaitForEvent()` can not be called until the `Cancel()` is called.
@@ -329,9 +330,9 @@ To send a request from one component `ClientService.Tizen` to another `ServerSer
         ```
 
 <a name="task"></a>
-## Using component task
+## Use component task
 
-Using [Tizen.Applications.ComponentBased.ComponentTask](https://samsung.github.io/TizenFX/API9/api/Tizen.Applications.ComponentBased.ComponentTask.html) class, a component can run a task to wait for events from other component properly.
+Using [Tizen.Applications.ComponentBased.ComponentTask](https://samsung.github.io/TizenFX/API9/api/Tizen.Applications.ComponentBased.ComponentTask.html){:target="_blank"} class, a component can run a task to wait for events from other component properly.
 
 1. Create a component task instance for receiving component `ServerService.Tizen` as follows:
     ```csharp

--- a/docs/application/dotnet/guides/app-management/component-port.md
+++ b/docs/application/dotnet/guides/app-management/component-port.md
@@ -332,7 +332,7 @@ To send a request from one component `ClientService.Tizen` to another `ServerSer
 <a name="task"></a>
 ## Use component task
 
-Using [Tizen.Applications.ComponentBased.ComponentTask](https://samsung.github.io/TizenFX/API9/api/Tizen.Applications.ComponentBased.ComponentTask.html){:target="_blank"} class, a component can run a task to wait for events from other component properly.
+Using [Tizen.Applications.ComponentBased.ComponentTask](https://samsung.github.io/TizenFX/API9/api/Tizen.Applications.ComponentBased.ComponentTask.html){:target="_blank"} class, a component can run a task to wait for events from other components properly.
 
 1. Create a component task instance for receiving component `ServerService.Tizen` as follows:
     ```csharp

--- a/docs/application/dotnet/guides/app-management/component-port.md
+++ b/docs/application/dotnet/guides/app-management/component-port.md
@@ -17,7 +17,7 @@ The main feature of the `Tizen.Applications.ComponentBased.ComponentPort` class 
 To enable your component to use the component port functionality, follow these steps:
 
 1.  You need two components to communicate with each other through the component port.
-2.  To use the methods and properties of the [Tizen.Applications.ComponentBased.ComponentPort](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ComponentBased.ComponentPort.html) and [Tizen.Applications.ComponentBased.ComponentTask](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ComponentBased.ComponentPort.html) classes, include the [Tizen.Applications.ComponentBased](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ComponentBased.html) namespace in your component:
+2.  To use the methods and properties of the [Tizen.Applications.ComponentBased.ComponentPort](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ComponentBased.ComponentPort.html) and [Tizen.Applications.ComponentBased.ComponentTask](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ComponentBased.ComponentTask.html) classes, include the [Tizen.Applications.ComponentBased](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ComponentBased.html) namespace in your component:
 
     ```csharp
     using Tizen.Applications.ComponentBased;

--- a/docs/application/dotnet/guides/app-management/component-port.md
+++ b/docs/application/dotnet/guides/app-management/component-port.md
@@ -17,7 +17,7 @@ The main feature of the `Tizen.Applications.ComponentBased.ComponentPort` class 
 To enable your component to use the component port functionality, follow these steps:
 
 1.  You need two components to communicate with each other through the component port.
-2.  To use the methods and properties of the [Tizen.Applications.ComponentBased.ComponentPort](https://samsung.github.io/TizenFX/API9/api/Tizen.Applications.ComponentBased.ComponentPort.html){:target="_blank"} and [Tizen.Applications.ComponentBased.ComponentTask](https://samsung.github.io/TizenFX/API9/api/Tizen.Applications.ComponentBased.ComponentPort.html){:target="_blank"} classes, include the [Tizen.Applications.ComponentBased](https://samsung.github.io/TizenFX/API9/api/Tizen.Applications.ComponentBased.html){:target="_blank"} namespace in your component:
+2.  To use the methods and properties of the [Tizen.Applications.ComponentBased.ComponentPort](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ComponentBased.ComponentPort.html) and [Tizen.Applications.ComponentBased.ComponentTask](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ComponentBased.ComponentPort.html) classes, include the [Tizen.Applications.ComponentBased](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ComponentBased.html) namespace in your component:
 
     ```csharp
     using Tizen.Applications.ComponentBased;
@@ -26,7 +26,7 @@ To enable your component to use the component port functionality, follow these s
 <a name="port"></a>
 ## Manage component port
 
-To send a request from one component `ClientService.Tizen` to another `ServerService.Tizen` component, use the [Tizen.Applications.ComponentBased.ComponentPort](https://samsung.github.io/TizenFX/API9/api/Tizen.Applications.ComponentBased.ComponentPort.html){:target="_blank"} class as follows:
+To send a request from one component `ClientService.Tizen` to another `ServerService.Tizen` component, use the [Tizen.Applications.ComponentBased.ComponentPort](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ComponentBased.ComponentPort.html) class as follows:
 
 1.  Create a component port instance for sending component `ClientService.Tizen` as follows:
 
@@ -332,7 +332,7 @@ To send a request from one component `ClientService.Tizen` to another `ServerSer
 <a name="task"></a>
 ## Use component task
 
-Using [Tizen.Applications.ComponentBased.ComponentTask](https://samsung.github.io/TizenFX/API9/api/Tizen.Applications.ComponentBased.ComponentTask.html){:target="_blank"} class, a component can run a task to wait for events from other components properly.
+Using [Tizen.Applications.ComponentBased.ComponentTask](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ComponentBased.ComponentTask.html) class, a component can run a task to wait for events from other components properly.
 
 1. Create a component task instance for receiving component `ServerService.Tizen` as follows:
     ```csharp

--- a/docs/application/dotnet/guides/app-management/package-manager.md
+++ b/docs/application/dotnet/guides/app-management/package-manager.md
@@ -3,7 +3,7 @@
 
 The package manager is used to retrieve detailed information on the installed packages on the device. This information includes the package name, label, path to the icon image, version, type, and installed storage.
 
-The main features of the `Tizen.Applications.PackageManager` class include:
+The main features of the `Tizen.Applications.PackageManager` class includes the following:
 
 -   Retrieving information for all installed packages
 
@@ -19,7 +19,7 @@ The main features of the `Tizen.Applications.PackageManager` class include:
 
 ## Prerequisites
 
-To enable your application to use the package management functionality:
+To enable your application to use the package management functionality, follow these steps:
 
 1.  To use the [Tizen.Applications.PackageManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.PackageManager.html) class, the application has to request permission by adding the following privilege to the `tizen-manifest.xml` file:
 
@@ -36,9 +36,9 @@ To enable your application to use the package management functionality:
     ```
 
 <a name="retrieve"></a>
-## Retrieving All Package Information
+## Retrieve all package information
 
-To retrieve all package information for installed packages:
+To retrieve all package information for installed packages, follow these steps:
 
 1.  Retrieve all package information with the `GetPackages()` method of the [Tizen.Applications.PackageManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.PackageManager.html) class:
 
@@ -64,9 +64,9 @@ To retrieve all package information for installed packages:
     ```
 
 <a name="info"></a>
-## Retrieving Specific Package Information
+## Retrieve specific package information
 
-To get specific package information:
+To get specific package information, follow these steps:
 
 1.  Retrieve information for a specific package with the `GetPackage()` method of the [Tizen.Applications.PackageManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.PackageManager.html) class:
 
@@ -90,9 +90,9 @@ To get specific package information:
     ```
 
 <a name="listen"></a>
-## Monitoring Package Events
+## Monitor package events
 
-To detect package-related events, such as installation, uninstallation, and updates:
+To detect package-related events, such as installation, uninstallation, and updates, follow the steps below:
 
 1.  Register event handlers for various events of the [Tizen.Applications.PackageManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.PackageManager.html) class.
 
@@ -118,6 +118,6 @@ To detect package-related events, such as installation, uninstallation, and upda
     }
     ```
 
-## Related Information
+## Related information
   * Dependencies
     -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/app-management/widget-control.md
+++ b/docs/application/dotnet/guides/app-management/widget-control.md
@@ -114,7 +114,7 @@ To communicate with the running widget instances, follow these steps:
         ```
 
 2.  Operate on the instances:
-    -   Get details of running widget instances and send an update to widget application:
+    -   Get details of running widget instances and send an update to the widget application:
 
         ```csharp
         foreach (WidgetControl.Instance ins in instances) {

--- a/docs/application/dotnet/guides/app-management/widget-control.md
+++ b/docs/application/dotnet/guides/app-management/widget-control.md
@@ -19,7 +19,7 @@ The main features of the `Tizen.Applications.WidgetControl` class includes the f
 
 -   [Listening to widget lifecycle events on widget applications](#listening_events)
 
-    For running widget applications, you can listen widget to application lifecycle events.
+    For running widget applications, you can listen to widget application lifecycle events.
 
 -   [Communicating with running widget instances](#communicating_instances)
 
@@ -66,7 +66,7 @@ IEnumerable<WidgetControl.Scale> scales = control.GetScales();
 <a name="listening_events"></a>
 ## Listen to widget lifecycle events on widget applications
 
-Add lifecycle listeners on the control to listen to the widget lifecycle events:
+Add lifecycle listeners on the control to listen to widget lifecycle events:
 
 ```csharp
 private static void OnCreated(object sender, Tizen.Applications.WidgetLifecycleEventArgs args)

--- a/docs/application/dotnet/guides/app-management/widget-control.md
+++ b/docs/application/dotnet/guides/app-management/widget-control.md
@@ -5,21 +5,21 @@ The widget control provides information about installing and running widget appl
 It also provides functions for the following:
 
 -   Sending update requests to the widget applications
--   Retrieving details of running instance for the same package widget applications
+-   Retrieving details of running instances for the same package widget applications
 
-The main features of the `Tizen.Applications.WidgetControl` class include:
+The main features of the `Tizen.Applications.WidgetControl` class includes the following:
 
 -   [Creating a widget control](#create_instance)
 
-    For using the widget control features, you can create widget control instance with specific widget ID.
+    For using the widget control features, you can create a widget control instance with a specific widget ID.
 
 -   [Getting information on widget applications](#getting_information)
 
-    For the widget applications that is installed but not running, you can retrieve widget information.
+    For the widget applications that are installed but not running, you can retrieve widget information.
 
--   [Listening widget lifecycle events on widget applications](#listening_events)
+-   [Listening to widget lifecycle events on widget applications](#listening_events)
 
-    For running widget applications, you can listen widget application lifecycle events.
+    For running widget applications, you can listen widget to application lifecycle events.
 
 -   [Communicating with running widget instances](#communicating_instances)
 
@@ -27,7 +27,7 @@ The main features of the `Tizen.Applications.WidgetControl` class include:
 
 ## Prerequisites
 
-To enable your application to use the widget control functionality:
+To enable your application to use the widget control functionality, follow these steps:
 
 1.  To use the methods and properties of the [Tizen.Applications.WidgetControl](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.WidgetControl.html) class, include the [Tizen.Applications](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.html) namespace in your application:
 
@@ -44,7 +44,7 @@ To enable your application to use the widget control functionality:
     ```
 
 <a name="create_instance"></a>
-## Creating a widget control
+## Create a widget control
 
 Create an instance of widget control with an ID of the widget application using the [Tizen.Applications.WidgetControl](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.WidgetControl.html) class:
 
@@ -53,7 +53,7 @@ WidgetControl control = new WidgetControl(Your Widget ID);
 ```
 
 <a name="getting_information"></a>
-## Getting Information on Widget Applications
+## Get information on widget applications
 
 Get the main application ID, package ID, and available scale lists from the control:
 
@@ -64,7 +64,7 @@ IEnumerable<WidgetControl.Scale> scales = control.GetScales();
 ```
 
 <a name="listening_events"></a>
-## Listening Widget Lifecycle Events on Widget Applications
+## Listen to widget lifecycle events on widget applications
 
 Add lifecycle listeners on the control to listen to the widget lifecycle events:
 
@@ -102,7 +102,7 @@ IEnumerable<WidgetControl.Scale> scales = control.GetScales();
 ```
 
 <a name="communicating_instances"></a>
-## Communicating with Running Widget Instances
+## Communicate with running widget instances
 
 To communicate with the running widget instances, follow these steps:
 
@@ -129,6 +129,6 @@ To communicate with the running widget instances, follow these steps:
         }
         ```
 
-## Related Information
+## Related information
   - Dependencies
     -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/app-management/widget-viewer.md
+++ b/docs/application/dotnet/guides/app-management/widget-viewer.md
@@ -2,17 +2,17 @@
 
 [Widgets](../applications/uiapplication/widget-app.md) are commonly used in applications like home screen (launcher) or lock screen. **Widget** is a simple component based on NUI View designed to show a personalized set of information.
 
-**Figure: Widget Viewer**
+**Figure: Widget viewer**
 
 ![Widget Viewer](./media/widget_viewer.png)
 
-**NUI** Framework provides API to use and view widgets in your application. To read more about widget applications you can check the following topics:
+**NUI** framework provides API to use and view widgets in your application. To read more about widget applications you can check the following topics:
 - [Widget Application Guide](../applications/uiapplication/widget-app.md)
 - [Widget Management Guide](./widget-control.md)
 
-Platform applications preinstalled in the Tizen image provides few simple widgets such as `Gallery`, `Music Player`, and `Contacts`. To check installed widgets application in your Tizen image, you can use SDB tool and pkginfo command line interface.
+Platform applications preinstalled in the Tizen image provide few simple widgets such as `Gallery`, `Music Player`, and `Contacts`. To check installed widgets application in your Tizen image, you can use the SDB tool and pkginfo command line interface.
 
-To open device/emulator shell use the SDB tool: 
+To open the device/emulator shell use the SDB tool: 
 
 ```shell
 sdb shell
@@ -66,9 +66,9 @@ In this case, the `Initialize()` function called from the `OnCreate()` callback:
 - Creates the `widgetsList` View instance and:
     - Set its size using `WidthResizePolicy` and `HeightResizePolicy` to screen size.
     - Setup horizontal `Layout` with padding and margin.
-- Creates the `widgetViewManager` instance and register current application as a viewer for installed widgets using [Application ID](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ApplicationInfo.html)
+- Creates the `widgetViewManager` instance and registers current application as a viewer for installed widgets using the [application ID](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ApplicationInfo.html).
 - Creates instances of two widgets. The `galleryWidget` and `contactsWidget` are created using `widgetViewManager` object.
-- Inserts created widgets into created `widgetsList` and add `widgetsList` to the default layer of the application window.
+- Inserts created widgets into created `widgetsList` and add `widgetsList` to the default layer of the application window:
 
 ```csharp
     void Initialize()

--- a/docs/application/dotnet/guides/app-management/widget-viewer.md
+++ b/docs/application/dotnet/guides/app-management/widget-viewer.md
@@ -10,7 +10,7 @@
 - [Widget Application Guide](../applications/uiapplication/widget-app.md)
 - [Widget Management Guide](./widget-control.md)
 
-Platform applications preinstalled in the Tizen image provide few simple widgets such as `Gallery`, `Music Player`, and `Contacts`. To check installed widgets application in your Tizen image, you can use the SDB tool and pkginfo command line interface.
+Platform applications preinstalled in the Tizen image provide a few simple widgets such as `Gallery`, `Music Player`, and `Contacts`. To check installed widget applications in your Tizen image, you can use the SDB tool and pkginfo command line interface.
 
 To open the device/emulator shell use the SDB tool: 
 
@@ -65,7 +65,7 @@ In this case, the `Initialize()` function called from the `OnCreate()` callback:
 
 - Creates the `widgetsList` View instance and:
     - Set its size using `WidthResizePolicy` and `HeightResizePolicy` to screen size.
-    - Setup horizontal `Layout` with padding and margin.
+    - Set up horizontal `Layout` with padding and margin.
 - Creates the `widgetViewManager` instance and registers current application as a viewer for installed widgets using the [application ID](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ApplicationInfo.html).
 - Creates instances of two widgets. The `galleryWidget` and `contactsWidget` are created using `widgetViewManager` object.
 - Inserts created widgets into created `widgetsList` and add `widgetsList` to the default layer of the application window:


### PR DESCRIPTION
### Change Description ###

This is the fifth PR in the process of updating the .NET applications section of Tizen Docs site.

This PR includes the fix of the following topic 

1. **Application management**.

List of files on which changes were made:

- /application/dotnet/guides/app-management/app-icons/
- /application/dotnet/guides/app-management/app-manager/
- /application/dotnet/guides/app-management/application-launcher/
- /application/dotnet/guides/app-management/application-preference/
- /application/dotnet/guides/app-management/cion/
- /application/dotnet/guides/app-management/component-manager/
- /application/dotnet/guides/app-management/component-port/
- /application/dotnet/guides/app-management/package-manager/
- /application/dotnet/guides/app-management/widget-control/
- /application/dotnet/guides/app-management/widget-viewer/

Signed off by: omar.saeed@samsung.com