### PR TITLE
.NET application site fix (Part - 8)

### DIFF
--- a/docs/application/dotnet/guides/location/geofences.md
+++ b/docs/application/dotnet/guides/location/geofences.md
@@ -1,9 +1,9 @@
 # Geofences
 
 
-A geofence is a virtual perimeter for a real-world geographic area. A geofence is defined by either a geopoint and radius for geopoint geofences, or by a MAC address for Wi-Fi and Bluetooth geofences. The geofence feature alerts the user when the geofence state changes (the user crosses the perimeter).
+A geofence is a virtual perimeter for a real-world geographic area. A geofence is defined by either a geopoint and radius for geopoint geofences or by a MAC address for Wi-Fi and Bluetooth geofences. The geofence feature alerts the user when the geofence state changes (the user crosses the perimeter).
 
-The main features of the Tizen.Location.Geofence namespace include:
+The main features of the Tizen.Location.Geofence namespace includes the following:
 
 -   Using the geofence service
 
@@ -15,16 +15,16 @@ The main features of the Tizen.Location.Geofence namespace include:
 
 -   Managing the geofence service
 
-    You can allow the user to [manage the geofence places and fences](#settings) through My Places.
+    You can allow the user to [manage the geofence places and fences](#settings) through My Places application.
 
 **Figure: Geofence architecture**
 
 ![Geofence architecture](./media/geofence.png)
 
 <a name="manager"></a>
-## Geofence Service
+## Geofence service
 
-With the geofence service, you can:
+With the geofence service, you can do the following:
 
 -   [Create different types of geofences](#start)
 -   [Get the current state](#status)
@@ -34,14 +34,14 @@ With the geofence service, you can:
 
 -   [Retrieve information about created geofences](#info)
 
-The device can receive alerts about the geofence when a particular geofence service is started using the `Start()` method of the [Tizen.Location.Geofence.GeofenceManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.Geofence.GeofenceManager.html) class.
+    The device can receive alerts about the geofence when a particular geofence service is started using the `Start()` method of the [Tizen.Location.Geofence.GeofenceManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.Geofence.GeofenceManager.html) class.
 
-If the user revokes permission to use the location information, an `UnauthorizedAccessException` is returned to the application attempting to use the geofence service.
+    If the user revokes permission to use the location information, an `UnauthorizedAccessException` is returned to the application attempting to use the geofence service.
 
-Asynchronous geofence-related alerts (in or out) and event handling (a fence added or removed) are implemented with event handlers. Geofence alerts are received using the values of the [Tizen.Location.Geofence.GeofenceState](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.Geofence.GeofenceState.html) enumeration.
+    Asynchronous geofence-related alerts (in or out) and event handling (a fence added or removed) are implemented with event handlers. Geofence alerts are received using the values of the [Tizen.Location.Geofence.GeofenceState](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.Geofence.GeofenceState.html) enumeration.
 
 <a name="definition"></a>
-## Geofence Definition
+## Geofence definition
 
 Geofence definition refers to defining an instance of the [Tizen.Location.Geofence.Fence](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.Geofence.Fence.html) class.
 
@@ -50,7 +50,7 @@ The 3 types of available geofences are geopoint, Wi-Fi, and Bluetooth. When crea
 Creating a geopoint geofence requires a geopoint and a radius, whereas Wi-Fi and Bluetooth geofences require a MAC address. Based on the defined geofence type, the geofence manager creates the fence for the particular application.
 
 <a name="settings"></a>
-## Geofence Management through My Places
+## Geofence management through My Places
 
 Tizen provides the user a way of managing geofence places and fences through the My Places application. The following figure shows the default places and supported fence types.
 
@@ -71,9 +71,9 @@ using Tizen.Location.Geofence;
 ```
 
 <a name="start"></a>
-## Starting the Geofence Service
+## Start the geofence service
 
-To start the geofence service:
+To start the geofence service, follow these steps:
 
 1.  Create a [Tizen.Location.Geofence.GeofenceManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.Geofence.GeofenceManager.html) object:
 
@@ -91,7 +91,7 @@ To start the geofence service:
     ```
 
 
-    > **Note**   
+    > [!NOTE]
 	> A place is used to accommodate a number of geofences and is identified by a place ID. Each place can have a name. A geofence is identified by a geofence ID.
 
 
@@ -122,13 +122,13 @@ To start the geofence service:
 
 5.  Start the geofence service using the `Start()` method of the `Tizen.Location.Geofence.GeofenceManager` class.
 
-    This call is asynchronous and only initiates the process of starting the service. Once the service is started, the added event handlers are invoked when their corresponding events take place. To know when the service becomes enabled, use the `StateChanged` event of the `Tizen.Location.Geofence.GeofenceManager` class.
+    This call is asynchronous and only initiates the process of starting the service. Once the service is started, the added event handlers are invoked when their corresponding events take place. To know when the service becomes enabled, use the `StateChanged` event of the `Tizen.Location.Geofence.GeofenceManager` class:
 
     ```csharp
     manager.Start(geofenceId);
     ```
 
-6.  Using the geofence service for geopoints adds to power consumption, so if the service is not used, stop the status alerts using the `Stop()` method of the `Tizen.Location.Geofence.GeofenceManager` class. Call the `Start()` method again if the alerts are needed.
+6.  Using the geofence service for geopoints adds to power consumption, so if the service is not used, stop the status alerts using the `Stop()` method of the `Tizen.Location.Geofence.GeofenceManager` class. Call the `Start()` method again if the alerts are needed:
 
     ```csharp
     manager.Stop(geofenceId);
@@ -144,9 +144,9 @@ To start the geofence service:
     If you destroy the `Tizen.Location.Geofence.GeofenceManager` instance, there is no need to call the `Stop()` method to stop the service, as the service is automatically stopped.
 
 <a name="status"></a>
-## Monitoring Geofence State Changes
+## Monitor geofence state changes
 
-To track the state of the geofence, use the `GeofenceEventChanged` event of the [Tizen.Location.Geofence.GeofenceManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.Geofence.GeofenceManager.html) class. An event handler is invoked whenever there is a request from the user, such as to add a geofence or to start a geofence service.
+To track the state of the geofence, use the `GeofenceEventChanged` event of the `Tizen.Location.Geofence.GeofenceManager` class. An event handler is invoked whenever there is a request from the user, such as to add a geofence or to start a geofence service.
 
 1.  Add the event handler for the `GeofenceEventChanged` event:
 
@@ -167,42 +167,42 @@ To track the state of the geofence, use the `GeofenceEventChanged` event of the 
     ```
 
 
-    > **Note**   
+    > [!NOTE]
 	> The geofence change event handler is used to let the user know whether the request is successful on the server side. This handler is invoked only in the case of an asynchronous method. For a synchronous method, an error is immediately returned.
 
 
 <a name="track"></a>    
-## Tracking the User for Geofence Crossing Alerts
+## Track the user for geofence crossing alerts
 
-To get information about whether the user has crossed the boundary of the geofence:
+To get information about whether the user has crossed the boundary of the geofence, follow these steps:
 
--   Receive event-based notifications with an event handler.
+1.  Receive event-based notifications with an event handler.
 
     You can be notified when the user crosses a particular fence. The handler receives the current state of the user (whether the user is in or out of the virtual boundaries of a geofence) with each call.
 
-    1.  Define the event handler:
+    -   Define the event handler:
 
         ```csharp
         EventHandler<GeofenceStateEventArgs> handler = (object sender, GeofenceStateEventArgs args) => {};
         ```
 
-    2.  Register the handler using the `StateChanged` event of the [Tizen.Location.Geofence.GeofenceManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.Geofence.GeofenceManager.html) class.
+    -   Register the handler using the `StateChanged` event of the `Tizen.Location.Geofence.GeofenceManager` class.
 
         ```csharp
         manager.StateChanged += handler;
         ```
 
--   Retrieve the current state on request.
+2.  Retrieve the current state on request.
 
     You can get the current state of the user with respect to a geofence, such as their in or out state and the duration of the current state.
 
-    1.  Create a [Tizen.Location.Geofence.FenceStatus](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.Geofence.FenceStatus.html) instance:
+    -   Create a [Tizen.Location.Geofence.FenceStatus](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.Geofence.FenceStatus.html) instance:
 
         ```csharp
         FenceStatus status = new FenceStatus(fenceId);
         ```
 
-    2.  To get the current state and duration of that state, use the `State` and `Duration` properties of the `Tizen.Location.Geofence.FenceStatus` class:
+    -   To get the current state and duration of that state, use the `State` and `Duration` properties of the `Tizen.Location.Geofence.FenceStatus` class:
 
         ```csharp
         GeofenceState state = status.State;
@@ -211,14 +211,14 @@ To get information about whether the user has crossed the boundary of the geofen
 
         The duration is provided in seconds.
 
-    3.  When no longer needed, destroy the `Tizen.Location.Geofence.FenceStatus` instance with the `Dispose()` method:
+    -   When no longer needed, destroy the `Tizen.Location.Geofence.FenceStatus` instance with the `Dispose()` method:
 
         ```csharp
         status.Dispose();
         ```
 
 <a name="proximity"></a>
-## Tracking the User for Proximity Alerts
+## Track the user for proximity alerts
 
 To get information about the user's proximity to a geofence, use an event handler that receives the user's proximity with each call:
 
@@ -228,25 +228,25 @@ To get information about the user's proximity to a geofence, use an event handle
     EventHandler<ProximityStateEventArgs> handler = (object sender, ProximityStateEventArgs args) => {};
     ```
 
-2.  Register the handler using the `ProximityChanged` event of the [Tizen.Location.Geofence.GeofenceManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.Geofence.GeofenceManager.html) class.
+2.  Register the handler using the `ProximityChanged` event of the `Tizen.Location.Geofence.GeofenceManager` class:
 
     ```csharp
     manager.ProximityChanged += handler;
     ```
 
 <a name="info"></a>
-## Retrieving Geofence Information
+## Retrieve geofence information
 
-To get information about a geofence:
+To get information about a geofence, follow these steps:
 
--   Get common information (such as the type and place) about any type of geofence:
+1.  Get common information (such as the type and place) about any type of geofence:
 
     ```csharp
     int placeId = fence.PlaceId;
     Fence type = fence.Type;
     ```
 
--   Get information specific to a geopoint geofence:
+2.  Get information specific to a geopoint geofence:
 
     ```csharp
     double latitude = fence.Latitude;
@@ -255,7 +255,7 @@ To get information about a geofence:
     string address = fence.Address;
     ```
 
--   Get information specific to a Wi-Fi or Bluetooth geofence:
+3.  Get information specific to a Wi-Fi or Bluetooth geofence:
 
     ```csharp
     string bssid = fence.Bssid;
@@ -263,6 +263,6 @@ To get information about a geofence:
     ```
 
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/location/geofences.md
+++ b/docs/application/dotnet/guides/location/geofences.md
@@ -3,7 +3,7 @@
 
 A geofence is a virtual perimeter for a real-world geographic area. A geofence is defined by either a geopoint and radius for geopoint geofences or by a MAC address for Wi-Fi and Bluetooth geofences. The geofence feature alerts the user when the geofence state changes (the user crosses the perimeter).
 
-The main features of the Tizen.Location.Geofence namespace includes the following:
+The main features of the Tizen.Location.Geofence namespace include the following:
 
 -   Using the geofence service
 
@@ -15,7 +15,7 @@ The main features of the Tizen.Location.Geofence namespace includes the followin
 
 -   Managing the geofence service
 
-    You can allow the user to [manage the geofence places and fences](#settings) through My Places application.
+    You can allow the user to [manage the geofence places and fences](#settings) through the My Places application.
 
 **Figure: Geofence architecture**
 
@@ -52,7 +52,7 @@ Creating a geopoint geofence requires a geopoint and a radius, whereas Wi-Fi and
 <a name="settings"></a>
 ## Geofence management through My Places
 
-Tizen provides the user a way of managing geofence places and fences through the My Places application. The following figure shows the default places and supported fence types.
+Tizen provides the user with a way of managing geofence places and fences through the My Places application. The following figure shows the default places and supported fence types.
 
 **Figure: My Places**
 

--- a/docs/application/dotnet/guides/location/location.md
+++ b/docs/application/dotnet/guides/location/location.md
@@ -1,8 +1,8 @@
 # Location Information
 
-Location information allows you to get a device's geographic position. Additionally, location-related information can also contain information about altitude, accuracy of the location and altitude readings, and the user's movement speed and direction.
+Location information allows you to get a device's geographic position. Additionally, location-related information can also contain information about altitude, the accuracy of the location and altitude readings, and the user's movement speed and direction.
 
-The main features of the Tizen.Location namespace include:
+The main features of the Tizen.Location namespace includes the following:
 
 -   Enabling the location service
 
@@ -14,9 +14,9 @@ The main features of the Tizen.Location namespace include:
 
 
 <a name="service"></a>
-## Location Service
+## Location service
 
-The [Tizen.Location](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.html) namespace provides the current location using the location sources specified in the [Tizen.Location.LocationType](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.LocationType.html) enumeration. You can [use the location service](#start) to manage location information in various ways:
+The [Tizen.Location](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.html) namespace provides the current location using the location sources specified in the [Tizen.Location.LocationType](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.LocationType.html) enumeration. You can [use the location service](#start) to manage location information in the following various ways:
 
 -   Get the user's current location
 
@@ -31,9 +31,8 @@ The [Tizen.Location](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.h
     You can create [virtual perimeters](#bound) and monitor when a device enters or leaves them.
 
 
-> **Note**
->
-> To test the Tizen location-based services on the emulator, provide location data (longitude and latitude) using the Emulator Control Panel.  
+> [!NOTE]
+> To test the Tizen location-based services on the emulator, provide location data (longitude and latitude) using Emulator Control Panel.  
 >
 > Since satellite data is not supported on the emulator, GPS status data is available on a target device only.
 
@@ -46,15 +45,15 @@ You can use the location state and updates as follows:
 -   If the location service is unable to run on the requested device due to weak radio reception, the location service state is set to `Disabled`. If this situation persists for a longer period, stop the service and try again later, to conserve the device battery.
 
 <a name="method"></a>
-## Location Types
+## Location types
 
-The [Tizen.Location.LocationType](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.LocationType.html) enumeration is used to specify the desired quality of service of the [Tizen.Location.Location](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.Location.html) instance. For example, a location-based weather forecast application can require only very basic information to distinguish a city or a neighborhood, while a GPS navigation application can require the highest quality level to pinpoint a map location. Selecting the appropriate quality level not only helps to run the system efficiently, but also leads to a good user experience.
+The [Tizen.Location.LocationType](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.LocationType.html) enumeration is used to specify the desired quality of service of the [Tizen.Location.Location](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.Location.html) instance. For example, a location-based weather forecast application can require only very basic information to distinguish a city or a neighborhood, while a GPS navigation application can require the highest quality level to pinpoint a map location. Selecting the appropriate quality level not only helps to run the system efficiently but also leads to a good user experience.
 
 Using the `Tizen.Location.LocationType` enumeration allows your application to specify the following location positioning system types:
 
 -   `Hybrid`, which selects the best method available at the moment
--   `Gps`, which uses the global positioning system
--   `Wps`, which uses the Wi-Fi positioning system
+-   `GPS`, which uses the global positioning system
+-   `WPS`, which uses the Wi-Fi positioning system
 -   `Passive`, which uses the passive mode
 
 ## Prerequisites
@@ -68,13 +67,13 @@ To use the [Tizen.Location](/application/dotnet/api/TizenFX/latest/api/Tizen.Loc
 ```
 
 <a name="start"></a>
-## Starting the Location Service
+## Start the location service
 
-To start the location service:
+To start the location service, proceed as follows:
 
 1.  Create a [Tizen.Location.Locator](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.Locator.html) instance with a specific value for its `LocationType` property before you use the location service.
 
-    In this example, GPS is used as the source of the position data. You can use other values of the [Tizen.Location.LocationType](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.LocationType.html) enumeration for hybrid and WPS sources.
+    In this example, GPS is used as the source of the position data. You can use other values of the [Tizen.Location.LocationType](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.LocationType.html) enumeration for hybrid and WPS sources:
 
     ```csharp
     Tizen.Location.Locator locator;
@@ -83,19 +82,19 @@ To start the location service:
 
     Each `Tizen.Location.Locator` is an independent service. Multiple instances can be created in the same application to provide different services, such as GPS and WPS. Events are set for a given instance and are called only if the service is started for their `Tizen.Location.Locator` instance.
 
-2.  Start the location service using the `Start()` method. This call is asynchronous and only initiates the process of starting the location service. Once the service is started, registered event handlers are invoked when their corresponding events take place. To know when the service becomes enabled, use the `ServiceStateChanged` event of the `Tizen.Location.Locator` class.
+2.  Start the location service using the `Start()` method. This call is asynchronous and only initiates the process of starting the location service. Once the service is started, registered event handlers are invoked when their corresponding events take place. To know when the service becomes enabled, use the `ServiceStateChanged` event of the `Tizen.Location.Locator` class:
 
     ```csharp
     locator.Start();
     ```
 
-3.  Using the location service consumes power, so if the service is not used, stop updating the location using the `Stop()` method. Call the `Start()` method again if updated position information is needed.
+3.  Using the location service consumes power, so if the service is not used, stop updating the location using the `Stop()` method. Call the `Start()` method again if updated position information is needed:
 
     ```csharp
     locator.Stop();
     ```
 
-4.  At the end of the application life-cycle, destroy all used resources, such as the `Tizen.Location.Locator` instance:
+4.  At the end of the application lifecycle, destroy all used resources, such as the `Tizen.Location.Locator` instance:
 
     ```csharp
     locator.Dispose();
@@ -105,9 +104,9 @@ To start the location service:
     If you destroy the `Tizen.Location.Locator` instance, there is no need to call the `Stop()` method to stop the service, as the service is automatically stopped. In addition, you do not have to remove any previously added event handlers.
 
 <a name="current_location"></a>
-## Getting the Current Location
+## Get the current location
 
-To synchronously retrieve the current location of the device:
+To synchronously retrieve the current location of the device, proceed as follows:
 
 1.  Register an event handler for location service state changes and start the location service:
 
@@ -142,11 +141,11 @@ To synchronously retrieve the current location of the device:
     ```
 
 <a name="update"></a>
-## Getting Location Events
+## Get location events
 
-You can get a notification of the device position being updated by using an event handler for the `LocationChanged` event of the [Tizen.Location.Locator](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.Locator.html) class. The event handler is invoked periodically, receiving the device's current position with every call. You can use the event handler to retrieve the device position (given as coordinates) and convert it to the corresponding address.
+You can get a notification of the device position being updated by using an event handler for the `LocationChanged` event of the `Tizen.Location.Locator` class. The event handler is invoked periodically, receiving the device's current position with every call. You can use the event handler to retrieve the device position (given as coordinates) and convert it to the corresponding address.
 
-To use the location change event handler:
+To use the location change event handler, proceed as follows:
 
 1.  Register the event handler:
 
@@ -167,16 +166,16 @@ To use the location change event handler:
     ```
 
 
-    > **Note**   
+    > [!NOTE]
 	> The event is called only if the location service has already been started.
 
 
 <a name="satellite"></a>
-## Getting Satellite Information
+## Get satellite information
 
 You can retrieve and update information about a satellite visible to the device. The information includes azimuth, elevation, PRN, SNR, and NMEA data. An event handler is invoked periodically, receiving information about the visible satellites with every call.
 
-To retrieve satellite information:
+To retrieve satellite information, proceed as follows:
 
 1.  Register an event handler for the `SatelliteStatusUpdated` event of the [Tizen.Location.GpsSatellite](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.GpsSatellite.html) class:
 
@@ -198,16 +197,16 @@ To retrieve satellite information:
     ```
 
 
-    > **Note**   
+    > [!NOTE]
 	> The event is called only if the location service has already been started.
 
 
 <a name="bound"></a>
-## Using Location Bounds
+## Use location bounds
 
 You can define a virtual perimeter, which is monitored to see whether the device enters or exits the area.
 
-To use a location boundary:
+To use a location boundary, proceed as follows:
 
 1.  Create location bounds with the required area type (rectangle, circle, or polygon) needed for your application:
 
@@ -234,7 +233,7 @@ To use a location boundary:
     locator.ZoneChanged += ZoneChangedHandler;
     ```
 
-    Implement the event handler for the `ZoneChanged` event of the [Tizen.Location.Locator](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.Locator.html) class:
+    Implement the event handler for the `ZoneChanged` event of the `Tizen.Location.Locator` class:
 
     ```csharp
     void ZoneChangedHandler(Object sender, ZoneChangedEventArgs e)
@@ -258,6 +257,6 @@ To use a location boundary:
     polygon.Dispose();
     ```
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/location/location.md
+++ b/docs/application/dotnet/guides/location/location.md
@@ -2,7 +2,7 @@
 
 Location information allows you to get a device's geographic position. Additionally, location-related information can also contain information about altitude, the accuracy of the location and altitude readings, and the user's movement speed and direction.
 
-The main features of the Tizen.Location namespace includes the following:
+The main features of the Tizen.Location namespace include the following:
 
 -   Enabling the location service
 
@@ -16,7 +16,7 @@ The main features of the Tizen.Location namespace includes the following:
 <a name="service"></a>
 ## Location service
 
-The [Tizen.Location](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.html) namespace provides the current location using the location sources specified in the [Tizen.Location.LocationType](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.LocationType.html) enumeration. You can [use the location service](#start) to manage location information in the following various ways:
+The [Tizen.Location](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.html) namespace provides the current location using the location sources specified in the [Tizen.Location.LocationType](/application/dotnet/api/TizenFX/latest/api/Tizen.Location.LocationType.html) enumeration. You can [use the location service](#start) to manage location information in the following ways:
 
 -   Get the user's current location
 

--- a/docs/application/dotnet/guides/location/overview.md
+++ b/docs/application/dotnet/guides/location/overview.md
@@ -7,13 +7,13 @@ You can use the following location and sensor features in your .NET applications
 
 -   [Geofences](geofences.md)
 
-    You can create geofences, which are virtual perimeters for a real-world geographic area. When a geofence is active, you can monitor the user location and receive alerts when the user enters or leaves the geofence area.
+    You can create geofences, which are virtual perimeters for a real-world geographic area. When a geofence is active, you can monitor the user's location and receive alerts when the user enters or leaves the geofence area.
 
 -   [Location Information](location.md)
 
-    The Location Manager provides the geographical location of the device for your application. You can access the user location, monitor location updates, and track the user movements within specific bounds or along a route. You can also manage the location settings, allowing the user to determine whether your application has access to location data.
+    The Location Manager provides the geographical location of the device for your application. You can access the user's location, monitor location updates, and track the user's movements within specific bounds or along a route. You can also manage the location settings, allowing the user to determine whether your application has access to location data.
 
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/machine-learning/machine-learning-inference.md
+++ b/docs/application/dotnet/guides/machine-learning/machine-learning-inference.md
@@ -15,7 +15,7 @@ You can use the following machine learning features in your .NET applications:
   Unlike the SingleShot class, you can compose a complex pipeline for changing media format and connecting multiple neural network models in the stream.
 
   > [!NOTE]
-  > This feature is available in the .NET APIs from Tizen 6.0.
+  > This feature is available in the .NET APIs since Tizen 6.0.
 
 ## Related information
 - Dependencies

--- a/docs/application/dotnet/guides/machine-learning/machine-learning-train.md
+++ b/docs/application/dotnet/guides/machine-learning/machine-learning-train.md
@@ -337,8 +337,8 @@ Type | Key | Value | Default value | Description
 &#xfeff;                                                     |                             | average                     |                         | Average pooling
 &#xfeff;                                                     |                             | global_max                  |                         | Global max pooling
 &#xfeff;                                                     |                             | global_average              |                         | Global average pooling
-&#xfeff;                                                     | pool_size                   | (array of unsigned integer) |                         | Comma-separated unsigned intergers for pooling size, `height, width`  respectively
-&#xfeff;                                                     | stride                      | (array of unsigned integer) | 1, 1                    | Comma-separated unsigned intergers for stride, `height, width`  respectively
+&#xfeff;                                                     | pool_size                   | (array of unsigned integer) |                         | Comma-separated unsigned integers for pooling size, `height, width`  respectively
+&#xfeff;                                                     | stride                      | (array of unsigned integer) | 1, 1                    | Comma-separated unsigned integers for stride, `height, width`  respectively
 &#xfeff;                                                     | padding                     | (categorical)               | valid                   | Padding type
 &#xfeff;                                                     |                             | valid                       |                         | No padding
 &#xfeff;                                                     |                             | same                        |                         | Preserve height/width dimension

--- a/docs/application/dotnet/guides/machine-learning/machine-learning-train.md
+++ b/docs/application/dotnet/guides/machine-learning/machine-learning-train.md
@@ -2,7 +2,7 @@
 
 You can use the `Tizen.MachineLearning.Train` class to construct, control, and train a machine learning model in Tizen devices.
 
-The main features of machine learning train includes the following:
+The main features of machine learning train include the following:
 
 - Constructing a deep neural network (DNN)
   
@@ -666,7 +666,7 @@ Let's assume a given model requires three inputs and two labels. This has been r
 #### Construct a dataset on code
 
 An empty dataset can be constructed with `Tizen.MachineLearning.Train.Dataset` class.
-A data provider added with `NNTrainerDatasetMode.Train`, `NNTrainerDatasetMode.Valid`, `NNTrainerDatasetMode.Test` will be used when training, validating and testing respectively.
+A data provider added with `NNTrainerDatasetMode.Train`, `NNTrainerDatasetMode.Valid`, `NNTrainerDatasetMode.Test` will be used when training, validating, and testing respectively.
 
 Consider setting property with `Tizen.MachineLearning.Train.Dataset.SetProperty` when the data provider needs certain properties.
 

--- a/docs/application/dotnet/guides/machine-learning/machine-learning-train.md
+++ b/docs/application/dotnet/guides/machine-learning/machine-learning-train.md
@@ -2,14 +2,19 @@
 
 You can use the `Tizen.MachineLearning.Train` class to construct, control, and train a machine learning model in Tizen devices.
 
-The main features of Machine Learning Train include:
+The main features of machine learning train includes the following:
 
 - Constructing a deep neural network (DNN)
-   - You can construct a DNN model using a model description file or by writing code through `Tizen.MachineLearning.Train` class.
+  
+  You can construct a DNN model using a model description file or by writing code through `Tizen.MachineLearning.Train` class.
+
 - Training with your own data
-   - `Tizen.MachineLearning.Train` class also allows you to train the model with your own data as a File I/O or by defining a data generator.
+  
+  `Tizen.MachineLearning.Train` class also allows you to train the model with your own data as a file I/O or by defining a data generator.
+
 - Evaluating the model during training
-   - You can validate and test your model during the training process easily by defining the dataset.
+  
+  You can validate and test your model during the training process easily by defining the dataset.
 
 > [!NOTE]
 > Every example code does not handle all error use cases.
@@ -17,7 +22,7 @@ The main features of Machine Learning Train include:
 
 ## Prerequisites
 
-To enable your application to use `Tizen.MachineLearning.Train` class:
+To enable your application to use `Tizen.MachineLearning.Train` class, follow the steps below:
 
 1. To use the method and properties of the `Tizen.MachineLearning.Train.Model`, `Tizen.MachineLearning.Train.Dataset`, `Tizen.MachineLearning.Train.Layer` and `Tizen.MachineLearning.Train.Optimizer`, include the `Tizen.MachineLearning.Train` namespace in your application:
 
@@ -32,7 +37,7 @@ To enable your application to use `Tizen.MachineLearning.Train` class:
     <feature name="http://tizen.org/feature/machine_learning.training">true</feature>
     ```
 
-   In case of saving or loading model files from the outside of the application's own resources, the application has to request permission by adding the following privileges to the `tizen-manifest.xml` file:
+   In case of saving or loading model files from outside of the application's own resources, the application has to request permission by adding the following privileges to the `tizen-manifest.xml` file:
 
     ```XML
     <privileges>
@@ -89,13 +94,13 @@ A number of properties can be set at `Model.Compile` and `Model.Run` phase:
 
 | Method                       | Key       | Value         | Description                            |
 | ---------------------------- | --------- | ------------- | -------------------------------------- |
-| `Model.Compile`, `Model.Run` | epochs    | (integer)     | Determines epochs for the model        |
-| &#xfeff;                     | save_path | (string)      | Model path to save parameters after a single epoch |
+| `Model.Compile`, `Model.Run` | epochs    | (integer)     | Determines epochs for the model.        |
+|                              | save_path | (string)      | Model path to save parameters after a single epoch. |
 
 ### Layer class
 
 `Tizen.MachineLearning.Train.Layer` class is a component that does actual computation while managing internal trainable parameters.
-The following example shows how to create, add and get layer to the model:
+The following example shows how to create, add and get the layer to the model:
 
 ```csharp
 // Create model
@@ -153,7 +158,7 @@ Type | Key | Value | Default value | Description
 &#xfeff;                                                     | weight_regularizer_constant | (float)                     | 1                       | Weight regularizer constant
 `NNTrainerLayerType.FC`                                      |                             |                             |                         | Fully connected layer
 &#xfeff;                                                     | unit                        | (unsigned integer)          |                         | Number of outputs
-`NNTrainerLayerType.Conv1D`                                  |                             |                             |                         | 1D Convolution layer
+`NNTrainerLayerType.Conv1D`                                  |                             |                             |                         | 1D convolution layer
 &#xfeff;                                                     | filters                     | (unsigned integer)          |                         | Number of filters
 &#xfeff;                                                     | kernel_size                 | (unsigned integer)          |                         | Kernel size
 &#xfeff;                                                     | stride                      | (unsigned integer)          | 1                       | Strides
@@ -162,7 +167,7 @@ Type | Key | Value | Default value | Description
 &#xfeff;                                                     |                             | same                        |                         | Preserve dimension
 &#xfeff;                                                     |                             | (unsigned integer)          |                         | Size of padding applied uniformly to all side
 &#xfeff;                                                     |                             | (array of unsigned integer of size 2) |                         | Padding for left, right
-`NNTrainerLayerType.Conv2D`                                  |                             |                             |                         | 2D Convolution layer
+`NNTrainerLayerType.Conv2D`                                  |                             |                             |                         | 2D convolution layer
 &#xfeff;                                                     | filters                     | (unsigned integer)          |                         | Number of filters
 &#xfeff;                                                     | kernel_size                 | (array of unsigned integer) |                         | Comma-separated unsigned integers for kernel size, `height, width` respectively
 &#xfeff;                                                     | stride                      | (array of unsigned integer) | 1, 1                    | Comma-separated unsigned integers for strides, `height, width` respectively
@@ -185,7 +190,7 @@ Type | Key | Value | Default value | Description
 &#xfeff;                                                     | return_sequences            | (boolean)                   | false                   | Return only the last output if true, else return full output
 &#xfeff;                                                     | dropout                     | (float)                     | 0                       | Dropout rate
 &#xfeff;                                                     | integrate_bias              | (boolean)                   | false                   | Integrate bias_ih, bias_hh to bias_h
-`NNTrainerLayerType.RNNCell`                                 |                             |                             |                         | RNN Cell layer
+`NNTrainerLayerType.RNNCell`                                 |                             |                             |                         | RNN cell layer
 &#xfeff;                                                     | unit                        | (unsigned integer)          |                         | Number of output neurons
 &#xfeff;                                                     | hidden_state_activation     | (categorical)               | tanh                    | Activation type
 &#xfeff;                                                     |                             | tanh                        |                         | Hyperbolic tangent
@@ -210,7 +215,7 @@ Type | Key | Value | Default value | Description
 &#xfeff;                                                     | dropout                     | (float)                     | 0                       | Dropout rate
 &#xfeff;                                                     | integrate_bias              | (boolean)                   | false                   | Integrate bias_ih, bias_hh to bias_h
 &#xfeff;                                                     | max_timestep                | (unsigned integer)          |                         | Maximum timestep
-`NNTrainerLayerType.LSTMCell`                                |                             |                             |                         | LSTM Cell layer
+`NNTrainerLayerType.LSTMCell`                                |                             |                             |                         | LSTM cell layer
 &#xfeff;                                                     | unit                        | (unsigned integer)          |                         | Number of output neurons
 &#xfeff;                                                     | hidden_state_activation     | (categorical)               | tanh                    | Activation type
 &#xfeff;                                                     |                             | tanh                        |                         | Hyperbolic tangent
@@ -240,7 +245,7 @@ Type | Key | Value | Default value | Description
 &#xfeff;                                                     | dropout                     | (float)                     | 0                       | Dropout rate
 &#xfeff;                                                     | integrate_bias              | (boolean)                   | false                   | Integrate bias_ih, bias_hh to bias_h
 &#xfeff;                                                     | reset_after                 | (boolean)                   | true                    | Apply reset gate before/after the matrix
-`NNTrainerLayerType.GRUCell`                                 |                             |                             |                         | GRU Cell layer
+`NNTrainerLayerType.GRUCell`                                 |                             |                             |                         | GRU cell layer
 &#xfeff;                                                     | unit                        | (unsigned integer)          |                         | Number of output neurons
 &#xfeff;                                                     | reset_after                 | (boolean)                   | true                    | Apply reset gate before/after the matrix multiplication
 &#xfeff;                                                     | hidden_state_activation     | (categorical)               | tanh                    | Activation type
@@ -255,7 +260,7 @@ Type | Key | Value | Default value | Description
 &#xfeff;                                                     |                             | softmax                     |                         | Softmax function
 &#xfeff;                                                     | dropout                     | (float)                     | 0                       | Dropout rate
 &#xfeff;                                                     | integrate_bias              | (boolean)                   | false                   | Integrate bias_ih, bias_hh to bias_h
-`NNTrainerLayerType.ZoneoutLSTMCell`                         |                             |                             |                         | Zoneout LSTM Cell layer
+`NNTrainerLayerType.ZoneoutLSTMCell`                         |                             |                             |                         | Zoneout LSTM cell layer
 &#xfeff;                                                     | unit                        | (unsigned integer)          |                         | Number of output neurons
 &#xfeff;                                                     | hidden_state_activation     | (categorical)               | tanh                    | Activation type
 &#xfeff;                                                     |                             | tanh                        |                         | Hyperbolic tangent
@@ -536,10 +541,10 @@ An empty model can be constructed with `Tizen.MachineLearning.Train.Model()`.
 
 ## Configure the model
 
-After constructing a model, the model can be configured.
+After constructing a model, the model can be configured by following the steps as described below:
 
 > [!NOTE]
-> The example code written here reproduces the model description from [Create Model from INI Formatted File](#create-a-model-from-ini-formatted-file) except the following is different:
+> The example code written here reproduces the model description from [create a model from INI formatted file](#create-a-model-from-ini-formatted-file) except the following is different:
 > - Relative path is changed to dynamic app resource and data path.
 > - Model related properties that can only be set at compile or run phase.
 
@@ -624,11 +629,11 @@ catch (Exception e)
 ```
 
 ### Set a dataset
-The dataset can be created from a file. Here, you need to provide streams of tensor data and arrays of values representing the label, usually one-hot-encoded.
+The dataset can be created from a file. Here, you need to provide streams of tensor data and arrays of values representing the label, usually one-hot encoded.
 
-#### Sample, batch and epoch
+#### Sample, batch, and epoch
 
-This section explains the following three concepts: sample, batch and epoch.
+This section explains the following three concepts: sample, batch, and epoch.
 
 Let's assume a given model requires three inputs and two labels. This has been reflected in the examples below:
 
@@ -656,19 +661,19 @@ Let's assume a given model requires three inputs and two labels. This has been r
 
     An epoch refers to a full, exhaustive visit to a dataset.
 
-    So, if you consider [Cifar-100](https://www.cs.toronto.edu/~kriz/cifar.html#The%20CIFAR-100%20dataset) dataset when using the full training set, a single training epoch will contain 50,000 samples. If batch size is 100, it will be of 500 batches (or iterations).
+    So, if you consider [Cifar-100](https://www.cs.toronto.edu/~kriz/cifar.html#The%20CIFAR-100%20dataset){:target="_blank"} dataset when using the full training set, a single training epoch will contain 50,000 samples. If the batch size is 100, it will be of 500 batches (or iterations).
 
 #### Construct a dataset on code
 
 An empty dataset can be constructed with `Tizen.MachineLearning.Train.Dataset` class.
-A data provider added with `NNTrainerDatasetMode.Train`, `NNTrainerDatasetMode.Valid`, `NNTrainerDatasetMode.Test` will be used when training, validating, training respectively.
+A data provider added with `NNTrainerDatasetMode.Train`, `NNTrainerDatasetMode.Valid`, `NNTrainerDatasetMode.Test` will be used when training, validating and testing respectively.
 
-Consider setting property with `Tizen.MachineLearning.Train.Dataset.SetProperty` when data provider needs certain properties.
+Consider setting property with `Tizen.MachineLearning.Train.Dataset.SetProperty` when the data provider needs certain properties.
 
 #### Set a dataset from file
 
 To create a dataset from files, each file must contain an array of samples.
-A single sample consists of an array of raw float array for input and another array or raw float array for labels that contains the same size as model output.
+A single sample consists of an array of raw float array for input and another array or raw float array for labels that contains the same size as model output:
 
 ```
 # If a model requires two inputs and a single label for a sample, a single sample would contain...
@@ -677,8 +682,8 @@ A single sample consists of an array of raw float array for input and another ar
 [[float array for input1][input 2][float array for label1]]
 ```
 
-As an example, again, consider [Cifar-100](https://www.cs.toronto.edu/~kriz/cifar.html#The%20CIFAR-100%20dataset) dataset.
-In Cifar-100 data, it contains an image of size 3 * 32 * 32 and a coarse label of 20 classes and a fine label of 100 classes.
+As an example, again, consider the [Cifar-100](https://www.cs.toronto.edu/~kriz/cifar.html#The%20CIFAR-100%20dataset){:target="_blank"} dataset.
+In Cifar-100 data, it contains an image of size 3 * 32 * 32 and a coarse label of 20 classes, and a fine label of 100 classes.
 
 If your model requires an image and two labels (coarse, fine) both one-hot encoded for a sample, the file layout would be:
 ```
@@ -744,13 +749,13 @@ catch (Exception e)
 ```
 ## Destroy the model
 
-Model will be disposed by GC, but you can use Dispose().
+Model will be disposed by GC, but you can use `Dispose()` method.
 `Tizen.MachineLearning.Train.Model.AddLayer`, `Tizen.MachineLearning.Train.Model.SetOptimizer`, and `Tizen.MachineLearning.Train.Model.SetDataset` transfers ownership to the model.
 `Tizen.MachineLearning.Train.Layer`, `Tizen.MachineLearning.Train.Optimizer` and `Tizen.MachineLearning.Train.Dataset` that belongs to the `model` are also deleted.
 
 ## Use the trained model for inference
 
-The trained model can be used for inference with [Machine Learning Inference API](machine-learning-inference.md).
+The trained model can be used for inference with Machine Learning Inference APIs.
 Ensure that the INI file contains the correct weight file in `save_path` in `[Model]` section.
 The valid INI file can be made with`Tizen.MachineLearning.Train.Model.Save` if you have constructed the model with the provided method.
 For example, you can use the trained model with a single API as follows:
@@ -766,7 +771,7 @@ string modelFilePath = Tizen.Applications.Application.Current.DirectoryInfo.Data
 var single = new SingleShot(modelFilePath, inInfo, outInfo);
 ```
 
-You can use the trained model with pipeline API as follows:
+You can use the trained model with Pipeline API as follows:
 
 ```csharp
 using Tizen.MachineLearning.Inference;

--- a/docs/application/dotnet/guides/machine-learning/overview.md
+++ b/docs/application/dotnet/guides/machine-learning/overview.md
@@ -1,17 +1,17 @@
 # Machine Learning
 
 
-Machine learning features help you to handle machine learning frameworks, like TensorFlow and TensorFlow-Lite, with the construction of a data pipeline.
+Machine learning features help you to handle machine learning frameworks, like TensorFlow and TensorFlow Lite, with the construction of a data pipeline.
 
 You can use the following machine learning features in your .NET applications:
 
 - [Machine Learning Inference](machine-learning-inference.md)
 
-  You can create data pipelines that contain the machine learning model filters. The pipeline can be assembled and controlled with various elements of [GStreamer](https://gstreamer.freedesktop.org/).
+  You can create data pipelines that contain the machine learning model filters. The pipeline can be assembled and controlled with various elements of [GStreamer](https://gstreamer.freedesktop.org/){:target="_blank"}.
 
 - [Machine Learning Train](machine-learning-train.md)
 
-  You can construct, control, and train a machine learning model on-the-fly. The training can be done using the code or with a set of format that describes the model. These models can be trained on the device locally when needed.
+  You can construct, control, and train a machine learning model on the fly. The training can be done using the code or with a set of format that describes the model. These models can be trained on the device locally when needed.
 
 ## Related information
 

--- a/docs/application/dotnet/guides/machine-learning/overview.md
+++ b/docs/application/dotnet/guides/machine-learning/overview.md
@@ -7,11 +7,11 @@ You can use the following machine learning features in your .NET applications:
 
 - [Machine Learning Inference](machine-learning-inference.md)
 
-  You can create data pipelines that contain the machine learning model filters. The pipeline can be assembled and controlled with various elements of [GStreamer](https://gstreamer.freedesktop.org/){:target="_blank"}.
+  You can create data pipelines that contain machine learning model filters. The pipeline can be assembled and controlled with various elements of [GStreamer](https://gstreamer.freedesktop.org/){:target="_blank"}.
 
 - [Machine Learning Train](machine-learning-train.md)
 
-  You can construct, control, and train a machine learning model on the fly. The training can be done using the code or with a set of format that describes the model. These models can be trained on the device locally when needed.
+  You can construct, control, and train a machine learning model on the fly. The training can be done using the code or with a set of formats that describe the model. These models can be trained on the device locally when needed.
 
 ## Related information
 

--- a/docs/application/dotnet/guides/machine-learning/pipeline.md
+++ b/docs/application/dotnet/guides/machine-learning/pipeline.md
@@ -2,14 +2,14 @@
 
 You can use the `Tizen.MachineLearning.Inference.Pipeline` class to manage the topology of data and the interconnection between processors and models.
 
-Pipeline allows you to construct and execute a pipeline with multiple neural network models, multiple inputs and output nodes, multiple data processors, pre-and-post processors, and various data path manipulators.
+Pipeline allows you to construct and execute a pipeline with multiple neural network models, multiple inputs and output nodes, multiple data processors, pre- and post-processors, and various data path manipulators.
 If the input is streamed data, Pipeline can simplify your application and improve its performance.
 
-The main features of Pipeline include:
+The main features of Pipeline includes the following:
 
 - Pipeline construction
 
-  You can [compose the data stream pipeline](#construct) using Machine Learning Inference with various elements of [GStreamer](https://gstreamer.freedesktop.org) and [NNStreamer](https://github.com/nnstreamer/nnstreamer).
+  You can [compose the data stream pipeline](#construct) using machine learning inference with various elements of [GStreamer](https://gstreamer.freedesktop.org){:target="_blank"} and [NNStreamer](https://github.com/nnstreamer/nnstreamer){:target="_blank"}.
 
 - Pushing the input data
 
@@ -25,7 +25,7 @@ The main features of Pipeline include:
 
 ## Prerequisites
 
-To enable your application to use the Machine Learning Inference API functionality:
+To enable your application to use the Machine Learning Inference API functionality, follow these steps:
 
 1. To use the methods and properties of the `Tizen.MachineLearning.Inference.Pipeline` class or its related classes such as `Tizen.MachineLearning.Inference.TensorsData` and `Tizen.MachineLearning.Inference.TensorsInfo`, include the `Tizen.MachineLearning.Inference` namespace in your application:
 
@@ -33,7 +33,7 @@ To enable your application to use the Machine Learning Inference API functionali
     using Tizen.MachineLearning.Inference;
     ```
 
-2. If the model file you want to use is located in the **media storage** or the **external storage**, the application has to request permission by adding the following privileges to the `tizen-manifest.xml` file:
+2. If the model file you want to use is located in the media storage or the external storage, the application has to request permission by adding the following privileges to the `tizen-manifest.xml` file:
 
     ```XML
     <privileges>
@@ -48,7 +48,7 @@ To enable your application to use the Machine Learning Inference API functionali
 <a name="construct"></a>
 ## Pipeline construction
 
-To construct a pipeline, you must have a pipeline description with the [GStreamer](https://gstreamer.freedesktop.org) and [NNStreamer](https://github.com/nnstreamer/nnstreamer) elements.
+To construct a Pipeline, you must have a Pipeline description with the [GStreamer](https://gstreamer.freedesktop.org){:target="_blank"} and [NNStreamer](https://github.com/nnstreamer/nnstreamer){:target="_blank"} elements.
 
 1. If the model file is located in the resource directory of your own application, you need to get its absolute path:
 
@@ -57,7 +57,7 @@ To construct a pipeline, you must have a pipeline description with the [GStreame
     string model_path = ResourcePath + "models/mobilenet_v1_1.0_224_quant.tflite";
     ```
 
-2. You can construct a pipeline with the description string, including the neural network framework and a model file:
+2. You can construct a Pipeline with the description string, including the neural network framework and a model file:
 
     ```csharp
     /* Create Pipeline instance with the pipeline description. */
@@ -71,7 +71,7 @@ To construct a pipeline, you must have a pipeline description with the [GStreame
 <a name="inputdata"></a>
 ## Push input data
 
-`SourceNode` provides a method to push input data into the pipeline:
+`SourceNode` provides a method to push input data into the Pipeline:
 
 ```csharp
 /* Get the source node with the name 'srcx'. */
@@ -93,7 +93,7 @@ src_node.Input(in_data);
 <a name="outputdata"></a>
 ## Subscribe to output data
 
-You can use `SinkNode` to get the output tensor data from the pipeline:
+You can use `SinkNode` to get the output tensor data from the Pipeline:
 
 ```csharp
 /* Firstly, declare the event handler for the data received event. */
@@ -118,12 +118,12 @@ pipe.Start();
 <a name="dataflow"></a>
 ## Data flow control
 
-If you need to stop the data stream or select the data flow with multiple stream paths for neural network models, Pipeline provides methods to handle the flow.
+If you need to stop the data stream or select the data flow with multiple stream paths for neural network models, Pipeline provides the following methods to handle the flow.
 
 1. Start or stop the data flow.
 
-    `Start()` and `Stop()` control the overall data flow of the pipeline asynchronously.
-    You can also get the pipeline state from the `State` property:
+    `Start()` and `Stop()` control the overall data flow of the Pipeline asynchronously.
+    You can also get the Pipeline state from the `State` property:
 
     ```csharp
     string description = "input-selector name=ins ! tensor_converter ! valve name=valvex ! tensor_sink name=sinkx " +
@@ -143,8 +143,8 @@ If you need to stop the data stream or select the data flow with multiple stream
 
 2. Open or close the stream.
 
-    The `valve` element controls the stream of a pipeline.
-    If you include a `valve` element in the pipeline description, you can get the instance of `ValveNode` with its name.
+    The `valve` element controls the stream of a Pipeline.
+    If you include a `valve` element in the Pipeline description, you can get the instance of `ValveNode` with its name.
     It provides a method to let the flow pass to a downstream element, or stop the flow:
 
     ```csharp
@@ -161,7 +161,7 @@ If you need to stop the data stream or select the data flow with multiple stream
 3. Select the stream path.
 
     `input-selector` and `output-selector` are the elements to select the data flow with multiple stream paths.
-    After getting `SwitchNode` in the pipeline, you can set the input or the output pad for which one gets the data flow:
+    After getting `SwitchNode` in the Pipeline, you can set the input or the output pad for which one gets the data flow:
 
     ```csharp
     /* Get the switch node with the name 'ins'. */
@@ -176,13 +176,13 @@ If you need to stop the data stream or select the data flow with multiple stream
 
 ## Custom Filter
 
-For your convenience, NNStreamer provides an interface for processing the tensor data with the `custom-easy` framework. After registering the user-defined callback method with the input and the output tensor information, NNStreamer can manipulate tensor data in the pipeline without an independent shared object. Since the callback method works as **filter** in the pipeline, it is named as `Custom Filter`.
+For your convenience, NNStreamer provides an interface for processing the tensor data with the `custom-easy` framework. After registering the user-defined callback method with the input and the output tensor information, NNStreamer can manipulate tensor data in the Pipeline without an independent shared object. Since the callback method works as filter in the Pipeline, it is named as `Custom Filter`.
 
 Note that the Custom Filter on the dotnet layer shows relatively lower performance than those of the native layer because of marshaling and unmarshalling between the dotnet and native layer. If your application is mission-critical, then use the native Custom Filter.
 
 1. Define Custom Filter and register it.
 
-    Before you use the Custom Filter in the pipeline, you have to register the Custom Filter with input and output tensor information, and its name:
+    Before you use the Custom Filter in the Pipeline, you have to register the Custom Filter with input and output tensor information, and its name:
 
     ```csharp
     /* Define the Custom Filter method */
@@ -205,9 +205,9 @@ Note that the Custom Filter on the dotnet layer shows relatively lower performan
     CustomFilter customFilter = CustomFilter.Create("custom-passthrough", in_info, out_info, InvokePassThrough);
     ```
 
-2. Construct a pipeline with Custom Filter.
+2. Construct a Pipeline with Custom Filter.
 
-    After registering the Custom Filter, you can use it when constructing the pipeline:
+    After registering the Custom Filter, you can use it when constructing the Pipeline:
 
     ```csharp
     /* framework is 'custom-easy' and registered name is used */
@@ -228,9 +228,9 @@ Note that the Custom Filter on the dotnet layer shows relatively lower performan
     src_node.Input(in_data);
     ```
 
-## Get and Set the property of a node
+## Get and set the property of a node
 
-All elements in the pipeline have specific properties and can be manipulated to control the operation of a pipeline. To get and set the property value, you have to get the element node in the pipeline by calling `GetNormal()` method:
+All elements in the Pipeline have specific properties and can be manipulated to control the operation of a Pipeline. To get and set the property value, you have to get the element node in the Pipeline by calling `GetNormal()` method:
 
 ```csharp
 string desc = "videotestsrc name=vsrc is-live=true ! videoconvert ! videoscale name=vscale ! " +

--- a/docs/application/dotnet/guides/machine-learning/pipeline.md
+++ b/docs/application/dotnet/guides/machine-learning/pipeline.md
@@ -5,7 +5,7 @@ You can use the `Tizen.MachineLearning.Inference.Pipeline` class to manage the t
 Pipeline allows you to construct and execute a pipeline with multiple neural network models, multiple inputs and output nodes, multiple data processors, pre- and post-processors, and various data path manipulators.
 If the input is streamed data, Pipeline can simplify your application and improve its performance.
 
-The main features of Pipeline includes the following:
+The main features of Pipeline include the following:
 
 - Pipeline construction
 
@@ -176,7 +176,7 @@ If you need to stop the data stream or select the data flow with multiple stream
 
 ## Custom Filter
 
-For your convenience, NNStreamer provides an interface for processing the tensor data with the `custom-easy` framework. After registering the user-defined callback method with the input and the output tensor information, NNStreamer can manipulate tensor data in the Pipeline without an independent shared object. Since the callback method works as filter in the Pipeline, it is named as `Custom Filter`.
+For your convenience, NNStreamer provides an interface for processing the tensor data with the `custom-easy` framework. After registering the user-defined callback method with the input and the output tensor information, NNStreamer can manipulate tensor data in the Pipeline without an independent shared object. Since the callback method works as a filter in the Pipeline, it is named `Custom Filter`.
 
 Note that the Custom Filter on the dotnet layer shows relatively lower performance than those of the native layer because of marshaling and unmarshalling between the dotnet and native layer. If your application is mission-critical, then use the native Custom Filter.
 

--- a/docs/application/dotnet/guides/machine-learning/singleshot.md
+++ b/docs/application/dotnet/guides/machine-learning/singleshot.md
@@ -1,8 +1,8 @@
-# Single Shot
+# SingleShot
 
 You can use the `Tizen.MachineLearning.Inference.SingleShot` class, to load the existing neural network model or your own specific model from the storage. After loading the model, you can invoke it with a single instance of input data. Then, you can get the inference output result.
 
-The main features of SingleShot include:
+The main features of SingleShot includes the following:
 
 - Managing tensor information
 
@@ -23,7 +23,7 @@ The main features of SingleShot include:
 
 ## Prerequisites
 
-To enable your application to use the Machine Learning Inference API functionality:
+To enable your application to use the Machine Learning Inference API functionality, follow these steps:
 
 1. To use the methods and properties of the `Tizen.MachineLearning.Inference.SingleShot` class or its related classes such as `Tizen.MachineLearning.Inference.TensorsData` and `Tizen.MachineLearning.Inference.TensorsInfo`, include the `Tizen.MachineLearning.Inference` namespace in your application:
 
@@ -31,7 +31,7 @@ To enable your application to use the Machine Learning Inference API functionali
     using Tizen.MachineLearning.Inference;
     ```
 
-2. If the model file you want to use is located in the **media storage** or the **external storage**, the application has to request permission by adding the following privileges to the `tizen-manifest.xml` file:
+2. If the model file you want to use is located in the media storage or the external storage, the application has to request permission by adding the following privileges to the `tizen-manifest.xml` file:
 
     ```XML
     <privileges>
@@ -47,7 +47,7 @@ To enable your application to use the Machine Learning Inference API functionali
 ## Manage tensor information
 
 In the example mentioned in this page, the MobileNet v1 model for TensorFlow Lite is used. This model is used for image classification.
-The input data type of the model is specified as bit width of each tensor and its input dimension is `3 X 224 X 224`.
+The input data type of the model is specified as the bit width of each tensor and its input dimension is `3 X 224 X 224`.
 The output data type of the model is the same as the input data type but the output dimension is `1001 X 1 X 1 X 1`.
 
 To configure the tensor information, you need to create a new instance of the `Tizen.MachineLearning.Inference.TensorsInfo` class. Then, you can add the tensor information such as data type, dimension, and name (optional) as shown in the following code:

--- a/docs/application/dotnet/guides/maps/here-credentials.md
+++ b/docs/application/dotnet/guides/maps/here-credentials.md
@@ -15,8 +15,8 @@ To get credentials, follow these steps:
 
     You can select between various [public or business plans](https://developer.here.com/plans){:target="_blank"}. Signing up for a plan automatically registers a new project.
 
-    1.  Select the plan that meets your requirements for the number of transactions you need, and click **Sign up**.
-    2.  Provide your contact details, and agree to the terms and conditions.
+    1.  Select the plan that meets your requirements for the number of transactions you need and click **Sign up**.
+    2.  Provide your contact details and agree to the terms and conditions.
 
         > [!NOTE]
 		> The registration does not support some regions and countries. If your contact details contain such a region or country, you cannot register a new application.

--- a/docs/application/dotnet/guides/maps/here-credentials.md
+++ b/docs/application/dotnet/guides/maps/here-credentials.md
@@ -1,30 +1,30 @@
-# Getting HERE Maps Credentials
+# Get HERE Maps Credentials
 
 
-The HERE Maps Plug-in for the Maps Service API is based on the HERE Maps services. It is provided as an example in the Tizen platform, and to use it on the HERE Maps, you need credentials for it.
+The HERE Maps plug-in for the Maps Service API is based on the HERE Maps services. It is provided as an example in the Tizen platform, and to use it on the HERE Maps, you need credentials for it.
 
-You can select HERE plans depending on the number of request queries and the kind of supported features you need, and pay for them accordingly. The following instructions provide a summary of how to get new credentials. For more information, see [HERE Developers](https://developer.here.com).
+You can select HERE plans depending on the number of request queries and the kind of supported features you need, and pay for them accordingly. The following instructions provide a summary of how to get new credentials. For more information, see [HERE developers](https://developer.here.com){:target="_blank"}.
 
-To get credentials:
+To get credentials, follow these steps:
 
-1.  Go to the [HERE Developers](https://developer.here.com) Web site and sign in.
+1.  Go to the [HERE Developers](https://developer.here.com){:target="_blank"} website and sign in.
 
     If you have no account, first register for the HERE Maps account.
 
 2.  Select a plan for using the HERE Maps services, and register a new project.
 
-    You can select between various [public or business plans](https://developer.here.com/plans). Signing up for a plan automatically registers a new project.
+    You can select between various [public or business plans](https://developer.here.com/plans){:target="_blank"}. Signing up for a plan automatically registers a new project.
 
     1.  Select the plan that meets your requirements for the number of transactions you need, and click **Sign up**.
     2.  Provide your contact details, and agree to the terms and conditions.
 
-        > **Note**   
+        > [!NOTE]
 		> The registration does not support some regions and countries. If your contact details contain such a region or country, you cannot register a new application.
 
 
 3.  Generate the credentials.
 
-    To access the new project, select **Projects** in the drop-down menu next to your user name in the upper-right corner of the screen, and click the project in the project list.
+    To access the new project, select **Projects** in the drop-down menu next to your username in the upper-right corner of the screen, and click the project in the project list.
 
     To generate the credentials, click **Generate App ID and App Code**.
 
@@ -38,12 +38,12 @@ To get credentials:
     var maps = new MapService("HERE", "XXXX/YYYY");
     ```
 
-    > **Note**   
+    > [!NOTE]
 	> According to the HERE Maps:
     > -   The app ID uniquely identifies your application.
     > -   The app code is used in the authentication process to identify a session.
 
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/maps/maps.md
+++ b/docs/application/dotnet/guides/maps/maps.md
@@ -3,7 +3,7 @@
 
 Map service features include geocoding, reverse geocoding, place searching, route calculation, and view widgets.
 
-The main features of Tizen.Maps namespace includes the following:
+The main features of Tizen.Maps namespace include the following:
 
 -   Discovering and selecting a map provider
 

--- a/docs/application/dotnet/guides/maps/maps.md
+++ b/docs/application/dotnet/guides/maps/maps.md
@@ -3,11 +3,11 @@
 
 Map service features include geocoding, reverse geocoding, place searching, route calculation, and view widgets.
 
-The main Tizen.Maps namespace features are:
+The main features of Tizen.Maps namespace includes the following:
 
 -   Discovering and selecting a map provider
 
-    You can also [specify basic maps preferences](#start).
+    You can also [specify basic map preferences](#start).
 
 -   Geocoding and reverse geocoding
 
@@ -25,20 +25,18 @@ The main Tizen.Maps namespace features are:
 
     With the [map view widget feature](#view), you can [create a map view widget](#maps_view) and set various properties (such as theme, language, and traffic).
 
-    You can create objects, such as markers, polylines and polygons, in the widget. You can also receive responses about events over the widget, and get various data from the events.
-
-You can also [customize service requests](#preference).
+    You can create objects, such as markers, polylines, and polygons, in the widget. You can also receive responses about events over the widget, and get various data from the events. You can also [customize service requests](#preference).
 
 <a name="supported_maps"> </a>
 The following map providers are supported:
 
--   [HERE Maps](https://developer.here.com) based on the [HERE REST API](https://developer.here.com/rest-apis).
+-   [HERE Maps](https://developer.here.com){:target="_blank"} based on the [HERE REST APIs](https://developer.here.com/rest-apis){:target="_blank"}.
 
     To use the HERE Maps, set the provider name to "HERE" and [get the HERE API keys](here-credentials.md).
 
 
-> **Note**   
-> To use the map service, you must get an access key to the map provider from the provider developer site. The service must be used according to the provider's Term of Use.
+> [!NOTE]
+> To use the map service, you must get an access key to the map provider from the provider developer site. The service must be used according to the provider's Terms of Use.
 
 <a name="geocode"></a>
 ## Geocodes
@@ -58,7 +56,7 @@ Only 1 type of reverse geocode request is provided:
 You can parse the reverse geocode response to use its details. The response contains structured address information consisting of, for example, a street name, building number, city name, postal code, district name, state name, and country.
 
 <a name="search_place"></a>
-## Place Search
+## Place search
 
 The following place search request types are provided:
 
@@ -69,11 +67,11 @@ The following place search request types are provided:
 After performing the [place service request](#use_search_place), you receive the place search response. You can parse the place search response to use its details. The response contains structured place information consisting of, for example, a place ID, name and URL, address, geographical location and distance from the center of the search area, place category, rating, review, and image.
 
 
-> **Note**   
+> [!NOTE]
 > Depending on the map provider, some types of place information can be unavailable.
 
 <a name="search_route"></a>
-## Route Search
+## Route search
 
 The following route search request types are provided:
 
@@ -83,15 +81,15 @@ The following route search request types are provided:
 After performing the [route service request](#use_search_route), you receive the route search response. You can parse the route calculation response to use its details. The response contains structured route information consisting of, for example, a route ID, geographical coordinates of the start and destination points, route bounding box, transportation mode, and total distance and duration.
 
 
-> **Note**   
+> [!NOTE]
 > Depending on the map provider, the route can be presented as a list of geographical points or segments. The segment list can also be presented as a list of geographical points or maneuvers.
 
 <a name="view"></a>
-## Map View Widget
+## Map view widget
 
 The map view widget feature includes drawing a map image on the map port, which is a specified rectangular area of the map application UI.
 
-With the widget, you can:
+With the widget, you can do the following:
 
 -   Show, move, and resize the widget.
 -   Set the map view widget theme.
@@ -108,7 +106,7 @@ You can [create objects in the widget](#maps_object). The following view object 
 
 The object properties can be changed after the object has been created.
 
-The map view and map object can [handle events](#maps_event). Each object has handlers to invoke callbacks for selected events of the [Tizen.Maps.MapObject](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.MapObject.html) and [Tizen.Maps.MapView](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.MapView.html) classes:
+The map view and map object can [handle events](#maps_event). Each object has handlers to invoke callbacks for selected events of the [Tizen.Maps.MapObject](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.MapObject.html) and [Tizen.Maps.MapView](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.MapView.html) classes. The events of each handler are described below:
 
 -   Gestures
     -   `Tizen.Maps.MapView.Scrolled`: Scroll gesture is detected over the widget.
@@ -122,13 +120,13 @@ The map view and map object can [handle events](#maps_event). Each object has ha
     -   `Tizen.Maps.MapView.ViewReady`: Map view widget is ready.
 
 
-> **Note**   
+> [!NOTE]
 > To use the map view on Xamarin.Forms, use Xamarin.Forms.Maps.
 
 
 ## Prerequisites
 
-To enable your application to use the map service functionality:
+To enable your application to use the map service functionality, follow the steps below:
 
 1.  To use the [Tizen.Maps](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.html) namespace, the application has to request permission by adding the following privileges to the `tizen-manifest.xml` file:
 
@@ -147,9 +145,9 @@ To enable your application to use the map service functionality:
     ```
 
 <a name="start"></a>
-## Starting the Map Service
+## Start the map service
 
-To start using the map service:
+To start using the map service, follow the steps below:
 
 1.  The [Tizen.Maps.MapService](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.MapService.html) instance relies on a particular map provider. To get a list of available map providers, use the `Providers` property of the `Tizen.Maps.MapService` class:
 
@@ -170,7 +168,7 @@ To start using the map service:
 
 3.  You must make sure that the device user has consented to allow the map provider to use their location information. Depending on the map provider, a UI window to get user consent can be shown on the screen.
 
-    If the consent request returns `false`, you cannot use most of the methods and properties of the Tizen.Maps namespace.
+    If the consent request returns `false`, you cannot use most of the methods and properties of the Tizen.Maps namespace:
 
     ```csharp
     bool isConsented = await maps.RequestUserConsent();
@@ -205,13 +203,13 @@ To start using the map service:
     To check the availability of other data features, follow the same approach using the keys from the [Tizen.Maps.ServiceData](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.ServiceData.html) enumerator.
 
 <a name="use_geocode"></a>
-## Using Geocode and Reverse Geocode Services
+## Use geocode and reverse geocode services
 
 To retrieve a geocode of a specified place, or the place information corresponding to given geographic coordinates, use one of the following approaches. The service requests can be [customized](#preference).
 
-To retrieve a geocode:
+To retrieve a geocode, follow the steps below:
 
--   To retrieve a geocode, use a string of free-formed address for the `CreateGeocodeRequest()` method of the [Tizen.Maps.MapService](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.MapService.html) object:
+1.  To retrieve a geocode, use a string of free-formed address for the `CreateGeocodeRequest()` method of the [Tizen.Maps.MapService](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.MapService.html) object:
 
     ```csharp
     try
@@ -229,7 +227,7 @@ To retrieve a geocode:
     }
     ```
 
--   To retrieve a geocode inside a specified area, use a string and an instance of the [Tizen.Maps.Area](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.Area.html) object for the `CreateGeocodeRequest()` method of the `Tizen.Maps.MapService` object:
+2.  To retrieve a geocode inside a specified area, use a string and an instance of the [Tizen.Maps.Area](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.Area.html) object for the `CreateGeocodeRequest()` method of the `Tizen.Maps.MapService` object:
 
     ```csharp
     try
@@ -248,7 +246,7 @@ To retrieve a geocode:
     }
     ```
 
--   To retrieve places specified as a structured address, use an instance of the [Tizen.Maps.PlaceAddress](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.PlaceAddress.html) object for the `CreateGeocodeRequest()` method of the `Tizen.Maps.MapService` object:
+3.  To retrieve places specified as a structured address, use an instance of the [Tizen.Maps.PlaceAddress](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.PlaceAddress.html) object for the `CreateGeocodeRequest()` method of the `Tizen.Maps.MapService` object:
 
     ```csharp
     try
@@ -270,9 +268,9 @@ To retrieve a geocode:
     }
     ```
 
-To retrieve a reverse geocode:
+To retrieve a reverse geocode, follow the steps below:
 
--   To retrieve a reverse geocode of specified geographic coordinates, use latitude and longitude for the `CreateReverseGeocodeRequest()` method of the `Tizen.Maps.MapService` object:
+1.  To retrieve a reverse geocode of specified geographic coordinates, use latitude and longitude for the `CreateReverseGeocodeRequest()` method of the `Tizen.Maps.MapService` object:
 
     ```csharp
     try
@@ -290,7 +288,7 @@ To retrieve a reverse geocode:
     }
     ```
 
--   To retrieve reverse geocodes of specified multiple geographic coordinates, use the `CreateMultiReverseGeocodeRequest()` method of the `Tizen.Maps.MapService` object:
+2.  To retrieve reverse geocodes of specified multiple geographic coordinates, use the `CreateMultiReverseGeocodeRequest()` method of the `Tizen.Maps.MapService` object:
 
     ```csharp
     try
@@ -313,11 +311,11 @@ To retrieve a reverse geocode:
     ```
 
 <a name="use_search_place"></a>
-## Using the Place Search Service
+## Use the place search service
 
 To search for a place with a diversity of search parameters, use one of the following approaches. The service requests can be [customized](#preference).
 
--   To retrieve places within a specified distance around the center coordinates, use an instance of the [Tizen.Maps.Geocoordinates](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.Geocoordinates.html) object for the `CreatePlaceSearchRequest()` method of the [Tizen.Maps.MapService](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.MapService.html) object:
+1.  To retrieve places within a specified distance around the center coordinates, use an instance of the [Tizen.Maps.Geocoordinates](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.Geocoordinates.html) object for the `CreatePlaceSearchRequest()` method of the [Tizen.Maps.MapService](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.MapService.html) object:
 
     ```csharp
     try
@@ -336,7 +334,7 @@ To search for a place with a diversity of search parameters, use one of the foll
     }
     ```
 
--   To retrieve places within a specified geographic boundary, use an instance of the [Tizen.Maps.Area](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.Area.html) object for the `CreatePlaceSearchRequest()` method of the `Tizen.Maps.MapService` object:
+2.  To retrieve places within a specified geographic boundary, use an instance of the [Tizen.Maps.Area](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.Area.html) object for the `CreatePlaceSearchRequest()` method of the `Tizen.Maps.MapService` object:
 
     ```csharp
     try
@@ -355,7 +353,7 @@ To search for a place with a diversity of search parameters, use one of the foll
     }
     ```
 
--   To retrieve places based on an address within a specified geographic boundary, use a string of free-formed address and an instance of the `Area` object for the `CreatePlaceSearchRequest()` method of the `Tizen.Maps.MapService` object:
+3.  To retrieve places based on an address within a specified geographic boundary, use a string of free-formed address and an instance of the `Area` object for the `CreatePlaceSearchRequest()` method of the `Tizen.Maps.MapService` object:
 
     ```csharp
     try
@@ -375,11 +373,11 @@ To search for a place with a diversity of search parameters, use one of the foll
     ```
 
 <a name="use_search_route"></a>
-## Using the Routing Service
+## Use the routing service
 
 To query a route from point A to point B, use one of the following approaches. The service requests can be [customized](#preference).
 
--   To query a route from one set of geographic coordinates to another:
+1.  To query a route from one set of geographic coordinates to another:
 
     ```csharp
     try
@@ -403,7 +401,7 @@ To query a route from point A to point B, use one of the following approaches. T
     }
     ```
 
--   To query a route passing through a specified set of waypoints:
+2.  To query a route passing through a specified set of waypoints:
 
     ```csharp
     try
@@ -432,13 +430,13 @@ To query a route from point A to point B, use one of the following approaches. T
     ```
 
 <a name="preference"></a>
-## Customizing the Service Requests
+## Customize service requests
 
 All map service requests can be customized with additional preferences. Preparing and sending the `preference` parameter with the service request allows the map provider to generate more accurate results.
 
-To customize the service request:
+To customize the service request, follow the steps below:
 
--   The example from [Using the Place Search Service](#use_search_place) can be modified as follows to include the customized preferences:
+1.  The example from [using the place search service](#use_search_place) can be modified as follows to include the customized preferences:
 
     ```csharp
     try
@@ -461,9 +459,9 @@ To customize the service request:
     }
     ```
 
--   To prepare preferences for the routing service, use the [Tizen.Maps.SearchPreference](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.SearchPreference.html) or [Tizen.Maps.IRouteSearchPreference](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.IRouteSearchPreference.html) methods.
+2.  To prepare preferences for the routing service, use the [Tizen.Maps.SearchPreference](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.SearchPreference.html) or [Tizen.Maps.IRouteSearchPreference](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.IRouteSearchPreference.html) methods.
 
-    The example from [Using the Routing Service](#use_search_route) can be modified as follows to include the customized preferences:
+    The example from [using the routing service](#use_search_route) can be modified as follows to include the customized preferences:
 
     ```csharp
     try
@@ -494,9 +492,9 @@ To customize the service request:
 If your map provider requires any specific preferences, use the `Tizen.Maps.SearchPreference` class with key-value pairs defined in the appropriate map provider documentation.
 
 <a name="maps_view"></a>
-## Using the Map View
+## Use the map view
 
-To use the map view:
+To use the map view, follow the steps below:
 
 1.  Before you use the view features, create a [Tizen.Maps.MapView](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.MapView.html) instance:
 
@@ -516,10 +514,10 @@ To use the map view:
     }
     ```
 
-2.  Set the map view properties:
+2.  To set the map view properties, proceed as follows:
     -   Set the map view type with the `MapType` property of the `Tizen.Maps.MapView` class.
 
-        For other available types, see the [Tizen.Maps.MapTypes](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.MapTypes.html) enumerator.
+        For other available types, see the [Tizen.Maps.MapTypes](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.MapTypes.html) enumerator:
 
         ```csharp
         mapview.MapType = MapTypes.Satellite;
@@ -557,30 +555,30 @@ To use the map view:
 
 
 
-    > **Note**   
+    > [!NOTE]
 	> To check whether a feature is supported, use `IsSupported()` method of the [Tizen.Maps.MapService](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.MapService.html) class with the [Tizen.Maps.ServiceData](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.ServiceData.html) enumerator.
 
 
 
-3.  Set the map view location and size:
+3.  To set the map view location and size, follow as proceeds:
 
-    Set the map view location with the `Resize()` method of the `Tizen.Maps.MapView` class, inherited from the `EvasObject` class:
+    -   Set the map view location with the `Resize()` method of the `Tizen.Maps.MapView` class, inherited from the `EvasObject` class:
 
-    ```csharp
-    mapview.Resize(400, 800);
-    ```
+        ```csharp
+        mapview.Resize(400, 800);
+        ```
 
-    You can also set the location with the `Move()` method of the `Tizen.Maps.MapView` class, inherited from the `EvasObject` class:
+    -   You can also set the location with the `Move()` method of the `Tizen.Maps.MapView` class, inherited from the `EvasObject` class:
 
-    ```csharp
-    mapview.Move(0, 0);
-    ```
+        ```csharp
+        mapview.Move(0, 0);
+        ```
 
-    Set the map view visibility with the `Show()` method of the `Tizen.Maps.MapView` class, inherited from the `EvasObject` class:
+    -   Set the map view visibility with the `Show()` method of the `Tizen.Maps.MapView` class, inherited from the `EvasObject` class:
 
-    ```csharp
-    mapview.Show();
-    ```
+        ```csharp
+        mapview.Show();
+        ```
 
 4.  Set the map view center with the `Center` property:
 
@@ -601,13 +599,13 @@ To use the map view:
     ```
 
 <a name="maps_object"></a>
-## Creating Map View Objects
+## Create map view objects
 
 You can create polyline, polygon, and marker objects for the map view.
 
-To create a map view object:
+To create a map view object, follow the steps below:
 
--   To create a polyline:
+1.  To create a polyline:
 
     ```csharp
     try
@@ -627,7 +625,7 @@ To create a map view object:
     }
     ```
 
--   To create a polygon:
+2.  To create a polygon:
 
     ```csharp
     try
@@ -646,7 +644,7 @@ To create a map view object:
     }
     ```
 
--   To create a marker:
+3.  To create a marker:
 
     ```csharp
     Pin pin = new Pin(new Geocoordinates(28.64362, 77.19865));
@@ -660,7 +658,7 @@ To create a map view object:
     Sticker sticker = new Sticker(new Geocoordinates(28.64362, 77.19865), "image/marker_sticker.png");
     ```
 
-To add a map view object to a map view widget:
+To add a map view object to a map view widget, follow these steps:
 
 1.  Add the object instance to the map view with the `Add()` method of the [Tizen.Maps.MapView](/application/dotnet/api/TizenFX/latest/api/Tizen.Maps.MapView.html) class:
 
@@ -675,9 +673,9 @@ To add a map view object to a map view widget:
     ```
 
 <a name="maps_event"></a>
-## Managing Map View Events
+## Manage map view events
 
-To handle map view events:
+To handle map view events, follow these steps:
 
 1.  Register an event handler, which is triggered when map view events occur:
 
@@ -698,7 +696,7 @@ To handle map view events:
     mapview.DoubleClicked -= handler;
     ```
 
-To handle map object events:
+To handle map object events, follow these steps:
 
 1.  Register an event handler, which is triggered when map object events occur:
 
@@ -718,7 +716,7 @@ To handle map object events:
     pin.Clicked -= handler;
     ```
 
-To handle map view ready events:
+To handle map view ready events, follow these steps:
 
 1.  Register an event handler, which is triggered when map view ready events occur:
 
@@ -737,6 +735,6 @@ To handle map view ready events:
     mapview.ViewReady -= handler;
     ```
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher


### PR DESCRIPTION
### Change Description ###

This is the eighth PR in updating the .NET applications section of the Tizen Docs site.

This PR includes the fix of the following topics:

Location [File count: 3]
Machine Learning [File count: 5]
Maps [File count: 2]

List of files on which changes were made:

/application/dotnet/guides/location/overview.md
/application/dotnet/guides/location/location.md
/application/dotnet/guides/location/geofences.md
/application/dotnet/guides/machine-learning/overview.md
/application/dotnet/guides/machine-learning/machine-learning-inference.md
/application/dotnet/guides/machine-learning/singleshot.md
/application/dotnet/guides/machine-learning/pipeline.md
/application/dotnet/guides/machine-learning/machine-learning-train.md
/application/dotnet/guides/maps/maps.md
/application/dotnet/guides/maps/here-credentials.md

Signed off by: [omar.saeed@samsung.com](mailto:omar.saeed@samsung.com)
