### PR TITLE
.NET application site fix (Part - 12)

### DIFF
--- a/docs/application/dotnet/guides/multimedia/camera.md
+++ b/docs/application/dotnet/guides/multimedia/camera.md
@@ -15,10 +15,10 @@ The main features of the `Tizen.Multimedia.Camera` class include the following:
 
 -   Setting the display for the camera preview
 
-    You can preview images in real time with the `StartPreview()` method of the `Tizen.Multimedia.Camera` class.
+    You can preview images in real-time with the `StartPreview()` method of the `Tizen.Multimedia.Camera` class.
     The camera provides support for the following features:
 
-    -   Pixel formats, such as NV12, NV12T, NV16, NV21, YUYV, UYVY, YUV420P, I420, YV12, RGB565, RGB888, RGBA, ARGB, JPEG, H264, INVZ, MJPEG, VP8 and VP9.
+    -   Pixel formats, such as NV12, NV12T, NV16, NV21, YUYV, UYVY, YUV420P, I420, YV12, RGB565, RGB888, RGBA, ARGB, JPEG, H264, INVZ, MJPEG, VP8, and VP9.
     -   Preview at the frame rate, which you can set by `PreviewFps` property.
     -   Rotation and flip of the preview.
 
@@ -42,13 +42,13 @@ The main features of the `Tizen.Multimedia.Camera` class include the following:
     -   Flash
     -   Focus
     -   Metering
-    -   EXIF tag (geo, orientation, software information and description)
+    -   EXIF tag (geo, orientation, software information, and description)
     -   Scene mode, HDR, theater
     -   Image quality
 
     Depending on the camera device type, the device supports different orientations, resolutions, or preview and capture formats. You can obtain this information from the device using the `SupportedPreviewResolutions`, `SupportedCapturePixelFormats`, or other `SupportedXXX` properties of the [Tizen.Multimedia.CameraCapabilities](/application/dotnet/api/TizenFX/latest/api/Tizen.Multimedia.CameraCapabilities.html) class.
 
-    Since devices can have multiple camera sensors with different capabilities, create a `Tizen.Multimedia.Camera` instance with a proper [Tizen.Multimedia.CameraDevice](/application/dotnet/api/TizenFX/latest/api/Tizen.Multimedia.CameraDevice.html) enumeration value, determining which camera sensor is used. Usually, the primary sensor is located on the back side and the secondary sensor on the front side of the device. Once the camera sensor is selected, the selected sensor starts working.
+    Since devices can have multiple camera sensors with different capabilities, create a `Tizen.Multimedia.Camera` instance with a proper [Tizen.Multimedia.CameraDevice](/application/dotnet/api/TizenFX/latest/api/Tizen.Multimedia.CameraDevice.html) enumeration value, determining which camera sensor is used. Usually, the primary sensor is located on the back side, and the secondary sensor on the front side of the device. Once the camera sensor is selected, the selected sensor starts working.
 
     > [!NOTE]
     > Simultaneous use of multiple camera sensors is not allowed.
@@ -195,7 +195,7 @@ To configure the camera, follow the below steps:
         {
             if (e.Preview.PlaneType == PlaneType.RgbPlane)
             {
-                /// Do something
+                /// do something
             }
         }
 
@@ -439,7 +439,7 @@ To set some attributes, follow the below steps:
 
 ## Release resources
 
-After you have finished working with the camera, stop the camera and clean up the application environment:
+After you have finished working with the camera, follow the steps below to stop the camera and clean up the application environment:
 
 1.  If autofocus is switched on, switch if off using the `StopFocusing()` method of the [Tizen.Multimedia.Camera](/application/dotnet/api/TizenFX/latest/api/Tizen.Multimedia.Camera.html) class:
 

--- a/docs/application/dotnet/guides/multimedia/media-conversions.md
+++ b/docs/application/dotnet/guides/multimedia/media-conversions.md
@@ -2,7 +2,7 @@
 
 You can perform various media conversions through codecs. You can encode and decode video and audio data.
 
-The main features of the Tizen.Multimedia.MediaCodec namespace include:
+The main features of the Tizen.Multimedia.MediaCodec namespace include the following:
 
 -   Preparing media codecs
 
@@ -17,9 +17,9 @@ The main features of the Tizen.Multimedia.MediaCodec namespace include:
     [Run the media codec loop](#RunCodec) and retrieve the output packet.
 
 <a name="PrepareCodec"></a>
-## Preparing Media Codecs
+## Prepare media codecs
 
-To prepare the media codecs:
+To prepare the media codecs, proceed as follows:
 
 1.  Create an instance of the [Tizen.Multimedia.MediaCodec.MediaCodec](/application/dotnet/api/TizenFX/latest/api/Tizen.Multimedia.MediaCodec.MediaCodec.html) class:
 
@@ -47,7 +47,7 @@ To prepare the media codecs:
 
 3.  To receive notifications whenever the input or output buffers are changed:
 
-    1.  To receive notifications when the input buffer is processed, register an event handler for the `InputProcessed` event of the `Tizen.Multimedia.MediaCodec.MediaCodec` class.
+    -   To receive notifications when the input buffer is processed, register an event handler for the `InputProcessed` event of the `Tizen.Multimedia.MediaCodec.MediaCodec` class.
 
         The event handler receives the currently-processing input packet:
 
@@ -60,7 +60,7 @@ To prepare the media codecs:
         }
         ```
 
-    2.  To receive notifications when the output buffers are dequeued, register an event handler for the `OutputAvailable` event of the `Tizen.Multimedia.MediaCodec.MediaCodec` class.
+    -   To receive notifications when the output buffers are dequeued, register an event handler for the `OutputAvailable` event of the `Tizen.Multimedia.MediaCodec.MediaCodec` class.
 
         The event handler receives the result packet:
 
@@ -76,9 +76,9 @@ To prepare the media codecs:
         ```
 
 <a name="FillPacket"></a>
-## Filling Media Packets
+## Fill media packets
 
-To create a media packet and fill it with data:
+To create a media packet and fill it with data, proceed as follows:
 
 1.  Create an instance of the [Tizen.Multimedia.MediaPacket](/application/dotnet/api/TizenFX/latest/api/Tizen.Multimedia.MediaPacket.html) class:
 
@@ -102,14 +102,14 @@ To create a media packet and fill it with data:
     ```
 
 <a name="RunCodec"></a>
-## Running Media Codecs
+## Run media codecs
 
 After [preparing the media codec](#PrepareCodec) and [filling the media packet with data](#FillPacket), run the media codec in the following loop:
 
 1.  When an input buffer is ready, read a chunk of input and copy it into the buffer to be encoded or decoded.
 2.  When an output buffer is ready, copy the encoded or decoded output from the buffer.
 
-To run the media codec loop:
+To run the media codec loop, proceed as follows:
 
 1.  Prepare the media codec using the `Prepare()` method of the [Tizen.Multimedia.MediaCodec.MediaCodec](/application/dotnet/api/TizenFX/latest/api/Tizen.Multimedia.MediaCodec.MediaCodec.html) class:
 
@@ -164,6 +164,6 @@ To run the media codec loop:
     mediaCodec.Unprepare();
     ```
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/multimedia/radio.md
+++ b/docs/application/dotnet/guides/multimedia/radio.md
@@ -113,7 +113,7 @@ To select and start playing a frequency, proceed as follows:
 1.  Set the frequency you want to play using the `Frequency` property of the [Tizen.Multimedia.Radio](/application/dotnet/api/TizenFX/latest/api/Tizen.Multimedia.Radio.html) class:
 
     ```csharp
-    radio.Frequency = newFrequncey;
+    radio.Frequency = newFrequency;
     ```
 
 2.  Start playing the frequency using the `Start()` method of the `Tizen.Multimedia.Radio` class:
@@ -132,7 +132,7 @@ To search for and tune in to an adjacent channel, use the `SeekUpAsync()` and `S
 For example, to seek down, use the `SeekDownAsync()` method:
 
 ```csharp
-var newFrequncey = await radio.SeekDownAsync();
+var newFrequency = await radio.SeekDownAsync();
 
 /// Search is complete, and the radio is tuned in to the new frequency
 /// Application sets the new frequency and updates the user interface

--- a/docs/application/dotnet/guides/multimedia/radio.md
+++ b/docs/application/dotnet/guides/multimedia/radio.md
@@ -2,7 +2,7 @@
 
 You can control the radio hardware in a device to provide radio playback in your application.
 
-The main features of the `Tizen.Multimedia.Radio` class include:
+The main features of the `Tizen.Multimedia.Radio` class include the following:
 
 -   Switching the radio on and off
 
@@ -25,7 +25,7 @@ You can only have one radio instance active at a time. Radio playback can be int
 ## Prerequisites
 
 
-To enable your application to use the radio functionality:
+To enable your application to use the radio functionality, proceed as follows:
 
 1.  To use the methods and properties of the [Tizen.Multimedia.Radio](/application/dotnet/api/TizenFX/latest/api/Tizen.Multimedia.Radio.html) class, include the [Tizen.Multimedia](/application/dotnet/api/TizenFX/latest/api/Tizen.Multimedia.html) namespace in your application:
 
@@ -39,7 +39,7 @@ To enable your application to use the radio functionality:
     Radio radio = new Radio();
     ```
 
-3.  To receive notifications when radio playback is interrupted, register an event handler for the `Interrupted` event of the `Tizen.Multimedia.Radio` class. Radio playback is interrupted, for example, when the radio application moves to the background.
+3.  To receive notifications when radio playback is interrupted, register an event handler for the `Interrupted` event of the `Tizen.Multimedia.Radio` class. Radio playback is interrupted, for example, when the radio application moves to the background:
 
     ```csharp
     radio.Interrupted += OnRadioInterrupted;
@@ -61,12 +61,12 @@ To enable your application to use the radio functionality:
     ```
 
 <a name="scan"></a>
-## Scanning for Radio Frequencies
+## Scan for radio frequencies
 
-To scan for all available radio frequencies:
+To scan for all available radio frequencies, proceed as follows:
 
 1.  Register and define event handlers for the events of the [Tizen.Multimedia.Radio](/application/dotnet/api/TizenFX/latest/api/Tizen.Multimedia.Radio.html) class:
-    -   To receive a notification each time the scan finds a new frequency, register an event handler for the `ScanUpdated` event. The event provides the kHz value of the found frequency.
+    -   To receive a notification each time the scan finds a new frequency, register an event handler for the `ScanUpdated` event. The event provides the kHz value of the found frequency:
 
         ```csharp
         radio.ScanCompleted += OnScanCompleted;
@@ -79,7 +79,7 @@ To scan for all available radio frequencies:
         }
         ```
 
-         > **Note**   
+         > [!NOTE]
 		 > Do not use radio operations (such as changing the `Frequency` property value or calling the `Start()` method) in the scan updated event handler.
 
 
@@ -106,9 +106,9 @@ To scan for all available radio frequencies:
     To cancel the scan before it completes, use the `StopScan()` method.
 
 <a name="tune"></a>
-## Tuning the Radio
+## Tuning the radio
 
-To select and start playing a frequency:
+To select and start playing a frequency, proceed as follows:
 
 1.  Set the frequency you want to play using the `Frequency` property of the [Tizen.Multimedia.Radio](/application/dotnet/api/TizenFX/latest/api/Tizen.Multimedia.Radio.html) class:
 
@@ -125,7 +125,7 @@ To select and start playing a frequency:
     If the radio emits no sound, check the signal strength with the `SignalStrength` property of the `Tizen.Multimedia.Radio` class. The property returns the current signal strength as a dBuV value.
 
 <a name="seek"></a>
-## Searching for an Adjacent Channel
+## Search for an adjacent channel
 
 To search for and tune in to an adjacent channel, use the `SeekUpAsync()` and `SeekDownAsync()` methods of the [Tizen.Multimedia.Radio](/application/dotnet/api/TizenFX/latest/api/Tizen.Multimedia.Radio.html) class. This is similar to the scanning operation, but only the nearest active frequency is searched for. Once the maximum frequency is reached in either direction, the search ends, and the radio is set to that frequency.
 
@@ -138,6 +138,6 @@ var newFrequncey = await radio.SeekDownAsync();
 /// Application sets the new frequency and updates the user interface
 ```
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/multimedia/screen-mirroring.md
+++ b/docs/application/dotnet/guides/multimedia/screen-mirroring.md
@@ -2,7 +2,7 @@
 
 You can mirror the device screen and sound to another device wirelessly using the screen mirroring feature. Tizen follows the Wi-Fi Display Technical Specification and supports the feature as a sink which receives shared data from a source device that supports the Wi-Fi Display, and displays it. Remember to prepare your application to use the screen mirroring sink functionality and set up the necessary callbacks before you start, and release the resources when you are done.
 
-The main features of the `Tizen.Multimedia.Remoting.ScreenMirroring` class include:
+The main features of the `Tizen.Multimedia.Remoting.ScreenMirroring` class include the following:
 
 -   Preparing for screen mirroring
 
@@ -34,9 +34,9 @@ using Tizen.Multimedia.Remoting;
 ```
 
 <a name="prepare"></a>
-## Preparing for Screen Mirroring
+## Prepare for screen mirroring
 
-To prepare for screen mirroring:
+To prepare for screen mirroring, proceed as follows:
 
 1.  Define and register an event handler for the `StateChanged` event of the [Tizen.Multimedia.Remoting.ScreenMirroring](/application/dotnet/api/TizenFX/latest/api/Tizen.Multimedia.Remoting.ScreenMirroring.html) class:
 
@@ -58,9 +58,9 @@ To prepare for screen mirroring:
     The screen mirroring state changes to `Prepared`.
 
 <a name="connect"></a>
-## Connecting and Starting Screen Mirroring
+## Connect and starting screen mirroring
 
-To connect to a source and start screen mirroring:
+To connect to a source and start screen mirroring, proceed as follows:
 
 1.  Connect to the screen mirroring source using the `ConnectAsync()` method of the [Tizen.Multimedia.Remoting.ScreenMirroring](/application/dotnet/api/TizenFX/latest/api/Tizen.Multimedia.Remoting.ScreenMirroring.html) class with the source IP address as a parameter:
 
@@ -79,7 +79,7 @@ To connect to a source and start screen mirroring:
     The screen mirroring state changes from `Connected` to `Playing`.
 
 <a name="handle"></a>
-## Handling Screen Mirroring Errors
+## Handle screen mirroring errors
 
 You can receive notifications of errors caused by internal screen mirroring issues or by the source device disconnecting the session. Define and register an event handler for the `ErrorOccurred` event of the [Tizen.Multimedia.Remoting.ScreenMirroring](/application/dotnet/api/TizenFX/latest/api/Tizen.Multimedia.Remoting.ScreenMirroring.html) class:
 
@@ -93,6 +93,6 @@ screenMirroring.ErrorOccurred += OnErrorOccurred;
 ```
 
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/multimedia/webrtc.md
+++ b/docs/application/dotnet/guides/multimedia/webrtc.md
@@ -347,7 +347,7 @@ You can change the state of the WebRTC. If you are ready for media sources that 
     }
     webRtc.IceGatheringStateChanged += (s, e) =>
     {
-        // You can stop waiting IceCandidate event when the State of this event is changed to WebRTCIceGatheringState.Completed.
+        // You can stop waiting IceCandidate event when the state of this event is changed to WebRTCIceGatheringState.Completed.
     }
     ...
     await webRtc.StartAsync();


### PR DESCRIPTION
### Change Description ###

This is the twelfth PR in updating the .NET applications section of the Tizen Docs site.

**File count: 5**

This PR includes the fix of the following files:

/application/dotnet/guides/multimedia/media-conversions.md
/application/dotnet/guides/multimedia/screen-mirroring.md
/application/dotnet/guides/multimedia/radio.md
/application/dotnet/guides/multimedia/camera.md
/application/dotnet/guides/multimedia/webrtc.md
Signed off by: [omar.saeed@samsung.com](mailto:omar.saeed@samsung.com)

