### PR TITLE
Fix links in Tizen 7.0 Public M2 release notes

### DIFF
--- a/docs/platform/release-notes/tizen-7-0-m2.md
+++ b/docs/platform/release-notes/tizen-7-0-m2.md
@@ -8,8 +8,8 @@ Release date: Oct. 31, 2022
 
 
 - Getting binaries and images
-  - Base: [http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Base/tizen-base_20220916.024010/](http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Base/tizen-base_20220916.024010/)
-  - Profile(Unified): [http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Unified/tizen-unified_20221017.061100/](http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Unified/tizen-unified_20221017.061100/)
+  - Base: [http://download.tizen.org/releases/milestone/TIZEN/Tizen/Tizen-Base/tizen-base_20220916.024010/](http://download.tizen.org/releases/milestone/TIZEN/Tizen/Tizen-Base/tizen-base_20220916.024010/)
+  - Profile(Unified): [http://download.tizen.org/releases/milestone/TIZEN/Tizen/Tizen-Unified/tizen-unified_20221017.061100/](http://download.tizen.org/releases/milestone/TIZEN/Tizen/Tizen-Unified/tizen-unified_20221017.061100/)
 
 - [How to flash to a device](../developing/flashing.md)
 


### PR DESCRIPTION
### Change Description ###

Fix links in Tizen 7.0 Public M2 Release Notes: `snapshots` -> `releases/milestone`.

### Bugs Fixed ###
No

### API Changes ###
No

cc @alpencolt @gbalykov