### PR TITLE
.NET application site fix (Part - 13)

### DIFF
--- a/docs/application/dotnet/guides/messaging/email.md
+++ b/docs/application/dotnet/guides/messaging/email.md
@@ -3,15 +3,15 @@
 
 You can access the email infrastructure to allow the user to exchange digital messages. Email systems are based on a store-and-forward model, in which email server computer systems accept, forward, deliver, and store messages on behalf of users, who only need to connect to the email infrastructure, typically an email server, with a network-enabled device for the duration of message submission or retrieval.
 
-The main feature of the Tizen.Messaging.Email namespace is email message sending. You can connect to an email server, and compose, save, and [send email messages](#sending) using SMTP.
+The main feature of the [Tizen.Messaging.Email](/application/dotnet/api/TizenFX/latest/api/Tizen.Messaging.Email.html) namespace is email message sending. You can connect to an email server, and compose, save, and [send email messages](#sending) using SMTP.
 
-The Tizen.Messaging.Email namespace can be utilized by any component in the application layer which helps the device user to manage email messaging. For example, the Email methods can be invoked by a multimedia module when the user wants to send a media file through email, or by an email application when the user tries to send an email message.
+The `Tizen.Messaging.Email` namespace can be utilized by any component in the application layer which helps the device user to manage email messaging. For example, the email methods can be invoked by a multimedia module when the user wants to send a media file through email, or by an email application when the user tries to send an email message.
 
 ## Prerequisites
 
-To enable your application to use the email functionality:
+To enable your application to use the email functionality, follow the steps below:
 
-1.  To use the [Tizen.Messaging.Email](/application/dotnet/api/TizenFX/latest/api/Tizen.Messaging.Email.html) namespace, the application has to request permission by adding the following privilege to the `tizen-manifest.xml` file:
+1.  To use the `Tizen.Messaging.Email` namespace, the application has to request permission by adding the following privilege to the `tizen-manifest.xml` file:
 
     ```XML
     <privileges>
@@ -19,16 +19,16 @@ To enable your application to use the email functionality:
     </privileges>
     ```
 
-2.  To use the methods and properties of the Tizen.Messaging.Email namespace, include it in your application:
+2.  To use the methods and properties of the `Tizen.Messaging.Email` namespace, include it in your application:
 
     ```csharp
     using Tizen.Messaging.Email;
     ```
 
 <a name="sending"></a>
-## Sending Email
+## Send an email
 
-To send an email message:
+To send an email message, follow the steps below:
 
 1.  Create the email message with an instance of the [Tizen.Messaging.Email.EmailMessage](/application/dotnet/api/TizenFX/latest/api/Tizen.Messaging.Email.EmailMessage.html) class, and set the message subject:
 
@@ -61,6 +61,6 @@ To send an email message:
     var result = await EmailSender.SendAsync(email);
     ```
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/messaging/messages.md
+++ b/docs/application/dotnet/guides/messaging/messages.md
@@ -3,7 +3,7 @@
 
 You can access the device messaging capabilities, including sending SMS and MMS messages.
 
-The main features of the Tizen.Messaging.Messages namespace include:
+The main features of the Tizen.Messaging.Messages namespace include the following:
 
 -   Text messaging (SMS)
 
@@ -21,14 +21,14 @@ The sent status of the SMS and MMS messages can be checked asynchronously. You r
 
 
 
-> **Note**   
+> [!NOTE]
 > You can test sending MMS messages on a target device only. The emulator does not support this feature.
 
 
 
 ## Prerequisites
 
-To enable your application to use the messaging functionality:
+To enable your application to use the messaging functionality, follow the steps below:
 
 1.  To use the [Tizen.Messaging.Messages](/application/dotnet/api/TizenFX/latest/api/Tizen.Messaging.Messages.html) namespace, the application has to request permission by adding the following privileges to the `tizen-manifest.xml` file:
 
@@ -39,16 +39,16 @@ To enable your application to use the messaging functionality:
     </privileges>
     ```
 
-2.  To use the methods and properties of the Tizen.Messaging.Messages namespace, include it in your application:
+2.  To use the methods and properties of the `Tizen.Messaging.Messages` namespace, include it in your application:
 
     ```csharp
     using Tizen.Messaging.Messages;
     ```
 
 <a name="managing_events"></a>
-## Managing Events
+## Manage events
 
-To manage events related to messages:
+To manage events related to messages, follow the steps below:
 
 1.  Define the `EventHandlerMessageReceived()` event handler, which is triggered when receiving a message:
 
@@ -72,11 +72,11 @@ To manage events related to messages:
     ```
 
 <a name="sending"></a>
-## Sending SMS or MMS Messages
+## Send SMS or MMS messages
 
 You can send SMS (Short Message Service) messages and MMS (Multimedia Message Service) messages with attachments (image or video files).
 
-To send a message:
+To send a message, follow the steps below:
 
 1.  Create a message by creating an instance of the [Tizen.Messaging.Messages.SmsMessage](/application/dotnet/api/TizenFX/latest/api/Tizen.Messaging.Messages.SmsMessage.html) or [Tizen.Messaging.Messages.MmsMessage](/application/dotnet/api/TizenFX/latest/api/Tizen.Messaging.Messages.MmsMessage.html) class.
 
@@ -102,7 +102,7 @@ To send a message:
         msg.Subject = "Tizen C# test subject";
         ```
 
-    -   Add attachments using their absolute path in the device file system. Before adding an attachment, create it as a new instance of the [Tizen.Messaging.Messages.MessagesAttachment](/application/dotnet/api/TizenFX/latest/api/Tizen.Messaging.Messages.MessagesAttachment.html) class and give it the appropriate attachment type by using values of the [Tizen.Messaging.Messages.MediaType](/application/dotnet/api/TizenFX/latest/api/Tizen.Messaging.Messages.MediaType.html) enumeration.
+    -   Add attachments using their absolute path in the device file system. Before adding an attachment, create it as a new instance of the [Tizen.Messaging.Messages.MessagesAttachment](/application/dotnet/api/TizenFX/latest/api/Tizen.Messaging.Messages.MessagesAttachment.html) class and give it the appropriate attachment type by using values of the [Tizen.Messaging.Messages.MediaType](/application/dotnet/api/TizenFX/latest/api/Tizen.Messaging.Messages.MediaType.html) enumeration:
 
         ```csharp
         var attachment = new MessagesAttachment(MediaType.Image, "/path/to/image/file");
@@ -116,7 +116,7 @@ To send a message:
     ```
 
 <a name="fetching"></a>
-## Fetching Messages from a Specified Message Box
+## Fetch messages from a specified message box
 To fetch messages from a message box, use the `SearchMessageAsync()` method of the [Tizen.Messaging.Messages.MessagesManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Messaging.Messages.MessagesManager.html) class with an appropriate filter:
 
 1.  Create a new filter as an instance of the [Tizen.Messaging.Messages.MessagesSearchFilter](/application/dotnet/api/TizenFX/latest/api/Tizen.Messaging.Messages.MessagesSearchFilter.html) class:
@@ -150,6 +150,6 @@ To fetch messages from a message box, use the `SearchMessageAsync()` method of t
     ```
 
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/messaging/overview.md
+++ b/docs/application/dotnet/guides/messaging/overview.md
@@ -17,6 +17,6 @@ You can use the following messaging features in your .NET applications:
 
     The application can receive push notifications from a push server. You can create a push server, register your application and connect to the push messaging service, and send notifications from the server to the application using the push messaging service.
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/messaging/push-server.md
+++ b/docs/application/dotnet/guides/messaging/push-server.md
@@ -3,18 +3,18 @@
 
 You can push events from an application server to your application on a Tizen device. If the message sending fails for any reason, an error code identifying the failure reason is returned. You can use the [error code](#error_codes) to determine how to handle the failure.
 
-The main features of the Tizen.Messaging.Push namespace for server developers include:
+The main features of the `Tizen.Messaging.Push` namespace for server developers include the following:
 
 -   Sending push notifications
 
     You can [send push notifications](#send_server) from the application server to an application.
 
 <a name="send_server"></a>
-## Sending Push Notifications
+## Send push notifications
 
 You can send notifications to your applications installed on Tizen devices. The basics of sending push notifications are covered in the [Push](push.md#send) guide. This use case covers more advanced information, such as sending multiple notifications in one request and sending multicast notifications.
 
-To send push notifications:
+To send push notifications, follow the steps below:
 
 1.  Determine the RQM server.
 
@@ -57,7 +57,7 @@ To send push notifications:
         }
         ```
 
-    - If you have data to send to the application but no need to notify the user, use the action field on the same level as the message field, instead of within the message field, and do not include the message field itself. In this case, the notification is delivered with the best effort.
+    - If you have data to send to the application but no need to notify the user, use the action field on the same level as the message field, instead of within the message field, and do not include the message field itself. In this case, the notification is delivered with the best effort:
 
         ```JSON
         {
@@ -134,7 +134,7 @@ To send push notifications:
             | `reliableOption` | The push server guarantees reliable message delivery if the `reliableOption` is set. The possible options are:<br><br>`NoReliable`: Do not send any acknowledgment back to an application server and do not store the notification in the push server if the push service did not receive the notification.<br>`Transport`: Send an acknowledgment back to the application server when the push service receives the notification.<br><br>This is an optional field, and if it does not exist, the server applies its default value (`Transport`). An acknowledgment at this point does not mean a response to the notification request, but an acknowledgment that the push service has received the notification. When the push service receives the notification, the push server sends this acknowledgment to the application server in a JSON format through HTTP. | Optional<br>Type: string<br>Default: transport   |
             | `sessionInfo`    | Connection information for an application. Third-party applications can define this field by themselves. | Optional<br>Type: string<br>Default: `NULL`      |
             | `timeStamp`      | Server time in milliseconds when a notification request has been made. | OptionalType: longDefault: `NULL`        |
-            | `expiryDate`     | Time period, in minutes, for storing the request in the push server if the delivery fails:<br><br>- If the value set to 0, the push server stores the request for 1440 minutes (24 hours).<br>- If the value is 1 - 2800, the push server stores the request for that number of minutes.If the push server default setting is less than the defined value, the push server stores the request according to its own setting.<br>- If the value is greater than 2880, the push server stores the request for 2880 minutes (48 hours).<br><br>This is an optional field, and if it does not exist, the server applies its default value (0). If `reliableOption` is set at `NoReliable`, this field is meaningless. | Optional<br>Type: int<br>Default: 0              |
+            | `expiryDate`     | Time period, in minutes, for storing the request in the push server if the delivery fails:<br><br>- If the value is set to 0, the push server stores the request for 1440 minutes (24 hours).<br>- If the value is 1 - 2800, the push server stores the request for that number of minutes. If the push server default setting is less than the defined value, the push server stores the request according to its own setting.<br>- If the value is greater than 2880, the push server stores the request for 2880 minutes (48 hours).<br><br>This is an optional field, and if it does not exist, the server applies its default value (0). If `reliableOption` is set at `NoReliable`, this field is meaningless. | Optional<br>Type: int<br>Default: 0              |
 
         The following examples illustrate the notification:
 
@@ -209,7 +209,7 @@ To send push notifications:
                 }
                 ```
 
-                > **Note**   
+                > [!NOTE]  
 				> In the above example, the 3008 error code means that the `regID` does not exist in the push server. It happens when your application of that particular `regID` was uninstalled or disabled by the user, and consequently the `regID` must be removed from your application server. When the application is reinstalled or enabled, it must repeat the [registration process](push.md#registration) and send a new `regID` to your application server.
 
 	-  Multiple request
@@ -425,7 +425,7 @@ To send push notifications:
 
 
 <a name="error_codes"></a>				
-## Error Codes
+## Error codes
 
 If sending a push notification request fails for some reason, the response message contains an error code.
 
@@ -459,8 +459,8 @@ The following table lists all possible error codes for push notifications, helpi
 | 3019        | Error of containing abnormal data        |
 | 3020        | Error of not supported reliability option |
 | 3021        | Error of bad padding exception           |
-| 3022        | Error of json parse exception            |
-| 3023        | Error of json mapping                    |
+| 3022        | Error of JSON parse exception            |
+| 3023        | Error of JSON mapping                    |
 | 3024        | Error of illegal blocksize               |
 | 3025        | Error occurred while decoding regID      |
 | 3026        | Error of no secret key field             |
@@ -483,9 +483,9 @@ The following table lists all possible error codes for push notifications, helpi
 | 3043        | Error of invalid type                    |
 | 3044        | Error of not registered application      |
 | 3045        | Error of application authentication failed |
-| 3046        | Error of not allowed to use Push Server  |
+| 3046        | Error of not allowed to use push server  |
 
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/messaging/push.md
+++ b/docs/application/dotnet/guides/messaging/push.md
@@ -7,7 +7,7 @@ Once your application is successfully registered in the push server through the 
 
 If a push message arrives when the application is running, the message is automatically delivered to the application. If the application is not running, the push service makes a sound or vibrates and adds a ticker or a badge notification to notify the user. By touching this notification, the user can check the message. If the application server sends a message with a `LAUNCH` option, the push service forcibly launches the application and hands over the message to the application.
 
-The main features of the Tizen.Messaging.Push namespace include:
+The main features of the [Tizen.Messaging.Push](/application/dotnet/api/TizenFX/latest/api/Tizen.Messaging.Push.html) namespace include the following:
 
 -   Connecting to the push service
 
@@ -34,7 +34,7 @@ The main features of the Tizen.Messaging.Push namespace include:
 ![Push messaging service](./media/ui_push_message.png)
 
 <a name="service"></a>
-## Service Architecture
+## Service architecture
 
 The following figure illustrates the service architecture of the Tizen push messaging service.
 
@@ -53,7 +53,7 @@ The following steps illustrate a typical scenario for using the push messaging s
 
     The application delivers the registration ID to the application server. This registration ID is used to identify the application installed on that particular device.
 
-4. When the application server needs to send a push message to the application on the particular device, it calls the Tizen server's open API to send the message together with the registration ID. (For more information for server developers on sending push messages, see [Sending Push Notifications](push-server.md#send_server).)
+4. When the application server needs to send a push message to the application on a particular device, it calls the Tizen server's open API to send the message together with the registration ID. (For more information for server developers on sending push messages, see [Sending Push Notifications](push-server.md#send_server).)
 
     A text message of up to 1024 bytes can be sent in a push message. If the application needs to download a large amount of data, the application server sends a link to the data in the push message.
 
@@ -63,7 +63,7 @@ The following steps illustrate a typical scenario for using the push messaging s
 ## Prerequisites
 
 
-To enable your application to use the push functionality:
+To enable your application to use the push functionality, follow the steps below:
 
 1.  To use the [Tizen.Messaging.Push](/application/dotnet/api/TizenFX/latest/api/Tizen.Messaging.Push.html) namespace, the application has to request permission by adding the following privilege to the `tizen-manifest.xml` file:
 
@@ -86,28 +86,28 @@ To enable your application to use the push functionality:
     <a name="permission"> </a>
     - Permission to Tizen push servers
 
-        To use the push messaging service, the application needs the permission to access the Tizen push server. Request the permission from the Tizen push service team using one of the following online request forms:
+        To use the push messaging service, the application needs permission to access the Tizen push server. Request permission from the Tizen push service team using one of the following online request forms:
 
-        -   [Request the permission for a new application](https://developer.tizen.org/webform/request-permission-tizen-push-service)
-        -   [Extend the expiration date or change the quota](https://developer.tizen.org/webform/request-extend-expiration-date-or-change-quota) for an application that already has the permission to use the push messaging service
+        -   [Request the permission for a new application](https://developer.tizen.org/webform/request-permission-tizen-push-service){:target="_blank"}
+        -   [Extend the expiration date or change the quota](https://developer.tizen.org/webform/request-extend-expiration-date-or-change-quota){:target="_blank"} for an application that already has the permission to use the push messaging service
 
         When the team approves the request, you receive a push app ID corresponding to your package ID.
 
-3. To use the methods and properties of the Tizen.Messaging.Push namespace, include it in your application:
+3. To use the methods and properties of the `Tizen.Messaging.Push` namespace, include it in your application:
 
     ```csharp
     using Tizen.Messaging.Push;
     ```
 
 
-> **Note**   
+> [!NOTE]
 > The push service supports launching an application in the background. Remember that you can deliver application data to your application without an unwanted UI launch.
 
 
 <a name="connect"></a>
-## Connecting to the Push Service
+## Connect to the push service
 
-To manage push service connections:
+To manage push service connections, follow the steps below:
 
 1.  Define event handlers:
 
@@ -147,8 +147,8 @@ To manage push service connections:
 
     After calling the `PushServiceConnect()` method, the application establishes a socket connection to the push service:
 
-    -   The `YOUR_PUSH_APP_ID` parameter is the push app ID received from the Tizen push server team when the access to the server was requested. Keep this push app ID confidential, otherwise your push notifications can be hijacked by malicious applications.
-    -   If the `PushServiceConnect()` method catches any exception, it means the connection to the service failed. This happens most likely when the [push privilege](#prerequisites) is not added into the application manifest.
+    -   The `YOUR_PUSH_APP_ID` parameter is the push app ID received from the Tizen push server team when access to the server was requested. Keep this push app ID confidential, otherwise, your push notifications can be hijacked by malicious applications.
+    -   If the `PushServiceConnect()` method catches any exception, it means the connection to the service failed. This happens most likely when the [push privilege](#prerequisites) is not added to the application manifest.
 
     If the connection with the push service succeeds, the application must request the unread notification messages sent during the disconnected state by using the `GetUnreadNotification()` method.
 
@@ -158,7 +158,7 @@ To manage push service connections:
 
     When the application terminates or no longer uses the push service, close the connection using the `PushServiceDisconnect()` method.
 
-    The `PushServiceDisconnect()` method returns all the resources allocated for the connection.
+    The `PushServiceDisconnect()` method returns all the resources allocated for the connection:
 
     ```csharp
     PushClient.PushServiceDisconnect();
@@ -215,15 +215,15 @@ To manage push service connections:
     The registration state is subject to change. Consequently, make sure that the application connects to the push service whenever it is launched.
 
 <a name="registration"></a>
-## Registering with the Push Server
+## Register with the push server
 
-To receive push notifications, the application must send a registration request to the Tizen push server. When the server receives this request, it assigns a registration ID that is unique to the application on the particular device. When sending a notification from your application server, this registration ID is used as a destination address of the application. If the application no longer needs to receive push notifications, it needs to send a deregistration request to the server.
+To receive push notifications, the application must send a registration request to the Tizen push server. When the server receives this request, it assigns a registration ID that is unique to the application on the particular device. When sending a notification from your application server, this registration ID is used the destination address of the application. If the application no longer needs to receive push notifications, it needs to send a deregistration request to the server.
 
-To register with the push server:
+To register with the push server, follow the steps below:
 
 1.  Request registration.
 
-    After connecting to the push service, request registration using the `PushServerRegister()` method of the [Tizen.Messaging.Push.PushClient](/application/dotnet/api/TizenFX/latest/api/Tizen.Messaging.Push.PushClient.html) class.
+    After connecting to the push service, request registration using the `PushServerRegister()` method of the [Tizen.Messaging.Push.PushClient](/application/dotnet/api/TizenFX/latest/api/Tizen.Messaging.Push.PushClient.html) class:
 
     ```csharp
     public static void OnStateUnregistered()
@@ -257,7 +257,7 @@ To register with the push server:
 
     - If the application is newly registered, send the registration ID issued by the push server to your application server.
 
-        If the ID is new or updated, you need to send it to your application server. This ID is used as a destination address to the application on a particular device. If the application has already sent the ID, you can skip this step.
+        If the ID is new or updated, you need to send it to your application server. This ID is used as a destination address for the application on a particular device. If the application has already sent the ID, you can skip this step:
 
     ```csharp
     public static void OnStateRegistered()
@@ -285,15 +285,14 @@ To register with the push server:
     }
     ```
 
-    >**Note**
-    >
+    >[!NOTE]
     >The `PushServiceUnregister()` method is not used if the application is intended to receive push notifications continuously while it is installed on the device. When the application is uninstalled, the push service detects the event and deregisters the application automatically.  
     >
     >On the other hand, if the application wants to receive push notifications only when a user logs in, the `PushServiceUnregister()` method must be called whenever the user logs out.
 
 
 <a name="security"></a>
-## Managing Security
+## Manage security
 
 When you send a notification with sensitive information, be aware of the chance that the notification gets hijacked by someone else. It is your responsibility to keep such sensitive information safe from malicious access. The following rules are strongly recommended:
 
@@ -314,7 +313,7 @@ When you send a notification with sensitive information, be aware of the chance 
     The AppSecret is a key to accessing the push server for sending notifications. If notifications are sent from your application server, the application does not need to know the AppSecret at all. Keep the AppSecret on the server and do not load any related information in the application. If you want device-to-device notification delivery without your application server, the application needs the AppSecret to send a notification from a device. In this case, it is your responsibility to keep the AppSecret safe.
 
 <a name="send"></a>
-## Sending Push Notifications
+## Send Push Notifications
 
 Once the application successfully sends its registration ID to the application server, you are ready to send push notifications from the application server to the application on that particular device. This use case describes how to send a simple push notification to the device. For advanced features, see the [Push Server](push-server.md) guide for server developers.
 
@@ -381,17 +380,17 @@ To send a notification:
     This use case focuses on how an application developer can construct a notification. For advanced features, see the [Push Server](push-server.md) guide for server developers.
 
 <a name="receive_push"></a>
-## Receiving Push Notifications
+## Receive push notifications
 
 When a notification arrives at the device, its delivery mechanism depends on whether the application is running.
 
-To handle incoming push notifications:
+To handle incoming push notifications, follow the steps below:
 
 -   Receive notifications when the application is running.
 
-    When a notification arrives to the application while it is running (more precisely, while the application is connected to the service), the `EventHandlerNotificationReceived()` event handler is called. You can handle the received notification in the event handler.
+    When a notification arrives at the application while it is running (more precisely, while the application is connected to the service), the `EventHandlerNotificationReceived()` event handler is called. You can handle the received notification in the event handler.
 
-    The following example shows how the application can retrieve the app data (payload), message, and timestamp from the received notification. When the `EventHandlerNotificationReceived()` event handler is called, you can retrieve the app data, message, and time stamp from `e.AppData`, `e.Message`, and `e.ReceivedAt` respectively.
+    The following example shows how the application can retrieve the app data (payload), message, and timestamp from the received notification. When the `EventHandlerNotificationReceived()` event handler is called, you can retrieve the app data, message, and time stamp from `e.AppData`, `e.Message`, and `e.ReceivedAt` respectively:
 
     ```csharp
     public static void EventHandlerNotificationReceived(object sender, PushMessageEventArgs e)
@@ -417,7 +416,7 @@ To handle incoming push notifications:
 
         By the way, when the application is launched by the push service, you need to determine the reason for the application launch and react to it appropriately.
 
-        The push service provides launch types when the application is launched by the service. Use the following code to figure out why the application is launched in both cases of receiving notification and changing registration state.
+        The push service provides launch types when the application is launched by the service. Use the following code to figure out why the application is launched in both cases of receiving notification and changing the registration state.
 
         1.  Get the requested application control:
 
@@ -429,7 +428,7 @@ To handle incoming push notifications:
             _extraDataSet = _appCtrl.ExtraData;
             ```
 
-        2. Determine the reason for the application launch. If the reason for the launch is a notification, retrieve the latest push message.
+        2. Determine the reason for the application launch. If the reason for the launch is a notification, retrieve the latest push message:
 
             ```csharp
             string GettedValue = "";
@@ -444,11 +443,11 @@ To handle incoming push notifications:
             }
             ```
 
-    - Store the notification at the push service database and request it later when the application is launched.
+    - Store the notification in the push service database and request it later when the application is launched.
 
         You need to set the action to `ALERT` or `SILENT` in the message field when sending the notification from the application server. When such a notification arrives at the device, the push service keeps the notification in the database and waits for the request from the application.
 
-        You can request for unread notifications from the push service. The request can be performed after connecting to the push server when the application is launched.
+        You can request unread notifications from the push service. The request can be performed after connecting to the push server when the application is launched:
 
         ```csharp
         PushClient.GetUnreadNotifications();
@@ -461,6 +460,6 @@ To handle incoming push notifications:
         You need to set the action to `DISCARD` in the message field when sending the notification from the application server. When such a notification arrives at the device, the push service delivers the notification only when the application is up and running. Otherwise, the push service does not store the notification and discards it.
 
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher


### PR DESCRIPTION
### Change Description ###



This PR includes the fix of the following files which is part of the .NET applications section of the Tizen Docs site:

File count: 5

/application/dotnet/guides/messaging/overview.md
/application/dotnet/guides/messaging/email.md
/application/dotnet/guides/messaging/messages.md
/application/dotnet/guides/messaging/push.md
/application/dotnet/guides/messaging/push-server.md
Signed off by: [omar.saeed@samsung.com](mailto:omar.saeed@samsung.com)
