### PR TITLE
Web application site fix (Part - 17)

### DIFF
--- a/docs/application/web/guides/connectivity/download.md
+++ b/docs/application/web/guides/connectivity/download.md
@@ -22,7 +22,7 @@ To use the Download API (in [mobile](../../api/latest/device_api/mobile/tizen/do
 <tizen:privilege name="http://tizen.org/privilege/download"/>
 ```
 
-## Managing downloads
+## Manage downloads
 
 To provide the user access to Internet resources, you must learn how to manage download operations through the following steps:
 
@@ -124,7 +124,7 @@ To provide the user access to Internet resources, you must learn how to manage d
       ```
         For any abandoned download operation, the resources are already released. Thus, the download operation cannot be resumed.
 
-## Checking the download state and information
+## Check the download state and information
 
 To provide the user access to Internet resources, you must learn how to check the state of a download operation and retrieve relevant information by following these steps:
 

--- a/docs/application/web/guides/connectivity/nbs.md
+++ b/docs/application/web/guides/connectivity/nbs.md
@@ -5,7 +5,7 @@ You can set a cellular network as a preferred route for Internet connections wit
 
 This feature is supported in mobile applications only.
 
-The main features of the Network Bearer Selection API include:
+The main features of the Network Bearer Selection API include the following:
 
 -   Requesting a route
 
@@ -33,9 +33,9 @@ To use the [Network Bearer Selection](../../api/latest/device_api/mobile/tizen/n
 
 <a name="request"></a>
 
-## Requesting a Route
+## Request a route
 
-To request a preferred route for Internet connection with the "www.tizen.org" host:
+To request a preferred route for Internet connection with the [Tizen](https://www.tizen.org/){:target="_blank"} host, follow these steps:
 
 1.  Define the needed callbacks:
 
@@ -62,9 +62,9 @@ To request a preferred route for Internet connection with the "www.tizen.org" ho
 
 
 <a name="release"></a>
-## Releasing a Route
+## Release a Route
 
-To cancel the routing policy for the connection with the "www.tizen.org" host:
+To cancel the routing policy for the connection with the [Tizen](https://www.tizen.org/){:target="_blank"} host, follow these steps:
 
 1.  Define the needed callbacks:
 
@@ -84,6 +84,6 @@ To cancel the routing policy for the connection with the "www.tizen.org" host:
     tizen.networkbearerselection.releaseRouteToHost('CELLULAR', 'www.tizen.org', onsuccess, onerror);
     ```
 
-## Related Information
+## Related information
 * Dependencies    
     - Tizen 2.4 and Higher for Mobile

--- a/docs/application/web/guides/connectivity/nfc.md
+++ b/docs/application/web/guides/connectivity/nfc.md
@@ -4,7 +4,7 @@ The Near Field Communication (NFC) service enables information exchange between 
 
 This feature is supported in mobile and wearable applications only.
 
-The main features of the NFC API include:
+The main features of the NFC API include the following:
 
 - NFC device management   
 
@@ -37,11 +37,11 @@ NFC provides the following advantages over short-range communication technologie
 - No device pairing requirements
 - Reduction in unwanted interruptions
 
-## NFC Tags and NDEF Messages
+## NFC tags and NDEF messages
 
 An **NFC tag** is a chip which can securely store personal information, such as debit card numbers or contact details. The methods of the `NFCTag` interface (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NFCTag) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NFCTag) applications) are used to access an NFC tag for reading or writing information. NFC tag types are identified using the `type` attribute of the `NFCTagType` type definition (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NFCTagType) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NFCTagType) applications).
 
-> **Note**  
+> [!NOTE]
 > Tizen supports the following NFC tag types: `GENERIC_TARGET`, `ISO14443_A`, `ISO14443_4A`, `ISO14443_3A`, `MIFARE_MINI`, `MIFARE_1K`, `MIFARE_4K`, `MIFARE_ULTRA`, `MIFARE_DESFIRE`, `ISO14443_B`, `ISO14443_4B`, `ISO14443_BPRIME`, `FELICA`, `JEWEL`, `ISO15693`, and `UNKNOWN_TARGET`.
 
 The NFC forum defines the NFC data exchange format (NDEF) for encapsulating the data exchanged between 2 NFC-enabled devices or an NFC-enabled device and an NFC tag. An **NDEF message** can store data in various formats, such as text, Multipurpose Internet Mail Extension (MIME) type object, or ultra-short RagTime Document (RTD). The NFC tags use NDEF for exchanging messages. Tizen provides the `NDEFMessage` interface (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NDEFMessage) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NDEFMessage) applications) to define an NDEF message.
@@ -84,14 +84,14 @@ To use the Application (in [mobile](../../api/latest/device_api/mobile/tizen/app
 <tizen:privilege name="http://tizen.org/privilege/nfc.tag"/>
 ```
 
-## Managing NFC Connectivity
+## Manage NFC connectivity
 
 To use NFC, retrieve the default NFC adapter using the `getDefaultAdapter()` method of the `NFCAdapter` interface (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NFCAdapter) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NFCAdapter) applications).
 
-> **Note**  
+> [!NOTE]
 > The NFC API does not provide methods to directly enable or disable the NFC adapter of the device. When NFC is required, you must request the built-in Settings application to let the user enable or disable NFC.
 
-To enable or disable the NFC service:
+To enable or disable the NFC service, follow these steps:
 
 1. To get the default NFC adapter, use the `getDefaultAdapter()` method and prepare an `ApplicationControl` object (in [mobile](../../api/latest/device_api/mobile/tizen/application.html#ApplicationControl) and [wearable](../../api/latest/device_api/wearable/tizen/application.html#ApplicationControl) applications) to request the NFC switching operation:
 
@@ -142,11 +142,11 @@ To enable or disable the NFC service:
    }
    ```
 
-## Detecting NFC Tags and Peer Devices
+## Detect NFC tags and peer devices
 
 To receive notifications when an NFC tag or peer device has been detected, register event listeners with the `setTagListener()` and `setPeerListener()` methods of the `NFCAdapter` interface (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NFCAdapter) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NFCAdapter) applications). You can use the `NFCTagDetectCallback` (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NFCTagDetectCallback) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NFCTagDetectCallback) applications) and `NFCPeerDetectCallback` (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NFCPeerDetectCallback) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NFCPeerDetectCallback) applications) interfaces to define event handlers for receiving the notifications about attaching and detaching NFC tags and peers, respectively.
 
-To detect NFC tags and peer devices:
+To detect NFC tags and peer devices, follow these steps:
 
 1. To get the default NFC adapter, use the `getDefaultAdapter()` method:
 
@@ -172,7 +172,7 @@ To detect NFC tags and peer devices:
 
 3. Register the listener to use the defined event handlers.
 
-   You can limit the listener to detect only specific NFC tag types by defining the tag types as the second parameter of the `setTagListener()` method. In the following example, only MIFARE tags are detected.
+   You can limit the listener to detect only specific NFC tag types by defining the tag types as the second parameter of the `setTagListener()` method. In the following example, only MIFARE tags are detected:
 
    ```
    /* Defines the tag types to be detected */
@@ -190,15 +190,15 @@ To detect NFC tags and peer devices:
 
 NFC peers are detected similarly as NFC tags, except that the `setPeerListener()` method is used to register the `NFCPeerDetectCallback` listener interface, and the `unsetPeerListener()` method is used to stop the peer detection.
 
-## Handling NDEF Messages
+## Handle NDEF messages
 
 You can handle NDEF messages by first creating NDEF records using the `NDEFRecord` interface (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NDEFRecord) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NDEFRecord) applications), and then adding the records to an NDEF message using the `records` attribute of the `NDEFMessage` interface (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NDEFMessage) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NDEFMessage) applications).
 
-To create NDEF messages:
+To create NDEF messages, follow these steps:
 
 1. To create an NDEF URI record, create an `NDEFRecordURI` interface instance (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NDEFRecordURI) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NDEFRecordURI) applications) and specify the URI parameter.
 
-   Additionally, you can create instances of the `NDEFRecord`, `NDEFRecordText` (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NDEFRecordText) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NDEFRecordText) applications), or `NDEFRecordMedia` (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NDEFRecordMedia) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NDEFRecordMedia) applications) interfaces based on the record type to be created.
+   Additionally, you can create instances of the `NDEFRecord`, `NDEFRecordText` (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NDEFRecordText) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NDEFRecordText) applications), or `NDEFRecordMedia` (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NDEFRecordMedia) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NDEFRecordMedia) applications) interfaces based on the record type to be created:
 
    ```
    var newRecord = new tizen.NDEFRecordURI('https://www.tizen.org/');
@@ -216,17 +216,17 @@ To create NDEF messages:
    newMessage.records[0] = newRecord;
    ```
 
-## Exchanging NDEF Data with Peers
+## Exchange NDEF data with peers
 
 To exchange data between peers, the `setReceiveNDEFListener()` method of the `NFCPeer` interface (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NFCPeer) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NFCPeer) applications) registers an event listener, which triggers an event when an NDEF message is received from a peer.
 
 You can use the `NDEFMessageReadCallback` interface (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NDEFMessageReadCallback) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NDEFMessageReadCallback) applications) to define event handlers for reading NDEF messages from peer devices.
 
-To exchange NDEF messages:
+To exchange NDEF messages, follow these steps:
 
 1. To receive NDEF messages from a peer device, use the `setReceiveNDEFListener()` method of the `NFCPeer` interface.
 
-   The `setReceiveNDEFListener()` method registers the `NDEFMessageReadCallback` listener interface, which is invoked when an NDEF message from a peer device is read.
+   The `setReceiveNDEFListener()` method registers the `NDEFMessageReadCallback` listener interface, which is invoked when an NDEF message from a peer device is read:
 
    ```
    /* NDEFMessageReadCallback listener */
@@ -246,20 +246,20 @@ To exchange NDEF messages:
    Peer.sendNDEF(newMessage);
    ```
 
-> **Note**  
+> [!NOTE]
 > If an application is in the background and uses the `sendNDEF()` method, an error callback is launched. This method can only be used on the foreground.
 
-## Exchanging NDEF Data with Tags
+## Exchange NDEF data with tags
 
 To exchange data between tags, you can read from tags and write to tags using the `readNDEF()` and `writeNDEF()` methods.
 
 You can use the `NDEFMessageReadCallback` interface (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NDEFMessageReadCallback) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NDEFMessageReadCallback) applications) to define event handlers for reading NDEF messages from tags.
 
-To exchange NDEF data with tags:
+To exchange NDEF data with tags, follow these steps:
 
 1. To read data from an NFC tag, use the `readNDEF()` method of the `NFCTag` interface (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NFCTag) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NFCTag) applications).
 
-   The `readNDEF()` method registers the `NDEFMessageReadCallback` listener interface, which is invoked when an NDEF message is read.
+   The `readNDEF()` method registers the `NDEFMessageReadCallback` listener interface, which is invoked when an NDEF message is read:
 
    ```
    /* NDEFMessageReadCallback listener */
@@ -286,14 +286,14 @@ To exchange NDEF data with tags:
 
    You can use the `transceive()` method to transfer raw data as a byte array to an NFC tag without knowing the underlying details of the tag.
 
-> **Note**  
+> [!NOTE]
 > If an application is in the background and uses the `writeNDEF()` or `transceive()` method, an error callback is launched. These methods can only be used on the foreground.
 
-## Using NFC Card Emulation
+## Use NFC card emulation
 
 You can enable NFC card emulation and monitor the secure element transaction taking place using the `NFCAdapter` interface (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NFCAdapter) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NFCAdapter) applications). The secure element transaction is carried out by the device. The Tizen application can detect the transaction, but does not take part in it. Interpreting the transaction data requires knowledge about the data protocol the transaction uses. With the required knowledge, the application can detect whether the transaction was successful.
 
-To enable or disable the NFC card emulation and detect secure element transactions:
+To enable or disable the NFC card emulation and detect secure element transactions, follow these steps:
 
 1. Declare the required variables and obtain the `NFCAdapter` object using the `getDefaultAdapter()` method of the `NFCManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NFCManager) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NFCManager) applications):
 
@@ -344,11 +344,11 @@ To enable or disable the NFC card emulation and detect secure element transactio
    adapter.cardEmulationMode = 'OFF';
    ```
 
-## Using NFC Host-based Card Emulation
+## Use NFC host-based card emulation
 
 You can handle HCE (host-based card emulation) events and transactions taking place using the `NFCAdapter` interface (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NFCAdapter) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NFCAdapter) applications). HCE is an on-device technology that permits a phone to perform card emulation on an NFC-enabled device without relying on access to a secure element. The transaction data is routed to the host application directly, instead of routing to a secure element. The Tizen application can detect the transaction and can take part in it.
 
-To detect NFC HCE events and manage AID (Application ID):
+To detect NFC HCE events and manage AID (Application ID), follow these steps:
 
 1. Specify an `AID` value for receiving HCE transaction events:
 
@@ -415,7 +415,7 @@ To detect NFC HCE events and manage AID (Application ID):
 
 2. Declare the required variables and obtain the `NFCAdapter` object using the `getDefaultAdapter()` method of the `NFCManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/nfc.html#NFCManager) and [wearable](../../api/latest/device_api/wearable/tizen/nfc.html#NFCManager) applications).
 
-   To enable NFC card emulation, change the value of the `cardEmulationMode` attribute.
+   To enable NFC card emulation, change the value of the `cardEmulationMode` attribute:
 
    ```
    var hceListenerId = 0;
@@ -426,7 +426,7 @@ To detect NFC HCE events and manage AID (Application ID):
 
 3. To detect the HCE event, use the `addHCEEventListener()` method of the `NFCAdapter` interface to register a listener.
 
-   Use the `sendHostAPDUResponse()` method of the `NFCAdapter` interface to send a host APDU response to a contactless front-end. (APDU - Application Protocol Data Unit - is defined in the ISO/IEC 7816-4 specification.)
+   Use the `sendHostAPDUResponse()` method of the `NFCAdapter` interface to send a host APDU response to a contactless front-end. (APDU - Application Protocol Data Unit - is defined in the ISO/IEC 7816-4 specification.):
 
    ```
    var successCB = function() {
@@ -496,7 +496,7 @@ To set your application as preferred for HCE events, call the `setPreferredApp()
 
 When an application no longer needs to receive card emulation events, change the routing priority back to the default setting by calling the `unsetPreferredApp()` method.
 
-## NFC Application Control Operations
+## NFC application control operations
 
 You can launch NFC applications based on the NDEF message content using the [application control](../app-management/app-controls.md) functionalities:
 
@@ -595,10 +595,10 @@ The following table lists the NFC operations, URI scheme and MIME.
 	</tbody>
 </table>
 
-\* The `<protocol_code>` and `<scheme>` must be in sync. See [NFCForum-TS-RTD_URI_1.0](http://members.nfc-forum.org/apps/group_public/document.php?document_id=5078) and NFC RTD (Record Type Definition) documentation on the NFC forum.
+\* The `<protocol_code>` and `<scheme>` must be in sync. See [NFCForum-TS-RTD_URI_1.0](https://github.com/haldean/ndef/blob/master/docs/NFCForum-TS-RTD_URI_1.0.pdf){:target="_blank"} and NFC RTD (Record Type Definition) documentation on the NFC forum.
 
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/connectivity/secure-element.md
+++ b/docs/application/web/guides/connectivity/secure-element.md
@@ -4,7 +4,7 @@ You can access secure elements in a device. You can access various secure elemen
 
 This feature is supported in mobile and wearable applications only.
 
-The main features of the Secure Element API include:
+The main features of the Secure Element API include the following:
 
 - Managing secure elements   
 
@@ -30,11 +30,11 @@ To use the Secure Element API (in [mobile](../../api/latest/device_api/mobile/ti
 <tizen:privilege name="http://tizen.org/privilege/secureelement"/>
 ```
 
-## Managing Secure Elements
+## Manage secure elements
 
 To use secure elements in your application, you must learn to retrieve them and track changes in them:
 
-1. To retrieve all the available secure element readers, use the `getReaders()` method of the `SEService` interface (in [mobile](../../api/latest/device_api/mobile/tizen/se.html#SEService) and [wearable](../../api/latest/device_api/wearable/tizen/se.html#SEService) applications). The method registers the `ReaderArraySuccessCallback` interface (in [mobile](../../api/latest/device_api/mobile/tizen/se.html#ReaderArraySuccessCallback) and [wearable](../../api/latest/device_api/wearable/tizen/se.html#ReaderArraySuccessCallback) applications), which is invoked when the list of available secure element readers has been successfully retrieved.
+1. To retrieve all the available secure element readers, use the `getReaders()` method of the `SEService` interface (in [mobile](../../api/latest/device_api/mobile/tizen/se.html#SEService) and [wearable](../../api/latest/device_api/wearable/tizen/se.html#SEService) applications). The method registers the `ReaderArraySuccessCallback` interface (in [mobile](../../api/latest/device_api/mobile/tizen/se.html#ReaderArraySuccessCallback) and [wearable](../../api/latest/device_api/wearable/tizen/se.html#ReaderArraySuccessCallback) applications), which is invoked when the list of available secure element readers has been successfully retrieved:
 
    ```
    function success(readers) {
@@ -79,7 +79,7 @@ To use secure elements in your application, you must learn to retrieve them and 
 
 To use secure elements in your application, you must learn to open sessions and channels:
 
-1. To open a session, use the `openSession()` method of the `Reader` interface (in [mobile](../../api/latest/device_api/mobile/tizen/se.html#Reader) and [wearable](../../api/latest/device_api/wearable/tizen/se.html#Reader) applications). The method registers the `SessionSuccessCallback` interface (in [mobile](../../api/latest/device_api/mobile/tizen/se.html#SessionSuccessCallback) and [wearable](../../api/latest/device_api/wearable/tizen/se.html#SessionSuccessCallback) applications), which is invoked when a session on a specific reader is opened.
+1. To open a session, use the `openSession()` method of the `Reader` interface (in [mobile](../../api/latest/device_api/mobile/tizen/se.html#Reader) and [wearable](../../api/latest/device_api/wearable/tizen/se.html#Reader) applications). The method registers the `SessionSuccessCallback` interface (in [mobile](../../api/latest/device_api/mobile/tizen/se.html#SessionSuccessCallback) and [wearable](../../api/latest/device_api/wearable/tizen/se.html#SessionSuccessCallback) applications), which is invoked when a session on a specific reader is opened:
 
    ```
    function successCB(session) {
@@ -94,7 +94,7 @@ To use secure elements in your application, you must learn to open sessions and 
 
 2. To open a channel within a session:
 
-   1. Open a basic channel with the `openBasicChannel()` method of the `Session` interface (in [mobile](../../api/latest/device_api/mobile/tizen/se.html#Session) and [wearable](../../api/latest/device_api/wearable/tizen/se.html#Session) applications). The method registers the `ChannelSuccessCallback` interface (in [mobile](../../api/latest/device_api/mobile/tizen/se.html#ChannelSuccessCallback) and [wearable](../../api/latest/device_api/wearable/tizen/se.html#ChannelSuccessCallback) applications), which is invoked when a channel is opened to communicate with a specific applet.
+   1. Open a basic channel with the `openBasicChannel()` method of the `Session` interface (in [mobile](../../api/latest/device_api/mobile/tizen/se.html#Session) and [wearable](../../api/latest/device_api/wearable/tizen/se.html#Session) applications). The method registers the `ChannelSuccessCallback` interface (in [mobile](../../api/latest/device_api/mobile/tizen/se.html#ChannelSuccessCallback) and [wearable](../../api/latest/device_api/wearable/tizen/se.html#ChannelSuccessCallback) applications), which is invoked when a channel is opened to communicate with a specific applet:
 
       ```
       function successCB(channel) {
@@ -112,17 +112,17 @@ To use secure elements in your application, you must learn to open sessions and 
       session.openBasicChannel([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe], successCB, errorCB);
       ```
 
-   2. Open a logical channel with the `openLogicalChannel()` method of the `Session` interface. As with a basic channel, the method registers the `ChannelSuccessCallback` interface.
+   2. Open a logical channel with the `openLogicalChannel()` method of the `Session` interface. As with a basic channel, the method registers the `ChannelSuccessCallback` interface:
 
       ```
       session.openLogicalChannel([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe], successCB, errorCB);
       ```
 
-## Transmitting APDUs to Secure Elements
+## Transmit APDUs to secure elements
 
 To use secure elements in your application, you must learn to transmit application protocol data units (APDU) to secure elements:
 
-1. To transmit an APDU command to a secure element, use the `transmit()` method of the `Channel` interface (in [mobile](../../api/latest/device_api/mobile/tizen/se.html#Channel) and [wearable](../../api/latest/device_api/wearable/tizen/se.html#Channel) applications).
+1. To transmit an APDU command to a secure element, use the `transmit()` method of the `Channel` interface (in [mobile](../../api/latest/device_api/mobile/tizen/se.html#Channel) and [wearable](../../api/latest/device_api/wearable/tizen/se.html#Channel) applications):
 
    ```
    /* APDU command is defined in ISO7816-4 */
@@ -140,7 +140,7 @@ To use secure elements in your application, you must learn to transmit applicati
    }
    ```
 
-## Closing Sessions and Channels
+## Closing sessions and channels
 
 To use secure elements in your application, you must learn to close sessions and channels:
 
@@ -169,7 +169,7 @@ To use secure elements in your application, you must learn to close sessions and
    ```
 
 
-## Related Information
+## Related information
 * Dependencies   
    - Tizen 2.4 and Higher for Mobile
    - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/messaging/messages.md
+++ b/docs/application/web/guides/messaging/messages.md
@@ -6,7 +6,7 @@ This feature is supported in mobile applications only.
 
 The messaging process used in HTML5 involves Uniform Resource Identifiers (URIs), which form values of attributes, such as `tel`, `mailto`, and `sms`. These attributes invoke external services which then perform the messaging tasks. The Messaging API minimizes your coding efforts by providing one-step capabilities to perform all high-level messaging-related operations.
 
-The main features of the Messaging API include:
+The main features of the Messaging API include the following:
 
 - Message writing and sending   
 
@@ -39,16 +39,16 @@ To use the [Messaging](../../api/latest/device_api/mobile/tizen/messaging.html) 
 <tizen:privilege name="http://tizen.org/privilege/messaging.write"/>
 ```
 
-## Creating and Sending Messages
+## Create and send messages
 
 You can create a message by using the [Message](../../api/latest/device_api/mobile/tizen/messaging.html#Message) object constructor, and you can set the message attributes and parameters using a [MessageInit](../../api/latest/device_api/mobile/tizen/messaging.html#MessageInit) object (for example, you can set the message service type - SMS, MMS or email - by using the `type` parameter).
 
-> **Note**  
+> [!NOTE]
 > The system assigns a unique read-only message ID to each message the first time it is processed, such as when sending it or creating a draft message for it.
 
-To create and send messages:
+To create and send messages, follow these steps:
 
-1. Retrieve the messaging service using the `getMessageServices()` method. The first parameter specifies the type of the messaging service to retrieve. There are 3 possible types: "messaging.sms", "messaging.mms" and "messaging.email". In the following example, the SMS service is retrieved.
+1. Retrieve the messaging service using the `getMessageServices()` method. The first parameter specifies the type of the messaging service to retrieve. There are 3 possible types: "messaging.sms", "messaging.mms" and "messaging.email". In the following example, the SMS service is retrieved:
 
    ```
    function errorCallback(error) {
@@ -60,7 +60,7 @@ To create and send messages:
 
 2. In the success callback of the `getMessageServices()` method, use the `Message` interface to define the content and attributes of the message, and then send the message using the `sendMessage()` method of the [MessageService](../../api/latest/device_api/mobile/tizen/messaging.html#MessageService) interface. The `sendMessage()` method requires both success and error event handlers. Depending on the result of the sending operation, the message is moved to the device's Sent Items or Drafts folder, and additionally stored in the message storage database.
 
-   If the message is not ready to be sent yet, save the message draft using the `addDraftMessage()` method of the [MessageStorage](../../api/latest/device_api/mobile/tizen/messaging.html#MessageStorage) interface.
+   If the message is not ready to be sent yet, save the message draft using the `addDraftMessage()` method of the [MessageStorage](../../api/latest/device_api/mobile/tizen/messaging.html#MessageStorage) interface:
 
    ```
    function onAddSuccess() {
@@ -88,7 +88,7 @@ To create and send messages:
 
    If sending MMS or email messages with attachments, add the attachments as an array of [MessageAttachment](../../api/latest/device_api/mobile/tizen/messaging.html#MessageAttachment) objects with the file path and the MIME type (`image/png`, `text/pdf`, or `text/html`) defined for each object.
 
-   Assign the array to the `attachments` attribute of the `Message` object.
+   Assign the array to the `attachments` attribute of the `Message` object:
 
    ```
    var msg = new tizen.Message('messaging.email');
@@ -98,7 +98,7 @@ To create and send messages:
 
 3. Define the message sending success callback that is called if the message is sent successfully. (For email, that means that the message is sent to the email delivery system, not to the final recipient of the message.)
 
-   For messaging technologies, such as SMS, where the message is sent individually to every message recipient, the success callback must be invoked individually for each recipient.
+   For messaging technologies, such as SMS, where the message is sent individually to every message recipient, the success callback must be invoked individually for each recipient:
 
    ```
    function messageSent(recipients) {
@@ -110,13 +110,13 @@ To create and send messages:
 
    Defining a sending error callback allows you to handle all possible errors and exceptions that can occur causing the message delivery to fail.
 
-## Selecting the SIM Card for Sending Messages
+## Select the SIM card for sending messages
 
 If there are multiple SIM cards in the device, by default the system determines which one is used to send a message. You can also specify the SIM card when sending an SMS.
 
 To add the dual SIM feature to your messaging application, you must learn to retrieve information on available SIM cards and select the SIM card to send SMS and MMS messages:
 
-1. To check how many SIM cards are available, call the `getCount()` method of the [SystemInfo](../../api/latest/device_api/mobile/tizen/systeminfo.html#SystemInfo) interface.
+1. To check how many SIM cards are available, call the `getCount()` method of the [SystemInfo](../../api/latest/device_api/mobile/tizen/systeminfo.html#SystemInfo) interface:
 
    ```
    var count = tizen.systeminfo.getCount('SIM');
@@ -157,13 +157,13 @@ To add the dual SIM feature to your messaging application, you must learn to ret
    tizen.messaging.getMessageServices('messaging.sms', serviceSuccess);
    ```
 
-## Managing Messages
+## Manage messages
 
 You can find, update, and delete stored messages with methods provided by the [MessageStorage](../../api/latest/device_api/mobile/tizen/messaging.html#MessageStorage) interface: `findMessages()`, `updateMessages()`, and `removeMessages()`. The interface allows you to manage message storages.
 
-To work with messages in the message store:
+To work with messages in the message store, follow these steps:
 
-1. Retrieve messages whose sender is "me" from the message storage using the `findMessages()` method of the `MessageStorage` interface .
+1. Retrieve messages whose sender is "me" from the message storage using the `findMessages()` method of the `MessageStorage` interface:
 
    When searching for messages, you can create [attribute filters](../data/data-filter.md#creating-attribute-filters), [attribute range filters](../data/data-filter.md#creating-attribute-range-filters), and [composite filters](../data/data-filter.md#creating-composite-filters) based on [specific filter attributes](../data/data-filter.md#messaging-filter-attributes). You can also [sort the search results](../data/data-filter.md#using-sorting-modes).
 
@@ -185,7 +185,7 @@ To work with messages in the message store:
 
 2. To update a message in the message storage, use the `updateMessages()` method. The method uses an array of `Message` objects found previously by the `findMessages()` method as a parameter.
 
-   In the following example, the `isRead` attribute of the first `Message` object in the given array is updated to `true`.
+   In the following example, the `isRead` attribute of the first `Message` object in the given array is updated to `true`:
 
    ```
    function successCallback() {
@@ -206,9 +206,9 @@ To work with messages in the message store:
    }
    ```
 
-## Finding Folders
+## Find folders
 
-To find message folders, use the `findFolders()` method of the [MessageStorage](../../api/latest/device_api/mobile/tizen/messaging.html#MessageStorage) interface:
+To find message folders, use the `findFolders()` method of the [MessageStorage](../../api/latest/device_api/mobile/tizen/messaging.html#MessageStorage) interface, follow these steps:
 
 1. To retrieve the messaging service, use the `getMessageServices()` method of the [Messaging](../../api/latest/device_api/mobile/tizen/messaging.html#Messaging) interface:
 
@@ -251,15 +251,15 @@ To find message folders, use the `findFolders()` method of the [MessageStorage](
    service.messageStorage.findFolders(filter, onFindFolders, onFindFoldersFail);
    ```
 
-## Synchronizing with the Server
+## Synchronize with the server
 
 To keep your email service accounts up-to-date, synchronize them with their respective external servers, such as Gmail and Microsoft Exchange, with the `sync()` method. You can also synchronize a single folder, such as the Inbox, with the `syncFolder()` method. You can specify the maximum number of messages that can be retrieved in each folder.
 
 It is possible that an email message is accessible through the [Message](../../api/latest/device_api/mobile/tizen/messaging.html#Message) object, but its full body or attachment has not been downloaded yet. You can load email messages and attachments from the email service with the `loadMessageBody()` and `loadMessageAttachment()` methods of the [MessageService](../../api/latest/device_api/mobile/tizen/messaging.html#MessageService) interface.
 
-To load email messages and attachments and synchronize email:
+To load email messages and attachments and synchronize email, follow these steps:
 
-1. Retrieve the messaging service using the `getMessageServices()` method.
+1. Retrieve the messaging service using the `getMessageServices()` method:
 
    ```
    tizen.messaging.getMessageServices('messaging.email', serviceListCB, errorCallback);
@@ -293,7 +293,7 @@ To load email messages and attachments and synchronize email:
    }
    ```
 
-5. To synchronize email with an external server:
+5. To synchronize email with an external server, follow these steps:
 
    1. To synchronize all account folders, use the `sync()` method:
 
@@ -307,7 +307,7 @@ To load email messages and attachments and synchronize email:
       tizen.messaging.getMessageServices('messaging.email', servicesListSuccessCB);
       ```
 
-   2. To synchronize a specific folder, use the `syncFolder()` method. In the following example, only folders containing "INBOX" in their name are synchronized.
+   2. To synchronize a specific folder, use the `syncFolder()` method. In the following example, only folders containing "INBOX" in their name are synchronized:
 
       ```
       var emailService; /* Assume email service is initialized */
@@ -332,13 +332,13 @@ To load email messages and attachments and synchronize email:
       emailService.messageStorage.findFolders(filter, folderQueryCallback));
       ```
 
-## Receiving Notifications on Message Storage Changes
+## Receive notifications on message storage changes
 
 You can register event listeners to monitor changes in the message storage, a particular conversation, or a particular message folder.
 
 The `addMessagesChangeListener()`, `addConversationsChangeListener()`, and `addFoldersChangeListener()` methods of the [MessageStorage](../../api/latest/device_api/mobile/tizen/messaging.html#MessageStorage) interface register an event listener, which starts asynchronously once the method returns the subscription identifier for the listener. You can use the [MessagesChangeCallback](../../api/latest/device_api/mobile/tizen/messaging.html#MessagesChangeCallback), [MessageConversationsChangeCallback](../../api/latest/device_api/mobile/tizen/messaging.html#MessageConversationsChangeCallback), and [MessageFoldersChangeCallback](../../api/latest/device_api/mobile/tizen/messaging.html#MessageFoldersChangeCallback) interfaces to define listener event handlers for receiving notifications about the changes.
 
-To receive notifications when messages and message folders are added, updated, or removed:
+o receive notifications when messages and message folders are added, updated, or removed, follow these steps:
 
 1. Define the needed variable:
 
@@ -380,10 +380,10 @@ To receive notifications when messages and message folders are added, updated, o
    msgService.messageStorage.removeChangeListener(watchId);
    ```
 
-> **Note**  
+> [!NOTE]
 > To provide notifications for changes in specific conversations or message folders, use the applicable methods and event handlers similarly as above.
 
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.4 and Higher for Mobile

--- a/docs/application/web/guides/messaging/overview.md
+++ b/docs/application/web/guides/messaging/overview.md
@@ -12,7 +12,7 @@ You can use the following messaging features in your Web applications:
 
   The application can receive push notifications from a push server. You can register your application and connect to the push service, to be ready to receive push notifications when they arrive.
 
-## Related Information
+## Related information
 * Dependencies  
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable


### PR DESCRIPTION
This PR includes the fix of the following files which are part of the web application guides section of the Tizen Docs site:

File count: 6

/application/web/guides/connectivity/nfc.md
/application/web/guides/connectivity/secure-element.md
/application/web/guides/connectivity/download.md
/application/web/guides/connectivity/nbs.md
/application/web/guides/messaging/overview.md
/application/web/guides/messaging/messages.md