### PR TITLE
.NET application site fix (Part - 20)

### DIFF
--- a/docs/application/dotnet/guides/uix/stt.md
+++ b/docs/application/dotnet/guides/uix/stt.md
@@ -5,7 +5,7 @@ STT (speech-to-text) features enable recognizing sound data recorded by the user
 
 When your application creates a handle and prepares the STT service, the STT daemon is invoked and connected for background work. This daemon and your application communicate as the server and the client.
 
-The main features of the Tizen.Uix.Stt namespace include:
+The main features of the Tizen.Uix.Stt namespace include the following:
 
 -   Preparing the STT service for use
 
@@ -22,13 +22,13 @@ The main features of the Tizen.Uix.Stt namespace include:
 <a name="basic_stt"></a>
 ## Basic STT Processes
 
-Using STT, you can:
+Using STT, you can accomplish the following tasks:
 
 -   Create a handle and register event handlers.
     -   Create an STT handle, which is used for distinguishing your application from other applications also using STT.
     -   [Get notifications on state changes](#set), language changes, recognition results, and errors by registered event handlers.
 -   Start, stop, and cancel recognition.
-    -   [Start recording the user voice](#option) by microphone and analyze the recorded data as text.
+    -   [Start recording the user's voice](#option) by microphone and analyze the recorded data as text.
     -   If you stop the recording manually, STT stops the recording and recognizes the sound data. The recognized text is then sent by the registered event handler.
     -   You also can set sounds which are played before STT recording starts or after it stops.
 -   Get the recognition result.
@@ -58,7 +58,7 @@ You can set the following parameters about STT:
 <a name="info_stt"></a>
 ## STT Information Retrieval
 
-You can get the following information about STT:
+You can get the following information about STT, follow these steps:
 
 -   [Get the current STT state](#get). The state is also applied as a precondition for each method.
 -   Get the default language.
@@ -81,10 +81,10 @@ To enable your application to use the STT functionality:
 
 2.  To use the STT library and create an STT handle, create a new instance of the [Tizen.Uix.Stt.SttClient](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.Stt.SttClient.html) class.
 
-    The instance is used to launch other STT methods. After the instance has been created, the STT state changes to `Created`.
+    The instance is used to launch other STT methods. After the instance has been created, the STT state changes to `Created`:
 
 
-    > **Note**   
+    > [!NOTE]
 	> STT is not thread-safe and depends on the Ecore main loop. Implement STT within the Ecore main loop and do not use it in a thread.
 
     ```csharp
@@ -117,11 +117,11 @@ To enable your application to use the STT functionality:
     }
     ```
 
-    > **Note**   
+    > [!NOTE]
 	> Do not use the `Dispose()` method inside an event handler. Within an event handler, the `Dispose()` method fails and invokes the `OperationFailed` error with the `ErrorOccurred` event of the `Tizen.Uix.Stt.SttClient` class.
 
 <a name="set"></a>
-## Registering Event Handlers
+## Register event handlers
 
 STT provides event handlers to get various information, such as the recognition result, state changes, language changes, and errors.
 
@@ -270,13 +270,13 @@ Event handlers can be set for the following events of the [Tizen.Uix.Stt.SttClie
     ```
 
 <a name="get"></a>
-## Getting Information
+## Get information
 
-To obtain the current STT state, the list of supported languages, and the current language:
+To obtain the current STT state, the list of supported languages, and the current language. Follow these steps:
 
 -   Retrieve the current STT state by using the `CurrentState` property of the [Tizen.Uix.Stt.SttClient](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.Stt.SttClient.html) class.
 
-    The STT state is changed by various STT methods, and it is applied as a precondition for each method.
+    The STT state is changed by various STT methods, and it is applied as a precondition for each method:
 
     ```csharp
     void GetState()
@@ -338,7 +338,7 @@ To obtain the current STT state, the list of supported languages, and the curren
 
 -   Retrieve or set the current engine for STT recognition by using the `Engine` property of the `Tizen.Uix.Stt.SttClient` class.
 
-    The supported language, silence detection, and supported recognition types depend on the STT engine.
+    The supported language, silence detection, and supported recognition types depend on the STT engine:
 
     ```csharp
     void SetGetCurrentEngine()
@@ -362,7 +362,7 @@ To obtain the current STT state, the list of supported languages, and the curren
 
 -   Check whether a recognition type is supported by the current engine, by using the `IsRecognitionTypeSupported()` method of the `Tizen.Uix.Stt.SttClient` class. Use the values of the [Tizen.Uix.Stt.RecognitionType](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.Stt.RecognitionType.html) enumeration as a parameter.
 
-    The normal recognition type, `Stt.RecognitionType.Free`, means that the whole recognition result is sent at the end of the recognition process. The `Stt.RecognitionType.Partial` recognition type is used to get a partial recognition result.
+    The normal recognition type, `Stt.RecognitionType.Free`, means that the whole recognition result is sent at the end of the recognition process. The `Stt.RecognitionType.Partial` recognition type is used to get a partial recognition result:
 
     ```csharp
     void CheckSupportedRecognitionType()
@@ -381,13 +381,13 @@ To obtain the current STT state, the list of supported languages, and the curren
     ```
 
 <a name="prepare"></a>
-## Connecting and Disconnecting STT
+## Connect and disconnect STT
 
-To operate STT:
+To operate STT, follow these steps:
 
 1.  After you have initialized STT by creating the [Tizen.Uix.Stt.SttClient](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.Stt.SttClient.html) class instance, connect the background STT daemon with the `Prepare()` method of that class.
 
-    The method is asynchronous and the STT state changes to `Ready`.
+    The method is asynchronous and the STT state changes to `Ready`:
 
     ```csharp
     void PrepareSttClient()
@@ -403,7 +403,7 @@ To operate STT:
     }
     ```
 
-    > **Note**   
+    > [!NOTE]
 	> If the error event handler is invoked after calling the `Tizen.Uix.Stt.SttClient.Prepare()` method, STT is not available.
 
 2.  When the connection is no longer needed, disconnect STT and change the STT state to `Created`, by using the `Unprepare()` method:
@@ -423,9 +423,9 @@ To operate STT:
     ```
 
 <a name="engine"></a>
-## Setting and Getting STT Engine Options
+## Set and get STT engine ptions
 
-To set and get STT engine options:
+To set and get STT engine options, follow these steps:
 
 -   Set the credential.
 
@@ -447,10 +447,10 @@ To set and get STT engine options:
 
 -   Set and get the private data.
 
-    The private data is a setting parameter for applying keys provided by the STT engine. To set the private data and use the corresponding key of the engine, use the `SetPrivateData()` method.
+    The private data is a setting parameter for applying keys provided by the STT engine. To set the private data and use the corresponding key of the engine, use the `SetPrivateData()` method:
 
 
-    > **Note**   
+    > [!NOTE]
 	> The key and data are determined by the STT engine. To set and get the private data, see the engine instructions.
 
     ```csharp
@@ -486,15 +486,15 @@ To set and get STT engine options:
     ```
 
 <a name="option"></a>
-## Setting Options and Controlling Recording
+## Set options and control recording
 
-To set the STT options and control recording:
+To set the STT options and control recording, follow these steps:
 
 -   Set the silence detection.
 
-    After STT starts recognizing sound, some STT engines can detect silence when the sound input from the user ends. If the silence detection is enabled, the STT library stops recognition automatically and sends the result. Otherwise, you can manually stop the recognition process using the `Stop()` method of the [Tizen.Uix.Stt.SttClient](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.Stt.SttClient.html) class.
+    After STT starts recognizing sound, some STT engines can detect silence when the sound input from the user ends. If silence detection is enabled, the STT library stops recognition automatically and sends the result. Otherwise, you can manually stop the recognition process using the `Stop()` method of the [Tizen.Uix.Stt.SttClient](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.Stt.SttClient.html) class.
 
-    To set the silence detection state, use the `SetSilenceDetection()` method, using values of the [Tizen.Uix.Stt.SilenceDetection](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.Stt.SilenceDetection.html) enumeration as a parameter. If you set the silence detection as `SilenceDetection.Auto`, STT works according to the global STT setting. This option must be set when STT is in the `Ready` state.
+    To set the silence detection state, use the `SetSilenceDetection()` method, using values of the [Tizen.Uix.Stt.SilenceDetection](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.Stt.SilenceDetection.html) enumeration as a parameter. If you set the silence detection as `SilenceDetection.Auto`, STT works according to the global STT setting. This option must be set when STT is in the `Ready` state:
 
     ```csharp
     void SetSilenceDetection(SilenceDetection type)
@@ -513,9 +513,9 @@ To set the STT options and control recording:
 
 -   Set or unset the start sound.
 
-    To play a sound before STT recognition starts, call the `SetStartSound()` method in the `Ready` state.
+    To play a sound before STT recognition starts, call the `SetStartSound()` method in the `Ready` state:
 
-    > **Note**   
+    > [!NOTE]
 	> The sound file path must be a full path. Only WAV format sound files are supported.
 
     ```csharp
@@ -552,7 +552,7 @@ To set the STT options and control recording:
 
     To play a sound when STT recognition stops, use the `SetStopSound()` method in the `Ready` state:
 
-    > **Note**   
+    > [!NOTE]
 	> The sound file path must be a full path. Only WAV format sound files are supported.
 
     ```csharp
@@ -590,10 +590,10 @@ To set the STT options and control recording:
 
         The connected STT daemon starts recording, and the STT state is changed to `Recording`.
 
-        > **Note**   
+        > [!NOTE]
 		> If the `Start()` method fails, check the error code and take appropriate action.
 
-        The language and recognition type must be supported by the current STT engine. If you set `NULL` as the language parameter, the STT default language is used based on the `DefaultLanguage` property of the currently-used `Tizen.Uix.Stt.SttClient` class instance.
+        The language and recognition type must be supported by the current STT engine. If you set `NULL` as the language parameter, the STT default language is used based on the `DefaultLanguage` property of the currently-used `Tizen.Uix.Stt.SttClient` class instance:
 
         ```csharp
         void Start(string language, RecognitionType type)
@@ -611,7 +611,7 @@ To set the STT options and control recording:
 
     -   While STT recording is in progress, you can retrieve the current recording volume using the `RecordingVolume` property of the `Tizen.Uix.Stt.SttClient` class.
 
-        The volume value is retrieved periodically with the short-term recorded sound data as dB (decibels). The STT volume normally has a negative value, and 0 is the maximum value.
+        The volume value is retrieved periodically with the short-term recorded sound data as dB (decibels). The STT volume normally has a negative value, and 0 is the maximum value:
 
         ```csharp
         void GetVolume()
@@ -631,7 +631,7 @@ To set the STT options and control recording:
 
     -   To stop the recording and get the recognition result, use the `Stop()` method.
 
-        The recording stops and the STT state is changed to `Processing`. When the recognition result has been processed, the `RecognitionResult` event triggers, and the state changes back to `Ready`.
+        The recording stops and the STT state is changed to `Processing`. When the recognition result has been processed, the `RecognitionResult` event triggers, and the state changes back to `Ready`:
 
         ```csharp
         void Stop()
@@ -666,6 +666,6 @@ To set the STT options and control recording:
         ```
 
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/uix/stt.md
+++ b/docs/application/dotnet/guides/uix/stt.md
@@ -58,7 +58,7 @@ You can set the following parameters about STT:
 <a name="info_stt"></a>
 ## STT Information Retrieval
 
-You can get the following information about STT, follow these steps:
+You can get the following information about STT by following these steps:
 
 -   [Get the current STT state](#get). The state is also applied as a precondition for each method.
 -   Get the default language.

--- a/docs/application/dotnet/guides/uix/tts.md
+++ b/docs/application/dotnet/guides/uix/tts.md
@@ -575,7 +575,7 @@ To add text, follow these steps:
 <a name="control"></a>
 ## Control playback
 
-To start, pause, and stop the playback. Follow the steps below:
+To start, pause, and stop the playback, follow the steps below:
 
 -   To start synthesizing the text added in the queue and play the resulting sound data in sequence, use the `Play()` method of the [Tizen.Uix.Tts.TtsClient](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.Tts.TtsClient.html) class.
 

--- a/docs/application/dotnet/guides/uix/tts.md
+++ b/docs/application/dotnet/guides/uix/tts.md
@@ -5,7 +5,7 @@ TTS (text-to-speech) features include synthesizing text into sound data as utter
 
 When your application creates a handle and prepares the TTS service, the TTS service is invoked and connected for background work. This service and your application communicate as the server and the client, respectively.
 
-The main features of the Tizen.Uix.Tts namespace include:
+The main features of the Tizen.Uix.Tts namespace includes the following:
 
 -   Preparing the TTS service for use
 
@@ -22,7 +22,7 @@ The main features of the Tizen.Uix.Tts namespace include:
 <a name="basic_tts"></a>
 ## Basic TTS processes
 
-Using TTS, you can:
+Using TTS, you can, you can accomplish the following tasks:
 
 -   Create a handle and register event handlers.
     -   Create a TTS handle which is used for distinguishing your application from other applications also using TTS.
@@ -60,7 +60,7 @@ You can set the following parameters about TTS:
 You can get the following information about TTS:
 
 -   [Get the current TTS state](#get). The state is also applied as a precondition for each method.
--   Get the current TTS service state. The service state is changed by internal behavior of the TTS service.
+-   Get the current TTS service state. The service state is changed by the internal behavior of the TTS service.
 -   Get the default voice.
     -   In TTS, the voice is defined as a combination of the language and the type, such as male or female.
     -   You can request the synthesis of the text with a specific voice, using the parameters of the `AddText()` method of the [Tizen.Uix.Tts.TtsClient](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.Tts.TtsClient.html) class. However, if you do not set a specific voice, TTS synthesizes the text with the default voice.
@@ -575,7 +575,7 @@ To add text, follow these steps:
 <a name="control"></a>
 ## Control playback
 
-To start, pause, and stop the playback, follow the steps below:
+To start, pause, and stop the playback. Follow the steps below:
 
 -   To start synthesizing the text added in the queue and play the resulting sound data in sequence, use the `Play()` method of the [Tizen.Uix.Tts.TtsClient](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.Tts.TtsClient.html) class.
 

--- a/docs/application/dotnet/guides/uix/voice-control-manager.md
+++ b/docs/application/dotnet/guides/uix/voice-control-manager.md
@@ -2,7 +2,7 @@
 Voice control manager features allow you to record voice and give responses for the recognized voice commands. You can register general and system voice commands such as "power on", "power off", "music play", "music stop", and so on. In addition, you can start and stop voice recording. When the voice recording is finished, you can receive multiple recognition results such as Automatic Speech Recognition (ASR) and matched commands from the commands list, which is registered by the application using the voice control client.
 
 
-The main features of the [Tizen.Uix.VoiceControlManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControlManager.html) namespace include:
+The main features of the [Tizen.Uix.VoiceControlManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControlManager.html) namespace includes the following:
 
 -   Creating a handle and registering event handlers.
     -   You can create a voice control manager handle and only one voice control manager instance can work on the device.
@@ -11,7 +11,7 @@ The main features of the [Tizen.Uix.VoiceControlManager](/application/dotnet/api
     -    You can register commands as System, Widget, Foreground, SystemBackground, and Background type on the voice control service. When you speak a registered command, the callback returns the recognized result.
 -   Starting, stopping, and canceling recognition.
     -   You can [start and stop voice recording](#start_and_stop_recording) using a microphone.
-    -   You can set to stop recording manually or automatically. If automatic stop is set, voice control manager stops recording when end of speech is detected.
+    -   You can set it to stop recording manually or automatically. If the automatic stop is set, the voice control manager stops recording when the end of speech is detected.
     -   When the voice recording finishes, the voice control service recognizes the speech data and finds matching commands among the registered commands.
 -   Getting the recognition result.
     -   The recognition result is invoked by the registered event handler.
@@ -73,12 +73,12 @@ The following figure illustrates the voice control manager life-cycle:
 
 In general scenario, following are the voice control manager service state:
 1.  The user starts recording for recognition by using a voice control manager application, button, or voice trigger. If the start is successful, the voice control service state changes to `Recording`. For more information on service states, see [Tizen.Uix.VoiceControlManager.ServiceState](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControlManager.ServiceState.html) enumeration.
-2.  After recording is completed, the service state changes to `Processing` for recognition processing.
-3.  After recognition is completed, the service state changes to `Ready`.
+2.  After the recording is completed, the service state changes to `Processing` for recognition processing.
+3.  After the recognition is completed, the service state changes to `Ready`.
 
 ## Prerequisites
 
-To enable your application to use the voice control functionality:
+To enable your application to use the voice control functionality, follow these steps:
 
 1.  To use the [Tizen.Uix.VoiceControlManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControlManager.html) class, the application has to request permission by adding the following privileges to the `tizen-manifest.xml` file:
 
@@ -143,7 +143,7 @@ To enable your application to use the voice control functionality:
     > Do not call the `Deinitialize()` method of the [Tizen.Uix.VoiceControlManager.VoiceControlManagerClient](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControlManager.VoiceControlManagerClient.html) class in a callback. Within a callback, the `Deinitialize()` method fails and returns `ErrorCode.OperationFailed`.
 
 <a name="callback"></a>
-## Manage Callbacks
+## Manage callbacks
 
 You can set or unset callbacks such as notification of recognition results, state changes, errors, and so on:
 
@@ -382,9 +382,9 @@ You can set or unset callbacks such as notification of recognition results, stat
     ```
 
 
--   Set the all recognition result received callback invoked when voice control engine sends the all recognition result to voice control manager.
+-   Set the all recognition result received callback invoked when the voice control engine sends all recognition results to the voice control manager.
 
-    In the callback, the recognized result, recognized text, and engine message results are included. Recognized result can include more than two voice commands, if the two voice commands have the same command string and are registered by each voice control clients.
+    In the callback, the recognized result, recognized text, and engine message results are included. Recognized results can include more than two voice commands if the two voice commands have the same command string and are registered by each voice control client.
 
     If you want to select specific command in the recognized result, you can use `SetRecognizedCommandsSelectionDelegate()` method:
 
@@ -446,9 +446,9 @@ You can set or unset callbacks such as notification of recognition results, stat
 
 -   Set the recognized commands selection callback invoked when the voice control manager select specific voice commands in all recognized result.
 
-    When utterance is recognized, all the recognized result can include more than two voice commands if these commands have the same command string that is registered by each voice control clients.
+    When an utterance is recognized, all the recognized results can include more than two voice commands if these commands have the same command string that is registered by each voice control client.
 
-    In this case, voice control manager can select specific voice commands from all recognized result to send voice control client using `SetRecognizedCommandsSelectionDelegate()`.
+    In this case, the voice control manager can select specific voice commands from all recognized results to send the voice control client using `SetRecognizedCommandsSelectionDelegate()`.
 
     You can select a valid command result from the recognized command selection:
 
@@ -562,11 +562,11 @@ You can set or unset callbacks such as notification of recognition results, stat
 <a name="start_and_stop_recording"></a>
 ## Start and stop recording
 
-You can start, stop, or cancel recording using voice control manager:
+You can start, stop, or cancel recording using voice control manager by following these steps:
 
 -   To start recording, use the `Start()` method with `exclusiveCommandOption` as the parameter.
     The connected voice control service starts recording and the voice control manager state is changed to `Recording`.
-    If the parameter `exclusiveCommandOption` value is true, voice control service recognizes only the exclusive commands.
+    If the parameter `exclusiveCommandOption` value is true, the voice control service recognizes only the exclusive commands.
     This method must be called when the voice control manager is in the `Ready` state:
 
     ```csharp
@@ -585,7 +585,7 @@ You can start, stop, or cancel recording using voice control manager:
 
 -   To stop recording, use the `Stop()` method.
     The recording stops and the voice control manager state is changed to `Processing`.
-    When the recognition command result is processed, the `RecognitionResult` event triggers, and the state changes back to `Ready`.
+    When the recognition command result is processed, the `RecognitionResult` event triggers and the state changes back to `Ready`.
     This method must be called when the voice control manager is in the `Recording` state:
 
     ```csharp
@@ -624,9 +624,9 @@ You can start, stop, or cancel recording using voice control manager:
 <a name="send_requests"></a>
 ## Send requests
 
-You can send requests using the voice control manager:
+Follow these steps to send requests using the voice control manager:
 
--   To send the event information to the voice control engine in purpose of activating specific action, use the `DoAction()` method.
+-   To send the event information to the voice control engine for purpose of activating specific action, use the `DoAction()` method.
 
     This method must be called when the voice control manager is in the `Ready` state:
 
@@ -663,9 +663,9 @@ You can send requests using the voice control manager:
     ```
 
 <a name="information"></a>
-## Retrieve Voice Control Manager Information
+## Retrieve voice control manager information
 
-To get information about the current states, service states, current and supported languages:
+To get information about the current states, service states, current and supported languages. Follow these steps:
 
 -   Get the current voice control manager state using the `State` property of the [Tizen.Uix.VoiceControlManager.VoiceControlManagerClient](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControlManager.VoiceControlManagerClient.html) class.
     The voice control manager state changes according to method calls:
@@ -804,11 +804,11 @@ To get information about the current states, service states, current and support
     }
     ```
 
--   Get or set private data between voice control manager and voice control engine.
+-   Get or set private data between the voice control manager and the voice control engine.
 
     You can use the `GetPrivateData()` and `SetPrivateData()` methods of the [Tizen.Uix.VoiceControlManager.VoiceControlManagerClient](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControlManager.VoiceControlManagerClient.html) class.
 
-    `GetPrivateData()` is used when the parameters move from voice control engine to voice control manager, while `SetPrivateData()` is used when the parameters move from voice control manager to voice control engine.
+    `GetPrivateData()` is used when the parameters move from the voice control engine to the voice control manager, while `SetPrivateData()` is used when the parameters move from the voice control manager to the voice control engine.
 
     This option must be set when the voice control manager is in the `Ready` state:
 
@@ -833,11 +833,11 @@ To get information about the current states, service states, current and support
 
 
 <a name="commands"></a>
-## Manage Commands
+## Manage commands
 
 You can use command group to manage the commands. You can add or remove the commands to the command group and retrieve the command information using the command group.
 
-To create a command group and commands:
+To create a command group and commands, follow these steps:
 
 1.  Create a command group with a command group handle.
 
@@ -1024,7 +1024,7 @@ To create a command group and commands:
 
 
 <a name="register_command"></a>
-## Register Command
+## Register command
 
 - You can register the commands for recognition by setting the command group to the voice control service from a file that includes the commands. The parameter `commandFilePath` is used to get the path of the file.
     If you want to update the registered commands, set the command group again with the updated commands:
@@ -1094,6 +1094,6 @@ To create a command group and commands:
     }
     ```
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 5.5 and Higher

--- a/docs/application/dotnet/guides/uix/voice-control-manager.md
+++ b/docs/application/dotnet/guides/uix/voice-control-manager.md
@@ -665,7 +665,7 @@ Follow these steps to send requests using the voice control manager:
 <a name="information"></a>
 ## Retrieve voice control manager information
 
-To get information about the current states, service states, current and supported languages. Follow these steps:
+To get information about the current states, service states, current and supported languages, follow these steps:
 
 -   Get the current voice control manager state using the `State` property of the [Tizen.Uix.VoiceControlManager.VoiceControlManagerClient](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControlManager.VoiceControlManagerClient.html) class.
     The voice control manager state changes according to method calls:

--- a/docs/application/dotnet/guides/uix/voice-control.md
+++ b/docs/application/dotnet/guides/uix/voice-control.md
@@ -121,7 +121,7 @@ To enable your application to use the voice control functionality, follow these 
 <a name="callback"></a>
 ## Manage callbacks
 
-To set and unset callbacks to get notifications about recognition results, state changes, and errors. Follow these steps:
+To set and unset callbacks to get notifications about recognition results, state changes, and errors, follow these steps:
 
 > [!NOTE]
 > Set and unset all callbacks when the voice control state is `Initialized` (the states are defined in the [Tizen.Uix.VoiceControl.State](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControl.State.html) enumeration).
@@ -278,7 +278,7 @@ To set and unset callbacks to get notifications about recognition results, state
 <a name="info"></a>
 ## Retrieve voice control information
 
-To get information about the current states, and current and supported languages. Follow these steps:
+To get information about the current states, and current and supported languages, follow these steps:
 
 -   Get the current voice control state using the `State` property of the [Tizen.Uix.VoiceControl.VoiceControlClient](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControl.VoiceControlClient.html) class.
 

--- a/docs/application/dotnet/guides/uix/voice-control.md
+++ b/docs/application/dotnet/guides/uix/voice-control.md
@@ -1,13 +1,13 @@
 # Voice Control
 
 
-Voice control features allow the user to control the device through their voice. You can register general voice commands, which allow you to recognize the sound data recorded by the user and send the result as a predefined command using the Voice control service.
+Voice control features allow the user to control the device through their voice. You can register general voice commands, which allow you to recognize the sound data recorded by the user and send the result as a predefined command using the voice control service.
 
-The main features of the Tizen.Uix.VoiceControl namespace include:
+The main features of the Tizen.Uix.VoiceControl namespace includes:
 
 -   Managing commands
 
-    You can use the Voice control service to register commands as foreground or background type. When the user speaks a registered command, the callback returns the recognition result.
+    You can use the voice control service to register commands as foreground or background type. When the user speaks a registered command, the callback returns the recognition result.
 
 -   Retrieving information
 
@@ -31,17 +31,17 @@ The main features of the Tizen.Uix.VoiceControl namespace include:
 
         You can retrieve a list of supported languages to check whether the language that you want is supported.
 
-To use the voice control:
+To use the voice control, follow these steps:
 
-1.  Set up the voice control and [register callbacks](#callback).
+1.  Set up voice control and [register callbacks](#callback).
 
     The initialization allows the voice control to distinguish your application from any other applications also using voice control. The registered callbacks allow you to receive notifications about changes in the service state, language, and recognition result, and about any errors.
 
 2.  Prepare the voice control.
 
-    The preparation connects the Voice control service for background work, such as recording and recognizing the user voice.
+    The preparation connects the voice control service for background work, such as recording and recognizing the user's voice.
 
-    When the application initializes and prepares the voice control, the Voice control daemon is invoked and connected for background work. The daemon and the application communicate as server and client.
+    When the application initializes and prepares the voice control, the voice control daemon is invoked and connected for background work. The daemon and the application communicate as server and client.
 
 3.  Set commands.
 
@@ -51,7 +51,7 @@ To use the voice control:
 
     The recognition result is sent through a registered callback.
 
-    If the registered command is duplicated or the user speaks multiple commands, the recognition result can contain multiple results. If you set duplicated commands, the Voice control service can reject the command. The rejection is shown in the result event.
+    If the registered command is duplicated or the user speaks multiple commands, the recognition result can contain multiple results. If you set duplicated commands, the voice control service can reject the command. The rejection is shown in the result event.
 
 5.  When no longer needed, unprepare and deinitialize the voice control.
 
@@ -59,14 +59,14 @@ To use the voice control:
 
 The following figure illustrates the voice control life-cycle states.
 
-**Figure: Voice control (left) and Voice control service (right) life-cycle states**
+**Figure: voice control (left) and voice control service (right) life-cycle states**
 
-![Voice control and Voice control service life-cycle states](./media/csapi_voice_control.png)
+![Voice control and voice control service life-cycle states](./media/csapi_voice_control.png)
 
 ## Prerequisites
 
 
-To enable your application to use the voice control functionality:
+To enable your application to use the voice control functionality, follow these steps:
 
 1.  To use the methods and properties of the [Tizen.Uix.VoiceControl.VoiceControlClient](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControl.VoiceControlClient.html) class, include it in your application:
 
@@ -85,10 +85,10 @@ To enable your application to use the voice control functionality:
 
     If the method call is successful, the voice control state changes to `Initialized` (the states are defined in the [Tizen.Uix.VoiceControl.State](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControl.State.html) enumeration).
 
-    > **Note**   
+    > [!NOTE]
 	> The voice control feature is not thread-safe and depends on the Ecore main loop. Implement voice control within the Ecore main loop and do not use it in a thread.
 
-3.  Prepare the Voice control service with the `Prepare()` method of the `Tizen.Uix.VoiceControl.VoiceControlClient` class, which connects the background Voice control daemon. The daemon records and recognizes audio data and converts sound to text.
+3.  Prepare the voice control service with the `Prepare()` method of the `Tizen.Uix.VoiceControl.VoiceControlClient` class, which connects the background voice control daemon. The daemon records and recognizes audio data and converts sound to text:
 
     ```csharp
     void prepare_vc()
@@ -115,15 +115,15 @@ To enable your application to use the voice control functionality:
 
     When the `Unprepare()` method of the `Tizen.Uix.VoiceControl.VoiceControlClient` class succeeds, the voice control state changes from `Ready` to `Initialized`.
 
-    > **Note**   
+    > [!NOTE]
 	> Do not call the `Deinitialize()` method of the `Tizen.Uix.VoiceControl.VoiceControlClient` class in a callback. Within a callback, the `Deinitialize()` method fails and returns `ErrorCode.OperationFailed`.
 
 <a name="callback"></a>
-## Managing Callbacks
+## Manage callbacks
 
-To set and unset callbacks to get notifications about recognition results, state changes, and errors:
+To set and unset callbacks to get notifications about recognition results, state changes, and errors. Follow these steps:
 
-> **Note**   
+> [!NOTE]
 > Set and unset all callbacks when the voice control state is `Initialized` (the states are defined in the [Tizen.Uix.VoiceControl.State](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControl.State.html) enumeration).
 
 -   Set the state change callback to be invoked when the voice control state changes:
@@ -155,7 +155,7 @@ To set and unset callbacks to get notifications about recognition results, state
     }
     ```
 
--   Set the service state change callback to be invoked when the Voice control service state changes:
+-   Set the service state change callback to be invoked when the voice control service state changes:
 
     ```csharp
     /// Callback
@@ -215,10 +215,10 @@ To set and unset callbacks to get notifications about recognition results, state
 
 -   Set the recognition result callback to be invoked when a voice command is recognized.
 
-    > **Note**   
-	> If the recognition result produces a reject event, the Voice control service has rejected the recognized command. Make sure that the command does not conflict with other commands and there are no duplicated commands.
+    > [!NOTE]
+	> If the recognition result produces a reject event, the voice control service has rejected the recognized command. Make sure that the command does not conflict with other commands and there are no duplicated commands.
 
-    To get the command, use the methods of the [Tizen.Uix.VoiceControl.VoiceCommandList](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControl.VoiceCommandList.html) class, which represents a list of recognized commands. The `Command` property of the [Tizen.Uix.VoiceControl.VoiceCommand](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControl.VoiceCommand.html) class contains the recognized text.
+    To get the command, use the methods of the [Tizen.Uix.VoiceControl.VoiceCommandList](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControl.VoiceCommandList.html) class, which represents a list of recognized commands. The `Command` property of the [Tizen.Uix.VoiceControl.VoiceCommand](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControl.VoiceCommand.html) class contains the recognized text:
 
     ```csharp
     /// Callback
@@ -276,13 +276,13 @@ To set and unset callbacks to get notifications about recognition results, state
     }
     ```
 <a name="info"></a>
-## Retrieving Voice Control Information
+## Retrieve voice control information
 
-To get information about the current states, and current and supported languages:
+To get information about the current states, and current and supported languages. Follow these steps:
 
 -   Get the current voice control state using the `State` property of the [Tizen.Uix.VoiceControl.VoiceControlClient](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControl.VoiceControlClient.html) class.
 
-    The voice control state changes according to method calls when the voice control is, for example, initialized and prepared.
+    The voice control state changes according to method calls when the voice control is, for example, initialized and prepared:
 
     ```csharp
     void get_state()
@@ -300,7 +300,7 @@ To get information about the current states, and current and supported languages
     2.  After recording, the service state changes to `Processing` for recognition processing.
     3.  After recognition is completed, the service state returns to `Ready`.
 
-    If the application uses continuous recognition, the voice control service state can be changed from `Processing` directly to `Recording`.
+    If the application uses continuous recognition, the voice control service state can be changed from `Processing` directly to `Recording`:
 
     ```csharp
     void get_service_state()
@@ -312,7 +312,7 @@ To get information about the current states, and current and supported languages
 
 -   Get the supported languages with a foreach method that triggers a separate callback for each language.
 
-    As long as the callback returns `true`, the foreach method continues to loop over the supported languages.
+    As long as the callback returns `true`, the foreach method continues to loop over the supported languages:
 
     ```csharp
     void get_supported_language()
@@ -333,15 +333,15 @@ To get information about the current states, and current and supported languages
 -   Get the current language with the `CurrentLanguage` property. The voice control recognition works for the current (default) language. Use the language change callback to be notified of language changes.
 
 <a name="commands"></a>
-## Managing Commands
+## Manage commands
 
-To create a command list and commands:
+To create a command list and commands, follow these steps:
 
 1.  Create a command list with a command list handle.
 
     The command list can include many commands, which each have a command text and type. The list can have both the `Foreground` and `Background` type commands (the types are defined in the [Tizen.Uix.VoiceControl.CommandType](/application/dotnet/api/TizenFX/latest/api/Tizen.Uix.VoiceControl.CommandType.html) enumeration. The foreground commands are valid when the application is in a visible state and the background commands are valid when the application is in a visible or invisible state.
 
-    You can access the command list after you set it to the voice control and when you get the recognition result.
+    You can access the command list after you set it to the voice control and when you get the recognition result:
 
     ```csharp
     void create_command_list()
@@ -359,7 +359,7 @@ To create a command list and commands:
 
 2.  Create a command.
 
-    First create a command handle, and then define the command and type.
+    First create a command handle, and then define the command and type:
 
     ```csharp
     void create_command()
@@ -380,7 +380,7 @@ To create a command list and commands:
 
 3.  Add the command to the command list.
 
-    If necessary, you can also remove commands from the command list.
+    If necessary, you can also remove commands from the command list:
 
     ```csharp
     void add_command()
@@ -440,9 +440,9 @@ To create a command list and commands:
         }
         ```
 
-    -   You can use the `Current` property of the `Tizen.Uix.VoiceControl.VoiceCommandList` class to get the current command in an output parameter.
+    -   You can use the `Current` property of the `Tizen.Uix.VoiceControl.VoiceCommandList` class to get the current command in an output parameter:
 
-           > **Note**   
+           > [!NOTE]
 		   > When you get the command handle with the `VoiceCommandList.Current` property, do not release it. To release the command handle, call the `Remove()` method of the `VoiceCommandList` class before destroying the `VoiceCommand` object.
 
         ```csharp
@@ -466,7 +466,7 @@ To create a command list and commands:
 
 4.  Register the commands for recognition by setting the command list to the voice control.
 
-    If you want to update registered commands, set the command list again with the updated commands.
+    If you want to update registered commands, set the command list again with the updated commands:
 
     ```csharp
     void set_command()
@@ -514,6 +514,6 @@ To create a command list and commands:
     ```
 
 
-## Related Information
+## Related information
 * Dependencies
   -   Tizen 4.0 and Higher


### PR DESCRIPTION
Change Description
This PR includes the fix of the following files which is part of the Text input and voice section under .NET application guides section of the Tizen Docs site:

File count: 4

/application/dotnet/guides/uix/stt.md
/application/dotnet/guides/uix/tts.md
/application/dotnet/guides/uix/voice-control.md
/application/dotnet/guides/uix/voice-control-manager.md