### PR TITLE
Fix default for crash manager crash reports root path

### DIFF
--- a/docs/platform/porting/system.md
+++ b/docs/platform/porting/system.md
@@ -2254,7 +2254,7 @@ The default configuration file for crash-manager is `/etc/crash-manager.conf`. I
      - `log/`: For logs
      - `temp/`: For files while creating report
 
-     Default value: `/opt/user/share/crash/`
+     Default value: `/opt/usr/share/crash/`
 
 -  **ReportType**  
      Specifies the type of the crash report. Possible values are:


### PR DESCRIPTION
### Change Description ###

It seems that `/opt/user/share/crash/` contains a typo. The default path seems to be `/opt/usr/share/crash/`. This PR fixes that typo.
