### PR TITLE
Web application site fix (Part - 22)

### DIFF
--- a/docs/application/web/guides/device/feedback.md
+++ b/docs/application/web/guides/device/feedback.md
@@ -4,7 +4,7 @@ You can handle feedback patterns (media or vibration) that can be played as a re
 
 This feature is supported in mobile and wearable applications only.
 
-The main features of the Feedback API include:
+The main features of the Feedback API include the following:
 
 - Checking for pattern support
 
@@ -18,7 +18,7 @@ Each feedback pattern can have separate media files of sound and vibration type.
 
 ## Prerequisites
 
-1. From Tizen 5.0 onwards, it is possible to make your application visible in the official site for Tizen applications only for devices that support the feedback vibration feature. To do so, you must specify the following feature in the `config.xml` file of the application:
+1. Since Tizen 5.0 onwards, it is possible to make your application visible in the official site for Tizen applications only for devices that support the feedback vibration feature. To do so, you must specify the following feature in the `config.xml` file of the application:
 
    ```
     <widget>
@@ -38,7 +38,7 @@ Each feedback pattern can have separate media files of sound and vibration type.
     }
     ```
 
-## Checking the Pattern
+## Check the pattern
 
 You can check whether a feedback type (sound or vibration) is supported for a specified pattern. To get information about the supported specified system predefined pattern type pairs, use the `isPatternSupported()` method of the `FeedbackManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/feedback.html#FeedbackManager) and [wearable](../../api/latest/device_api/wearable/tizen/feedback.html#FeedbackManager) applications):
 
@@ -52,11 +52,11 @@ if (!isSupported) {
 console.log('pattern ' + pattern + ' is' + isSupportedStr + ' supported');
 ```
 
-## Setting the Media Pattern
+## Set the media pattern
 
 The available predefined system patterns are defined in the `FeedbackPattern` enumeration (in [mobile](../../api/latest/device_api/mobile/tizen/feedback.html#FeedbackPattern) and [wearable](../../api/latest/device_api/wearable/tizen/feedback.html#FeedbackPattern) applications).
 
-To start and stop playing various types of predefined reactions:
+To start and stop playing various types of predefined reactions, follow these steps:
 
 1. To set a specified type of reaction for an event, use the `play()` method of the `FeedbackManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/feedback.html#FeedbackManager) and [wearable](../../api/latest/device_api/wearable/tizen/feedback.html#FeedbackManager) applications):
 
@@ -74,7 +74,7 @@ To start and stop playing various types of predefined reactions:
    tizen.feedback.stop();
    ```
 
-## Related Information
+## Related information
 * Dependencies   
    - Tizen 3.0 and Higher for Mobile
    - Tizen 3.0 and Higher for Wearable

--- a/docs/application/web/guides/device/web-view.md
+++ b/docs/application/web/guides/device/web-view.md
@@ -4,7 +4,7 @@ You can set Web view properties.
 
 This feature is supported in mobile and TV applications only.
 
-The main features of the Web Setting API include:
+The main features of the Web Setting API include the following:
 
 - Setting user agents
 
@@ -14,7 +14,7 @@ The main features of the Web Setting API include:
 
   You can [delete all cookies](#deleting-web-view-cookies) set for the running Web application.
 
-## Setting a User Agent for a Running Application
+## Set a user agent for a running application
 
 Use the `setUserAgentString()` method to set a Web view user agent string:
 
@@ -28,7 +28,7 @@ var userAgent = 'CUSTOM_USER_AGENT_STRING';
 tizen.websetting.setUserAgentString(userAgent, successCallback);
 ```
 
-## Deleting Web View Cookies
+## Delet Web view cookies
 
 Use the `removeAllCookies()` method to delete all the Web view cookies:
 
@@ -40,7 +40,7 @@ function CookiesRemovedSuccessCallback() {
 tizen.websetting.removeAllCookies(CookiesRemovedSuccessCallback);
 ```
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 3.0 and Higher for Wearable

--- a/docs/application/web/guides/error/error.md
+++ b/docs/application/web/guides/error/error.md
@@ -4,26 +4,26 @@ You can handle generic error situations in your application.
 
 The Tizen API is mandatory for Tizen Mobile, Wearable, and TV profiles, which means that it is supported on all mobile, wearable, and TV devices. All mandatory APIs are supported on the Tizen emulators.
 
-The main error handling features of the Tizen API include:
+The main error handling features of the Tizen API include the following:
 
 - Exception handling
 
   You can enable the Tizen APIs to throw errors synchronously with the `WebAPIException` interface (in [mobile](../../api/latest/device_api/mobile/tizen/tizen.html#WebAPIException), [wearable](../../api/latest/device_api/wearable/tizen/tizen.html#WebAPIException), and [TV](../../api/latest/device_api/tv/tizen/tizen.html#WebAPIException) applications), or return errors in the error event handlers of asynchronous methods with the `WebAPIError` interface (in [mobile](../../api/latest/device_api/mobile/tizen/tizen.html#WebAPIError), [wearable](../../api/latest/device_api/wearable/tizen/tizen.html#WebAPIError), and [TV](../../api/latest/device_api/tv/tizen/tizen.html#WebAPIError) applications).
 
-   > **Note**  
-   > Do not use the `code` attribute of the `WebAPIException` interface to distinguish errors, because the code of the exception object is set to `0` for new error types that are not defined in [DOMException](https://heycam.github.io/webidl/#idl-DOMException).
+   > [!NOTE]
+   > Do not use the `code` attribute of the `WebAPIException` interface to distinguish errors, because the code of the exception object is set to `0` for new error types that are not defined in [DOMException](https://heycam.github.io/webidl/#idl-DOMException){:target="_blank"}.
 
 - Generic event handling  
 
   You can [handle the results of asynchronous operations](#using-the-generic-event-handlers) with generic events. The operations can implemented using the `SuccessCallback` (in [mobile](../../api/latest/device_api/mobile/tizen/tizen.html#SuccessCallback), [wearable](../../api/latest/device_api/wearable/tizen/tizen.html#SuccessCallback), and [TV](../../api/latest/device_api/tv/tizen/tizen.html#SuccessCallback) applications) and `ErrorCallback` (in [mobile](../../api/latest/device_api/mobile/tizen/tizen.html#ErrorCallback), [wearable](../../api/latest/device_api/wearable/tizen/tizen.html#ErrorCallback), and [TV](../../api/latest/device_api/tv/tizen/tizen.html#ErrorCallback) applications) event handlers of the Tizen API.
 
-## Using the Generic Event Handlers
+## Use the generic Event Handlers
 
-Learning how to use generic, predefined event handlers allows you handle application operations and errors efficiently:
+Learning how to use generic, predefined event handlers allows you handle application operations and errors efficiently, follow these steps:
 
 1. The generic `onSuccess()` event handler of the `SuccessCallBack` interface (in [mobile](../../api/latest/device_api/mobile/tizen/tizen.html#SuccessCallback), [wearable](../../api/latest/device_api/wearable/tizen/tizen.html#SuccessCallback), and [TV](../../api/latest/device_api/tv/tizen/tizen.html#SuccessCallback) applications) can be used with methods that do not require a return value when successful.
 
-   In this example, the event handler is used to stop a running application with the `kill()` method of the `Application` interface (in [mobile](../../api/latest/device_api/mobile/tizen/application.html#Application), [wearable](../../api/latest/device_api/wearable/tizen/application.html#Application), and [TV](../../api/latest/device_api/tv/tizen/application.html#Application) applications).
+   In this example, the event handler is used to stop a running application with the `kill()` method of the `Application` interface (in [mobile](../../api/latest/device_api/mobile/tizen/application.html#Application), [wearable](../../api/latest/device_api/wearable/tizen/application.html#Application), and [TV](../../api/latest/device_api/tv/tizen/application.html#Application) applications):
 
    ```
    function onSuccess() {
@@ -35,7 +35,7 @@ Learning how to use generic, predefined event handlers allows you handle applica
 
 2.  The generic `onError()` event handler of the `ErrorCallBack` interface (in [mobile](../../api/latest/device_api/mobile/tizen/tizen.html#ErrorCallback), [wearable](../../api/latest/device_api/wearable/tizen/tizen.html#ErrorCallback), and [TV](../../api/latest/device_api/tv/tizen/tizen.html#ErrorCallback) applications) can be used with methods that only require an error as an input parameter in the error callback.
 
-    In this example, the event handler is used to handle possible errors with the `getCalendars()` method of the `CalendarManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/calendar.html#CalendarManager) and [wearable](../../api/latest/device_api/wearable/tizen/calendar.html#CalendarManager) applications).
+    In this example, the event handler is used to handle possible errors with the `getCalendars()` method of the `CalendarManager` interface (in [mobile](../../api/latest/device_api/mobile/tizen/calendar.html#CalendarManager) and [wearable](../../api/latest/device_api/wearable/tizen/calendar.html#CalendarManager) applications):
 
     ```
     function errorCallback(error) {

--- a/docs/application/web/guides/security/privacy-related-permissions.md
+++ b/docs/application/web/guides/security/privacy-related-permissions.md
@@ -9,7 +9,7 @@ Before Tizen 4.0, the pop-up requesting the user's consent to use privacy-relate
 > [!NOTE]
 > Since Tizen 8.0, all Privacy Privilege Manager APIs are deprecated and will be removed without any alternative.
 
-The main features of the Privacy Privilege API include:
+The main features of the Privacy Privilege API include the following:
 
 -   Checking privilege status
 
@@ -27,9 +27,9 @@ For a list of privacy-related privileges, see [Security and API Privileges](../.
 > Use `requestPermissions()` to request multiple privileges instead of calling `requestPermission()` multiple times.
 
 <a name="requesting"></a>
-## Requesting Permissions
+## Request permissions
 
-To verify whether an application has permission to use a privilege, and to request permission if required:
+To verify whether an application has permission to use a privilege, and to request permission if required, follow these steps:
 
 1.  To verify whether an application has permission to use a particular privilege, use the `checkPermission()` method:
 
@@ -41,7 +41,7 @@ To verify whether an application has permission to use a privilege, and to reque
     The result of the call is returned as a value of the `PermissionType` enumeration (in [mobile](../../api/latest/device_api/mobile/tizen/ppm.html#PermissionType) and [wearable](../../api/latest/device_api/wearable/tizen/ppm.html#PermissionType) applications).
 
 2. React to the permission check appropriately:
-    - If the result value is `PPM_ALLOW`, the application is allowed to perform operations related to the privilege. For example, the application can enable additional UI elements or functionalities.
+    - If the result value is `PPM_ALLOW`, the application is allowed to perform operations related to the privilege. For example, the application can enable additional UI elements or functionalities:
 
       ```
       switch (result) {
@@ -50,7 +50,7 @@ To verify whether an application has permission to use a privilege, and to reque
 		      break;
       ```
 
-    - If the result value is `PPM_DENY`, the application is not allowed to perform operations related to the privilege. Any attempt to use such functionality without the user's consent fails. Usually, this means that invoking any API method that involves the privilege results in an error.
+    - If the result value is `PPM_DENY`, the application is not allowed to perform operations related to the privilege. Any attempt to use such functionality without the user's consent fails. Usually, this means that invoking any API method that involves the privilege results in an error:
 
       ```
 	      case "PPM_DENY":
@@ -60,7 +60,7 @@ To verify whether an application has permission to use a privilege, and to reque
 
     - If the result value is `PPM_ASK`, the application must request permission from the user with the `requestPermission()` method, which displays a dialog box. When the user makes a decision, a callback defined as the second parameter is invoked.
 
-      The dialog box asking for user permission is shown only if the `requestPermission()` method does not throw an exception.
+      The dialog box asking for user permission is shown only if the `requestPermission()` method does not throw an exception:
 
       ```
 	      case "PPM_ASK":
@@ -71,7 +71,7 @@ To verify whether an application has permission to use a privilege, and to reque
 
 3. If you need to request user permission, handle the user decision within the `PermissionSuccessCallback` callback used in the `requestPermission()` method.
 
-    The user decision is returned in the first parameter of the callback as a value of the `PermissionRequestResult` enumeration (in [mobile](../../api/latest/device_api/mobile/tizen/ppm.html#PermissionRequestResult) and [wearable](../../api/latest/device_api/wearable/tizen/ppm.html#PermissionRequestResult) applications). The second parameter contains the permission that is being requested.
+    The user decision is returned in the first parameter of the callback as a value of the `PermissionRequestResult` enumeration (in [mobile](../../api/latest/device_api/mobile/tizen/ppm.html#PermissionRequestResult) and [wearable](../../api/latest/device_api/wearable/tizen/ppm.html#PermissionRequestResult) applications). The second parameter contains the permission that is being requested:
 
     ```
     /* Define PermissionSuccessCallback */
@@ -100,7 +100,7 @@ To verify whether an application has permission to use a privilege, and to reque
 > [!NOTE]
 > Since the privileges are grouped, the user's decision regarding 1 privilege applies to the whole group of related privileges. For example, if the user has granted permission to use the `http://tizen.org/privilege/account.read` privilege, permission is automatically granted to the `http://tizen.org/privilege/account.write` privilege also. Be aware that both privileges need to be declared in the application manifest file. If you declare only 1 of them, the above rule does not apply.
 
-## Related Information
+## Related information
 - Dependencies
   - Tizen 4.0 and Higher for Mobile
   - Tizen 4.0 and Higher for Wearable

--- a/docs/application/web/guides/security/secure-key.md
+++ b/docs/application/web/guides/security/secure-key.md
@@ -4,7 +4,7 @@ The key manager allows you to [control data access](#data-access-control) by sec
 
 The Key Manager API is mandatory for Tizen Mobile, Wearable, and TV profiles, which means that it is supported on all mobile, wearable, and TV devices. All mandatory APIs are supported on the Tizen emulators.
 
-The main features of the Key Manager API include:
+The main features of the Key Manager API include the following:
 
 - Saving data		
 
@@ -18,7 +18,7 @@ The main features of the Key Manager API include:
 
   You can [remove data](#removing-data) from a repository. You can remove both data that you have added yourself, and data that another application has added and granted you permissions to remove.
 
-## Data Access Control
+## Data access control
 
 With the key manager, you can control various security aspects of your application:
 
@@ -44,9 +44,9 @@ With the key manager, you can control various security aspects of your applicati
 
 ![Key manager process](./media/key_manager.png)
 
-## Saving Data
+## Save data
 
-To save data in a repository:
+To save data in a repository, follow these steps:
 
 1. Save the data using the `saveData()` method:
 
@@ -75,9 +75,9 @@ To save data in a repository:
    }
    ```
 
-## Getting Data
+## Get data
 
-To retrieve data from a repository:
+To retrieve data from a repository, follow these steps:
 
 - Retrieve data which your application has added:
 
@@ -113,9 +113,9 @@ To retrieve data from a repository:
   }
   ```
 
-## Removing Data
+## Remove data
 
-To remove data from a repository:
+To remove data from a repository, follow these steps:
 
 1. Remove data which your application has added:
 
@@ -151,7 +151,7 @@ To remove data from a repository:
    }
    ```
 
-## Related Information
+## Related information
 * Dependencies   
   - Tizen 3.0 and Higher for Mobile
   - Tizen 3.0 and Higher for Wearable

--- a/docs/application/web/guides/security/tee-client.md
+++ b/docs/application/web/guides/security/tee-client.md
@@ -3,7 +3,7 @@
 > [!NOTE]
 > TEEC API is deprecated since Tizen 6.5 and will be removed after two releases without any alternatives.
 
-You can create secure communications by executing your application in a trusted execution environment (TEE), and communicating with other applications within that environment. To implement TEE communication, you can use the LibTeec API, which is based on the GlobalPlatform&reg; [TEE Client API](https://www.globalplatform.org/specificationsdevice.asp).
+You can create secure communications by executing your application in a trusted execution environment (TEE), and communicating with other applications within that environment. To implement TEE communication, you can use the LibTeec API, which is based on the GlobalPlatform&reg; [TEE Client API](https://www.globalplatform.org/specificationsdevice.asp){:target="_blank"}.
 
 You can run applications in 2 environments: a rich environment (like Linux) with client applications (CA) and a secure environment with trusted applications (TA).
 
@@ -11,7 +11,7 @@ You can run applications in 2 environments: a rich environment (like Linux) with
 
 ![TEE communication architecture](./media/libteec_architecture.png)
 
-The main features of the LibTeec API include:
+The main features of the LibTeec API include the following:
 
 -   Connecting to a trusted application
 
@@ -21,13 +21,13 @@ The main features of the LibTeec API include:
 
     You can [pass commands from a client application to a trusted application](#secure_commands), including [using shared memory blocks](#shared_memory).
 
-> **Note**  
+> [!NOTE]
 > For security reasons, each device vendor usually uses their own TEE solution. If you intend your LibTeec application to be used on a real device, you must test your application on the TEE solution provided by the specific vendor. When developing and installing your trusted application, refer to the documentation provided by the vendor.
 
 
 ## Prerequisites
 
-To enable your application to use the TEE communication functionality:
+To enable your application to use the TEE communication functionality, follow these steps:
 
 -   To use the LibTeec API, the application has to request permission by adding the following privilege to the `config.xml` file:
 
@@ -35,7 +35,7 @@ To enable your application to use the TEE communication functionality:
     <tizen:privilege name="http://tizen.org/privilege/tee.client"/>
     ```
 
-    > **Note**  
+    > [!NOTE]
     > To be able to use this privilege, your application must be signed with a partner-level certificate.
 
 -   The trusted applications must be placed in a non-secure application install or resource directory before they can be discovered and transferred to the TEE.
@@ -43,11 +43,11 @@ To enable your application to use the TEE communication functionality:
 
 
 <a name="connecting"></a>
-## Connecting Applications
+## Connect applications
 
 To connect a client application to a trusted application, first create a new TEE context with the `getContext()` method, and then open a session with the trusted application with the `openSession()` method of the context, identifying the trusted application by its UUID:
 
-> **Note**  
+> [!NOTE]
 > A client application can connect only to its own trusted application. Built-in security rules prevent connecting to other trusted applications.
 
 ```
@@ -73,13 +73,13 @@ try {
 ```
 
 <a name="secure_commands"></a>
-## Sending Secure Commands
+## Send secure commands
 
 After opening a session with a trusted application, a client application can execute methods in the trusted application by sending secure commands to the trusted application.
 
 To send a command, use the `invokeCommand()` method, with the first parameter identifying the method to be executed by the trusted application, and the second parameter containing an array of the executable method's parameters. The parameter array can have at most 4 elements.
 
-You can use 3 types of objects in the parameters array:
+You can use the following 3 types of objects in the parameters array:
 
 -   `TeecValue` object (in [mobile](../../api/latest/device_api/mobile/tizen/libteec.html#TeecValue), [wearable](../../api/latest/device_api/wearable/tizen/libteec.html#TeecValue), and [TV](../../api/latest/device_api/tv/tizen/libteec.html#TeecValue) applications), which contains 1 or 2 simple integers.
 -   `TeecTempMemory` object (in [mobile](../../api/latest/device_api/mobile/tizen/libteec.html#TeecTempMemory), [wearable](../../api/latest/device_api/wearable/tizen/libteec.html#TeecTempMemory), and [TV](../../api/latest/device_api/tv/tizen/libteec.html#TeecTempMemory) applications), which contains a local memory reference.
@@ -121,11 +121,11 @@ try {
 
 
 <a name="shared_memory"></a>
-## Using Shared Memory
+## Use shared memory
 
 You can handle a block of data without copying it to and from the trusted environment. For example, the client application can share a block of encrypted data from a data provider with the trusted application, and the trusted application can decrypt it.
 
-To share a memory block between a client application and a trusted application:
+To share a memory block between a client application and a trusted application, follow these steps:
 
 1.  Allocate a new memory block as shared memory with the `allocateSharedMemory()` method:
 
@@ -191,7 +191,7 @@ To share a memory block between a client application and a trusted application:
     }
     ```
 
-## Related Information
+## Related information
 - Dependencies
   - Tizen 4.0 and Higher for Mobile
   - Tizen 4.0 and Higher for Wearable


### PR DESCRIPTION
This PR includes the fix of the following files which are part of the web application guides section of the Tizen Docs site:

File count: 6

/application/web/guides/device/web-view.md
/application/web/guides/device/feedback.md
/application/web/guides/security/secure-key.md
/application/web/guides/security/tee-client.md
/application/web/guides/security/privacy-related-permissions.md
/application/web/guides/error/error.md