### PR TITLE
Web application site fix (Part - 18)

### DIFF
--- a/docs/application/web/guides/messaging/push.md
+++ b/docs/application/web/guides/messaging/push.md
@@ -8,7 +8,7 @@ Push notification helps your application server send data to your application on
 
 If a push message arrives when the application is running, the message is automatically delivered to the application. If the application is not running, the push service makes a sound or vibrates and adds a ticker or a badge notification to notify the user. By touching this notification, the user can check the message. If the application server sends a message with a `LAUNCH` option, the push service forcibly launches the application and hands over the message to the application.
 
-The main features of the Push API include:
+The main features of the Push API include the following:
 
 - Registering to the push service   
 
@@ -30,7 +30,7 @@ The main features of the Push API include:
 
   The push service implements the RESTful open API for sending a push message. For more information on sending push notifications, see [Push Server](../../../native/guides/messaging/push-server.md).
 
-> **Note**  
+> [!NOTE]
 > Remember about security issues when sending notifications with sensitive information. For a list of strongly recommended rules, see [Managing Security](../../../native/guides/messaging/push.md#managing-security).
 
 ## Architecture
@@ -41,7 +41,7 @@ The architecture of the Tizen Push service is described in detail in the [mobile
 
 ![Service architecture](./media/push-overview.png)
 
-To receive push notifications for your application:
+To receive push notifications for your application, follow these steps:
 
 1. Request permission to access the Tizen push servers for using the push service API.
 2. Wait for a confirmation email for the request.
@@ -51,7 +51,7 @@ To receive push notifications for your application:
 
 ## Prerequisites
 
-To enable your application to use the push functionality:
+To enable your application to use the push functionality, follow these steps:
 
 1. To use the Push API (in [mobile](../../api/latest/device_api/mobile/tizen/push.html), [wearable](../../api/latest/device_api/wearable/tizen/push.html), and [TV](../../api/latest/device_api/tv/tizen/push.html) applications), the application has to request permission by adding the following privilege to the `config.xml` file:
 
@@ -73,12 +73,12 @@ To enable your application to use the push functionality:
 
       To use the push messaging service, the application needs permission to access the Tizen push server. Request permission from the Tizen push service team using one of the following online request forms:
 
-      - [Request permission for a new application](https://developer.tizen.org/webform/request-permission-tizen-push-service)
-      - [Extend the expiration date or change the quota](https://developer.tizen.org/webform/request-extend-expiration-date-or-change-quota) for an application that already has permission to use the push messaging service
+      - [Request permission for a new application](https://developer.tizen.org/webform/request-permission-tizen-push-service){:target="_blank"}.
+      - [Extend the expiration date or change the quota](https://developer.tizen.org/webform/request-extend-expiration-date-or-change-quota){:target="_blank"} for an application that already has permission to use the push messaging service
 
       When the team approves the request, you receive a push app ID corresponding to your package ID.
 
-## Registering to the Push Service
+## Register to the push service
 
 To receive push notifications, you must learn how to register your application to the push service:
 
@@ -104,7 +104,7 @@ To receive push notifications, you must learn how to register your application t
      }
      ```
 
-  2. Register the application for the service with the `register()` method. This operation has to be done only once.
+  2. Register the application for the service with the `register()` method. This operation has to be done only once:
 
      ```
      /* Request application registration */
@@ -113,7 +113,7 @@ To receive push notifications, you must learn how to register your application t
 
 - Since Tizen 3.0:
 
-  Before registering, you must connect to the push service:
+  Before registering, you must connect to the push service, follow these steps to connect to the push service:
 
   1. Define event handlers:
 
@@ -144,7 +144,7 @@ To receive push notifications, you must learn how to register your application t
      }
      ```
 
-  2. Connect to the push service with the `connect()` method. The `register()` method is called in the `stateChangeCallback()` callback. This operation has to be done only once.
+  2. Connect to the push service with the `connect()` method. The `register()` method is called in the `stateChangeCallback()` callback. This operation has to be done only once:
 
      ```
      /* Connect to push service */
@@ -162,7 +162,7 @@ if (registrationId != null) {
 
 Since Tizen 3.0, you must connect to the push service before getting the registration ID.
 
-## Receiving Push Notifications
+## Receive push notifications
 
 You can connect to the push service and start receiving push notifications with the `connectService()` method up to Tizen 2.4, or with the `connect()` method since Tizen 3.0. Up to Tizen 2.4, you must pass the `PushNotificationCallback` listener (in [mobile](../../api/latest/device_api/mobile/tizen/push.html#PushNotificationCallback) and  [wearable](../../api/latest/device_api/wearable/tizen/push.html#PushNotificationCallback) applications) as a parameter in the method to receive push notifications. Since Tizen 3.0, you must pass the `PushRegistrationStateChangeCallback` (in [mobile](../../api/latest/device_api/mobile/tizen/push.html#PushRegistrationStateChangeCallback), [wearable](../../api/latest/device_api/wearable/tizen/push.html#PushRegistrationStateChangeCallback), and [TV](../../api/latest/device_api/tv/tizen/push.html#PushRegistrationStateChangeCallback) applications) and `PushNotificationCallback` callbacks (in [mobile](../../api/latest/device_api/mobile/tizen/push.html#PushNotificationCallback), [wearable](../../api/latest/device_api/wearable/tizen/push.html#PushNotificationCallback), and [TV](../../api/latest/device_api/tv/tizen/push.html#PushNotificationCallback) applications) as parameters in the method. The first callback is called when the registration change state changes. This callback is called at least once, just after the connection is established. The second callback is called when notification messages arrive. You can also pass the `ErrorCallback` as a parameter to be called if the connection request fails.
 
@@ -174,7 +174,7 @@ When a notification arrives at the device, its delivery mechanism depends on whe
 
 - When the application is not running    
 
-  If the notification arrives when the application is not running, there are 3 ways to handle the notification:
+  If the notification arrives when the application is not running, these are the 3 ways to handle the notification:
 
   - Forcibly launch the application and deliver the notification to it.        
 
@@ -196,7 +196,7 @@ When a notification arrives at the device, its delivery mechanism depends on whe
 
 To take advantage of the push technology, you must learn how to connect to the push service and receive push notifications:
 
-1. Define the event handlers for the push connection. The push notifications are delivered in the success event handler.
+1. Define the event handlers for the push connection. The push notifications are delivered in the success event handler:
 
    ```
    function errorCallback(response) {
@@ -258,9 +258,9 @@ tizen.push.disconnect();
 
 To learn how send a simple push notification to the device, see [Sending Push Notifications](../../../native/guides/messaging/push.md#sending-push-notifications). For advanced features in sending notifications, see the [Push Server](../../../native/guides/messaging/push-server.md) guide for server developers.
 
-## Retrieving Missed Push Messages
+## Retrieve missed push messages
 
-While the application is not running, messages cannot be delivered. To retrieve such missed push messages:
+While the application is not running, messages cannot be delivered. Follow these steps to retrieve such missed push messages:
 
 - Up to Tizen 2.4:
 
@@ -319,9 +319,9 @@ While the application is not running, messages cannot be delivered. To retrieve 
 
 The notification callback passed to the `connectService()` (up to Tizen 2.4) or `connect()` (since Tizen 3.0) method is called for every unread message.
 
-## Handling a Launch by the Push Service
+## Handle a launch by the push service
 
-If the application is launched by the push service, determine the reason for the application launch and react to it appropriately:
+If the application is launched by the push service, follow these steps to determine the reason for the application launch and react to it appropriately:
 
 1. Get the requested application control with the `getRequestedAppControl()` method:
 
@@ -329,7 +329,7 @@ If the application is launched by the push service, determine the reason for the
    var requestedAppControl = tizen.application.getCurrentApplication().getRequestedAppControl().appControl;
    ```
 
-2. Determine the reason for the application launch. If the reason for the launch is a notification, retrieve the latest push message.
+2. Determine the reason for the application launch. If the reason for the launch is a notification, retrieve the latest push message:
 
    ```
    for (var i = 0; i < requestedAppControl.data.length; ++i) {
@@ -353,11 +353,11 @@ If the application is launched by the push service, determine the reason for the
    }
    ```
 
-## Retrieving Messages When Launched by the Push Service
+## Retrieve messages when launched by the push service
 
 If the application is launched by the push service due to a notification, use the `getPushMessage()` method to return the last undelivered push message. If none exists, the method returns `NULL`.
 
-To retrieve and read the last message:
+To retrieve and read the last message, follow these steps:
 
 1. Retrieve the message:
 
@@ -380,7 +380,7 @@ To retrieve and read the last message:
    }
    ```
 
-## Related Information
+## Related information
 * Dependencies   
    - Tizen 2.4 and Higher for Mobile
    - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/sensors/device-sensors.md
+++ b/docs/application/web/guides/sensors/device-sensors.md
@@ -4,7 +4,7 @@ You can access and manage sensor data from [various sensors on the device](#supp
 
 This feature is supported in mobile and wearable applications only.
 
-The main features of the Sensor API include:
+The main features of the Sensor API include the following:
 
 - Managing sensors
 
@@ -18,9 +18,9 @@ The main features of the Sensor API include:
 
   You can [retrieve information about the technical limits of the sensor](#obtaining-sensor-hardware-information).
 
-## Managing Sensors
+## Manage sensors
 
-Learning how to start, read and stop a sensor is a basic sensor management skill:
+Learning how to start, read and stop a sensor is a basic sensor management skill, follow these steps to manage sensors:
 
 <a name="support"></a>
 1. Check that the sensor is supported by the device using the `getCapability()` method of the `SystemInfo` interface (in [mobile](../../api/latest/device_api/mobile/tizen/systeminfo.html#SystemInfo) and [wearable](../../api/latest/device_api/wearable/tizen/systeminfo.html#SystemInfo) applications) for the proper [capability](#capability) related to the sensor:
@@ -77,7 +77,7 @@ Learning how to start, read and stop a sensor is a basic sensor management skill
    proximitySensor.stop();
    ```
 
-## Receiving Notifications on Sensor Data Changes
+## Receive notifications on sensor data changes
 
 Learning how to register a change event handler for sensor data enables your application to react to changes without the need to check current values constantly:
 
@@ -91,9 +91,9 @@ Learning how to register a change event handler for sensor data enables your app
 
 2. Register a change listener to be called when the sensor data changes.
 
-   To register a  change listener, use the `setChangeListener()` method of the `Sensor` interface (in [mobile](../../api/latest/device_api/mobile/tizen/sensor.html#Sensor) and [wearable](../../api/latest/device_api/wearable/tizen/sensor.html#Sensor) applications).
+   To register a  change listener, use the `setChangeListener()` method of the `Sensor` interface (in [mobile](../../api/latest/device_api/mobile/tizen/sensor.html#Sensor) and [wearable](../../api/latest/device_api/wearable/tizen/sensor.html#Sensor) applications):
 
-   This command requires 3 parameters:
+   This command requires the following 3 parameters:
 
    - The first one is a handle to the callback method, which is invoked for every incoming event.
    - The second determines the amount of time (in milliseconds) passing between 2 consecutive events. Valid values are integers from 10 to 1000, inclusively. For example, the value 100 results in approximately 10 events being send every second.
@@ -132,17 +132,17 @@ Learning how to register a change event handler for sensor data enables your app
    lightSensor.start(onsuccessCB);
    ```
 
-3. To stop receiving notifications on sensor data changes, use the `unsetChangeListener()` method of the Sensor interface.
+3. To stop receiving notifications on sensor data changes, use the `unsetChangeListener()` method of the Sensor interface:
 
    ```
    lightSensor.unsetChangeListener();
    ```
 
-## Obtaining Sensor Hardware Information
+## Obtain sensor hardware information
 
 Learning how to retrieve information about the sensor hardware enables your application to know the sensor's technical limits:
 
-1. Define a success callback for handling a `SensorHardwareInfo` object (in [mobile](../../api/latest/device_api/mobile/tizen/sensor.html#SensorHardwareInfo) and [wearable](../../api/latest/device_api/wearable/tizen/sensor.html#SensorHardwareInfo) applications). You can also define an optional error callback.
+1. Define a success callback for handling a `SensorHardwareInfo` object (in [mobile](../../api/latest/device_api/mobile/tizen/sensor.html#SensorHardwareInfo) and [wearable](../../api/latest/device_api/wearable/tizen/sensor.html#SensorHardwareInfo) applications). You can also define an optional error callback:
 
    ```
    function onsuccessCB(hwInfo) {
@@ -170,7 +170,7 @@ Learning how to retrieve information about the sensor hardware enables your appl
    ```
 
 <a name="capability"></a>
-## Supported Sensors
+## Supported sensors
 
 The following table lists the sensor capabilities you can use to [determine whether a specific sensor is supported](#support) on a device.
 
@@ -195,7 +195,7 @@ The following table lists the sensor capabilities you can use to [determine whet
 | Proximity sensor                         | `http://tizen.org/feature/sensor.proximity` |
 | Ultraviolet sensor                       | `http://tizen.org/feature/sensor.ultraviolet` |
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/sensors/ham.md
+++ b/docs/application/web/guides/sensors/ham.md
@@ -4,7 +4,7 @@ You can access and record human activity data from various [sensors](#supported-
 
 This feature is supported in mobile and wearable applications only.
 
-The main features of the Human Activity Monitor API include:
+The main features of the Human Activity Monitor API include the following:
 
 - Retrieving data
 
@@ -35,7 +35,7 @@ To use the Human Activity Monitor API (in [mobile](../../api/latest/device_api/m
 <tizen:privilege name="http://tizen.org/privilege/location"/>
 ```
 
-## Retrieving Data
+## Retrieve data
 
 Enabling the monitor and retrieving data is a basic Human Activity Monitor (HAM) management skill:
 
@@ -96,9 +96,9 @@ Enabling the monitor and retrieving data is a basic Human Activity Monitor (HAM)
    tizen.humanactivitymonitor.stop('HRM');
    ```
 
-## Managing Data Recording
+## Manage data record
 
-The Human Activity Monitor API allows you to record and retrieve saved sensor data:
+The Human Activity Monitor API allows you to record and retrieve saved sensor data, , follow these steps to record and retrieve saved sensor data:
 
 1. To check whether a sensor is supported, use the `getCapability()` method of the `SystemInfo` interface (in [mobile](../../api/latest/device_api/mobile/tizen/systeminfo.html#SystemInfo) and [wearable](../../api/latest/device_api/wearable/tizen/systeminfo.html#SystemInfo) applications):
 
@@ -110,7 +110,7 @@ The Human Activity Monitor API allows you to record and retrieve saved sensor da
    }
    ```
 
-2. To enable data recording, use the `startRecorder()` method of the `HumanActivityMonitorManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/humanactivitymonitor.html#HumanActivityMonitorManager) and [wearable](../../api/latest/device_api/wearable/tizen/humanactivitymonitor.html#HumanActivityMonitorManager) applications). Optionally, you can also define an interval and period for the data recording.
+2. To enable data recording, use the `startRecorder()` method of the `HumanActivityMonitorManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/humanactivitymonitor.html#HumanActivityMonitorManager) and [wearable](../../api/latest/device_api/wearable/tizen/humanactivitymonitor.html#HumanActivityMonitorManager) applications). Optionally, you can also define an interval and period for the data recording:
 
    ```
    var type = 'PRESSURE';
@@ -147,7 +147,7 @@ The Human Activity Monitor API allows you to record and retrieve saved sensor da
 
 4. To get the data sliced by an interval, you can use a combination of the `anchorTime` and `interval` options in the `HumanActivityRecorderQuery` interface.
 
-   Some human activity recorder types do not allow slicing the data by an interval.
+   Some human activity recorder types do not allow slicing the data by an interval:
 
    ```
    /* To retrieve data everyday at midnight */
@@ -158,7 +158,7 @@ The Human Activity Monitor API allows you to record and retrieve saved sensor da
 
 5. To read the human activity recorder data from the database, use the `readRecorderData()` method of the `HumanActivityMonitorManager` interface with the query.
 
-   Even if your application never recorded any data, you can access any data that has been recorded in the database by other applications.
+   Even if your application never recorded any data, you can access any data that has been recorded in the database by other applications:
 
    ```
    function onerror(error) {
@@ -180,7 +180,7 @@ The Human Activity Monitor API allows you to record and retrieve saved sensor da
    }
    ```
 
-## Using User-defined Intervals
+## Use user-defined intervals
 
 The Human Activity Monitor API allows the user to select their own intervals for collecting samples in a specified range using the `HumanActivityMonitorOption` interface (in [mobile](../../api/latest/device_api/mobile/tizen/humanactivitymonitor.html#HumanActivityMonitorOption) and [wearable](../../api/latest/device_api/wearable/tizen/humanactivitymonitor.html#HumanActivityMonitorOption) applications). Such functionality can be used to build more power-efficient data collection applications (the less often the device gathers data, the less energy is used). You can change the interval according to the device state, for example, when the display is switched off, the sampling interval can be decreased.
 
@@ -226,7 +226,7 @@ The Human Activity Monitor API allows the user to select their own intervals for
    tizen.humanactivitymonitor.stop('HRM');
    ```
 
-## Receiving Notifications on Pedometer Data Changes
+## Receive notifications on pedometer data changes
 
 Learning how to register a listener for accumulative allows you to monitor the step count maintained by the system without enabling the Pedometer sensor and the `PEDOMETER` monitor is a basic Human Activity Monitor (HAM) management skill:
 
@@ -250,7 +250,7 @@ Learning how to register a listener for accumulative allows you to monitor the s
    tizen.humanactivitymonitor.unsetAccumulativePedometerListener();
    ```
 
-## Monitoring Sleep
+## Monitor sleep
 
 Learning how to monitor user's sleep is a basic Human Activity Monitor (HAM) management skill:
 
@@ -271,7 +271,7 @@ Learning how to monitor user's sleep is a basic Human Activity Monitor (HAM) man
    tizen.humanactivitymonitor.stop('SLEEP_MONITOR');
    ```
 
-## Detecting Sleep
+## Detect sleep
 
 Learning how to detect whether the user is asleep is a basic Human Activity Monitor (HAM) management skill:
 
@@ -292,7 +292,7 @@ Learning how to detect whether the user is asleep is a basic Human Activity Moni
    tizen.humanactivitymonitor.stop('SLEEP_DETECTOR');
    ```
 
-## Supported Monitors
+## Supported monitors
 
 The following table introduces the available monitor types and lists the monitor capabilities you can use to [determine whether a specific monitor is supported](#support) on a device.
 
@@ -307,7 +307,7 @@ The following table introduces the available monitor types and lists the monitor
 | Sleep monitor                        | `http://tizen.org/feature/sensor.sleep_monitor` | When the sleep sensor is started, a change callback is invoked when data changes. Use the `getHumanActivityData()` method to get the current data. |
 | Sleep detector                        | `http://tizen.org/feature/sensor.sleep_monitor` | When the sleep sensor is started, a change callback is invoked when data changes. Use the `getHumanActivityData()` method to get the current data. |
 
-## Supported Recorders in Wearable Applications
+## Supported recorders in wearable applications
 
 The following table introduces the available recorder types and lists the capabilities you can use to [determine whether a specific recorder is supported](#support) on a device.
 
@@ -317,7 +317,7 @@ The following table introduces the available recorder types and lists the capabi
 | -------- | ---------------------------------------- | ---------------------------------------- |
 | Pressure | `http://tizen.org/feature/sensor.barometer` | Use the `startRecorder()` and `stopRecorder()` methods to record the pressure sensor data for the specific period of time. Use the `readRecorderData()` method to read the recorded pressure sensor data. |
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/sensors/sensors.md
+++ b/docs/application/web/guides/sensors/sensors.md
@@ -12,7 +12,7 @@ The following sensor features apply in **mobile and wearable applications only**
 
   You can read and manage data from various sensors on the device, and also receive notifications when the sensor data changes. You can access information from various environmental sensors, such as the light and magnetic sensors, and from user-related sensors, such as the heart rate monitor.
 
-## Related Information
+## Related information
 - Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/text-input/input-method.md
+++ b/docs/application/web/guides/text-input/input-method.md
@@ -1,6 +1,6 @@
 # IME Application
 
-Tizen Web IME (Input Method Editor) applications are written in HTML5 for Tizen, combining HTML, JavaScript, and CSS into a package that can be installed on a Tizen device, such as Samsung Gear, or the Tizen Emulator. Both the Tizen device and the emulator must run Tizen version 2.3 or higher to run Web IME applications.
+Tizen Web IME (Input Method Editor) applications are written in HTML5 for Tizen, combining HTML, JavaScript, and CSS into a package that can be installed on a Tizen device, such as Samsung Gear, or Tizen Emulator. Both the Tizen device and the emulator must run Tizen version 2.3 or higher to run Web IME applications.
 
 This feature is supported in wearable applications only.
 
@@ -22,9 +22,9 @@ The communication between the Web IME and the `ise-web-helper-agent` module is a
 
 Since the Web IME runs within a Web container and communicates with it, as a Web IME application developer you do not need knowledge of the platform architecture or details of the native API. You can develop Web IME applications as if they were normal Web applications, as long as the `web-helper-client.js` file is included and properly used.
 
-## Supported Application Types
+## Supported application types
 
-Tizen Web IME can interact with 2 types of Tizen applications:
+Tizen Web IME can interact with the following 2 types of Tizen applications:
 
 - In-house (native) application
 - Downloaded (Web) application
@@ -94,28 +94,28 @@ The following table lists the events that you can implement in your handler obje
 | `onUpdateSurroundingText(cursor, text)`  | Handler for the surrounding text signal update.<br><br>`cursor` parameter: Cursor position.<Br>`text` parameter: Surrounding text near the cursor. |
 | `onUpdateSelection(text)`                | Handler for the selection signal update.<br><br>`text` parameter: Currently selected text. |
 
-> **Note**  
+> [!NOTE]
 > The Device APIs are currently not supported in Web IME applications. Device API support is expected to be included in the next version.
 
-## Web IME Configuration
+## Web IME configuration
 
-The Web IME configuration follows the Tizen packaging policy with certain extensions. Tizen applications are packaged according to the [Widget packaging guidelines](https://www.w3.org/TR/2011/REC-widgets-20110927/). For more information on Tizen extensions to configuration elements, see [Configuration Elements](../../../tizen-studio/web-tools/config-editor.md#elements) and [Extending Configuration Elements](../../../tizen-studio/web-tools/config-editor.md#ww_extend).
+The Web IME configuration follows the Tizen packaging policy with certain extensions. Tizen applications are packaged according to the [Widget packaging guidelines](https://www.w3.org/TR/widgets/){:target="_blank"}. For more information on Tizen extensions to configuration elements, see [Configuration Elements](../../../tizen-studio/web-tools/config-editor.md#elements) and [Extending Configuration Elements](../../../tizen-studio/web-tools/config-editor.md#ww_extend).
 
 Internally, the application package manager is responsible for installing, uninstalling, and updating packages and storing their information.
 
 Tizen has the following additional configuration elements:
 
 - `tizen:category`  
-   To identify with other IMEs, the Web IME application must contain the UUID information.
+   To identify with other IMEs, the Web IME application must contain the UUID information:
 
   ```
   <tizen:category name="http://tizen.org/category/ime"/>
   ```
 
 - `tizen:uuid`  
-   Added to identify the Web IME application type. If this element is defined, the application type is IME.
+   Added to identify the Web IME application type. If this element is defined, the application type is IME:
 
-  > **Note**  
+  > [!NOTE]
   > The Device APIs are currently not supported in Web IME applications. Device API support is expected to be included in the next version.
 
   ```
@@ -123,7 +123,7 @@ Tizen has the following additional configuration elements:
   ```
 
 - `tizen:languages`  
-    The locale string in the `<tizen:language>` element can be used to display the input language the specific Input Method Editor supports. The `<tizen:languages>` parent element can have more than 1 `<tizen:language>` child element.
+    The locale string in the `<tizen:language>` element can be used to display the input language the specific Input Method Editor supports. The `<tizen:languages>` parent element can have more than 1 `<tizen:language>` child element:
 
   ```
   <tizen:languages>
@@ -132,12 +132,12 @@ Tizen has the following additional configuration elements:
   </tizen:languages>
   ```
 
-> **Note**  
+> [!NOTE]
 > 2-letter primary codes are reserved for [ISO639] language abbreviations. 2-letter codes include `fr` (French), `de` (German), `it` (Italian), `nl` (Dutch), `el` (Greek), `es` (Spanish), `pt` (Portuguese), `ar` (Arabic), `he` (Hebrew), `ru` (Russian), `zh` (Chinese), `ja` (Japanese), `hi` (Hindi), `ur` (Urdu), and `sa` (Sanskrit).  
 > 
-> Any 2-letter subcode is understood to be a [ISO3166] country code. For more information, see [http://www.w3.org/TR/html401/struct/dirlang.html](http://www.w3.org/TR/html401/struct/dirlang.html).
+> Any 2-letter subcode is understood to be a [ISO3166] country code. For more information, see [Language information and text direction](http://www.w3.org/TR/html401/struct/dirlang.html){:target="_blank"}.
 
-## Hardware Key Events
+## Hardware key events
 
 The Web IME is capable of not only showing a soft keyboard and emitting key events to the client application, but also handling hardware key events and translating them to a specific language. This is very common when entering texts in CJK (Chinese, Japanese, and Korean) languages, where each key event must be composed to produce a final result string.
 
@@ -145,9 +145,9 @@ When a hardware key is pressed, the client application receives the key event an
 
 When creating the handler object for `WebHelperClient`, implement the `onProcessKeyEvent()` method if you want to translate each hardware key event.
 
-The following example translates the key event to a string "ㅁ", which is a Korean character mapped to the `a` key event.
+The following example translates the key event to a string "ㅁ", which is a Korean character mapped to the `a` key event:
 
-> **Note**  
+> [!NOTE]
 > To provide full support for Korean character composition, a more complex process is needed. This example is only a demonstration.
 
 ```
@@ -167,13 +167,13 @@ WebHelperClient.initialize(WebHelperClientHandler);
 
 When the processing of a hardware key event is completed, the `onProcessKeyEvent` event handler must return `true`. Otherwise, the client application considers the Web IME as not reacting to the key event, and tries to invoke its fallback handler, which appends an additional `a` to the committed "ㅁ" string.
 
-## Key Events, Commit Strings, and Pre-edit Strings
+## Key events, commit strings, and pre-edit strings
 
 Key events, commit strings and pre-edit strings are needed to send appropriate messages to the client application.
 
 Key events, when sent to the client application, use the same process as when a hardware key is pressed. Therefore, sending a key event to the client application using the `sendKeyEvent()` method calls the Web IME `onProcessKeyEvent()` event handler.
 
-To prevent the key event from being sent back to the Web IME (as there is no need to translate that key event again), use the `forwardKeyEvent()` method that invokes the client application's fallback key event handler.
+To prevent the key event from being sent back to the Web IME (as there is no need to translate that key event again), use the `forwardKeyEvent()` method that invokes the client application's fallback key event handler:
 
 ```
 <script type="text/javascript">
@@ -212,7 +212,7 @@ WebHelperClient.updatePreeditString('abc');
 WebHelperClient.updatePreeditString('def');
 ```
 
-## Web IME Life-cycle
+## Web IME life-cycle
 
 The Web IME applications have exactly the same life-cycle as the native IME applications. They have 4 states: unloaded, invisible, visible, and terminated.
 
@@ -228,9 +228,9 @@ A Web IME in the visible or invisible state can move on to the terminated state 
 - The system is shut down.
 - A different Web IME is selected in setting the application keyboard selection menu.
 
-## Sample IME Application
+## Sample IME application
 
-To create an IME application:
+To create an IME application, follow these steps:
 
 1. To create the Web IME project, launch Tizen Studio and go to **File > New > Tizen Project**.
 2. In the Project Wizard, select **Template** as the project type, **WEARABLE** profile and applicable version, **Web Application** type, and **Web Input Method Editor** template.
@@ -241,6 +241,6 @@ To create an IME application:
 6. In the emulator, change the default keyboard with the Web IME you developed in **Setting > Text input**.   
 ![Setting main](./media/web_ime_setting_main.png)![Setting text input](./media/web_ime_setting_text_input.png)
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/text-input/text-input.md
+++ b/docs/application/web/guides/text-input/text-input.md
@@ -16,7 +16,7 @@ You can use the following text input and voice features in your Web applications
 
   You can register general voice commands and enable the user to control the Web application with their voice.
 
-## Related Information
+## Related information
 * Dependencies  
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable


### PR DESCRIPTION
This PR includes the fix of the following files which are part of the web application guides section of the Tizen Docs site:

File count: 6

/application/web/guides/messaging/push.md
/application/web/guides/sensors/sensors.md
/application/web/guides/sensors/ham.md
/application/web/guides/sensors/device-sensors.md
/application/web/guides/text-input/text-input.md
/application/web/guides/text-input/input-method.md