### PR TITLE
.NET application site fix (Part - 19)

### DIFF
--- a/docs/application/dotnet/guides/uix/input-method-manager.md
+++ b/docs/application/dotnet/guides/uix/input-method-manager.md
@@ -2,9 +2,9 @@
 # Input Method Manager
 
 
-You can manage the input method editors (IMEs) installed on the device. After your IME application is installed, you can use the input method manager to open a list of installed IMEs, allow the user to enable an installed IME, and show an IME selector, in which the user can see the enabled IMEs and select one as a default keyboard.
+You can manage the IMEs (Input Method Editors) installed on the device. After your IME application is installed, you can use the input method manager to open a list of installed IMEs, allow the user to enable an installed IME, and show an IME selector, in which the user can see the enabled IMEs and select one as a default keyboard.
 
-The main features of the Tizen.Uix.InputMethodManager namespace include:
+The main features of the Tizen.Uix.InputMethodManager namespace include the following:
 
 -   Showing the IME list
 
@@ -28,7 +28,7 @@ The main features of the Tizen.Uix.InputMethodManager namespace include:
 
 ## Prerequisites
 
-To enable your application to use the input method management functionality:
+To enable your application to use the input method management functionality, follow these steps:
 
 1.  To use the [Tizen.Uix.InputMethodManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.InputMethodManager.html) namespace, the application has to request permission by adding the following privilege to the `tizen-manifest.xml` file:
 
@@ -45,7 +45,7 @@ To enable your application to use the input method management functionality:
     ```
 
 <a name="list"></a>
-## Showing the IME List
+## Show the IME list
 
 To launch the IME list menu to show the installed IMEs, use the `ShowIMEList()` method of the [Tizen.Uix.InputMethodManager.Manager](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.InputMethodManager.Manager.html) class:
 
@@ -64,7 +64,7 @@ void ShowImeList()
 ```
 
 <a name="selector"></a>
-## Showing the IME Selector
+## Show the IME selector
 
 To launch the IME selector menu to allow the user to select the default keyboard, use the `ShowIMESelector()` method of the [Tizen.Uix.InputMethodManager.Manager](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.InputMethodManager.Manager.html) class:
 
@@ -83,11 +83,11 @@ void ShowImeSelector()
 ```
 
 <a name="enable"></a>
-## Checking the IME State
+## Check the IME state
 
 To check whether a specific IME is enabled, to check the current default keyboard, or to get the number of enabled (usable) IMEs:
 
--   To check whether a specific IME is enabled, use the `IsIMEEnabled()` method of the [Tizen.Uix.InputMethodManager.Manager](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.InputMethodManager.Manager.html) class. As a parameter, use the application ID of the IME whose status you want to check.
+-   To check whether a specific IME is enabled, use the `IsIMEEnabled()` method of the [Tizen.Uix.InputMethodManager.Manager](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.InputMethodManager.Manager.html) class. As a parameter, use the application ID of the IME whose status you want to check:
 
     ```csharp
     bool IsImeEnabled(string appId)
@@ -138,6 +138,6 @@ To check whether a specific IME is enabled, to check the current default keyboar
     ```
 
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/uix/input-method.md
+++ b/docs/application/dotnet/guides/uix/input-method.md
@@ -106,7 +106,7 @@ To allow the user to move the floating keyboard, follow these steps:
     GestureRecognizers.Add (panGesture);
     ```
 
-3.  Call the `SetFloatingDragStart()` and `SetFloatingDragEnd()` method when a drag event is received:
+3.  Call the `SetFloatingDragStart()` and `SetFloatingDragEnd()` methods when a drag event is received:
 
     ```csharp
     void OnPanUpdated (object sender, PanUpdatedEventArgs e)

--- a/docs/application/dotnet/guides/uix/input-method.md
+++ b/docs/application/dotnet/guides/uix/input-method.md
@@ -1,11 +1,11 @@
 # Input Method
 
 
-The input method editor (IME) is an input panel (keyboard) that lets the user input text and the platform receive the entered data. The user can select an IME as their default keyboard in the device Settings application.
+The IME (Input Method Editor) is an input panel (keyboard) that lets the user input text and the platform receive the entered data. The user can select an IME as their default keyboard in the device Settings application.
 
 You can create an application that provides a new IME. You can start the IME application life-cycle, interact with the current IME UI state, and retrieve attributes and events.
 
-The main features of the Tizen.Uix.InputMethod namespace include:
+The main features of the Tizen.Uix.InputMethod namespace include the following:
 
 -   Managing the IME life-cycle
 
@@ -40,7 +40,7 @@ The main features of the Tizen.Uix.InputMethod namespace include:
 
 ## Prerequisites
 
-To enable your application to use the input method functionality:
+To enable your application to use the input method functionality follow these steps:
 
 1.  To use the [Tizen.Uix.InputMethod](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.InputMethod.html) namespace, the application has to request permission by adding the following privilege to the `tizen-manifest.xml` file:
 
@@ -57,9 +57,9 @@ To enable your application to use the input method functionality:
     ```
 
 <a name="start"></a>
-## Starting the IME Life-cycle
+## Start the IME life-cycle
 
-To start the IME application life-cycle:
+To start the IME application life-cycle, follow these steps:
 
 1.  Register the mandatory `Create()`, `Terminate()`, `Show()`, and `Hide()` event handlers:
 
@@ -86,9 +86,9 @@ To start the IME application life-cycle:
     }
     ```
 
-## Using Floating Keyboard
+## Use floating keyboard
 
-To allow the user to move the floating keyboard:
+To allow the user to move the floating keyboard, follow these steps:
 
 1.  Call the `SetFloatingMode()` method:
 
@@ -122,6 +122,6 @@ To allow the user to move the floating keyboard:
     }
     ```
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/uix/overview.md
+++ b/docs/application/dotnet/guides/uix/overview.md
@@ -23,12 +23,12 @@ You can use the following text input and voice features in your .NET application
 
 -   [Voice Control](voice-control.md)
 
-    You can allow the user to control the device through voice commands. You can register voice commands, which trigger a callback when the user speaks to them.
+    You can allow the user to control the device through voice commands. You can register voice commands, which trigger a callback when the user speaks.
 
 -   [Voice Control Manager](voice-control-manager.md)
 
     You can record voice and give responses to the recognized voice commands. You can register general and system voice commands such as "power on", "power off", "music play", "music stop", and so on. In addition, you can start and stop voice recording.
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/uix/overview.md
+++ b/docs/application/dotnet/guides/uix/overview.md
@@ -11,11 +11,11 @@ You can use the following text input and voice features in your .NET application
 
 -   [Sticker](sticker.md)
 
-    You can provide sticker information to applications that wants to read the sticker information. You can also retrieve the sticker information stored by the provider application.
+    You can provide sticker information to applications that want to read the sticker information. You can also retrieve the sticker information stored by the provider application.
 
 -   [Speech-to-text](stt.md)
 
-    You can recognize sound data recorded by the user and send the result as text. The result text can, for example, be displayed on the screen.
+    You can recognize sound data recorded by the user and send the result as text. The text can, for example, be displayed on the screen.
 
 -   [Text-to-speech](tts.md)
 
@@ -23,11 +23,11 @@ You can use the following text input and voice features in your .NET application
 
 -   [Voice Control](voice-control.md)
 
-    You can allow the user to control the device through voice commands. You can register voice commands, which trigger a callback when the user speaks them.
+    You can allow the user to control the device through voice commands. You can register voice commands, which trigger a callback when the user speaks to them.
 
 -   [Voice Control Manager](voice-control-manager.md)
 
-    You can record voice and give responses for the recognized voice commands. You can register general and system voice commands such as "power on", "power off", "music play", "music stop", and so on. In addition, you can start and stop voice recording.
+    You can record voice and give responses to the recognized voice commands. You can register general and system voice commands such as "power on", "power off", "music play", "music stop", and so on. In addition, you can start and stop voice recording.
 
 ## Related Information
 * Dependencies

--- a/docs/application/dotnet/guides/uix/sticker.md
+++ b/docs/application/dotnet/guides/uix/sticker.md
@@ -3,7 +3,7 @@
 
 The Sticker feature provides users with fun experiences to share sticker information. The Sticker applications are composed of a [Sticker provider application](#provider_application) and [Sticker consumer applications](#consumer_application). The Sticker provider creates stickers and you can create your own Sticker consumer applications that use the stickers created by the Sticker provider. The Sticker provider application can store sticker details such as URI, keyword, and group name in the Sticker database. The Sticker consumer applications can retrieve sticker information using the Sticker API.
 
-The main features of the Tizen.Uix.Sticker namespace includes the following:
+The main features of the Tizen.Uix.Sticker namespace include the following:
 
 - Preparing the Sticker service for use
 


### PR DESCRIPTION
Change Description
This PR includes the fix of the following files which is part of the Text input and voice section under .NET application guides section of the Tizen Docs site:

File count: 4

/application/dotnet/guides/uix/overview.md
/application/dotnet/guides/uix/input-method.md
/application/dotnet/guides/uix/input-method-manager.md
/application/dotnet/guides/uix/sticker.md