### PR TITLE
.NET application site fix (Part - 16)

### DIFF
--- a/docs/application/dotnet/guides/security/dpm.md
+++ b/docs/application/dotnet/guides/security/dpm.md
@@ -47,7 +47,7 @@ To manage device policies, follow the steps below:
    ```csharp
        MediaPolicy mediaPolicy = dpm.getPolicy<MediaPolicy>();
    ```
-   > **Note**
+   > [!NOTE]
    >
    > The DevicePolicyManager instance must exist when you use the policy instance.
 
@@ -89,7 +89,7 @@ To manage device policies, follow the steps below:
    mediaPolicy.Dispose();
    dpm.Dispose();
    ```
-   > **Note**
+   > [!NOTE]
    >
    > The policy instance must be destroyed before the DPM instance.
 

--- a/docs/application/dotnet/guides/security/dpm.md
+++ b/docs/application/dotnet/guides/security/dpm.md
@@ -3,12 +3,12 @@
 
 The Device Policy Management (DPM) framework supports enterprise applications by providing IT administrator functions to create security-aware applications. These applications are useful in scenarios where IT administrators require rich control over employee devices.
 
-DPM framework consists of:
+The DPM framework consists of the following tools:
 
 - **Device policy client library**: This contains all the device administration functions that a client application can call. The device policy client library communicates with the device policy manager using a built-in remote method invocation (RMI) engine.
 - **Device policy manager**: This manages all the device policies. It also provides interfaces for the device policy client library.
 
-The main features of the [Tizen.Security.DevicePolicyManager](/application/dotnet/api/TizenFX/master/api/Tizen.Security.DevicePolicyManager.html) namespace are:
+The main features of the [Tizen.Security.DevicePolicyManager](/application/dotnet/api/TizenFX/master/api/Tizen.Security.DevicePolicyManager.html) namespace are as follows:
 
 - Managing policies
 
@@ -33,9 +33,9 @@ using Tizen.Security.DevicePolicyManager;
 ```
 
 <a name="client_application"></a>
-## Managing Device Policies
+## Manage device policies
 
-To manage device policies:
+To manage device policies, follow the steps below:
 
 1. Create a `DevicePolicyManager` instance:
 
@@ -93,6 +93,6 @@ To manage device policies:
    >
    > The policy instance must be destroyed before the DPM instance.
 
-## Related Information
+## Related information
 - Dependencies
   - Tizen 5.5 and Higher

--- a/docs/application/dotnet/guides/security/dpm.md
+++ b/docs/application/dotnet/guides/security/dpm.md
@@ -48,7 +48,6 @@ To manage device policies, follow the steps below:
        MediaPolicy mediaPolicy = dpm.getPolicy<MediaPolicy>();
    ```
    > [!NOTE]
-   >
    > The DevicePolicyManager instance must exist when you use the policy instance.
 
 3. Register an event handler to manage the policies of the policy instance:
@@ -90,7 +89,6 @@ To manage device policies, follow the steps below:
    dpm.Dispose();
    ```
    > [!NOTE]
-   >
    > The policy instance must be destroyed before the DPM instance.
 
 ## Related information

--- a/docs/application/dotnet/guides/security/overview.md
+++ b/docs/application/dotnet/guides/security/overview.md
@@ -25,6 +25,6 @@ You can use the following security features in your .NET applications:
 
     You can create security-aware applications to manage device policies. In enterprise settings, you can provide rich control for IT administrators over employee devices.
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/security/privacy-related-permissions.md
+++ b/docs/application/dotnet/guides/security/privacy-related-permissions.md
@@ -5,7 +5,7 @@ You can check current permissions for privacy-related privileges and request use
 
 Before Tizen 4.0, the pop-up requesting the user's consent to use privacy-related privileges was triggered by first access to protected resources or functionality. Since Tizen 4.0, you can decide the moment in the application life-cycle when permissions are granted. It can be at the application startup, or at the moment when some additional functionality is to be used. For example, a notepad application where the user can enter both text notes and photographs does not automatically require camera access in order to be used (maybe the user only wants to add text notes). Optimally, the application requests the user to grant camera access permission only when the user needs the camera.
 
-The main features of the `Tizen.Security.PrivacyPrivilegeManager` class include:
+The main features of the `Tizen.Security.PrivacyPrivilegeManager` class include the following:
 
 -   Checking privilege status
 
@@ -24,7 +24,7 @@ For a list of privacy-related privileges, see [Security and API Privileges](../.
 
 ## Prerequisites
 
-To enable your application to use the privacy-related permissions functionality:
+To enable your application to use the privacy-related permissions functionality, follow the steps mentioned below:
 
 1.  To use the methods and properties of the [Tizen.Security](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.html) namespace, include it in your application:
 
@@ -40,8 +40,8 @@ To enable your application to use the privacy-related permissions functionality:
     > The `Tizen.Security.PrivacyPrivilegeManager` class is not thread-safe.
 
 <a name="requesting"></a>
-## Requesting Permissions
-To check whether an application has permission to use a privilege, and to request permission if required:
+## Request permission
+To check whether an application has permission to use a privilege and to request permission if required, follow the steps mentioned below:
 
 1.  To check whether an application has permission to use a particular privilege, use the `CheckPermission()` method of the [Tizen.Security.PrivacyPrivilegeManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.PrivacyPrivilegeManager.html) class:
 
@@ -59,7 +59,7 @@ To check whether an application has permission to use a privilege, and to reques
 
 2.  React to the permission check appropriately:
 
-    -   If the result value is `Allow`, the application is allowed to perform operations related to the privilege. For example, the application can enable additional UI elements or functionalities.
+    -   If the result value is `Allow`, the application is allowed to perform operations related to the privilege. For example, the application can enable additional UI elements or functionalities:
 
         ```csharp
                 switch (result)
@@ -69,7 +69,7 @@ To check whether an application has permission to use a privilege, and to reques
                         break;
         ```
 
-    -   If the result value is `Deny`, the application is not allowed to perform operations related to the privilege. Any attempt to use such functionality without the user's consent fails. Usually, this means that invoking any method that involves the privilege results in an error.
+    -   If the result value is `Deny`, the application is not allowed to perform operations related to the privilege. Any attempt to use such functionality without the user's consent fails. Usually, this means that invoking any method that involves the privilege results in an error:
 
         ```csharp
                     case CheckResult.Deny:
@@ -77,9 +77,9 @@ To check whether an application has permission to use a privilege, and to reques
                         break;
         ```
 
-    -   If the result value is `Ask`, the application must request permission from the user with the `RequestPermission()` method, which displays a dialog box. When the user makes a decision, an event handler is invoked (the event handler must have been [previously registered](#handler)).
+    -   If the result value is `Ask`, the application must request permission from the user with the `RequestPermission()` method, which displays a dialog box. When the user makes a decision, an event handler is invoked (the event handler must have been [previously registered](#handler)):
 
-        The dialog box asking for user permission is shown only if the `RequestPermission()` method does not throw an exception.
+        The dialog box asking for user permission is shown only if the `RequestPermission()` method does not throw an exception:
 
         ```csharp
                     case CheckResult.Ask:
@@ -101,7 +101,7 @@ To check whether an application has permission to use a privilege, and to reques
 
     The user decision is returned in the event handler as the `result` property of the [Tizen.Security.RequestResponseEventArgs](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.RequestResponseEventArgs.html) class.
 
-    Make sure the event handler is registered before calling the `RequestPermission()` method of the `Tizen.Security.PrivacyPrivilegeManager` class. For a Xamarin.Forms application, the best place to register the event handler is the `Xamarin.Forms.Application.OnStart()` life-cycle method.
+    Make sure the event handler is registered before calling the `RequestPermission()` method of the `Tizen.Security.PrivacyPrivilegeManager` class. For a Xamarin.Forms application, the best place to register the event handler is the `Xamarin.Forms.Application.OnStart()` life-cycle method. This is shown in the following code block:
 
     ```csharp
     private void SetupPPMHandler(string privilege)
@@ -146,14 +146,14 @@ To check whether an application has permission to use a privilege, and to reques
 
     If the decision is definitive, any subsequent `RequestPermission()` calls result in an immediate response with an appropriate result: `AllowForever` or `DenyForever`. However, the user can change the status of privacy-related privileges later by modifying the privacy settings on the device. For this reason, the application must always check the status of privacy-related privileges before using protected functionality.
 
-## Requesting Multiple Permissions
+## Request multiple permissions
 
 This section describes how to check and request multiple privileges in a single API call.
 
 > [!NOTE]
 > Multiple privileges in a single API call are supported from Tizen 5.5.
 
-To check whether an application has permission to use a privilege, and to request permission if required:
+To check whether an application has permission to use a privilege and to request permission if required, follow the steps below:
 
 1. To verify whether an application has permission to use privileges, use `CheckPermissions()`:
 
@@ -173,7 +173,7 @@ To check whether an application has permission to use a privilege, and to reques
             for (int iterator = 0; iterator &lt; results.Length; ++iterator)
             {
       ```
-   -   If the result value is `Allow`, the application is allowed to perform operations related to the privilege. For example, the application can enable additional UI elements or functionalities.
+   -   If the result value is `Allow`, the application is allowed to perform operations related to the privilege. For example, the application can enable additional UI elements or functionalities:
          ```csharp
                 switch (results[iterator])
                 {
@@ -182,7 +182,7 @@ To check whether an application has permission to use a privilege, and to reques
                     break;
          ```
 
-   -   If the result value is `Deny`, the application is not allowed to perform operations related to the privilege. Any attempt to use such functionality without the user's consent fails. Usually, this means that invoking any method that involves the privilege results in an error.
+   -   If the result value is `Deny`, the application is not allowed to perform operations related to the privilege. Any attempt to use such functionality without the user's consent fails. Usually, this means that invoking any method that involves the privilege results in an error:
          ```csharp
                 case CheckResult.Deny:
                     // Privilege can't be used
@@ -190,7 +190,7 @@ To check whether an application has permission to use a privilege, and to reques
          ```
 
    -   If the result value is `Ask`, the application must request permission from the user with the `RequestPermissions()` method, which displays a dialog box. When the user makes a decision, the answers are returned as
-  [Tizen.Security.RequestMultipleResponseEventArgs](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.RequestMultipleResponseEventArgs.html).
+  [Tizen.Security.RequestMultipleResponseEventArgs](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.RequestMultipleResponseEventArgs.html):
 
          ```csharp
                 case CheckResult.Ask:
@@ -231,9 +231,9 @@ To check whether an application has permission to use a privilege, and to reques
       ```
 
 > [!NOTE]
-> Since the privileges are grouped, the user's decision regarding 1 privilege applies to the whole group of related privileges. For example, if the user has granted permission to use the `http://tizen.org/privilege/account.read` privilege, permission is automatically granted to the `http://tizen.org/privilege/account.write` privilege also. Be aware that both privileges need to be declared in the application manifest file. If you declare only 1 of them, the above rule does not apply.
+> Since the privileges are grouped, the user's decision regarding one privilege applies to the whole group of related privileges. For example, if the user has granted permission to use the `http://tizen.org/privilege/account.read` privilege, permission is automatically granted to the `http://tizen.org/privilege/account.write` privilege also. Be aware that both privileges need to be declared in the application manifest file. If you declare only one of them, the above rule does not apply.
 
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/security/privacy-related-permissions.md
+++ b/docs/application/dotnet/guides/security/privacy-related-permissions.md
@@ -77,7 +77,7 @@ To check whether an application has permission to use a privilege and to request
                         break;
         ```
 
-    -   If the result value is `Ask`, the application must request permission from the user with the `RequestPermission()` method, which displays a dialog box. When the user makes a decision, an event handler is invoked (the event handler must have been [previously registered](#handler)):
+    -   If the result value is `Ask`, the application must request permission from the user with the `RequestPermission()` method, which displays a dialog box. When the user makes a decision, an event handler is invoked (the event handler must have been [previously registered](#handler)).
 
         The dialog box asking for user permission is shown only if the `RequestPermission()` method does not throw an exception:
 
@@ -88,14 +88,14 @@ To check whether an application has permission to use a privilege and to request
                 }
         ```
 
-    ```csharp
+        ```csharp
+            }
+            catch (Exception e)
+            {
+                /// Handle exception
+            }
         }
-        catch (Exception e)
-        {
-            /// Handle exception
-        }
-    }
-    ```
+        ```
 
 3.  <a name="handler"></a>If you need to request user permission, handle the user decision within an event handler registered for the `ResponseFetched` event of the [Tizen.Security.PrivacyPrivilegeManager.ResponseContext](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.PrivacyPrivilegeManager.ResponseContext.html) class.
 

--- a/docs/application/dotnet/guides/security/privilege.md
+++ b/docs/application/dotnet/guides/security/privilege.md
@@ -14,16 +14,16 @@ Since Tizen 3.0, some privileges are categorized as privacy-related. The user ca
 ## Prerequisites
 
 
-To use the methods and properties of the [Tizen.Security.Privilege](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.Privilege.html) class, include the [Tizen.Security](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.html) namespace in your application. If you want to designate a privilege's type, include the [Tizen.Applications](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.html) namespace too.
+To use the methods and properties of the [Tizen.Security.Privilege](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.Privilege.html) class, include the [Tizen.Security](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.html) namespace in your application. If you want to designate a privilege's type, include the [Tizen.Applications](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.html) namespace too. This is shown in the following code block:
 
 ```csharp
 using Tizen.Security;
 using Tizen.Applications;
 ```
 <a name="get"></a>
-## Getting Privilege Information
+## Get privilege information
 
-To get various privilege information:
+To get various privilege information, follow these steps:
 
 -   Get the privilege display name using the `GetDisplayName()` method of the `Tizen.Security.Privilege` class:
 
@@ -67,6 +67,6 @@ To get various privilege information:
     ```
 
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/security/secure-repository.md
+++ b/docs/application/dotnet/guides/security/secure-repository.md
@@ -584,7 +584,7 @@ To load files, follow these steps:
     ```
 
 <a name="access_control"></a>
-## Implementing Access Control
+## Implement Access Control
 
 Each client can adjust access control rules for their own data, certificates, and keys.
 

--- a/docs/application/dotnet/guides/security/secure-repository.md
+++ b/docs/application/dotnet/guides/security/secure-repository.md
@@ -5,7 +5,7 @@ You can use a secure repository to store keys, certificates, and sensitive data 
 
 The secure repository features are provided by a key manager. An application functions as a key manager client, and accesses the secure repository through the key manager.
 
-The main features of the Tizen.Security.SecureRepository namespace include:
+The main features of the Tizen.Security.SecureRepository namespace include the following:
 
 -   Data store policy
 
@@ -28,7 +28,7 @@ The main features of the Tizen.Security.SecureRepository namespace include:
 
 ![Key manager process](./media/key_manager.png)
 
-The key manager provides 2 types of operations:
+The key manager provides 2 types of operations, as shown below:
 
 -   Secure repository operations
 
@@ -64,9 +64,9 @@ using Tizen.Security.SecureRepository;
 ```
 
 <a name="save_get_remove_keys"></a>
-## Saving, Getting, or Removing a Key
+## Save, get, or remove a key
 
-To store, retrieve, or remove a client's keys from the key manager:
+To store, retrieve, or remove a client's keys from the key manager, follow these steps:
 -   Save a new key by using the `Save()` method of the [Tizen.Security.SecureRepository.KeyManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.SecureRepository.KeyManager.html) class:
 
     ```csharp
@@ -183,9 +183,9 @@ To store, retrieve, or remove a client's keys from the key manager:
     ```
 
 <a name="save_get_remove_certs"></a>
-## Saving, Getting, or Removing a Certificate
+## Save, get, or remove a certificate
 
-To store, retrieve, or remove a client's certificates from the key manager:
+To store, retrieve, or remove a client's certificates from the key manager, follow these steps:
 
 -   Save a new certificate by using the `Save()` method of the [Tizen.Security.SecureRepository.CertificateManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.SecureRepository.CertificateManager.html) class:
 
@@ -277,9 +277,9 @@ To store, retrieve, or remove a client's certificates from the key manager:
     ```
 
 <a name="save_get_remove_data"></a>
-## Saving, Getting, or Removing Data
+## Save, get, or remove data
 
-To store, retrieve, or remove a client's data from the key manager:
+To store, retrieve, or remove a client's data from the key manager, follow these steps:
 
 -   Save new data using the `Save()` method of the [Tizen.Security.SecureRepository.DataManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.SecureRepository.DataManager.html) class:
 
@@ -347,11 +347,11 @@ To store, retrieve, or remove a client's data from the key manager:
     ```
 
 <a name="creating_keys"></a>
-## Creating Keys
+## Create keys
 
 You can create 4 kinds of keys or key pairs with the [Tizen.Security.SecureRepository.KeyManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.SecureRepository.KeyManager.html) class: RSA, ECDSA, DSA, and AES.
 
-To create keys:
+To create keys, follow these steps:
 
 -   Create an RSA key pair using the `CreateRsaKeyPair()` method:
 
@@ -427,9 +427,9 @@ To create keys:
     ```
 
 <a name="create_verify_sigs"></a>
-## Creating and Verifying Signatures
+## Create and verify signatures
 
-To create and verify a signature:
+To create and verify a signature, follow these steps:
 
 1.  Create an RSA key pair with the `CreateRsaKeyPair()` method of the [Tizen.Security.SecureRepository.KeyManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.SecureRepository.KeyManager.html) class:
 
@@ -489,11 +489,11 @@ To create and verify a signature:
     ```
 
 <a name="cert_chain"></a>
-## Verifying and Returning a Certificate Chain
+## Verify and return a certificate chain
 
 The certificate manager verifies a certificate chain and returns it. The trusted root certificate of the chain must exist in the system certificate storage or be specified in the parameters.
 
-To handle certificate chains:
+To handle certificate chains, follow these steps:
 
 -   Verify and return a certificate chain using the `GetCertificateChain()` method of the [Tizen.Security.SecureRepository.CertificateManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.SecureRepository.CertificateManager.html) class:
 
@@ -542,11 +542,11 @@ To handle certificate chains:
     ```
 
 <a name="load_file"></a>
-## Loading a Certificate File or a PKCS\#12 File
+## Load a certificate file or a PKCS\#12 file
 
 You can load a certificate from a file in the DER or PEM formats. The secure repository can also load a private key, certificate, or chain of CA certificates from a PKCS\#12 file.
 
-To load files:
+To load files, follow these steps:
 
 -   Load a certificate from an external file with the `Load()` method of the [Tizen.Security.SecureRepository.Certificate](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.SecureRepository.Certificate.html) class:
 
@@ -588,7 +588,7 @@ To load files:
 
 Each client can adjust access control rules for their own data, certificates, and keys.
 
-To implement access control rules:
+To implement access control rules, follow these steps:
 
 1.  Store the data for which you want to define access control rules by using the `Save()` method of the [Tizen.Security.SecureRepository.DataManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.SecureRepository.DataManager.html) class:
 
@@ -639,6 +639,6 @@ To implement access control rules:
         ```
 
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/security/secure-repository.md
+++ b/docs/application/dotnet/guides/security/secure-repository.md
@@ -584,7 +584,7 @@ To load files, follow these steps:
     ```
 
 <a name="access_control"></a>
-## Implement Access Control
+## Implement access control
 
 Each client can adjust access control rules for their own data, certificates, and keys.
 

--- a/docs/application/dotnet/guides/security/tee-client.md
+++ b/docs/application/dotnet/guides/security/tee-client.md
@@ -11,7 +11,7 @@ You can run applications in 2 environments: a rich world (like Linux) with clien
 
 ![TEE communication architecture](./media/libteec_architecture.png)
 
-The main features of the Tizen.Security.TEEC namespace include:
+The main features of the Tizen.Security.TEEC namespace include the following:
 
 -   Connecting to a trusted application
 
@@ -24,7 +24,7 @@ The main features of the Tizen.Security.TEEC namespace include:
 ## Prerequisites
 
 
-To enable your application to use the TEE communication functionality:
+To enable your application to use the TEE communication functionality, follow the steps below:
 
 1.  To make your application visible in the official site for Tizen applications only for devices that support TEE communication, the application must specify the following feature in the `tizen-manifest.xml` file:
 
@@ -67,9 +67,9 @@ To enable your application to use the TEE communication functionality:
     ```
 
 <a name="connecting_applications"></a>
-## Connecting Applications
+## Connect applications
 
-To communicate between applications, you must connect a client application to a trusted application by creating a session:
+To communicate between applications, you must connect a client application to a trusted application by creating a session, follow the steps below:
 
 1.  Open a session with the `OpenSession()` method of the [Tizen.Security.TEEC.Context](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.Context.html) class, which returns the session as a new instance of the [Tizen.Security.TEEC.Session](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.Session.html) class.
 
@@ -92,11 +92,11 @@ To communicate between applications, you must connect a client application to a 
     ```
 
 <a name="sending_secure_commands"></a>
-## Sending Secure Commands
+## Send secure commands
 
 After opening a session with a trusted application, a client application can execute functions in the trusted application by sending secure commands to the trusted application.
 
-To send function call commands:
+To send function call commands, follow the steps below:
 
 -   To send a command for invoking a function without parameters, use the `InvokeCommand()` method of the [Tizen.Security.TEEC.Session](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.Session.html) class, with the first parameter identifying the function to be executed by the trusted application:
 
@@ -154,9 +154,9 @@ To send function call commands:
         ```
 
 <a name="using_shared_memory"></a>
-## Using Shared Memory
+## Use shared memory
 
-To share a memory block between a client application and a trusted application:
+To share a memory block between a client application and a trusted application, follow the steps below:
 
 -   To send a function call command to the trusted application, including an allocated shared memory reference:
     1.  Allocate a new memory block as shared memory with the `AllocateSharedMemory()` method of the [Tizen.Security.TEEC.Context](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.Context.html) class, which returns the block as a new instance of the [Tizen.Security.TEEC.SharedMemory](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.SharedMemory.html) class:
@@ -215,6 +215,6 @@ To share a memory block between a client application and a trusted application:
 
 
 
-## Related Information
+## Related information
   * Dependencies
     -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/security/tee-client.md
+++ b/docs/application/dotnet/guides/security/tee-client.md
@@ -3,7 +3,7 @@
 > [!NOTE]
 > TEEC API is deprecated since Tizen 6.5 and will be removed after two releases without any alternatives.
 
-You can create secure communications by executing your application in a trusted execution environment (TEE), and communicating with other applications within that environment. To implement TEE communication, you can use the libteec API, which is based on the GlobalPlatform® [TEE Client API](https://www.globalplatform.org/specs-library).
+You can create secure communications by executing your application in a trusted execution environment (TEE), and communicating with other applications within that environment. To implement TEE communication, you can use the libteec API, which is based on the GlobalPlatform® [TEE Client API](https://www.globalplatform.org/specs-library){:target="_blank"}.
 
 You can run applications in 2 environments: a rich world (like Linux) with client applications (CA) and a secure world with trusted applications (TA).
 
@@ -44,7 +44,7 @@ To enable your application to use the TEE communication functionality, follow th
     }
     ```
 
-    > **Note**   
+    > [!NOTE]  
 	> In TV applications, you can test the TEE communication functionality on an emulator only. Most target devices do not currently support this feature.
 
 
@@ -71,7 +71,7 @@ To enable your application to use the TEE communication functionality, follow th
 
 To communicate between applications, you must connect a client application to a trusted application by creating a session, follow the steps below:
 
-1.  Open a session with the `OpenSession()` method of the [Tizen.Security.TEEC.Context](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.Context.html) class, which returns the session as a new instance of the [Tizen.Security.TEEC.Session](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.Session.html) class.
+1.  Open a session with the `OpenSession()` method of the [Tizen.Security.TEEC.Context](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.Context.html) class, which returns the session as a new instance of the [Tizen.Security.TEEC.Session](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.Session.html) class:
 
     ```csharp
     Guid ta_uuid = new Guid("  "); /// Trusted application GUID
@@ -121,7 +121,7 @@ To send function call commands, follow the steps below:
             Value p2 = new Value(10, 200, TEFValueType.InOut);
         ```
 
-    2.  Send the command to the trusted application with the `InvokeCommand()` method of the `Tizen.Security.TEEC.Session` class. The second parameter is a new instance of the [Tizen.Security.TEEC.Parameter](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.Parameter.html) class containing the 2 integer parameter values.
+    2.  Send the command to the trusted application with the `InvokeCommand()` method of the `Tizen.Security.TEEC.Session` class. The second parameter is a new instance of the [Tizen.Security.TEEC.Parameter](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.Parameter.html) class containing the 2 integer parameter values:
 
         ```csharp
             ses.InvokeCommand(1, new Parameter[] {p1, p2});
@@ -142,7 +142,7 @@ To send function call commands, follow the steps below:
             TempMemoryReference p1 = new TempMemoryReference((IntPtr)(&val), 1024, TEFTempMemoryType.InOut);
         ```
 
-    2.  Send the command to the trusted application with the `InvokeCommand()` method of the `Tizen.Security.TEEC.Session` class. The second parameter is a new instance of the `Tizen.Security.TEEC.Parameter` class containing the memory reference.
+    2.  Send the command to the trusted application with the `InvokeCommand()` method of the `Tizen.Security.TEEC.Session` class. The second parameter is a new instance of the `Tizen.Security.TEEC.Parameter` class containing the memory reference:
 
         ```csharp
             ses.InvokeCommand(1, new Parameter[] {p1});
@@ -167,7 +167,7 @@ To share a memory block between a client application and a trusted application, 
             SharedMemory shm = ctx.AllocateSharedMemory(1024, SharedMemoryFlags.InOut);
         ```
 
-    2.  Register a memory reference based on the shared memory block by creating a new instance of the [Tizen.Security.TEEC.RegisteredMemoryReference](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.RegisteredMemoryReference.html) class, and send the function call command to the trusted application with the `InvokeCommand()` method of the [Tizen.Security.TEEC.Session](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.Session.html) class. The registered memory reference is passed in a new instance of the [Tizen.Security.TEEC.Parameter](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.Parameter.html) class.
+    2.  Register a memory reference based on the shared memory block by creating a new instance of the [Tizen.Security.TEEC.RegisteredMemoryReference](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.RegisteredMemoryReference.html) class, and send the function call command to the trusted application with the `InvokeCommand()` method of the [Tizen.Security.TEEC.Session](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.Session.html) class. The registered memory reference is passed in a new instance of the [Tizen.Security.TEEC.Parameter](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.Parameter.html) class:
 
         ```csharp
             RegisteredMemoryReference p1 = new RegisteredMemoryReference(shm, 1024, 0, RegisteredMemoryReference.InOut);
@@ -195,7 +195,7 @@ To share a memory block between a client application and a trusted application, 
             SharedMemory shm = ctx.RegisterSharedMemory(memaddr, 1024, SharedMemoryFlags.InOut);
         ```
 
-    2.  Register a memory reference based on the shared memory block by creating a new instance of the `Tizen.Security.TEEC.RegisteredMemoryReference` class, and send the function call command to the trusted application with the `InvokeCommand()` method of the `Tizen.Security.TEEC.Session` class. The registered memory reference is passed in a new instance of the `Tizen.Security.TEEC.Parameter` class.
+    2.  Register a memory reference based on the shared memory block by creating a new instance of the `Tizen.Security.TEEC.RegisteredMemoryReference` class, and send the function call command to the trusted application with the `InvokeCommand()` method of the `Tizen.Security.TEEC.Session` class. The registered memory reference is passed in a new instance of the `Tizen.Security.TEEC.Parameter` class:
 
         ```csharp
             RegisteredMemoryReference p1 = new RegisteredMemoryReference(shm, 1024, 0, RegisteredMemoryReference.InOut);

--- a/docs/application/dotnet/guides/security/tee-client.md
+++ b/docs/application/dotnet/guides/security/tee-client.md
@@ -45,7 +45,7 @@ To enable your application to use the TEE communication functionality, follow th
     ```
 
     > [!NOTE]  
-	> In TV applications, you can test the TEE communication functionality on an emulator only. Most target devices do not currently support this feature.
+    > In TV applications, you can test the TEE communication functionality on an emulator only. Most target devices do not currently support this feature.
 
 
 2.  To use the methods and properties of the [Tizen.Security.TEEC](/application/dotnet/api/TizenFX/latest/api/Tizen.Security.TEEC.html) namespace, include it in your application:


### PR DESCRIPTION
### Change Description ###

This PR includes the fix of the following files which is part of the Security section under the .NET application guides section of the Tizen Docs site:

Files changed (6):
application/dotnet/guides/security/overview.md
application/dotnet/guides/security/secure-repository.md
application/dotnet/guides/security/privilege.md
application/dotnet/guides/security/privacy-related-permissions.md
application/dotnet/guides/security/tee-client.md
application/dotnet/guides/security/dpm.md

Signed-off by: safir.zawad@samsung.com 