### PR TITLE
Web application site fix (Part - 07)

### DIFF
--- a/docs/application/web/guides/app-management/common-appcontrols.md
+++ b/docs/application/web/guides/app-management/common-appcontrols.md
@@ -2,12 +2,12 @@
 
 An application control provides functions for launching other applications with a specific operation, URI, MIME type, and extra data. The requesting application can get a result back from the launched application. This topic introduces the common application controls that you can use.
 
-> **Note**  
+> [!NOTE]
 > It is possible that no application suitable to receive the application control exists. In that case, before you send the launch request, verify that a suitable application exists.
 
 ## Browser
 
-### Performing a Web Search
+### Perform a Web search
 
 The search operation is available depending on whether the installed application supports it or not.
 
@@ -42,7 +42,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Loading a Web Page
+### Load a Web page
 
 The view operation is available depending on whether the installed application supports it or not.
 
@@ -63,7 +63,7 @@ To open a Web page, use the `http://tizen.org/appcontrol/operation/view` operati
 - `file:<path>`
 - `javascript:<path>`
 
-#### MIME Type (Optional)
+#### MIME type (Optional)
 
 - `image/svg+xml`
 - `text/html`
@@ -87,7 +87,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 ## Calendar
 The calendar application control is available depending on whether the installed application supports it or not.
 
-### Adding a Calendar Event
+### Add a calendar event
 
 To add a new event to the user's calendar, use the `http://tizen.org/appcontrol/operation/add` operation with the `application/vnd.tizen.calendar` MIME type. To specify various event details, refer to the extras defined below.
 
@@ -103,7 +103,7 @@ To add a new event to the user's calendar, use the `http://tizen.org/appcontrol/
 
 `application/vnd.tizen.calendar`
 
-#### Extra Input
+#### Extra input
 
 | Key                                      | Description                              | Note                  |
 | ---------------------------------------- | ---------------------------------------- | --------------------- |
@@ -113,13 +113,13 @@ To add a new event to the user's calendar, use the `http://tizen.org/appcontrol/
 | `http://tizen.org/appcontrol/data/title` | The title of the event. This key must be passed as a string. | This key is optional. |
 | `http://tizen.org/appcontrol/data/text`  | The description of the event. This key must be passed as a string. | This key is optional. |
 
-#### Extra Output
+#### Extra output
 
 | Key                                   | Description                              |
 | ------------------------------------- | ---------------------------------------- |
 | `http://tizen.org/appcontrol/data/id` | The database record ID of the event (ID in the `_calendar_event` view). This key must be passed as a string. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControlData = [new tizen.ApplicationControlData('http://tizen.org/appcontrol/data/title', ['My event']),
@@ -135,7 +135,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Editing a Calendar Event
+### Edit a calendar event
 
 To edit an existing event in the user's calendar, use the `http://tizen.org/appcontrol/operation/edit` operation with the `application/vnd.tizen.calendar` MIME type. To specify various event details, refer to the extras defined below.
 
@@ -151,7 +151,7 @@ To edit an existing event in the user's calendar, use the `http://tizen.org/appc
 
 `application/vnd.tizen.calendar`
 
-#### Extra Input
+#### Extra input
 
 | Key                                      | Description                              | Note                   |
 | ---------------------------------------- | ---------------------------------------- | ---------------------- |
@@ -162,13 +162,13 @@ To edit an existing event in the user's calendar, use the `http://tizen.org/appc
 | `http://tizen.org/appcontrol/data/title` | The title of event. This key must be passed as a string. | This key is optional. |
 | `http://tizen.org/appcontrol/data/text`  | The description of event. This key must be passed as a string. | This key is optional. |
 
-#### Extra Output
+#### Extra output
 
 | Key                                   | Description                              |
 | ------------------------------------- | ---------------------------------------- |
 | `http://tizen.org/appcontrol/data/id` | The database record ID of the event (ID in the `_calendar_event` view). This key must be passed as a string. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControlData = [new tizen.ApplicationControlData('http://tizen.org/appcontrol/data/id', ['1']),
@@ -185,7 +185,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Viewing a Calendar Event
+### View a calendar event
 
 To display a specified event in the user's calendar, use the `http://tizen.org/appcontrol/operation/view` operation. To specify various event details, refer to the extras defined below.
 
@@ -212,13 +212,13 @@ For example: `file://<media storage path>/file.vcs`
 - `text/x-vcalendar` (for vcalendar file)
 - `text/vcalendar` (for vcalendar file)
 
-#### Extra Input
+#### Extra input
 
 | Key                                   | Description                              | Note                                     |
 | ------------------------------------- | ---------------------------------------- | ---------------------------------------- |
 | `http://tizen.org/appcontrol/data/id` | The database record ID of the event (ID in the `_calendar_event` view). This key must be passed as a string. | This key is mandatory when the MIME type is set to `application/vnd.tizen.calendar`. |
 
-#### Example Code
+#### Example code
 
 ```
 /* To view a calendar event from a vcs file */
@@ -245,7 +245,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Selecting a Calendar Event
+### Select a calendar event
 
 To select a specified event in the user's calendar, use the `http://tizen.org/appcontrol/operation/pick` operation with the `application/vnd.tizen.calendar` MIME type. To specify various event details, refer to the extras defined below.
 
@@ -261,22 +261,22 @@ To select a specified event in the user's calendar, use the `http://tizen.org/ap
 
 `application/vnd.tizen.calendar`
 
-#### Extra Input
+#### Extra input
 
 | Key                                      | Description                              | Note                  |
 | ---------------------------------------- | ---------------------------------------- | --------------------- |
 | `http://tizen.org/appcontrol/data/type`  | The type of items to be delivered. The available values are `id` (default) and `vcs`. This key must be passed as a string. | This key is optional. |
-| `http://tizen.org/appcontrol/data/selection_mode` | The selection mode of the PICK operation. The available values are `single` (default) and `multiple`. This key must be passed as a string. | This key is optional. |
+| `http://tizen.org/appcontrol/data/selection_mode` | The selection mode of the pick operation. The available values are `single` (default) and `multiple`. This key must be passed as a string. | This key is optional. |
 | `http://tizen.org/appcontrol/data/total_count` | The total number of events to be returned. This key must be passed as a string. | This key is optional. |
 
-#### Extra Output
+#### Extra output
 
 | Key                                      | Description                              |
 | ---------------------------------------- | ---------------------------------------- |
 | `http://tizen.org/appcontrol/data/type`  | The type of items to be delivered. The available values are `id` and `vcs`. This key must be passed as a string. |
 | `http://tizen.org/appcontrol/data/selected` | The database record ID of the event (ID in the `_calendar_event` view) or the paths of the vcs files. This key must be passed as an array. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControlData = [new tizen.ApplicationControlData('http://tizen.org/appcontrol/data/type', ['id']),
@@ -295,7 +295,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 ## Call
 The call application control is available depending on whether the installed application supports it or not.
 
-### Making a Phone Call
+### Make a phone call
 
 To directly initiate a phone call, use the `http://tizen.org/appcontrol/operation/call` operation with a phone number URI scheme.
 
@@ -328,7 +328,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Launching a Call Application with a Phone Number
+### Launch a call application with a phone number
 
 To open a call application and display a predefined a phone number, use the `http://tizen.org/appcontrol/operation/dial` action with a phone number URI scheme. When the call application opens, it displays the phone number, but the user must press the **Call** button to initiate the phone call.
 
@@ -348,7 +348,7 @@ If empty, a dialer UI without a number is presented.
 
 For example: `tel:+821234567890`
 
-#### Example Code
+#### Example code
 
 ```
 var appControl = new tizen.ApplicationControl('http://tizen.org/appcontrol/operation/dial',
@@ -364,7 +364,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 ## Camera
 The camera application control is available depending on whether the installed application supports it or not.
 
-### Capturing a Picture or Video
+### Capture a picture or video
 
 To take a picture or record video, use the `http://tizen.org/appcontrol/operation/create_content` operation with the MIME type. To specify an option, refer to the extras defined below.
 
@@ -381,19 +381,19 @@ To take a picture or record video, use the `http://tizen.org/appcontrol/operatio
 - `image/*`
 - `video/*`
 
-#### Extra Input
+#### Extra input
 
 | Key                                      | Description                              | Note                  |
 | ---------------------------------------- | ---------------------------------------- | --------------------- |
 | `http://tizen.org/appcontrol/data/total_size` | The total size of items to be returned in bytes. This key must be passed as a string. | This key is optional. |
 
-#### Extra Output
+#### Extra output
 
 | Key                                      | Description                              |
 | ---------------------------------------- | ---------------------------------------- |
 | `http://tizen.org/appcontrol/data/selected` | The path of the created image or video file. This key must be passed as a string. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControl = new tizen.ApplicationControl('http://tizen.org/appcontrol/operation/create_content',
@@ -406,7 +406,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Capturing a Picture
+### Capture a picture
 
 To capture a still image, use the `http://tizen.org/appcontrol/operation/image_capture` operation. To specify an option, refer to the extras defined below.
 
@@ -418,19 +418,19 @@ To capture a still image, use the `http://tizen.org/appcontrol/operation/image_c
 
 `http://tizen.org/appcontrol/operation/image_capture`
 
-#### Extra Input
+#### Extra input
 
 | Key                                      | Description                              | Note                  |
 | ---------------------------------------- | ---------------------------------------- | --------------------- |
 | `http://tizen.org/appcontrol/data/total_size` | The total size of items to be returned in bytes. This key must be passed as a string. | This key is optional. |
 
-#### Extra Output
+#### Extra output
 
 | Key                                      | Description                              |
 | ---------------------------------------- | ---------------------------------------- |
 | `http://tizen.org/appcontrol/data/selected` | The path of the created file. This key must be passed as a string. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControl = new tizen.ApplicationControl('http://tizen.org/appcontrol/operation/image_capture',
@@ -443,7 +443,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Capturing a Video
+### Capture a video
 
 To record a video, use the `http://tizen.org/appcontrol/operation/video_capture` operation. To specify an option, refer to the extras defined below.
 
@@ -455,19 +455,19 @@ To record a video, use the `http://tizen.org/appcontrol/operation/video_capture`
 
 `http://tizen.org/appcontrol/operation/video_capture`
 
-#### Extra Input
+#### Extra input
 
 | Key                                      | Description                              | Note                  |
 | ---------------------------------------- | ---------------------------------------- | --------------------- |
 | `http://tizen.org/appcontrol/data/total_size` | The total size of items to be returned in bytes. This key must be passed as a string. | This key is optional. |
 
-#### Extra Output
+#### Extra output
 
 | Key                                      | Description                              |
 | ---------------------------------------- | ---------------------------------------- |
 | `http://tizen.org/appcontrol/data/selected` | The path of the created file. This key must be passed as a string. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControl = new tizen.ApplicationControl('http://tizen.org/appcontrol/operation/video_capture',
@@ -482,7 +482,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 
 ## Contact
 
-### Adding a Contact
+### Add a contact
 The contact adding operation is available depending on whether the installed application supports it or not.
 
 To add a new contact, use the `http://tizen.org/appcontrol/operation/add` operation with the `application/vnd.tizen.contact` MIME type. To specify various contact details, refer to the extras defined below.
@@ -499,7 +499,7 @@ To add a new contact, use the `http://tizen.org/appcontrol/operation/add` operat
 
 `application/vnd.tizen.contact`
 
-#### Extra Input
+#### Extra input
 
 | Key                                      | Description                              | Note                  |
 | ---------------------------------------- | ---------------------------------------- | --------------------- |
@@ -508,13 +508,13 @@ To add a new contact, use the `http://tizen.org/appcontrol/operation/add` operat
 | `http://tizen.org/appcontrol/data/url`   | The homepage URL. This key must be passed as a string. | This key is optional. |
 | `http://tizen.org/appcontrol/data/name`  | The contact's name. This key must be passed as a string. | This key is optional. |
 
-#### Extra Output
+#### Extra output
 
 | Key                                   | Description                              |
 | ------------------------------------- | ---------------------------------------- |
 | `http://tizen.org/appcontrol/data/id` | The database record ID of the added person (ID in the `_contacts_person` view). This key must be passed as a string. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControlData = [new tizen.ApplicationControlData('http://tizen.org/appcontrol/data/phone', ['0123456789']),
@@ -532,7 +532,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Editing a Contact
+### Edit a contact
 The contact editing operation is available depending on whether the installed application supports it or not.
 
 To edit a known contact, use the `http://tizen.org/appcontrol/operation/edit` operation with the `application/vnd.tizen.contact` MIME type. To specify various contact details, refer to the extras defined below.
@@ -549,7 +549,7 @@ To edit a known contact, use the `http://tizen.org/appcontrol/operation/edit` op
 
 `application/vnd.tizen.contact`
 
-#### Extra Input
+#### Extra input
 
 | Key                                      | Description                              | Note                   |
 | ---------------------------------------- | ---------------------------------------- | ---------------------- |
@@ -558,13 +558,13 @@ To edit a known contact, use the `http://tizen.org/appcontrol/operation/edit` op
 | `http://tizen.org/appcontrol/data/email` | The email address that is added to the contact. This key must be passed as a string. | This key is optional. |
 | `http://tizen.org/appcontrol/data/url`   | The homepage URL that is added to the contact. This key must be passed as a string. | This key is optional. |
 
-#### Extra Output
+#### Extra output
 
 | Key                                   | Description                              |
 | ------------------------------------- | ---------------------------------------- |
 | `http://tizen.org/appcontrol/data/id` | The database record ID of the person to be edited (ID in the `_contacts_person` view). This key must be passed as a string. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControlData = [new tizen.ApplicationControlData('http://tizen.org/appcontrol/data/id', ['personId']),
@@ -582,7 +582,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Viewing a Contact
+### View a contact
 The contact viewing operation is available depending on whether the installed application supports it or not.
 
 To display a specified contact in the contact database, use the `http://tizen.org/appcontrol/operation/view` operation. To specify various contact details, refer to the extras defined below.
@@ -608,13 +608,13 @@ To display a specified contact from a vcard file, use the `file:` URI. To displa
 - `text/vcard`
 - `text/x-vcard`
 
-#### Extra Input
+#### Extra input
 
 | Key                                   | Description                              | Note                                     |
 | ------------------------------------- | ---------------------------------------- | ---------------------------------------- |
 | `http://tizen.org/appcontrol/data/id` | The database record ID of the edited person (ID in the `_contacts_person` view). This key must be passed as a string. | This key is mandatory when the MIME type is set to `application/vnd.tizen.contact`. |
 
-#### Example Code
+#### Example code
 
 ```
 function launchContactDetails(personId) {
@@ -643,7 +643,7 @@ function launchViewVcard(uri) {
 }
 ```
 
-### Selecting a Contact
+### Select a contact
 
 The contact selection operation is available depending on whether the installed application supports it or not.
 
@@ -661,22 +661,22 @@ To select a specified contact in the user's contacts, use the `http://tizen.org/
 
 `application/vnd.tizen.contact`
 
-#### Extra Input
+#### Extra input
 
 | Key                                      | Description                              | Note                  |
 | ---------------------------------------- | ---------------------------------------- | --------------------- |
-| `http://tizen.org/appcontrol/data/selection_mode` | The selection mode of the PICK operation. The available values are `single` (default) and `multiple`. This key must be passed as a string. | This key is optional. |
+| `http://tizen.org/appcontrol/data/selection_mode` | The selection mode of the pick operation. The available values are `single` (default) and `multiple`. This key must be passed as a string. | This key is optional. |
 | `http://tizen.org/appcontrol/data/type`  | The type of items to be delivered. The available values are `id` (default), `phone`, `email`, and `vcf`. This key must be passed as a string. | This key is optional. |
 | `http://tizen.org/appcontrol/data/total_count` | The total number of events to be returned. This key must be passed as a string. | This key is optional. |
 
-#### Extra Output
+#### Extra output
 
 | Key                                      | Description                              |
 | ---------------------------------------- | ---------------------------------------- |
 | `http://tizen.org/appcontrol/data/type`  | The type of items to be delivered. The available values are `id`, `phone`, `email`, and `vcf`. This key must be passed as a string. |
 | `http://tizen.org/appcontrol/data/selected` | The extra field to get the return information. The content of this key depends on its type:<br> - `id`: The database record ID of the selected person (ID in the `_contacts_person` view).<Br> - `phone`: The database record ID of the number of the selected person (ID in the `_contacts_number` view).<br> - `email`: The database record ID of the email of the selected person (ID in the `_contacts_email` view).<br> - `vcf`: The path to the vCard file.<Br>This key must be passed as an array. |
 
-#### Example Code
+#### Example code
 
 ```
 function launchContactPick(selectionMode, dataType) {
@@ -710,7 +710,7 @@ function launchContactPick(selectionMode, dataType) {
 }
 ```
 
-### Sharing a Contact
+### Share a contact
 The contact sharing operation is available depending on whether the installed application supports it or not.
 
 To share a single contact, use the `http://tizen.org/appcontrol/operation/share` operation with the `application/vnd.tizen.contact` MIME type. To specify various contact details, refer to the extras defined below.
@@ -723,14 +723,14 @@ To share a single contact, use the `http://tizen.org/appcontrol/operation/share`
 
 `application/vnd.tizen.contact`
 
-#### Extra Input
+#### Extra input
 
 | Key                                     | Description                              | Note                   |
 | --------------------------------------- | ---------------------------------------- | ---------------------- |
 | `http://tizen.org/appcontrol/data/id`   | The database record ID of the person (ID in the `_contacts_person` view) when `http://tizen.org/appcontrol/data/type` is set to `person`.<br>The database record ID of my profile (ID in the `_contacts_my_profile` view) when `http://tizen.org/appcontrol/data/type` is set to `my_profile`. This key must be passed as a string. | This key is mandatory. |
 | `http://tizen.org/appcontrol/data/type` | The type of contact. The available values are `my_profile` and `person`. This key must be passed as a string. | This key is mandatory. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControlData = [new tizen.ApplicationControlData('http://tizen.org/appcontrol/data/type', ['person']),
@@ -747,7 +747,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Sharing Multiple Contacts
+### Share multiple contacts
 The multiple contact sharing operation is available depending on whether the installed application supports it or not.
 
 To share a set of contacts, use the `http://tizen.org/appcontrol/operation/multi_share` operation with the `application/vnd.tizen.contact` MIME type. To specify various contact details, refer to the extras defined below.
@@ -760,13 +760,13 @@ To share a set of contacts, use the `http://tizen.org/appcontrol/operation/multi
 
 `application/vnd.tizen.contact`
 
-#### Extra Input
+#### Extra input
 
 | Key                                   | Description                              | Note                   |
 | ------------------------------------- | ---------------------------------------- | ---------------------- |
 | `http://tizen.org/appcontrol/data/id` | The database record IDs of the person (ID in the `_contacts_person` view). This key must be passed as an array. | This key is mandatory. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControlData = [new tizen.ApplicationControlData('http://tizen.org/appcontrol/data/id',
@@ -786,7 +786,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 ## Email
 The email application control is available depending on whether the installed application supports it or not.
 
-### Composing an Email
+### Compose an email
 
 To compose an email with optional recipients, subject, and body text, use the `http://tizen.org/appcontrol/operation/compose` operation.
 
@@ -804,7 +804,7 @@ To compose an email with optional recipients, subject, and body text, use the `h
 
 If the `mailto:` field is empty, it filters out all but email applications in the system, and you can use the extra data only to pass optional parameters.
 
-#### Extra Input
+#### Extra input
 
 | Key                                      | Description                              | Note                  |
 | ---------------------------------------- | ---------------------------------------- | --------------------- |
@@ -815,7 +815,7 @@ If the `mailto:` field is empty, it filters out all but email applications in th
 | `http://tizen.org/appcontrol/data/text`  | The body of the email to be sent. This key must be passed as a string. | This key is optional. |
 | `http://tizen.org/appcontrol/data/path`  | The list of multiple file paths to be shared in an email message. This key must be passed as an array. | This key is optional. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControlData = [new tizen.ApplicationControlData('http://tizen.org/appcontrol/data/cc', ['cc@tizen.org', 'cc2@tizen.org']),
@@ -834,7 +834,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Sharing a Single File Using an Email Message
+### Share a single file using an email message
 
 To share a single file of any MIME type in an email message, use the `http://tizen.org/appcontrol/operation/share` operation.
 
@@ -858,7 +858,7 @@ Any MIME type that your application needs, such as `image/jpg`, `video/*`, or `*
 
 If sharing a single item through `http://tizen.org/appcontrol/data/path` and the URI is specified with `mailto:`, the MIME type must be explicitly set.
 
-#### Extra Input
+#### Extra input
 
 | Key                                     | Description                              | Note                                     |
 | --------------------------------------- | ---------------------------------------- | ---------------------------------------- |
@@ -880,7 +880,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Sharing Multiple Items Using an Email Message
+### Sharing multiple items using an email message
 
 To share multiple files of any MIME type using an email message, use the `http://tizen.org/appcontrol/operation/multi_share` operation.
 
@@ -904,13 +904,13 @@ Any MIME type that your application needs, such as `image/jpg`, `video/*`, or `*
 
 If you try to share a set of files with different MIME types, use `<type>/*` or `*/*`. For example, if you send `video/mp4` and `audio/ogg`, the MIME type must be `*/*`.
 
-#### Extra Input
+#### Extra input
 
 | Key                                     | Description                              | Note                   |
 | --------------------------------------- | ---------------------------------------- | ---------------------- |
 | `http://tizen.org/appcontrol/data/path` | The list of multiple file paths to be shared in an email message. This key must be passed as an array. | This key is mandatory. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControlData = [new tizen.ApplicationControlData('http://tizen.org/appcontrol/data/path', ['img_path']),
@@ -927,7 +927,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Sharing Text in an Email
+### Share text in an email
 
 To share any text with an email message, use the `http://tizen.org/appcontrol/operation/share_text` operation. You can also define the message subject and a list of file attachments.
 
@@ -945,7 +945,7 @@ To share any text with an email message, use the `http://tizen.org/appcontrol/op
 
 Only an empty `mailto:` field is allowed. It filters out all but email applications in the system.
 
-#### Extra Input
+#### Extra input
 
 | Key                                      | Description                              | Note                   |
 | ---------------------------------------- | ---------------------------------------- | ---------------------- |
@@ -953,7 +953,7 @@ Only an empty `mailto:` field is allowed. It filters out all but email applicati
 | `http://tizen.org/appcontrol/data/subject` | The subject of an email message. This key must be passed as a string. | This key is optional.  |
 | `http://tizen.org/appcontrol/data/path`  | The list of multiple file paths to be shared using an email message. This key must be passed as an array. | This key is optional. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControlData = [new tizen.ApplicationControlData('http://tizen.org/appcontrol/data/path', ['img_path']),
@@ -971,10 +971,10 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-## File Storage
+## File storage
 The file storage application control is available depending on whether the installed application supports it or not.
 
-### Retrieving a Specific Type of File
+### Retrieve a specific type of file
 
 To select any kind of file from the storage, use the `http://tizen.org/appcontrol/operation/pick` operation with the corresponding MIME type. To give options for the pick operation, refer to the extras defined below.
 
@@ -986,7 +986,7 @@ To select any kind of file from the storage, use the `http://tizen.org/appcontro
 
 \*/\*
 
-#### Extra Input
+#### Extra input
 
 | Key                                      | Description                              | Note                  |
 | ---------------------------------------- | ---------------------------------------- | --------------------- |
@@ -994,13 +994,13 @@ To select any kind of file from the storage, use the `http://tizen.org/appcontro
 | `http://tizen.org/appcontrol/data/total_count` | The total number of items to be returned. This key must be passed as a string. | This key is optional. |
 | `http://tizen.org/appcontrol/data/total_size` | The total size of items to be returned in bytes. This key must be passed as a string. | This key is optional. |
 
-#### Extra Output
+#### Extra output
 
 | Key                                      | Value Description                        |
 | ---------------------------------------- | ---------------------------------------- |
 | `http://tizen.org/appcontrol/data/selected` | The list of selected file paths. This key must be passed as an array. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControlData = [new tizen.ApplicationControlData('http://tizen.org/appcontrol/data/selection_mode', ['single'])];
@@ -1015,7 +1015,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Downloading a File
+### Download a file
 
 To download a file, use the `http://tizen.org/appcontrol/operation/download` operation and specify the URL in the URI.
 
@@ -1030,7 +1030,7 @@ To request this operation, the `http://tizen.org/privilege/download` privilege i
 - `http:<path>`
 - `https:<path>`
 
-#### Example Code
+#### Example code
 
 ```
 var appControl = new tizen.ApplicationControl('http://tizen.org/appcontrol/operation/download',
@@ -1043,11 +1043,11 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-## Input Delegator
+## Input delegator
 
 The input delegator application control is available depending on whether the installed application supports it or not.
 
-### Receiving User Input
+### Receive user input
 
 To receive a specific type of input from the user, use the `http://tizen.org/appcontrol/operation/get_input` operation. To give an option for the input delegator, refer to the extras defined below.
 
@@ -1066,7 +1066,7 @@ To receive a specific type of input from the user, use the `http://tizen.org/app
 - `audio/*`
 - `*/*`
 
-#### Extra Input
+#### Extra input
 
 | Key                                      | Description                              | Note                                     |
 | ---------------------------------------- | ---------------------------------------- | ---------------------------------------- |
@@ -1080,14 +1080,14 @@ To receive a specific type of input from the user, use the `http://tizen.org/app
 | `http://tizen.org/appcontrol/data/input_cursor_position_get` | The current position of the cursor in the keyboard input type. This key must be passed as a string. | This key is optional, and **it is supported since Tizen 4.0.** |
 | `http://tizen.org/appcontrol/data/input_reply_type` | The reply type. This key must be passed as a string. The available values are:<br> - `input_voice`: Receive the result as voice<br> - `input_emoticon`: Receive the result as an emoticon<Br> - `input_keyboard`: Receive the result as keyboard input<br> - `input_reply`: Receive the result as reply input<br> - `input_image`: Receive the result as an image<br> - `input_audio`: Receive the result as audio | This key is optional |
 
-#### Extra Output
+#### Extra output
 
 | Key                                     | Value description                        | Note                                     |
 | --------------------------------------- | ---------------------------------------- | ---------------------------------------- |
 | `http://tizen.org/appcontrol/data/text` | The result string from the input delegator. This key must be passed as a string. | -                                        |
 | `http://tizen.org/appcontrol/data/path` | The list of multiple file paths from the input delegator. This key must be passed as an array. | This key is optional |
 
-#### Example Code
+#### Example code
 
 ```
 var appControlData = new tizen.ApplicationControlData('http://tizen.org/appcontrol/data/input_type', ['input_voice']);
@@ -1107,7 +1107,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 The map application control is available depending on whether the installed application supports it or not.
 
 
-### Showing a Location on a Map
+### Show a location on a map
 
 To open a map to show a location, use the `http://tizen.org/appcontrol/operation/view` operation with an URI. To specify various map details, refer to the extras defined below.
 
@@ -1123,7 +1123,7 @@ To open a map to show a location, use the `http://tizen.org/appcontrol/operation
    Show the map at the location of a given keyword (address or POI). For example: `geo:0,0?q=Eiffel%20Tower`  
    All strings passed in the `geo:` URI must be encoded. If only `geo:` is used, it filters out all but map applications in the system, and the location to be shown depends on the application scenario and configuration.
 
-#### Example Code
+#### Example code
 
 ```
 var appControl = new tizen.ApplicationControl('http://tizen.org/appcontrol/operation/view',
@@ -1136,7 +1136,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Picking a Location from the Map
+### Pick a location from the map
 
 To pick a location from the map, use the `http://tizen.org/appcontrol/operation/pick` operation. To specify various map details, refer to the extras defined below.
 
@@ -1154,13 +1154,13 @@ All strings passed in the `geo:` URI must be encoded.
 
 If only `geo:` is used, it filters out all but map applications in the system, and the location to be shown depends on the application scenario and configuration.
 
-#### Extra Input
+#### Extra input
 
 | Key                                     | Description                              | Note                                     |
 | --------------------------------------- | ---------------------------------------- | ---------------------------------------- |
-| `http://tizen.org/appcontrol/data/type` | The type of items to be delivered. The available values are `address` (default), `image`, `poi`, `geocode`, `uri`, or `all`. This key must be passed as a string. | This key is optional. **The poi value is not supported in Tizen 2.4.** **The geocode and uri values are supported since Tizen 3.0.** |
+| `http://tizen.org/appcontrol/data/type` | The type of items to be delivered. The available values are `address` (default), `image`, `poi`, `geocode`, `uri`, or `all`. This key must be passed as a string. | This key is optional. **The POI value is not supported in Tizen 2.4.** **The geocode and uri values are supported since Tizen 3.0.** |
 
-#### Extra Output
+#### Extra output
 
 | Key                                      | Description                              | Note                                     |
 | ---------------------------------------- | ---------------------------------------- | ---------------------------------------- |
@@ -1170,7 +1170,7 @@ If only `geo:` is used, it filters out all but map applications in the system, a
 | `http://tizen.org/appcontrol/data/url`   | The URI of a place that shows the selected location. This key must be passed as a string. | **This key is supported since Tizen 3.0.** |
 | `http://tizen.org/appcontrol/data/path`  | The file path of the image showing the selected location. This key must be passed as a string. | -                                        |
 
-#### Example Code
+#### Example code
 
 ```
 var appControlData = [new tizen.ApplicationControlData('http://tizen.org/appcontrol/data/type', ['poi'])];
@@ -1199,7 +1199,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 
 ## Message
 
-### Composing a Message
+### Compose a message
 The message composition operation is available depending on whether the installed application supports it or not.
 
 To compose a new message, use the `http://tizen.org/appcontrol/operation/compose` operation. To specify various message details, refer to the extras defined below.
@@ -1219,7 +1219,7 @@ To compose a new message, use the `http://tizen.org/appcontrol/operation/compose
 - `mmsto:<phone-number>`  
    For example: `mmsto:+17913331234`
 
-#### Extra Input
+#### Extra input
 
 | Key                                      | Description                              | Note                  |
 | ---------------------------------------- | ---------------------------------------- | --------------------- |
@@ -1228,7 +1228,7 @@ To compose a new message, use the `http://tizen.org/appcontrol/operation/compose
 | `http://tizen.org/appcontrol/data/subject` | The subject of an MMS message. If this value is set for an SMS message, the message is automatically converted to MMS. This key must be passed as a string. | This key is optional. |
 | `http://tizen.org/appcontrol/data/path`  | The list of multiple file paths to be shared in a multimedia message. This key must be passed as an array. | This key is optional. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControlData = [new tizen.ApplicationControlData('http://tizen.org/appcontrol/data/text', ['My text']),
@@ -1244,7 +1244,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Sharing a Single Item Using a Message
+### Share a single item using a message
 The single item sharing operation is available depending on whether the installed application supports it or not.
 
 To share a single item using an MMS message, use the `http://tizen.org/appcontrol/operation/share` operation.
@@ -1270,13 +1270,13 @@ Any MIME type that your application needs, such as `image/jpg`, `video/*`, or `*
 
 If sharing a single item through `http://tizen.org/appcontrol/data/path` and the URI is specified with `mmsto:`, the MIME type must be explicitly set.
 
-#### Extra Input
+#### Extra input
 
 | Key                                     | Description                              | Note                                     |
 | --------------------------------------- | ---------------------------------------- | ---------------------------------------- |
 | `http://tizen.org/appcontrol/data/path` | When the URI is set to `mmsto`, a path to a single file to be shared must be provided using this key. Otherwise, the key is ignored. This key must be passed as a string. | This key is mandatory when the URI is set to `mmsto`. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControlData = [new tizen.ApplicationControlData('http://tizen.org/appcontrol/data/path', ['img_path'])];
@@ -1291,7 +1291,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Sharing Multiple Items Using a Message
+### Share multiple items using a message
 The multiple item sharing operation is available depending on whether the installed application supports it or not.
 
 To share multiple items using an MMS message, use the `http://tizen.org/appcontrol/operation/multi_share` operation.
@@ -1310,19 +1310,19 @@ To share multiple items using an MMS message, use the `http://tizen.org/appcontr
 
 Only an empty `mmsto:` field is allowed. This can be used to filter out all but message applications available in the system.
 
-#### MIME Type (Mandatory)
+#### MIME type (Mandatory)
 
 Any MIME type that your application needs, such as `image/jpg`, `video/*`, or `*/*`
 
 If you try to share a set of files with different MIME types, use `<type>/*` or `*/*`. For example, if you send `video/mp4` and `audio/ogg`, the MIME type must be `*/*`.
 
-#### Extra Input
+#### Extra input
 
 | Key                                     | Description                              | Note                   |
 | --------------------------------------- | ---------------------------------------- | ---------------------- |
 | `http://tizen.org/appcontrol/data/path` | The list of multiple file paths to be shared in a multimedia message. This key must be passed as an array. | This key is mandatory. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControlData = [new tizen.ApplicationControlData('http://tizen.org/appcontrol/data/path', ['img_path']),
@@ -1339,7 +1339,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Sharing Text in a Message
+### Share text in a message
 The text sharing operation is available depending on whether the installed application supports it or not.
 
 To share any text with an SMS or MMS message, use the `http://tizen.org/appcontrol/operation/share_text` operation.
@@ -1359,7 +1359,7 @@ To share any text with an SMS or MMS message, use the `http://tizen.org/appcontr
 
 Only an empty `sms:` or `mmsto:` field is allowed. This can be used to filter out all but message applications available in the system.
 
-#### Extra Input
+#### Extra input
 
 | Key                                      | Description                              | Note                   |
 | ---------------------------------------- | ---------------------------------------- | ---------------------- |
@@ -1367,7 +1367,7 @@ Only an empty `sms:` or `mmsto:` field is allowed. This can be used to filter ou
 | `http://tizen.org/appcontrol/data/subject` | The subject of an MMS message. If it is set for an SMS message, the message is automatically converted to MMS. This key must be passed as a string. | This key is optional. |
 | `http://tizen.org/appcontrol/data/path`  | The list of multiple file paths to be shared in a multimedia message. This key must be passed as an array. | This key is optional. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControlData = [new tizen.ApplicationControlData('http://tizen.org/appcontrol/data/text', ['Hello, My name is Tizy.']),
@@ -1386,7 +1386,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 
 ## Multimedia
 
-### Playing an Audio or Video File
+### Play an audio or video file
 The audio or video file playback operation is available depending on whether the installed application supports it or not.
 
 To play an audio or video file, use the `http://tizen.org/appcontrol/operation/view` operation with a URI. To specify various details, refer to the extras defined below.
@@ -1403,7 +1403,7 @@ To play an audio or video file, use the `http://tizen.org/appcontrol/operation/v
 - `rtsp:<path>`
 - `rtp:<path>`
 
-#### MIME Type (Optional)
+#### MIME type (Optional)
 
 - `audio/*`
 - `video/*`
@@ -1415,7 +1415,7 @@ To play an audio or video file, use the `http://tizen.org/appcontrol/operation/v
 - `application/x-smaf`
 - `application/vnd.smaf`
 
-#### Example Code
+#### Example code
 
 ```
 var appControl = new tizen.ApplicationControl('http://tizen.org/appcontrol/operation/view',
@@ -1428,7 +1428,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Viewing an Image File
+### View an image file
 The image file viewing operation is available depending on whether the installed application supports it or not.
 
 To display an image file, use the `http://tizen.org/appcontrol/operation/view` operation with a URI. To specify various details, refer to the extras defined below.
@@ -1443,11 +1443,11 @@ To display an image file, use the `http://tizen.org/appcontrol/operation/view` o
 - `https:<path>`
 - `file:<path>`
 
-#### MIME Type (Optional)
+#### MIME type (Optional)
 
 - `image/*`
 
-#### Example Code
+#### Example code
 
 ```
 var appControl = new tizen.ApplicationControl('http://tizen.org/appcontrol/operation/view',
@@ -1460,7 +1460,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Retrieving a Media File
+### Retrieve a media file
 The media file retrieval operation is available depending on whether the installed application supports it or not.
 
 To retrieve a specific type of media file, use the `http://tizen.org/appcontrol/operation/pick` operation. To specify various details, refer to the extras defined below.
@@ -1469,13 +1469,13 @@ To retrieve a specific type of media file, use the `http://tizen.org/appcontrol/
 
 `http://tizen.org/appcontrol/operation/pick`
 
-#### MIME Type (Optional)
+#### MIME type (Optional)
 
 - `audio/*`
 - `image/*`
 - `video/*`
 
-#### Extra Input
+#### Extra input
 
 | Key                                      | Description                              | Note                  |
 | ---------------------------------------- | ---------------------------------------- | --------------------- |
@@ -1483,13 +1483,13 @@ To retrieve a specific type of media file, use the `http://tizen.org/appcontrol/
 | `http://tizen.org/appcontrol/data/total_count` | The total number of items to be returned. This key must be passed as a string. | This key is optional. |
 | `http://tizen.org/appcontrol/data/total_size` | The total size of items to be returned in bytes. This key must be passed as a string. | This key is optional. |
 
-#### Extra Output
+#### Extra output
 
 | Key                                      | Value Description                        |
 | ---------------------------------------- | ---------------------------------------- |
 | `http://tizen.org/appcontrol/data/selected` | The paths of the selected files. This key must be passed as an array. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControl = new tizen.ApplicationControl('http://tizen.org/appcontrol/operation/pick',
@@ -1502,11 +1502,11 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-## System Settings
+## System settings
 The system settings application control is available depending on whether the installed application supports it or not.
 
 
-### Showing System Settings
+### Show system settings
 
 To display various setting menus for, for example, Connections, Devices, and System Information, use the `http://tizen.org/appcontrol/operation/setting` operation.
 
@@ -1518,7 +1518,7 @@ To display various setting menus for, for example, Connections, Devices, and Sys
 
 `http://tizen.org/appcontrol/operation/setting`
 
-#### Example Code
+#### Example code
 
 ```
 var appControl = new tizen.ApplicationControl('http://tizen.org/appcontrol/operation/setting',
@@ -1535,7 +1535,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 The Bluetooth settings application control is available depending on whether the installed application supports it or not.
 
 
-### Showing Bluetooth Settings to Activate Bluetooth
+### Show Bluetooth settings to activate Bluetooth
 
 To launch the Bluetooth setting application to allow the user to activate or deactivate Bluetooth, use the `http://tizen.org/appcontrol/operation/setting/bt_enable` operation.
 
@@ -1547,7 +1547,7 @@ To launch the Bluetooth setting application to allow the user to activate or dea
 
 `http://tizen.org/appcontrol/operation/setting/bt_enable`
 
-#### Example Code
+#### Example code
 
 ```
 var appControl = new tizen.ApplicationControl('http://tizen.org/appcontrol/operation/setting/bt_enable',
@@ -1560,7 +1560,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-### Showing Bluetooth Settings to Configure Visibility
+### Showing Bluetooth settings to configure visibility
 
 To launch the Bluetooth setting application to allow the user to configure the visibility of the device, use the `http://tizen.org/appcontrol/operation/setting/bt_visibility` operation.
 
@@ -1572,7 +1572,7 @@ To launch the Bluetooth setting application to allow the user to configure the v
 
 `http://tizen.org/appcontrol/operation/setting/bt_visibility`
 
-#### Example Code
+#### Example code
 
 ```
 var appControl = new tizen.ApplicationControl('http://tizen.org/appcontrol/operation/setting/bt_visibility',
@@ -1585,10 +1585,10 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-## Settings for Location
+## Settings for location
 The location settings application control is available depending on whether the installed application supports it or not.
 
-### Showing Location Settings
+### Show location settings
 
 To launch the location setting application to allow the user to configure the source of the location information, use the `http://tizen.org/appcontrol/operation/setting/location` operation.
 
@@ -1602,7 +1602,7 @@ If the location service is not active when an application tries to use the `Huma
 
 `http://tizen.org/appcontrol/operation/setting/location`
 
-#### Example Code
+#### Example code
 
 ```
 var appControl = new tizen.ApplicationControl('http://tizen.org/appcontrol/operation/setting/location',
@@ -1618,7 +1618,7 @@ tizen.application.launchAppControl(appControl, null, function() {
 ## Settings for NFC
 The NFC settings application control is available depending on whether the installed application supports it or not.
 
-### Showing NFC Settings
+### Showing NFC settings
 
 To launch the NFC setting application to allow the user to activate or deactivate NFC, use the `http://tizen.org/appcontrol/operation/setting/nfc` operation.
 
@@ -1630,13 +1630,13 @@ To launch the NFC setting application to allow the user to activate or deactivat
 
 `http://tizen.org/appcontrol/operation/setting/nfc`
 
-#### Extra Input
+#### Extra input
 
 | Key                     | Description                              | Note                                     |
 | ----------------------- | ---------------------------------------- | ---------------------------------------- |
 | `APP_CONTROL_DATA_TYPE` | The NFC setting menu type to be shown. This key must be passed as a string. The available values are:<br>  - `nfc` (default): Default setting menu is launched<br>  - `tap_n_pay`: Tap & pay setting menu is launched. The support for this value depends on the device NFC settings. | This key is optional, and **it is supported since Tizen 3.0**. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControl = new tizen.ApplicationControl('http://tizen.org/appcontrol/operation/setting/nfc',
@@ -1664,7 +1664,7 @@ To launch the Wi-Fi setting application to allow the user to activate and config
 
 `http://tizen.org/appcontrol/operation/setting/wifi`
 
-#### Example Code
+#### Example code
 
 ```
 var appControl = new tizen.ApplicationControl('http://tizen.org/appcontrol/operation/setting/wifi',
@@ -1677,10 +1677,10 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-## Voice Recorder
+## Voice recorder
 The voice recorder application control is available depending on whether the installed application supports it or not.
 
-### Recording Audio
+### Record audio
 
 To record audio, use the `http://tizen.org/appcontrol/operation/create_content` operation with the audio MIME type. To give an option for recording audio, refer to the extras defined below.
 
@@ -1688,23 +1688,23 @@ To record audio, use the `http://tizen.org/appcontrol/operation/create_content` 
 
 `http://tizen.org/appcontrol/operation/create_content`
 
-#### MIME Type (Mandatory)
+#### MIME type (Mandatory)
 
 Audio MIME type, such as `audio/m4a`, `audio/ogg`, and `audio/*`
 
-#### Extra Input
+#### Extra input
 
 | Key                                      | Description                              | Note                  |
 | ---------------------------------------- | ---------------------------------------- | --------------------- |
 | `http://tizen.org/appcontrol/data/total_size` | The total size of items to be returned in bytes. This key must be passed as a string. | This key is optional. |
 
-#### Extra Output
+#### Extra output
 
 | Key                                      | Value Description                        |
 | ---------------------------------------- | ---------------------------------------- |
 | `http://tizen.org/appcontrol/data/selected` | The path of the created audio file. This key must be passed as a string. |
 
-#### Example Code
+#### Example code
 
 ```
 var appControl = new tizen.ApplicationControl('http://tizen.org/appcontrol/operation/create_content',
@@ -1717,6 +1717,6 @@ tizen.application.launchAppControl(appControl, null, function() {
 }, null);
 ```
 
-## Related Information
+## Related information
 * Dependencies
   - Each application control is available depending on whether the installed application supports it or not.

--- a/docs/application/web/guides/app-management/data-control.md
+++ b/docs/application/web/guides/app-management/data-control.md
@@ -30,13 +30,13 @@ To use the Data Control API (in [mobile](../../api/latest/device_api/mobile/tize
 <tizen:privilege name="http://tizen.org/privilege/appmanager.launch"/>
 ```
 
-## Managing Data in Key-value Pairs
+## Manage data in key-value pairs
 
 Learning how to manage map-type data allows you to use key-value pairs exposed by a DataControl provider:
 
 1. Retrieve the `MappedDataControlConsumer` object (in [mobile](../../api/latest/device_api/mobile/tizen/datacontrol.html#MappedDataControlConsumer), [wearable](../../api/latest/device_api/wearable/tizen/datacontrol.html#MappedDataControlConsumer), and [TV](../../api/latest/device_api/tv/tizen/datacontrol.html#MappedDataControlConsumer) applications) using the `getDataControlConsumer()` method of the `DataControlManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/datacontrol.html#DataControlManager), [wearable](../../api/latest/device_api/wearable/tizen/datacontrol.html#DataControlManager), and [TV](../../api/latest/device_api/tv/tizen/datacontrol.html#DataControlManager) applications). This object allows accessing the key-value data stored by the DataControl provider.
 
-   You need a running DataControl provider application, which uses the `"http://tizen.org/datacontrol/provider/DictionaryDataControlProvider"` provider ID.
+   You need a running DataControl provider application, which uses the `"http://tizen.org/datacontrol/provider/DictionaryDataControlProvider"` provider ID:
 
    ```
    /* Get the map-type DataControlConsumerObject */
@@ -45,7 +45,7 @@ Learning how to manage map-type data allows you to use key-value pairs exposed b
    }
    ```
 
-2. To meet the API requirement of using unique request identifiers, define a global variable, which is incremented every time a new request ID is needed. When the Data Control API responds to a request, it provides the request ID, which allows connecting the response with the specific request.
+2. To meet the API requirement of using unique request identifiers, define a global variable, which is incremented every time a new request ID is needed. When the Data Control API responds to a request, it provides the request ID, which allows connecting the response with the specific request:
 
    ```
    var globalReqId = new Date().getTime() % 2e9;
@@ -106,13 +106,13 @@ Learning how to manage map-type data allows you to use key-value pairs exposed b
      }
      ```
 
-## Managing SQL-type Data
+## Manage SQL-type data
 
 Learning how to manage SQL-type data allows you to use databases exposed by a DataControl provider:
 
 1. To retrieve a `SQLDataControlConsumer` object (in [mobile](../../api/latest/device_api/mobile/tizen/datacontrol.html#SQLDataControlConsumer), [wearable](../../api/latest/device_api/wearable/tizen/datacontrol.html#SQLDataControlConsumer), and [TV](../../api/latest/device_api/tv/tizen/datacontrol.html#SQLDataControlConsumer) applications), use the `getDataControlConsumer()` method of the `DataControlManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/datacontrol.html#DataControlManager), [wearable](../../api/latest/device_api/wearable/tizen/datacontrol.html#DataControlManager), and [TV](../../api/latest/device_api/tv/tizen/datacontrol.html#DataControlManager) applications). This object allows accessing the data stored by the DataControl provider.
 
-   You need a running DataControl provider application, which uses the `"http://tizen.org/datacontrol/provider/DictionaryDataControlProvider"` provider ID.
+   You need a running DataControl provider application, which uses the `"http://tizen.org/datacontrol/provider/DictionaryDataControlProvider"` provider ID:
 
    ```
    /* Get the SQL type DataControlConsumerObject */
@@ -121,7 +121,7 @@ Learning how to manage SQL-type data allows you to use databases exposed by a Da
    }
    ```
 
-2. To meet the API requirement of using unique request identifiers, define a global variable, which is incremented every time new request ID is needed. When the Data Control API responds to a request, it provides the request ID, which allows connecting the response with the specific request.
+2. To meet the API requirement of using unique request identifiers, define a global variable, which is incremented every time new request ID is needed. When the Data Control API responds to a request, it provides the request ID, which allows connecting the response with the specific request:
 
    ```
    var globalReqId = new Date().getTime() % 2e9;
@@ -206,13 +206,13 @@ Learning how to manage SQL-type data allows you to use databases exposed by a Da
      }
      ```
 
-## Monitoring Provider Data Changes
+## Monitor provider data changes
 
 Learning how to add a listener allows you to receive notifications about DataControl provider data changes:
 
 1. To monitor changes in the DataControl provider data, you must retrieve a `SQLDataControlConsumer` object (in [mobile](../../api/latest/device_api/mobile/tizen/datacontrol.html#SQLDataControlConsumer), [wearable](../../api/latest/device_api/wearable/tizen/datacontrol.html#SQLDataControlConsumer), and [TV](../../api/latest/device_api/tv/tizen/datacontrol.html#SQLDataControlConsumer) applications) or a `MappedDataControlConsumer` object (in [mobile](../../api/latest/device_api/mobile/tizen/datacontrol.html#MappedDataControlConsumer), [wearable](../../api/latest/device_api/wearable/tizen/datacontrol.html#MappedDataControlConsumer), and [TV](../../api/latest/device_api/tv/tizen/datacontrol.html#MappedDataControlConsumer) applications). Retrieve the required object using the `getDataControlConsumer()` method of the `DataControlManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/datacontrol.html#DataControlManager), [wearable](../../api/latest/device_api/wearable/tizen/datacontrol.html#DataControlManager), and [TV](../../api/latest/device_api/tv/tizen/datacontrol.html#DataControlManager) applications).
 
-   You need a running DataControl provider application, which uses the `"http://tizen.org/datacontrol/provider/DictionaryDataControlProvider"` provider ID.
+   You need a running DataControl provider application, which uses the `"http://tizen.org/datacontrol/provider/DictionaryDataControlProvider"` provider ID:
 
    ```
    /* Get the map-type DataControlConsumerObject */
@@ -282,7 +282,7 @@ Learning how to add a listener allows you to receive notifications about DataCon
    }
    ```
 
-> **Note**  
+> [!NOTE]
 > To monitor DataControl provider data changes, it is not enough to implement a listener in the DataControl consumer. You also need to implement the data change sending functionality in the DataControl provider.  
 > The data sending implementation determines the actual change data returned to the DataControl consumer. For more information on the DataControl provider implementation, see [Monitoring Data Changes](../../../native/guides/app-management/data-control.md#monitoring-data-changes).
 

--- a/docs/application/web/guides/app-management/message-port.md
+++ b/docs/application/web/guides/app-management/message-port.md
@@ -4,7 +4,7 @@ Your Web applications can communicate with other Web or native applications. The
 
 The Message Port API is mandatory for Tizen Mobile, Wearable, and TV profiles, which means that it is supported on all mobile, wearable, and TV devices. All mandatory APIs are supported on the Tizen emulators.
 
-The main features of the Message Port API include:
+The main features of the Message Port API include the following:
 
 - Sending messages
 
@@ -28,7 +28,7 @@ The main features of the Message Port API include:
 
   ![Trusted message ports](./media/message_port_trusted.png)
 
-## Managing Message Ports
+## Manage message ports
 
 You can send and receive messages through 2 types of message ports:
 
@@ -50,7 +50,7 @@ Learning how to send messages to and receive responses from other Tizen applicat
    var localPort = tizen.messageport.requestLocalMessagePort('SAMPLE_PORT');
    ```
 
-2. To retrieve an instance of the `RemoteMessagePort` interface, use the `requestRemoteMessagePort()` method of the `tizen.messageport` object. The `RemoteMessagePort` interface sends messages to the port identified by an `ApplicationId` and a port name.
+2. To retrieve an instance of the `RemoteMessagePort` interface, use the `requestRemoteMessagePort()` method of the `tizen.messageport` object. The `RemoteMessagePort` interface sends messages to the port identified by an `ApplicationId` and a port name:
 
    ```
    var targetApplicationId = tizen.application.getCurrentApplication().appInfo.id;

--- a/docs/application/web/guides/app-management/packages.md
+++ b/docs/application/web/guides/app-management/packages.md
@@ -28,7 +28,7 @@ To use the Package API (in [mobile](../../api/latest/device_api/mobile/tizen/pac
 ```
 
 <a name="retrieve"></a>
-## Retrieving Package Information
+## Retrieve package information
 
 You can retrieve information about packages in various ways:
 
@@ -49,20 +49,20 @@ Learning how to retrieve information about installed packages allows you to mana
 
    The list of installed packages is returned to the `PackageInformationArraySuccessCallback()` methods as an array of `PackageInformation` objects.
 
-2. To retrieve basic package information, use the `getPackageInfo()` method of the `PackageManager` interface, specifying the package ID. If no package ID is set, the method retrieves the information for the application package calling the method.
+2. To retrieve basic package information, use the `getPackageInfo()` method of the `PackageManager` interface, specifying the package ID. If no package ID is set, the method retrieves the information for the application package calling the method:
 
    ```
    var packageInfo = tizen.package.getPackageInfo('org.tizen.calculator');
    ```
 
 <a name="manage"></a>
-## Managing Packages
+## Manage packages
 
-You can manage the package installation using the `install()` and `uninstall()` methods of the `PackageManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/package.html#PackageManager), [wearable](../../api/latest/device_api/wearable/tizen/package.html#PackageManager), and [TV](../../api/latest/device_api/tv/tizen/package.html#PackageManager) applications). Additionally, you can receive notifications of the installation and uninstallation progress using the `PackageProgressCallback` interface (in [mobile](../../api/latest/device_api/mobile/tizen/package.html#PackageProgressCallback), [wearable](../../api/latest/device_api/wearable/tizen/package.html#PackageProgressCallback), and [TV](../../api/latest/device_api/tv/tizen/package.html#PackageProgressCallback) applications).
+You can manage the package installation using the `install()` and `uninstall()` methods of the `PackageManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/package.html#PackageManager), [wearable](../../api/latest/device_api/wearable/tizen/package.html#PackageManager), and [TV](../../api/latest/device_api/tv/tizen/package.html#PackageManager) applications). Additionally, you can receive notifications of the installation and uninstallation progress using the `PackageProgressCallback` interface (in [mobile](../../api/latest/device_api/mobile/tizen/package.html#PackageProgressCallback), [wearable](../../api/latest/device_api/wearable/tizen/package.html#PackageProgressCallback), and [TV](../../api/latest/device_api/tv/tizen/package.html#PackageProgressCallback) applications)
 
 Learning how to install and uninstall packages is a basic package management skill:
 
-1. To install a package, use the `install()` method of the `PackageManager` interface, specifying the local package installation path on your device. You can retrieve the installation progress using the `PackageProgressCallback` interface.
+1. To install a package, use the `install()` method of the `PackageManager` interface, specifying the local package installation path on your device. You can retrieve the installation progress using the `PackageProgressCallback` interface:
 
    ```
    var onInstallation = {
@@ -79,7 +79,7 @@ Learning how to install and uninstall packages is a basic package management ski
    });
    ```
 
-2. To uninstall a package, use the `uninstall()` method of the `PackageManager` interface, specifying the package ID. You can retrieve the uninstallation progress using the `PackageProgressCallback` interface.
+2. To uninstall a package, use the `uninstall()` method of the `PackageManager` interface, specifying the package ID. You can retrieve the uninstallation progress using the `PackageProgressCallback` interface:
 
    ```
    var onUninstallation = {
@@ -95,7 +95,7 @@ Learning how to install and uninstall packages is a basic package management ski
    ```
 
 <a name="receive"></a>
-## Receiving Package Change Notifications
+## Receive package change notifications
 
 You can receive notifications of changes in the list of installed packages. The `setPackageInfoEventListener()` method of the `PackageManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/package.html#PackageManager), [wearable](../../api/latest/device_api/wearable/tizen/package.html#PackageManager), and [TV](../../api/latest/device_api/tv/tizen/package.html#PackageManager) applications) registers an event listener for changes in the installed packages list. To unsubscribe the listener, use the `unsetPackageInfoEventListener()` method. You can use the `PackageInformationEventCallback` interface (in [mobile](../../api/latest/device_api/mobile/tizen/package.html#PackageInformationEventCallback), [wearable](../../api/latest/device_api/wearable/tizen/package.html#PackageInformationEventCallback), and [TV](../../api/latest/device_api/tv/tizen/package.html#PackageInformationEventCallback) applications) to define listeners for receiving notifications.
 
@@ -130,7 +130,7 @@ Learning to receive notifications when the list of installed packages changes al
    ```
 
 
-## Related Information
+## Related information
 * Dependencies   
    - Tizen 2.4 and Higher for Mobile
    - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/app-management/widget-info.md
+++ b/docs/application/web/guides/app-management/widget-info.md
@@ -4,10 +4,10 @@ You can manage installed widgets and widget instances in various ways, such as r
 
 This feature is supported in mobile and wearable applications only.
 
-> **Note**  
+> [!NOTE]
 > Do not use "widget" as a name for any of your global variables, as it is the name of a global W3C object.
 
-The main features of the Widget Service API include:
+The main features of the Widget Service API include are as follows:
 
 - Widget retrieval   
 
@@ -22,7 +22,7 @@ The main features of the Widget Service API include:
   You can [manage widget instances](#instance) by changing the instance data update interval and managing the instance content.
 
 <a name="widget"></a>
-## Widget Retrieval
+## Widget retrieval
 
 Using the `WidgetServiceManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/widgetservice.html#WidgetServiceManager) and [wearable](../../api/latest/device_api/wearable/tizen/widgetservice.html#WidgetServiceManager) applications), you can:
 
@@ -30,11 +30,11 @@ Using the `WidgetServiceManager` interface (in [mobile](../../api/latest/device_
 - Receive information about the primary widget ID or size related to the specific size type.
 
 <a name="get_widget"></a>
-### Retrieving a Widget
+### Retrieve a widget
 
 Learning how to retrieve the installed widget list is a basic widget management skill:
 
-1. Define a success handler implementing the `WidgetArraySuccessCallback` interface (in [mobile](../../api/latest/device_api/mobile/tizen/widgetservice.html#WidgetArraySuccessCallback) and [wearable](../../api/latest/device_api/wearable/tizen/widgetservice.html#WidgetArraySuccessCallback) applications). Optionally, you can specify an error handler too.
+1. Define a success handler implementing the `WidgetArraySuccessCallback` interface (in [mobile](../../api/latest/device_api/mobile/tizen/widgetservice.html#WidgetArraySuccessCallback) and [wearable](../../api/latest/device_api/wearable/tizen/widgetservice.html#WidgetArraySuccessCallback) applications). Optionally, you can specify an error handler too:
 
    ```
    var successCallback = function(widgets) {
@@ -46,7 +46,7 @@ Learning how to retrieve the installed widget list is a basic widget management 
    };
    ```
 
-2. To get a list of all installed widgets, use the `getWidgets()` method of the `WidgetServiceManager` interface. If the optional `packageId` parameter is given, only the widgets belonging to the given package are returned.
+2. To get a list of all installed widgets, use the `getWidgets()` method of the `WidgetServiceManager` interface. If the optional `packageId` parameter is given, only the widgets belonging to the given package are returned:
 
    ```
    var packageId = 'org.tizen.contacts';
@@ -60,7 +60,7 @@ Learning how to retrieve the installed widget list is a basic widget management 
    ```
 
 <a name="info"></a>
-### Retrieving ID and Size Information
+### Retrieve ID and size information
 
 Learning how to retrieve the primary widget ID or size makes using the Widget Service API easy and convenient:
 
@@ -77,7 +77,7 @@ Learning how to retrieve the primary widget ID or size makes using the Widget Se
   ```
 
 <a name="management"></a>
-## Widget Management
+## Widget management
 
 Using the `Widget` interface (in [mobile](../../api/latest/device_api/mobile/tizen/widgetservice.html#Widget) and [wearable](../../api/latest/device_api/wearable/tizen/widgetservice.html#Widget) applications), you can:
 
@@ -89,7 +89,7 @@ Using the `Widget` interface (in [mobile](../../api/latest/device_api/mobile/tiz
 <a name="name"></a>
 ### Retrieving the Widget Name
 
-To retrieve the widget name:
+To retrieve the widget name, follow these steps:
 
 1. Retrieve the widget whose name you need:
 
@@ -97,21 +97,21 @@ To retrieve the widget name:
    var myWidget = tizen.widgetservice.getWidget('org.tizen.gallery.widget');
    ```
 
-2. To get the widget name, use the `getName()` method of the `Widget` interface. If the locale parameter is omitted, the system locale is used.
+2. To get the widget name, use the `getName()` method of the `Widget` interface. If the locale parameter is omitted, the system locale is used:
 
    ```
    var name = myWidget.getName('en-us');
    ```
 
 <a name="instances"></a>
-### Retrieving Widget Instances
+### Retrieve widget instances
 
 Learning how to retrieve information about installed widget instances makes the Widget Service API more useful:
 
-> **Note**  
+> [!NOTE]
 > The `WidgetInstance.id` value (in [mobile](../../api/latest/device_api/mobile/tizen/widgetservice.html#WidgetInstance::id) and [wearable](../../api/latest/device_api/wearable/tizen/widgetservice.html#WidgetInstance::id) applications) is volatile and can change after device reboot.
 
-1. Define a success handler implementing the `WidgetInstancesCallback` interface (in [mobile](../../api/latest/device_api/mobile/tizen/widgetservice.html#WidgetInstancesCallback) and [wearable](../../api/latest/device_api/wearable/tizen/widgetservice.html#WidgetInstancesCallback) applications). Optionally, you can specify an error handler too.
+1. Define a success handler implementing the `WidgetInstancesCallback` interface (in [mobile](../../api/latest/device_api/mobile/tizen/widgetservice.html#WidgetInstancesCallback) and [wearable](../../api/latest/device_api/wearable/tizen/widgetservice.html#WidgetInstancesCallback) applications). Optionally, you can specify an error handler too:
 
    ```
    var successCallback = function(instances) {
@@ -130,7 +130,7 @@ Learning how to retrieve information about installed widget instances makes the 
    ```
 
 <a name="variants"></a>
-### Retrieving Widget Variants
+### Retrieve widget variants
 
 To retrieve variants representing all the supported widget size types:
 
@@ -165,7 +165,7 @@ To retrieve variants representing all the supported widget size types:
    ```
 
 <a name="receive"></a>
-### Monitoring Widget Changes
+### Monitor widget changes
 
 Learning to receive notifications when the state of the widget has been changed is a useful widget management skill. There are 4 states that can be noticed: `CREATE`, `DESTROY`, `PAUSE`, and `RESUME`.
 
@@ -196,20 +196,20 @@ Learning to receive notifications when the state of the widget has been changed 
    ```
 
 <a name="instance"></a>
-## Widget Instance Management
+## Widget instance management
 
 Using the `WidgetInstance` interface (in [mobile](../../api/latest/device_api/mobile/tizen/widgetservice.html#WidgetInstance) and [wearable](../../api/latest/device_api/wearable/tizen/widgetservice.html#WidgetInstance) applications), you can:
 
 - Change the update period of the instance using the `changeUpdatePeriod()` method.
 - Send or get content to and from the widget instance.
 
-> **Note**  
+> [!NOTE]
 > These features are not supported by Web widgets. You can only use them in Web applications to manage installed widgets. For more information, see [Web Device API supported by Widget Engine](../../api/latest/wearable_widget/web_widget.html#user-content-web-device-api).
 
 <a name="period"></a>
-### Changing the Update Period
+### Change the update period
 
-To change the update interval for the widget instance:
+To change the update interval for the widget instance, follow these steps:
 
 1. Retrieve the widget instance with the `getInstances()` method:
 
@@ -230,7 +230,7 @@ To change the update interval for the widget instance:
    ```
 
 <a name="content"></a>
-### Sending and Getting Content
+### Send and get content
 
 Learning how to send and get the widget content is a useful widget management skill:
 
@@ -246,13 +246,13 @@ Learning how to send and get the widget content is a useful widget management sk
    myWidget.getInstances(successCallback);
    ```
 
-2. To send data to the widget, use the `sendContent()` method of the `WidgetInstance` interface. The second parameter defines whether the instance is updated even if the provider is paused.
+2. To send data to the widget, use the `sendContent()` method of the `WidgetInstance` interface. The second parameter defines whether the instance is updated even if the provider is paused:
 
    ```
    instance.sendContent(data, true);
    ```
 
-3. To retrieve widget instance content, define a success handler implementing the `WidgetContentCallback` interface (in [mobile](../../api/latest/device_api/mobile/tizen/widgetservice.html#WidgetContentCallback) and [wearable](../../api/latest/device_api/wearable/tizen/widgetservice.html#WidgetContentCallback) applications). Optionally, you can specify an error handler too.
+3. To retrieve widget instance content, define a success handler implementing the `WidgetContentCallback` interface (in [mobile](../../api/latest/device_api/mobile/tizen/widgetservice.html#WidgetContentCallback) and [wearable](../../api/latest/device_api/wearable/tizen/widgetservice.html#WidgetContentCallback) applications). Optionally, you can specify an error handler too:
 
    ```
    var successCallback = function(object) {
@@ -271,7 +271,7 @@ Learning how to send and get the widget content is a useful widget management sk
    ```
 
 
-## Related Information
+## Related information
 * Dependencies   
    - Tizen 3.0 and Higher for Mobile
    - Tizen 2.3.2 and Higher for Wearable

--- a/docs/application/web/guides/cordova/cordova.md
+++ b/docs/application/web/guides/cordova/cordova.md
@@ -37,7 +37,7 @@ You can use the following Cordova features in your Web applications:
 - [Notification Dialogs](./dialogs.md)  
 	You can make different types of input dialog boxes and notifications to the user.
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 3.0 and Higher for Mobile
   - Tizen 3.0 and Higher for Wearable


### PR DESCRIPTION
This PR includes the fix of the following files which are part of the web application guides section of the Tizen Docs site:

File count: 6

/application/web/guides/app-management/common-appcontrols.md
/application/web/guides/app-management/widget-info.md
/application/web/guides/app-management/packages.md
/application/web/guides/app-management/message-port.md
/application/web/guides/app-management/data-control.md
/application/web/guides/cordova/cordova.md


