### PR TITLE
[privilege-info][ACR-1737] Remove deprecated API from doc

### DIFF
--- a/docs/application/native/guides/security/privilege.md
+++ b/docs/application/native/guides/security/privilege.md
@@ -65,14 +65,6 @@ To get various privilege information:
                                                         &description);
     ```
 
-- Get the privacy display name using the `privilege_info_get_privacy_display_name()` function:
-
-    ```
-    char* privacy_display_name = NULL;
-    int ret = privilege_info_get_privacy_display_name("http://tizen.org/privilege/account.read",
-                                                      &privacy_display_name);
-    ```
-
 - Get the privilege information in a list form using the `privilege_info_get_privilege_info_list()` function:
 
     ```


### PR DESCRIPTION
### Change Description ###

- privilege_info_get_privacy_display_name() is deprecated since Tizen 7.5 hence remove docs related to it accordingly.

### API Changes ###

 - ACR: https://code.sec.samsung.net/jira/browse/ACR-1737

