### PR TITLE
Web application site fix (Part - 03)

### DIFF
--- a/docs/application/web/tutorials/process/app-dev-process.md
+++ b/docs/application/web/tutorials/process/app-dev-process.md
@@ -7,7 +7,7 @@ Tizen provides the tools required to manage your Web application life-cycle from
 ![Web application development process](./media/app_dev_process_mw.png)
 
 <a name="plan"></a>
-## Planning and Designing the Application
+## Plan and design the application
 
 The first step in creating a Tizen Web application is planning and designing it using the design tools of your choice.
 
@@ -16,7 +16,7 @@ For information on planning and designing your applications, see [Tizen Web Guid
 Once you have finished the application plan and design, you are ready to create the application project.
 
 <a name="create"></a>
-## Creating the Application Project
+## Create the application project
 
 After you have planned and designed your application, you are ready to [create the application project](creating-app-project.md) in Tizen Studio.
 
@@ -24,24 +24,24 @@ Tizen Studio provides various project templates that make it easier for you to s
 you can select a specific template or sample. Based on the selection, the Tizen Web [Project Wizard](../../../tizen-studio/web-tools/project-wizard.md) automatically creates basic functionalities that the application has to implement to be able to run. The default project files and folders are also created.
 
 <a name="set"></a>
-## Setting Project Properties
+## Set project properties
 
 After creating the application project, you can [configure the properties of the project and the Web application](setting-properties.md) to achieve the required functionality and features for your application.
 
 <a name="design"></a>
-## Designing the Application UI
+## Design the application UI
 
 You can design the application UI using the UI components defined in the [Tizen Advanced UI Framework](../../api/latest/ui_fw_api/ui_fw_api_cover.htm).
 
 <a name="code"></a>
-## Coding the Application
+## Code the application
 
 [Code your application](coding-app.md) in Tizen Studio using the APIs defined in the Web [API References](../../api/latest/device_api/mobile/index.html).
 
 Once you have finished coding your application, you are ready to build your application.
 
 <a name="build"></a>
-## Building the Application
+## Build the application
 
 When Tizen Studio builds an application, the following process is executed:  
   1. Validation check for:
@@ -50,12 +50,12 @@ When Tizen Studio builds an application, the following process is executed:
      - Privilege
 
   2. Compile for:
-     - Coffeescript
+     - CoffeeScript
      - Less
 
- > **Note**  
- > About the output files:  
- > -   Compiled coffeescript output file name is `<file name>.js`. This file is used when the project is packed to the WGT package file, but the script tag's reference path must be changed manually.
+ > [!NOTE]
+ > About the output files:
+ > -   Compiled CoffeeScript output file name is `<file name>.js`. This file is used when the project is packed to the WGT package file, but the script tag's reference path must be changed manually.
  > -   Compiled less output file name is `<file name>.css`. This file is   used when the project is packed to the WGT package file, but the script tag's reference path must be changed manually.
 
 If the project has errors, they are shown in the **Problems** and **Project Explorer** views after the build.
@@ -74,7 +74,7 @@ You can build a Web application automatically or manually:
 
     You can build your project at your convenience. If you want to use the manual build, ensure that the **Project &gt; Build Automatically** option is not selected.
 
-  > **Note**  
+  > [!NOTE]
   > In the manual build mode:  
   > -   Ensure that you have the latest build output before you run or debug a project.
   > -   To remove a project build output, select `Project > Clean` in the Tizen Studio menu.
@@ -92,7 +92,7 @@ You can build a Web application automatically or manually:
     Set the options in Tizen Studio menu: **Window &gt; Preferences &gt; Tizen Studio &gt; Web &gt; Editor &gt; Privilege**.
 
 <a name="run"></a>
-## Running and Debugging the Application
+## Run and debug the application
 
 When Tizen Studio runs or debugs the application, the following process is executed:
 
@@ -116,7 +116,7 @@ You can run your application in one of the following environments:
 
 -   [Simulator](run-debug-app.md#simulator)
 
-    The Tizen Web simulator allows you to run application that use the Tizen Web APIs.
+    Tizen Web simulator allows you to run application that use the Tizen Web APIs.
 
 You can run the application smartly:
 
@@ -126,7 +126,7 @@ You can run the application smartly:
 For more information on the debugging process and tools, see [Debugging Web Applications](run-debug-app.md#debug).
 
 <a name="package"></a>
-## Packaging the Application
+## Package the application
 
 When Tizen Studio packages the application, the following process is executed:
 
@@ -172,16 +172,16 @@ actual project files.
 Additionally, you can [localize the Web application](setting-properties.md#localization) to support different languages and environments.
 
 <a name="multi"></a>
-## Developing Multiple Projects as a Combined Package
+## Develope multiple projects as a combined package
 
 Tizen supports multi-project applications that combine different types of application templates in hybrid and companion applications.
 
 <a name="hybrid"></a>
-### Packaging Hybrid Applications
+### Packaging hybrid applications
 
 A hybrid application package combines a Web application and 1 or more native service applications.
 
-To create and run a hybrid application:
+To create and run a hybrid application, follow these steps:
 
 1. Create a project for a [Web UI application](creating-app-project.md) and [native service application](../../../native/tutorials/process/app-dev-process.md#creating).
 2. To establish a project reference between a UI and service application:  
@@ -196,7 +196,7 @@ To create and run a hybrid application:
     To modify the build configuration of the service application, see [Building the
     Application](../../../native/tutorials/process/app-dev-process.md#build).
 
-> **Note**  
+> [!NOTE]
 > Tizen has limited a multi-project application combination policy for device usability. If you do not follow the policy, the submission of your application to the store can be rejected.
 
 
@@ -250,11 +250,11 @@ For more information on hybrid applications and their package structure, see Hyb
 [Hybrid Application Package](../../index.md#hap).
 
 <a name="cert"></a>
-## Certifying and Publishing the Application
+## Certify and publish the application
 
 After you have packaged your application, you are ready to certify and publish your application.
 
-To certify and publish your application:
+To certify and publish your application, follow these steps:
 
 -   Upload your mobile Web application to the official site for Tizen applications, your wearable Web application to the Samsung Galaxy Apps Store, or your TV Web application to the Samsung App Store for registration.
 
@@ -267,11 +267,11 @@ To certify and publish your application:
 You can also upgrade your application after certification. If you want to withdraw your application from distribution and operation, you need to request for application retirement from the store.
 
 <a name="upgrade"></a>
-## Upgrading the Application
+## Upgrade the application
 
 You can upgrade your application even after you have certified and published it at the official site for Tizen applications, Samsung Galaxy Apps Store, or Samsung App Store.
 
-To upgrade your application:
+To upgrade your application, follow these steps:
 
 1.  Update your application version, and if needed the privileges, in the `config.xml` configuration file in Tizen Studio.
 2.  Update the application code as needed.

--- a/docs/application/web/tutorials/process/coding-app.md
+++ b/docs/application/web/tutorials/process/coding-app.md
@@ -1,5 +1,5 @@
 
-# Coding Applications
+# Code Applications
 
 When coding your application, you must consider the following issues:
 
@@ -14,7 +14,7 @@ When coding your application, you must consider the following issues:
 3.  Destroy allocated resources and save the current application state.
 
 <a name="hover"></a>
-## Using Hover Help
+## Hover Help
 
 Tizen Studio supports hover help for Web API and W3C Widget APIs.
 
@@ -25,7 +25,7 @@ The hover help provides input from the [API Reference](../../api/latest/device_a
 ![Hover help](./media/hover_help.png)
 
 <a name="add"></a>
-## Adding External Source Code or Library
+## Add external source code or library
 
 External source files are located in the project directory, and its `/js` and `/css` sub-directories. You can add a new folder or source file (such as CSS, HTML, JSON, XML, and JavaScript) to your existing project.
 
@@ -46,5 +46,5 @@ You can add files in the following ways (as an example, the instructions illustr
 
 
 
-> **Note**  
+> [!NOTE]
 > You can also drag and drop external source files or libraries.  If you drop a file to the **Project Explorer** view, the **File Operation** dialog appears, and allows you to either copy the file or create a link to it.

--- a/docs/application/web/tutorials/process/creating-app-project.md
+++ b/docs/application/web/tutorials/process/creating-app-project.md
@@ -1,11 +1,11 @@
 
-# Creating the Application Project
+# Create the Application Project
 
 You can create a Web application project by selecting from a variety of
 templates and samples. The following instructions are specific for
 creating the project with a template.
 
-To create a Web application project:
+To create a Web application project, follow the steps below:
 
 1.  In Tizen Studio, select **File &gt; New &gt; Tizen Project**.
 
@@ -26,7 +26,7 @@ To create a Web application project:
 
     2.  Select the profile (**Mobile**, **Wearable**, or **TV**) and
       version from a drop-down list and click **Next**.  
-        >  **Note**  
+        > [!NOTE]
         > If you cannot see the TV profile option, open the Package Manager and make sure that you have installed the TV extension packages in the **Extension SDK** tab.
 
         ![Selecting the profile and version](./media/create_project_wizard_version_wearable.png)
@@ -41,7 +41,7 @@ To create a Web application project:
 
     5. Define the project properties and click **Finish**.  
        You can fill the project name. You can also select the location and working sets by clicking **More properties**.  
-       >  **Note**  
+       > [!NOTE]
        > The Tizen API names cannot be used as project names. The project name must be more than 2 characters and is restricted to the following regular expression: \[a-zA-Z\]\[a-zA-Z0-9-\]{2,49}.
 
        ![Defining properties](./media/create_project_wizard_properties_ww.png)
@@ -51,9 +51,9 @@ To create a Web application project:
 The new application project is shown in the **Project Explorer** view of Tizen Studio, with default content in the `config.xml` file as well as in several project folders.
 
 <a name="import"></a>
-## Importing a Project
+## Import a project
 
-If you have an existing Tizen application project, you can import it into Tizen Studio:  
+If you have an existing Tizen application project, you can import it into Tizen Studio by following these steps:  
 1.  In the Tizen Studio menu, go to **File &gt; Import &gt; Tizen &gt; Tizen Project**, and click **Next**.
 2.  Select the location of the root directory or archive file of the Tizen project and click **Next**.
 3.  If you want to convert the project profile and version, use the

--- a/docs/application/web/tutorials/process/run-debug-app.md
+++ b/docs/application/web/tutorials/process/run-debug-app.md
@@ -1,10 +1,10 @@
 
-# Running and Debugging Applications
+# Run and Debug Applications
 
 You can run your application on the [emulator](#emulator) or the [target device](#target). You can also run mobile applications on the [simulator](#simulator). Use the [Rapid Development Support](#rds) feature to speed up the development tasks. If your application does not run without problems, you can [debug](#debug) it.
 
 <a name="emulator"></a>
-## Running Web Applications on the Emulator
+## Run Web applications on emulator
 
 You can debug Tizen Web applications on the [emulator](../../../tizen-studio/common-tools/emulator.md) using the **Project Explorer** view or the Tizen Studio menu.
 
@@ -28,19 +28,19 @@ To run the application on the emulator, do one of the following:
 
 To stop the emulator, right-click the emulator and click **Close**.
 
-> **Note**  
+> [!NOTE]
 > Running an emulator instance requires a minimum free disk space of 20 MB. The emulator image can occupy up to 10 GB of disk space.
 
 <a name="target"></a>
-## Running Web Applications on a Target Device
+## Run Web applications on a target device
 
 You can run Tizen Web applications on a target device using the **Project Explorer** view or the Tizen Studio menu.
 
-To run your application on the target device:
+To run your application on the target device, follow these steps:
 
 1.  Connect the target device to your computer.
 2.  Open the **Run Configurations** window by doing one of the following:
-    -   In the **Project Explorer** view, right-click the project andselect **Run As &gt; Run Configurations**.
+    -   In the **Project Explorer** view, right-click the project and select **Run As &gt; Run Configurations**.
     -   In the Tizen Studio menu, go to **Run &gt; Run Configurations**.
 
 3.  In the **Run Configurations** window, click **New Launch
@@ -63,12 +63,12 @@ To run your application on the target device:
 If the Web application successfully launches on the target device, the [JavaScript Log Console View](../../../tizen-studio/web-tools/web-editor.md#js_log) is automatically launched in Tizen Studio. The JavaScript Log Console view displays Web application JavaScript logs.
 
 <a name="simulator"></a>
-## Running Mobile Web Applications on the Simulator
+## Run mobile Web applications on simulator
 
 You can run Tizen Web applications on the [Web Simulator](../../../tizen-studio/web-tools/web-simulator.md) using the **Project Explorer** view or the Tizen Studio menu.
 
-> **Note**  
-> The Tizen Web Simulator runs only on the Google Chrome&trade; browser. To use the Web Simulator, download and install the [Google Chrome&trade;](http://www.google.com/chrome/) browser. You can manually specify the installation location of the browser in the [simulator preferences](../../../tizen-studio/web-tools/web-simulator.md#pref).
+> [!NOTE]
+> The Tizen Web Simulator runs only on the Google Chrome&trade; browser. To use the Web Simulator, download and install the [Google Chrome&trade;](http://www.google.com/chrome/){:target="_blank"} browser. You can manually specify the installation location of the browser in the [simulator preferences](../../../tizen-studio/web-tools/web-simulator.md#pref).
 
 If you are running your Web application on the Web Simulator for the first time, create a running configuration by selecting **Run &gt; Run Configurations &gt; Tizen Web Simulator Application** in the Tizen Studio menu. The running configuration contains the application launch settings.
 
@@ -80,14 +80,14 @@ To run your application on the Simulator, do one of the following:
 
 When the application is launched, the Web Simulator loads the file specified in the **Content** field of the `config.xml` file. The mostly commonly specified file is `index.html`.
 
-The simulator renders your application on the browser using the [WebKit](http://www.webkit.org/) engine. All the Google Chrome&trade; browser development features are available (by pressing the **F12** keyboard key) in the simulator, as is the [Web Inspector](../../../tizen-studio/web-tools/web-inspector.md) tool. You can leverage the advantages of the Web Simulator tool by setting the device screen size and orientation, and by sending events and messages, such as geolocation data and sensor input events, to your application for debugging it.
+The simulator renders your application on the browser using the [WebKit](http://www.webkit.org/){:target="_blank"} engine. All the Google Chrome&trade; browser development features are available (by pressing the **F12** keyboard key) in the simulator, as is the [Web Inspector](../../../tizen-studio/web-tools/web-inspector.md) tool. You can leverage the advantages of the Web Simulator tool by setting the device screen size and orientation, and by sending events and messages, such as geolocation data and sensor input events, to your application for debugging it.
 
  <a name="debug"></a>
-## Debugging Web Applications
+## Debug Web applications
 
 Debugging a Web application enables you to understand its flow of control. You can debug a Web application by running it on the target device and debugging its JavaScript code. JavaScript code debugging uses the [Web Inspector](../../../tizen-studio/web-tools/web-inspector.md) tool.
 
-To debug your application on the target device:  
+To debug your application on the target device, follow these steps:  
 1.  Connect the target device to your computer.
 2.  Open the **Debug Configurations** window by doing one of the following:
     -   In the **Project Explorer** view, right-click the project and select **Debug As &gt; Debug Configurations**.
@@ -116,7 +116,7 @@ To debug your application on the target device:
     -   Inspect resources
     -   Debug JavaScript code
 
-    > **Note**  
+    > [!NOTE]
     > The Web Inspector always opens in a new window. Life-cycle synchronization between the application to be debugged and the Web Inspector browser is not supported.
     >
     > Installing the Google Chrome&trade; browser on the device is mandatory for the Web Inspector to work. When the Google Chrome&trade; browser is installed on the device, Tizen Studio automatically detects it. To select the browser path, go to `Window > Preferences > Tizen Studio > Web > Chrome`.
@@ -151,13 +151,13 @@ When using RDS, the application is first launched normally. After the launch, a 
 
 If an error occurs during execution, the application is launched in the normal mode instead.
 
-To launch the application in normal mode:  
+Follow these steps to launch the application in normal mode:  
 1.  Package the application.
 2.  Transfer the packaged file to the target.
 3.  Install the packaged file in the target. If the application is
     already installed, uninstall it before the installation.
 
-To launch the application in RDS mode:  
+Follow these steps to launch the application in RDS mode:  
 1.  Search for the changed files (modified, added, and deleted) and
     transfer them to the target as a background process.
 2.  Reinstall the changed files.
@@ -166,7 +166,7 @@ To launch the application in RDS mode:
 
 The RDS option is enabled as default. To disable it, in Tizen Studio, go to **Window &gt; Preferences &gt; Tizen Studio &gt; Rapid Development Support**.
 
-> **Note**  
+> [!NOTE]
 > RDS is not supported in multi-app projects.
 >
 > If you want to remove an application from your device, you must manually delete the installed application as the launch process does not have an uninstall process.

--- a/docs/application/web/tutorials/process/setting-properties.md
+++ b/docs/application/web/tutorials/process/setting-properties.md
@@ -1,18 +1,18 @@
 
-# Setting Project Properties
+# Set Project Properties
 
 Before you implement the actual application functionality, define all the necessary properties for your application project:
 
 - To set the application project properties for [build](#set) and [JSON properties](#set_json), right-click the project in Tizen Studio **Project Explorer** view and select **Properties**. After setting or changing a property, click **OK**.
 - To define the [Web application configuration](#set_widget), edit the `config.xml` file.  
-  > **Note**  
+  > [!NOTE]
   > Only modify the Web application configuration by using the
     configuration editor in Tizen Studio. If you create or edit the    `config.xml` file using any other text editor, your application may    not work as expected.
 
 After you have finished setting the project properties, you are ready to [design the UI](app-dev-process.md#design).
 
 <a name="set"></a>
-## Setting Build Properties
+## Set build properties
 
 You can set build properties for your project. To select the build properties:
 
@@ -21,7 +21,7 @@ You can set build properties for your project. To select the build properties:
 2. Check **Optimize web resources**, and add any files for excluding    optimization in the **Optimization** panel.
 
 <a name="set_json"></a>
-## Setting the JSON Property
+## Set the JSON property
 
 You can set a JSON property for your project. To select the JSON property:
 
@@ -29,7 +29,7 @@ You can set a JSON property for your project. To select the JSON property:
 2. Check **Enable JSON validation in project**.
 
 <a name="set_widget"></a>
-## Setting the Web Application Configuration
+## Set the Web application configuration
 
 The Web application configuration consists of application information, such as version, features, and privileges, which are available for the application. To configure the application information in the Web application configuration editor, double-click the application `config.xml` file in the **Project Explorer** view.
 
@@ -40,7 +40,7 @@ The Web application configuration consists of application information, such as v
 You can [edit the application properties using the form tabs of the Web application configuration editor](../../../tizen-studio/web-tools/config-editor.md#edit).
 
 <a name="overview"></a>
-### Defining and Editing General Information in the Overview Tab
+### Define and edit general information in the Overview tab
 
 You can define and edit general information about the application in the **Overview** tab of the Web application configuration editor.
 
@@ -89,11 +89,11 @@ You can perform the following tasks using the **Overview** tab:
 (maximized fullscreen).
 
 <a name="feature"></a>
-### Declaring Required Software or Hardware Features in the Features Tab
+### Declare required software or hardware features in the Features tab
 
 You can declare any device software or hardware features that your application requires to run properly. The declaration can be used for application filtering in the official site for Tizen applications.
 
-To enable filtering for your Web application:
+To enable filtering for your Web application, follow these steps:
 
 1.  In the **Features** tab, click **+**.
 2.  Select the needed features from the [predefined list of features available for filtering](../app-filtering.md).
@@ -108,11 +108,11 @@ After saving the feature information with the Web application configuration edit
 ```
 
 <a name="privilege"></a>
-### Specifying Privileges in the Privileges Tab
+### Specify privileges in the Privileges tab
 
 You can use features and services provided by privileged APIs, which handle platform and user-sensitive data. You can specify an API, or API groups, accessed and used by the Web application in the **Privileges** tab of the Web application configuration editor. The tab serves as a standardized tool to request the binding of an IRI-identifiable runtime component for a Web application to use at runtime.
 
-To add a privilege:
+To add a privilege, follow these steps:
 
 1.  In the **Privileges** tab, click **+**.
 2.  In the **Add privilege** window, select an option:
@@ -128,7 +128,7 @@ After saving the privilege information with the Web application configuration ed
 ```
 
 <a name="policy"></a>
-### Defining External Access Policies in the Policy Tab
+### Define external access policies in the Policy tab
 
 According to the W3C Access Requests Policy (WARP), you cannot access external network resources by default. If you require access to an external network resource, you must request network resource permissions for the Web application using the **Policy** tab of the Web application configuration editor.
 
@@ -147,7 +147,7 @@ The following table lists the policy properties you can edit in the **Policy** t
   **content-security-policy** </td>
   <td>
 
-  Used to define an additional content security policy for a packaged or hosted application. The policy string is defined according to [Content Security Policy Level 2](http://www.w3.org/TR/2015/CR-CSP2-20150721/) (in mobile and TV applications) and [Content Security Policy 1.0](http://www.w3.org/TR/2012/CR-CSP-20121115/) (in wearable applications).</td>
+  Used to define an additional content security policy for a packaged or hosted application. The policy string is defined according to [Content Security Policy Level 2](https://www.w3.org/TR/CSP2/){:target="_blank"} (in mobile and TV applications) and [Content Security Policy 1.0](https://www.w3.org/TR/CSP1/){:target="_blank"} (in wearable applications).</td>
 </tr>
 <tr>
   <td>
@@ -184,7 +184,7 @@ After setting the policy information with the Web application configuration edit
 ```
 
 <a name="localization"></a>
-### Adding Localized Application Details in the Localization Tab
+### Add localized application details in the Localization tab
 
 You can provide localized versions of the application name, description, and license in the **Localization** tab of the Web application configuration editor.
 
@@ -216,7 +216,7 @@ To add a localized name, description, or license:
 You can localize a Web application to adapt to various languages and cultural environments by creating different Web application versions for different languages. For more information, see [Localizing Web Applications](../../../tizen-studio/web-tools/web-localization.md).
 
 <a name="preferences"></a>
-### Declaring Name-value Pairs in the Preferences Tab
+### Declare name-value pairs in the Preferences tab
 
 You can declare name-value pairs which can be set and retrieved using the Widget Interface API (in [mobile](../../api/latest/w3c_api/w3c_api_m.html#widget), [wearable](../../api/latest/w3c_api/w3c_api_w.html#widget), and [TV](../../api/latest/w3c_api/w3c_api_tv.html#widget) applications) in the **Preferences** tab of the Web application configuration editor. These name-value pairs, or preferences, are used by the Web application during execution.
 
@@ -229,7 +229,7 @@ After saving the preference information with the Web application configuration e
 ```
 
 <a name="tizen"></a>
-### Configuring the Tizen Schema Extension in the Tizen Tab
+### Configure the Tizen schema extension in the Tizen tab
 
 The **Tizen** tab of the Web application configuration editor shows the Tizen schema extension. Some of the attributes specified on this tab are mandatory and must be defined, whereas others are optional.
 
@@ -529,10 +529,10 @@ The following table describes the schema extension properties that you can edit.
 </table>
 
 <a name="source"></a>
-### Editing the config.xml File in the Source Tab
+### Edit the config.xml file in the Source tab
 
 The **Source** tab of the Web application configuration editor shows the code of the `config.xml` file. You can [edit the basic syntax of the XML document](../../../tizen-studio/web-tools/config-editor.md) and also see how changes made on the other tabs are reflected in the raw XML source content.
 
-> **Note**  
+> [!NOTE]
 > The `config.xml` must conform not only to the XML file format
 but also to the W3C specification requirements. If you edit application information manually in the `config.xml` file source code, you can introduce errors preventing the application from running normally.


### PR DESCRIPTION
This PR includes the fix of the following files which are part of the web application guides section of the Tizen Docs site:

File count: 5

/application/web/tutorials/process/app-dev-process.md
/application/web/tutorials/process/creating-app-project.md
/application/web/tutorials/process/setting-properties.md
/application/web/tutorials/process/coding-app.md
/application/web/tutorials/process/run-debug-app.md