### PR TITLE
Web application site fix (Part - 08)

### DIFF
--- a/docs/application/web/guides/cordova/console.md
+++ b/docs/application/web/guides/cordova/console.md
@@ -4,7 +4,7 @@ You can write messages to the system console for debugging purposes.
 
 The Console API is mandatory for Tizen Mobile, Wearable, and TV profiles, which means that it is supported on all mobile, wearable, and TV devices. All mandatory APIs are supported on the Tizen emulators.
 
-The main features of the Console API include:
+The main features of the Console API include the following:
 
 - Writing log messages and errors
 
@@ -18,7 +18,7 @@ The main features of the Console API include:
 
   You can [measure the time elapsed during an operation](#measuring-timing).
 
-> **Note**  
+> [!NOTE]
 > To see the message writing results, use the system console in the Tizen Studio or use the `sdb dlog` command.
 
 The global `console` object contains some additional features defined by Cordova.
@@ -38,7 +38,7 @@ function onDeviceReady() {
 
 The `console` global object is available earlier, but it points to a default system console.
 
-## Writing Log Messages and Errors
+## Write log messages and errors
 
 To write simple log and error messages to the system console, use the `log()` and `error()` methods:
 
@@ -47,12 +47,12 @@ console.log('console.log works well');
 console.error('console.error works well');
 ```
 
-> **Note**  
+> [!NOTE]
 > To see the writing results, use the system console available in your Tizen Studio or use the `sdb dlog` command.
 
-## Formatting Objects
+## Format objects
 
-To print a JavaScript representation of a specified object:
+To print a JavaScript representation of a specified object, follow these steps:
 
 - To print without formatting:
 
@@ -68,9 +68,9 @@ To print a JavaScript representation of a specified object:
   console.dir('my object %o', john);
   ```
 
-## Measuring Timing
+## Measure time
 
-To measure the time elapsed during an operation:
+To measure the time elapsed during an operation, follow these steps:
 
 1. Start the timer and give it a label (a string), which is used to identify the timer:
 
@@ -97,7 +97,7 @@ To measure the time elapsed during an operation:
    ```
 
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 3.0 and Higher for Mobile
   - Tizen 3.0 and Higher for Wearable

--- a/docs/application/web/guides/cordova/core.md
+++ b/docs/application/web/guides/cordova/core.md
@@ -22,7 +22,7 @@ Cordova defines a common interface for success and error callbacks:
   - `name`: Short text representing the type of the error
   - `message`: Text containing information about the error
 
-> **Note**  
+> [!NOTE]
 > To perform any Cordova-related operations, you must wait until Cordova is fully set up (the `deviceready` event occurs):
 > ```
 > document.addEventListener('deviceready', onDeviceReady, false);
@@ -35,7 +35,7 @@ Cordova defines a common interface for success and error callbacks:
 
 
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 3.0 and Higher for Mobile
   - Tizen 3.0 and Higher for Wearable

--- a/docs/application/web/guides/cordova/device.md
+++ b/docs/application/web/guides/cordova/device.md
@@ -29,9 +29,9 @@ function onDeviceReady() {
 ```
 
 <a name="loginfo"></a>
-## Accessing Device Properties
+## Access device properties
 
-To retrieve information on the device, Cordova, and operating system, and output it in the system log:
+To retrieve information on the device, Cordova, and operating system, and output it in the system log, follow these steps:
 
 1. Prepare a handler for the `deviceready` event:
 
@@ -56,7 +56,7 @@ To retrieve information on the device, Cordova, and operating system, and output
    ```
 
 
-## Related Information
+## Related information
 * Dependencies   
    - Tizen 3.0 and Higher for Mobile
    - Tizen 3.0 and Higher for Wearable

--- a/docs/application/web/guides/cordova/devicemotion.md
+++ b/docs/application/web/guides/cordova/devicemotion.md
@@ -4,7 +4,7 @@ You can access the [acceleration values](#acceleration-values) from the device a
 
 The Device Motion API is mandatory for Tizen Mobile, Wearable, and TV profiles, which means that it is supported on all mobile, wearable, and TV devices. All mandatory APIs are supported on the Tizen emulators.
 
-The main features of the Device Motion API include:
+The main features of the Device Motion API include the following:
 
 - Getting the current acceleration        
 
@@ -14,7 +14,7 @@ The main features of the Device Motion API include:
 
   You can [get the acceleration along the X, Y, and Z axes at regular intervals](#monitoring-the-acceleration-values).
 
-## Acceleration Values
+## Acceleration values
 
 The acceleration data is captured into the `Acceleration` interface (in [mobile](../../api/latest/device_api/mobile/tizen/cordova/device-motion.html#Acceleration), [wearable](../../api/latest/device_api/wearable/tizen/cordova/device-motion.html#Acceleration), and [TV](../../api/latest/device_api/tv/tizen/cordova/device-motion.html#Acceleration) applications). The acceleration values include the effect of gravity (9.81 m/s2), so that when a device lies flat and facing up, the x, y, and z values returned must be 0, 0, and 9.81.
 
@@ -41,9 +41,9 @@ function onDeviceReady() {
 }
 ```
 
-## Getting the Current Acceleration
+## Get the current acceleration
 
-To get the current acceleration along the X, Y, and Z axes:
+To get the current acceleration along the X, Y, and Z axes, follow these steps:
 
 1. Define a callback method to be invoked with the current acceleration values:
 
@@ -70,9 +70,9 @@ To get the current acceleration along the X, Y, and Z axes:
    navigator.accelerometer.getCurrentAcceleration(onSuccess, onError);
    ```
 
-## Monitoring the Acceleration Values
+## Monitor the acceleration values
 
-To retrieve the acceleration along the X, Y, and Z axes at regular intervals:
+To retrieve the acceleration along the X, Y, and Z axes at regular intervals, follow these steps:
 
 1. Define a callback method to be invoked with the current acceleration values:
 
@@ -115,7 +115,7 @@ To retrieve the acceleration along the X, Y, and Z axes at regular intervals:
    ```
 
 
-## Related Information
+## Related information
 * Dependencies   
    - Tizen 3.0 and Higher for Mobile
    - Tizen 3.0 and Higher for Wearable

--- a/docs/application/web/guides/cordova/events.md
+++ b/docs/application/web/guides/cordova/events.md
@@ -38,7 +38,7 @@ window.onload = function() {
 };
 ```
 
-## Adding Event Listeners
+## Add event listeners
 
 The applications typically use the `document.addEventListener()` method to attach an event listener once the `deviceready` event fires. This means that event listeners for other events (such as `pause`, `resume`, and `backbutton`) are added during or after the `deviceready` event handler:
 
@@ -59,13 +59,13 @@ function onVolumeUp() {
 }
 ```
 
-## Handling Pause and Resume Events
+## Handle pause and resume events
 
 The pause event signals that the application is put into the background. This happens typically when the screen is being locked or when the user switches to a different application. The resume event signals that the application returns from the background to the foreground.
 
 To handle the `pause` and `resume` events:
 
-1. Define the event handlers for the `pause` and `resume` events:
+1. Define the event handlers for the `pause` and `resume` events, follow these steps:
 
    ```
    function onPause() {
@@ -84,7 +84,7 @@ To handle the `pause` and `resume` events:
    document.addEventListener('resume', onResume);
    ```
 
-## Handling Button Press Events
+## Handle button press events
 
 You can add event listeners for specific button press events, as defined in the following table.
 
@@ -102,7 +102,7 @@ You can add event listeners for specific button press events, as defined in the 
 
 Events are triggered when the corresponding button is pressed.
 
-To add event listeners for the menu, volume up, and volume down buttons:
+To add event listeners for the menu, volume up, and volume down buttons, follow these steps:
 
 1. Define the event handlers for the `menubutton`, `volumeupbutton`, and `volumeupbutton` events:
 
@@ -118,7 +118,7 @@ To add event listeners for the menu, volume up, and volume down buttons:
 
 2. In the `deviceready` event handler, [add the listeners](#adding-event-listeners).
 
-   In this example, the same listener is used for both the volume up and down buttons.
+   In this example, the same listener is used for both the volume up and down buttons:
 
    ```
    document.addEventListener('menubutton', onMenuButton);
@@ -128,7 +128,7 @@ To add event listeners for the menu, volume up, and volume down buttons:
 
 When you press the buttons, the result is shown in the system console.
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 3.0 and Higher for Mobile
   - Tizen 3.0 and Higher for Wearable

--- a/docs/application/web/guides/cordova/file.md
+++ b/docs/application/web/guides/cordova/file.md
@@ -4,7 +4,7 @@ You can perform operations on files and directories stored in the device filesys
 
 The File API is mandatory for Tizen Mobile, Wearable, and TV profiles, which means that it is supported on all mobile, wearable, and TV devices. All mandatory APIs are supported on the Tizen emulators.
 
-The main features of the File API include:
+The main features of the File API include the following:
 
 - Resolving the filesystem
 
@@ -28,7 +28,7 @@ The main features of the File API include:
 
 ## Prerequisites
 
-To enable your application to use the file functionality:
+To enable your application to use the file functionality, follow these steps:
 
 1. To perform any Cordova-related operations, you must wait until Cordova is fully set up (the `deviceready` event occurs):
 
@@ -49,9 +49,9 @@ To enable your application to use the file functionality:
    <tizen:privilege name="http://tizen.org/privilege/filesystem.write"/>
    ```
 
-## Resolving Filesystem Entries
+## Resolve filesystem entries
 
-To resolve the initial root for other filesystem operations:
+To resolve the initial root for other filesystem operations, follow these steps:
 
 - Use the `requestFileSystem()` global async method:
 
@@ -67,7 +67,7 @@ To resolve the initial root for other filesystem operations:
       };
       ```
 
-    - Call the method with the created callbacks. The filesystem request can use a temporary or persistent filesystem with a defined size.
+    - Call the method with the created callbacks. The filesystem request can use a temporary or persistent filesystem with a defined size:
 
       ```
       requestFileSystem(TEMPORARY, 1024*1024, successCallback, errorCallback);
@@ -106,9 +106,9 @@ To resolve the initial root for other filesystem operations:
     Entry name example.txt
     ```
 
-## Operating on Directories
+## Operate on directories
 
-To create directories and files, delete directories, and read entries within directories:
+To create directories and files, delete directories, and read entries within directories, follow these steps:
 
 - To create a directory, you can use the `getDirectory()` method:
 
@@ -189,9 +189,9 @@ To create directories and files, delete directories, and read entries within dir
   success
   ```
 
-## Operating on Entries
+## Operate on entries
 
-To move, copy, and delete entries, or access entry metadata, parent information, and URL:
+To move, copy, and delete entries, or access entry metadata, parent information, and URL, follow these steps:
 
 - To look up metadata about an entry, you can use the `getMetadata()` method:
 
@@ -283,7 +283,7 @@ To move, copy, and delete entries, or access entry metadata, parent information,
   });
   ```
 
-  > **Note**  
+  > [!NOTE]
   > You cannot delete a non-empty directory or the filesystem root directory.
 
   The following output is shown in the system log:
@@ -309,9 +309,9 @@ To move, copy, and delete entries, or access entry metadata, parent information,
   URL: file:///home/owner/apps_rw/WfigBlWDyf/tmp/testDirectory/
   ```
 
-## Operating on Files
+## Operate on files
 
-To create files, see [Resolving Filesystem Entries](#resolving-filesystem-entries). To create a writer for a file and access file details:
+To create files, see [Resolving Filesystem Entries](#resolving-filesystem-entries). To create a writer for a file and access file details, follow these steps:
 
 - To create a `FileWriter` object (in [mobile](../../api/latest/device_api/mobile/tizen/cordova/file.html#FileWriter), [wearable](../../api/latest/device_api/wearable/tizen/cordova/file.html#FileWriter), and [TV](../../api/latest/device_api/tv/tizen/cordova/file.html#FileWriter) applications), use the `createWriter()` method:
 
@@ -328,7 +328,7 @@ To create files, see [Resolving Filesystem Entries](#resolving-filesystem-entrie
   created fileWriter object for testFile.txt
   ```
 
-- To access a `File` object (in [mobile](../../api/latest/device_api/mobile/tizen/cordova/file.html#File), [wearable](../../api/latest/device_api/wearable/tizen/cordova/file.html#File), and [TV](../../api/latest/device_api/tv/tizen/cordova/file.html#File) applications), use the `file()` method. The object represents the current state of the file.
+- To access a `File` object (in [mobile](../../api/latest/device_api/mobile/tizen/cordova/file.html#File), [wearable](../../api/latest/device_api/wearable/tizen/cordova/file.html#File), and [TV](../../api/latest/device_api/tv/tizen/cordova/file.html#File) applications), use the `file()` method. The object represents the current state of the file:
 
   ```
   var f; /* Must be a FileEntry object resolved using methods presented before */
@@ -343,9 +343,9 @@ To create files, see [Resolving Filesystem Entries](#resolving-filesystem-entrie
   created file object for example.txt
   ```
 
-## Reading and Writing File Content
+## Read and write file content
 
-To read and write file content:
+To read and write file content, follow these steps:
 
 - To read a file and return the data as a base64-encoded data URL, you can use the `readAsDataURL()` method:
 
@@ -528,7 +528,7 @@ To read and write file content:
   abort
   ```
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 3.0 and Higher for Mobile
   - Tizen 3.0 and Higher for Wearable


### PR DESCRIPTION
This PR includes the fix of the following files which are part of the web application guides section of the Tizen Docs site:

File count: 6

/application/web/guides/cordova/core.md
/application/web/guides/cordova/console.md
/application/web/guides/cordova/device.md
/application/web/guides/cordova/devicemotion.md
/application/web/guides/cordova/events.md
/application/web/guides/cordova/file.md