### PR TITLE
Mark NLP APIs as deprecated since Tizen 7.5

### DIFF
--- a/docs/application/dotnet/guides/nlp/nlp.md
+++ b/docs/application/dotnet/guides/nlp/nlp.md
@@ -1,9 +1,9 @@
 # Natural Language Processing (NLP)
 
+NLP is a subset of Natural Language Toolkit that specifies an interface and a protocol for basic natural language processing. Tizen enables you to use Natural Language Process (NLP) functionalities, such as language detection, parts of speech, word tokenization, and named entity detection. For more information, see the [NLTK Forum](http://www.nltk.org/).
+
 > [!NOTE]
 > NLP API is deprecated since Tizen 7.5 and will be removed after two releases without any alternatives.
-
-NLP is a subset of Natural Language Toolkit that specifies an interface and a protocol for basic natural language processing. Tizen enables you to use Natural Language Process (NLP) functionalities, such as language detection, parts of speech, word tokenization, and named entity detection. For more information, see the [NLTK Forum](http://www.nltk.org/).
 
 The main features of the Tizen.Nlp namespace include:
 

--- a/docs/application/dotnet/guides/nlp/nlp.md
+++ b/docs/application/dotnet/guides/nlp/nlp.md
@@ -1,5 +1,7 @@
 # Natural Language Processing (NLP)
 
+> [!NOTE]
+> NLP API is deprecated since Tizen 7.5 and will be removed after two releases without any alternatives.
 
 NLP is a subset of Natural Language Toolkit that specifies an interface and a protocol for basic natural language processing. Tizen enables you to use Natural Language Process (NLP) functionalities, such as language detection, parts of speech, word tokenization, and named entity detection. For more information, see the [NLTK Forum](http://www.nltk.org/).
 
@@ -7,7 +9,7 @@ The main features of the Tizen.Nlp namespace include:
 
 -   Word Tokenize support
 
-    You can get tokens from a sentence, the type of return is [WordTokenizeResult](#wordtokenize). 
+    You can get tokens from a sentence, the type of return is [WordTokenizeResult](#wordtokenize).
     This method breaks up the sentence into words and punctuation.
 
 -   Part of Speech support


### PR DESCRIPTION
### Change Description ###

- Mark NLP APIs as deprecated since Tizen 7.5

### API Changes ###

 - ACR: https://code.sec.samsung.net/jira/browse/TCSACR-528