### PR TITLE
Web application site fix (Part - 15)

### DIFF
--- a/docs/application/web/guides/multimedia/audio.md
+++ b/docs/application/web/guides/multimedia/audio.md
@@ -4,7 +4,7 @@ You can control the volume level of several sound types and get information abou
 
 This feature is supported in mobile and wearable applications only.
 
-The main features of the Sound API include:
+The main features of the Sound API include the following:
 
 - Managing the volume level and sound mode
 
@@ -30,9 +30,9 @@ To use the Sound API (in [mobile](../../api/latest/device_api/mobile/tizen/sound
 <tizen:privilege name="http://tizen.org/privilege/volume.set"/>
 ```
 
-## Managing Volume and Sound Mode
+## Manage volume and sound mode
 
-Managing volume levels and sound modes is a basic multimedia management skill:
+Managing volume levels and sound modes is a basic multimedia management skill, follow these steps to manage volume and sound mode:
 
 1. Get the current volume level using the `getVolume()` method:
 
@@ -55,9 +55,9 @@ Managing volume levels and sound modes is a basic multimedia management skill:
    console.log('Sound Mode is ' + mode);
    ```
 
-## Monitoring Volume and Sound Mode Changes
+## Monitor volume and sound mode changes
 
-Managing volume and sound mode changes is a basic multimedia management skill:
+Managing volume and sound mode changes is a basic multimedia management skill, follow these steps to monitor volume and sound mode:
 
 1. Register the volume change listener to track changes in the volume level:
 
@@ -82,9 +82,9 @@ Managing volume and sound mode changes is a basic multimedia management skill:
    tizen.sound.setSoundModeChangeListener(onsuccessCB);
    ```
 
-## Managing Sound Devices
+## Manage sound devices
 
-Learning how to list connected and activated sound devices allows you to manage sound devices more effectively:
+Learning how to list connected and activated sound devices allows you to manage sound devices more effectively, follow these steps to manage sound devices:
 
 1. Get a list of the current sound devices in a connected state using the `getConnectedDeviceList()` method:
 
@@ -108,7 +108,7 @@ Learning how to list connected and activated sound devices allows you to manage 
    }
    ```
 
-## Monitoring the Sound Device State
+## Monitor the sound device state
 
 Learning how to monitor changes in the sound device state makes it easier for you to manage the sound devices:
 
@@ -138,7 +138,7 @@ Learning how to monitor changes in the sound device state makes it easier for yo
    tizen.sound.removeDeviceStateChangeListener(listenerId);
    ```
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/multimedia/jpeg-exif.md
+++ b/docs/application/web/guides/multimedia/jpeg-exif.md
@@ -4,7 +4,7 @@ You can access and modify EXIF information in a JPEG file (with the common `.jpg
 
 The Exif API is mandatory for Tizen Mobile, Wearable, and TV profiles, which means that it is supported on all mobile, wearable, and TV devices. All mandatory APIs are supported on the Tizen emulators.
 
-The main features of the Exif API include:
+The main features of the Exif API include the following:
 
 - Loading EXIF information
 
@@ -22,11 +22,11 @@ The main features of the Exif API include:
 
   You can [copy EXIF information from one JPEG file to another](#copying-the-exif-data).
 
-## Loading the EXIF Data
+## Load the EXIF data
 
 Learning how to retrieve EXIF data from JPEG files is a useful content management skill:
 
-1. To retrieve the EXIF data from an image file, you need the absolute URI of the file (for example `file:///opt/usr/media/Images/tizen.jpg`). The `tizen.filesystem.resolve()` and `toURI()` methods can be used to convert a virtual path to a URI.
+1. To retrieve the EXIF data from an image file, you need the absolute URI of the file (for example `file:///opt/usr/media/Images/tizen.jpg`). The `tizen.filesystem.resolve()` and `toURI()` methods can be used to convert a virtual path to a URI:
 
    ```
    var fileURI = '';
@@ -42,7 +42,7 @@ Learning how to retrieve EXIF data from JPEG files is a useful content managemen
    tizen.filesystem.resolve('images/tizen.jpg', resolveSuccess, resolveFail);
    ```
 
-2. With a valid `File` object, use the `getExifInfo()` method of the `ExifManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/exif.html#ExifManager), [wearable](../../api/latest/device_api/wearable/tizen/exif.html#ExifManager), and [TV](../../api/latest/device_api/tv/tizen/exif.html#ExifManager) applications) and pass the URI to the method.
+2. With a valid `File` object, use the `getExifInfo()` method of the `ExifManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/exif.html#ExifManager), [wearable](../../api/latest/device_api/wearable/tizen/exif.html#ExifManager), and [TV](../../api/latest/device_api/tv/tizen/exif.html#ExifManager) applications) and pass the URI to the method:
 
    ```
    function onSuccess(exifInfo) {
@@ -58,7 +58,7 @@ Learning how to retrieve EXIF data from JPEG files is a useful content managemen
 
    With a valid `exifInfo` object, you can access various `ExifInformation` attributes (in [mobile](../../api/latest/device_api/mobile/tizen/exif.html#ExifInformation), [wearable](../../api/latest/device_api/wearable/tizen/exif.html#ExifInformation), and [TV](../../api/latest/device_api/tv/tizen/exif.html#ExifInformation) applications), such as width, height, orientation, and flash.
 
-3. To retrieve the EXIF thumbnail from the image:
+3. To retrieve the EXIF thumbnail from the image, follow these steps:
 
    1. Resolve the input JPEG file:
 
@@ -91,7 +91,7 @@ Learning how to retrieve EXIF data from JPEG files is a useful content managemen
       }
       ```
 
-## Adding EXIF Data
+## Add EXIF data
 
 Learning how to add EXIF data to JPEG files is a useful content management skill:
 
@@ -134,13 +134,13 @@ Learning how to add EXIF data to JPEG files is a useful content management skill
    tizen.exif.saveExifInfo(myNewExif, onSaveSuccess, onSaveError);
    ```
 
-## Updating the EXIF Data
+## Update the EXIF data
 
 Learning how to update EXIF data in JPEG files is a useful content management skill:
 
 1. To update the EXIF data, load the `ExifInformation` object (in [mobile](../../api/latest/device_api/mobile/tizen/exif.html#ExifInformation), [wearable](../../api/latest/device_api/wearable/tizen/exif.html#ExifInformation), and [TV](../../api/latest/device_api/tv/tizen/exif.html#ExifInformation) applications) from the file and change the values of the object properties.
 
-   You can remove information from the file by setting the property to `null`.
+   You can remove information from the file by setting the property to `null`:
 
    ```
    function getSuccess(exifInfo) {
@@ -167,7 +167,7 @@ Learning how to update EXIF data in JPEG files is a useful content management sk
    tizen.exif.saveExifInfo(exifInfo, saveSuccess);
    ```
 
-## Copying the EXIF Data
+## Copy the EXIF data
 
 Learning how to copy EXIF data between JPEG files is a useful content management skill:
 
@@ -212,7 +212,7 @@ Learning how to copy EXIF data between JPEG files is a useful content management
    }
    ```
 
-## Related Information
+## Related information
 * Dependencies   
    - Tizen 2.4 and Higher for Mobile
    - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/multimedia/media-controller.md
+++ b/docs/application/web/guides/multimedia/media-controller.md
@@ -2,12 +2,12 @@
 
 You can have your client application communicate with a media server.
 
-To manage the media using the Media Controller API, you have to develop two applications:
+To manage the media using the Media Controller API, you have to develop the following applications:
 
 - Client that sends requests to the server in order to change, for example, the playback state and position modes.
 - Server that directly manages the media on the device.
 
-The main features of the Media Controller API include:
+The main features of the Media Controller API include the following:
 
 - Setting up the client and server pair
 
@@ -78,9 +78,9 @@ To use the Media Controller API (in [mobile](../../api/latest/device_api/mobile/
 <tizen:privilege name="http://tizen.org/privilege/mediacontroller.server"/>
 ```
 
-## Getting Client and Server
+## Get client and server
 
-To manage the media controller features in your application, you must learn to set up the client and server pair:
+To manage the media controller features in your application, you must learn to set up the client and server pair, follow these steps to set up the client and server pair:
 
 1. Create a media controller server using the `createServer()` method:
 
@@ -117,7 +117,7 @@ To manage the media controller features in your application, you must learn to s
    mcClient.findServers(findSuccessCallback, findErrorCallback);
    ```
 
-## Managing Requests
+## Manage requests
 
 To manage the media controller features in your application, you must learn to handle requests from the client to the server:
 
@@ -179,7 +179,7 @@ To manage the media controller features in your application, you must learn to h
    mcServerInfo.playback.sendShuffleMode(true, replyCallback);
    ```
 
-## Setting and Getting Server Icon URI
+## Set and get server icon URI
 
 You can update the icon URI address of a media controller server, which can then be accessed
 from the client application. The default value of the server icon URI attribute is null.
@@ -200,7 +200,7 @@ To use the icon URI attribute in your media controller application, follow these
     console.log(mcServerInfo.iconURI);
     ```
 
-## Receiving Notifications from Server
+## Receive notifications from server
 
 To manage the media controller features in your application, you must learn to receive notifications from the server:
 
@@ -236,9 +236,9 @@ To manage the media controller features in your application, you must learn to r
    mcServerInfo.playback.removePlaybackInfoChangeListener(watcherId);
    ```
 
-## Sending and Receiving Custom Commands
+## Send and receive custom commands
 
-To manage the media controller features in your application, you must learn to send custom commands:
+To manage the media controller features in your application, you must learn to send custom commands, follow these steps to send and receive custom commands:
 
 <a name="send_custom_commands"></a>
 
@@ -294,7 +294,7 @@ To manage the media controller features in your application, you must learn to s
 
       The `watcherId` variable stores the value, which can be used in the future to remove the listener from the server using the `removeCommandListener()` method.
 
-## Sending and Receiving Custom Events
+## Send and receive custom events
 
 Custom command enables the client application to talk to the server application.
 The communication in the opposite direction is done with the help of custom events.
@@ -366,13 +366,13 @@ The communication in the opposite direction is done with the help of custom even
       recipient.sendEvent(eventName, eventData, eventReplyReceived);
       ```
 
-## Sending and Receiving Search Requests from Client to Server
+## Send and receive search requests from client to server
 
 Client application can send search requests, which consist of a collection of search conditions.
 Server listens for the incoming search requests and handles them accordingly.
 After handling a request, server sends a response to the client that sent the request.
 
-### Receiving Search Request
+### Receive search request
 
 To receive and handle search request on the server, follow these steps:
 
@@ -401,7 +401,7 @@ To receive and handle search request on the server, follow these steps:
     mcServer.setSearchRequestListener(searchRequestCallback);
     ```
 
-### Sending Search Request
+### Send search request
 
 To send the search request from the client application, follow these steps:
 
@@ -441,7 +441,7 @@ To send the search request from the client application, follow these steps:
     mcServerInfo.sendSearchRequest(request, searchReplyCallback);
     ```
 
-## Setting Content Type for Currently Playing Media
+## Set content type for currently playing media
 
 Server can set content type for current playback. Client can access this type (read-only)
 and perform some actions that depend on the content-type, such as displaying different icons for
@@ -469,7 +469,7 @@ different types of media items.
     ```
 
 
-## Setting Content Age Rating for Currently Playing Media
+## setting content age rating for currently playing media
 
 Server can set age rating for current playback. Client can access this rating (read-only) and perform some actions such as displaying a warning for underage users.
 
@@ -492,7 +492,7 @@ Server can set age rating for current playback. Client can access this rating (r
     }
     ```
 
-## Managing Playlists on Server Side
+## Manage playlists on server side
 
 To manage the media controller playlists in your server application, you must learn to create, save, and delete playlists.
 
@@ -594,7 +594,7 @@ To manage the media controller playlists in your server application, you must le
    mcServer.playlists.deletePlaylist(playlist.name, deleteSuccess, deleteFailure);
    ```
 
-## Managing Playlists on Client Side
+## Manage playlists on client side
 
 To manage the media controller playlist in your application, you must handle requests from the client to the server:
 
@@ -656,7 +656,7 @@ To manage the media controller playlist in your application, you must handle req
 
         ```
 
-## Media Controller Server Abilities
+## Media controller server abilities
 
 Various abilities can be set to give the information to the clients about the supported features. These abilities can be divided into two groups:
 
@@ -681,7 +681,7 @@ Various abilities can be set to give the information to the clients about the su
     - displayRotation: Setting display orientations.
     - displayMode: Setting display modes.
 
-### Setting Media Controller Server Abilities
+### Set media controller server abilities
 
 You can set the media server abilities as follows:
 
@@ -697,7 +697,7 @@ mcServer.abilities.displayMode.fullScreen = "YES";
 mcServer.abilities.displayRotation.rotation180 = "YES";
 ```
 
-### Checking Media Controller Server Abilities
+### Check media controller server abilities
 
 Using `saveAbilities()` is required to save changes of playback abilities into database, otherwise changes will have no effect on the device and clients will not be notified about an update. Other abilities are updated instantly and there is no need to manually save these abilities.
 
@@ -713,7 +713,7 @@ console.log("ability REWIND: " + mcServerInfo.abilities.playback.rewind);
 console.log("ability FORWARD: " + mcServerInfo.abilities.playback.forward);
 ```
 
-### Monitoring Media Controller Server Abilities
+### Monitor media controller server abilities
 
 You can monitor changes of server abilities using the `addAbilityChangeListener` method on client side. You will also receive the notifications about every ability change on the server side:
 
@@ -767,7 +767,7 @@ After the first use of `subscribe()`, you will stop receiving changes from not s
 You can stop monitoring the specific server, using the analogical `unsubscribe()` method. In case, if no server is subscribed, notifications from all active servers will be sent.
 
 
-## Media Controller Server Features
+## Media controller server features
 
 Media controller API provides the following methods to change and monitor server features:
 - Subtitles
@@ -831,7 +831,7 @@ watcherId = mcServer.displayRotation.addChangeRequestListener(changeListener);
 
 
 
-## Related Information
+## Related information
 - Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 3.0 and Higher for Wearable

--- a/docs/application/web/guides/multimedia/metadata.md
+++ b/docs/application/web/guides/multimedia/metadata.md
@@ -2,7 +2,7 @@
 
 You can extract metadata information from multimedia files. Metadata is the information about multimedia files.
 
-The main features of the Metadata API include:
+The main features of the Metadata API include the following:
 
 - Extracting simple metadata informations
 
@@ -65,7 +65,7 @@ When all the needed metadata is extracted, the file handle needs to be released 
 
 ## Extract artwork
 
-1. Create a file handle using `createFileHandle()`. Ensure your file includes an artwork.
+1. Create a file handle using `createFileHandle()`. Ensure your file includes an artwork:
 
    ```javascript
    var filePath = "music/sample.mp3";
@@ -78,7 +78,7 @@ When all the needed metadata is extracted, the file handle needs to be released 
    var artwork = fileHandle.getArtwork();
    ```
 
-3. Blob object can be easily shown in your application in html *&lt;img&gt;* tag
+3. Blob object can be easily shown in your application in html *&lt;img&gt;* tag:
 
    ```javascript
    var elem = document.getElementById("blobImage");
@@ -89,7 +89,7 @@ When all the needed metadata is extracted, the file handle needs to be released 
 
 ## Extract thumbnail frame
 
-1. Create a file handle using `createFileHandle()` for a video file.
+1. Create a file handle using `createFileHandle()` for a video file:
 
    ```javascript
    var filePath = "videos/sample_video.mp4";
@@ -102,7 +102,7 @@ When all the needed metadata is extracted, the file handle needs to be released 
    var thumbnail = fileHandle.getThumbnailFrame();
    ```
 
-3. Blob object can be easily shown in your application in html *&lt;img&gt;* tag
+3. Blob object can be easily shown in your application in html *&lt;img&gt;* tag:
 
    ```javascript
    var elem = document.getElementById("blobImage");
@@ -113,14 +113,14 @@ When all the needed metadata is extracted, the file handle needs to be released 
 
 ## Extract certain frame
 
-1. Create a file handle using `createFileHandle()` for a video file.
+1. Create a file handle using `createFileHandle()` for a video file:
 
    ```javascript
    var filePath = "videos/sample_video.mp4";
    var fileHandle = tizen.metadata.createFileHandle(filePath);
    ```
 
-2. When the file handle is created, thumbnail frame can be extracted. You need to provide timestamp information (in milliseconds) and a flag indicating accuracy. When the flag value is set to `true`, flag indicates extracting an exact frame for the given time. When the value is `false`, flag indicates extracting an <a href="https://en.wikipedia.org/wiki/Video_compression_picture_types">I-frame</a> nearest to the given time. Gathering nearest I-frame has better performance.
+2. When the file handle is created, thumbnail frame can be extracted. You need to provide timestamp information (in milliseconds) and a flag indicating accuracy. When the flag value is set to `true`, flag indicates extracting an exact frame for the given time. When the value is `false`, flag indicates extracting an [I-frame](https://en.wikipedia.org/wiki/Video_compression_picture_types){:target="_blank"} nearest to the given time. Gathering nearest I-frame has better performance:
 
    ```javascript
    var timestamp = 2000;
@@ -128,7 +128,7 @@ When all the needed metadata is extracted, the file handle needs to be released 
    var frame = fileHandle.getFrameAtTime(timestamp, returnExactFrame);
    ```
 
-3. Blob object can be easily shown in your application in html *&lt;img&gt;* tag
+3. Blob object can be easily shown in your application in html *&lt;img&gt;* tag:
 
    ```javascript
    var elem = document.getElementById("blobImage");
@@ -139,14 +139,14 @@ When all the needed metadata is extracted, the file handle needs to be released 
 
 ## Extract lyrics
 
-1. Create a file handle using `createFileHandle()`. Lyrics need to be included in multimedia file as SYLT metadata tag. Supported formats of encoding are at least <a href="http://www.ietf.org/rfc/rfc2279.txt">UTF-8</a> and <a href="http://en.wikipedia.org/wiki/ISO/IEC_8859-1">ISO-8859-1</a>. Other formats can be ignored depending on the platform.
+1. Create a file handle using `createFileHandle()`. Lyrics need to be included in multimedia file as SYLT metadata tag. Supported formats of encoding are at least [UTF-8](http://www.ietf.org/rfc/rfc2279.txt){:target="_blank"} and [ISO-8859-1](http://en.wikipedia.org/wiki/ISO/IEC_8859-1){:target="_blank"}. Other formats can be ignored depending on the platform:
 
    ```javascript
    var filePath = "music/sample.mp3";
    var fileHandle = tizen.metadata.createFileHandle(filePath);
    ```
 
-2. When the file handle is created, check how many lyrics are included.
+2. When the file handle is created, check how many lyrics are included:
 
    ```javascript
    var lyricsNum = fileHandle.get("SYNCLYRICS_NUM");
@@ -163,7 +163,7 @@ When all the needed metadata is extracted, the file handle needs to be released 
 
 4. After use, release the file handle.
 
-## Related Information
+## Related information
 - Dependencies
   - Tizen 6.0 and Higher for Mobile
   - Tizen 6.0 and Higher for Wearable

--- a/docs/application/web/guides/multimedia/overview.md
+++ b/docs/application/web/guides/multimedia/overview.md
@@ -36,7 +36,7 @@ You can use the following media and camera features in your Web applications:
 
   You can control the device camera by using the camera options. You can capture images and record video.
 
-## Related Information
+## Related information
 - Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/multimedia/player-util.md
+++ b/docs/application/web/guides/multimedia/player-util.md
@@ -4,7 +4,7 @@ You can control the audio latency mode of the W3C player.
 
 This feature is supported in mobile and wearable applications only.
 
-The main features of the Player Util API include:
+The main features of the Player Util API include the following:
 
 - Getting the latency mode
 
@@ -14,7 +14,7 @@ The main features of the Player Util API include:
 
   You can [set the latency mode of the player](#setting-the-latency-mode) with the `setLatencyMode()` method.
 
-## Getting the Current Latency Mode
+## Get the current latency mode
 
 To get the current latency mode, use the `getLatencyMode()` method:
 
@@ -27,7 +27,7 @@ try {
 }
 ```
 
-## Setting the Latency Mode
+## Set the latency mode
 
 To set a new latency mode, use one of the available modes defined in the `LatencyMode` enumerator (in [mobile](../../api/latest/device_api/mobile/tizen/playerutil.html#LatencyMode) and [wearable](../../api/latest/device_api/wearable/tizen/playerutil.html#LatencyMode) applications):
 
@@ -39,7 +39,7 @@ try {
 }
 ```
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable


### PR DESCRIPTION
This PR includes the fix of the following files which are part of the web application guides section of the Tizen Docs site:

File count: 6

/application/web/guides/multimedia/overview.md
/application/web/guides/multimedia/jpeg-exif.md
/application/web/guides/multimedia/metadata.md
/application/web/guides/multimedia/audio.md
/application/web/guides/multimedia/player-util.md
/application/web/guides/multimedia/media-controller.md