### PR TITLE
Web application site fix (Part - 25)

### DIFF
--- a/docs/application/web/guides/w3c/communication/comm-guide.md
+++ b/docs/application/web/guides/w3c/communication/comm-guide.md
@@ -20,7 +20,7 @@ The main communication features are:
 
   Enables you to exchange push data with the server.
 
-## Related Information
+## Related information
 * Dependencies  
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/w3c/multimedia/getusermedia.md
+++ b/docs/application/web/guides/w3c/multimedia/getusermedia.md
@@ -2,13 +2,13 @@
 
 You can access multimedia streams, such as camera, on a local device. The feature can be used, for example, for real-time communication, recording, and surveillance.
 
-The main features of the getUserMedia API include:
+The main features of the getUserMedia API include the following:
 
 - Retrieving multimedia streams
 
   You can use the `navigator.webkitGetUserMedia()` method to request user access to [retrieve the multimedia streams](#accessing-a-video-stream) of local devices, such as camera. The method returns the media as a JSON object.
 
-  > **Note**  
+  > [!NOTE]
   > The TV applications support the `navigator.webkitGetUserMedia()` method for the microphone only, because a TV has no camera.
 
 
@@ -16,10 +16,10 @@ The main features of the getUserMedia API include:
 
   You can [capture media content](#capturing-a-media-frame) and transform it to various formats.
 
-> **Note**  
-> Tizen supports a WebKit-based `GetUserMedia()` method, so always add the `webkit` prefix to the method name.
+  > [!NOTE]
+  > Tizen supports a WebKit-based `GetUserMedia()` method, so always add the `webkit` prefix to the method name.
 
-## Accessing a Video Stream
+## Access a video stream
 
 Learning how to access a video stream is a basic user media management skill:
 
@@ -55,13 +55,13 @@ Learning how to access a video stream is a basic user media management skill:
    </script>
    ```
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [video_stream.html](http://download.tizen.org/misc/examples/w3c_html5/media/get_user_media)
+- [video_stream.html](http://download.tizen.org/misc/examples/w3c_html5/media/get_user_media){:target="_blank"}
 
-## Capturing a Media Frame
+## Capture a media frame
 
 Learning how to capture a frame and display it in a video element is a basic user media management skill:
 
@@ -112,13 +112,13 @@ Learning how to capture a frame and display it in a video element is a basic use
    </script>
    ```
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [capturing_webcam.html](http://download.tizen.org/misc/examples/w3c_html5/media/get_user_media)
+- [capturing_webcam.html](http://download.tizen.org/misc/examples/w3c_html5/media/get_user_media){:target="_blank"}
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/w3c/multimedia/media-capture.md
+++ b/docs/application/web/guides/w3c/multimedia/media-capture.md
@@ -1,6 +1,6 @@
 # HTML Media Capture
 
-Media capture uses the `capture` attribute of the [HTMLInputElement](http://www.w3.org/TR/2012/WD-html-media-capture-20120712/#dfn-htmlinputelement) interface to [activate features](#activating-the-media-capture), such as camera or microphone, to enable direct media capture when the user is uploading a file.
+Media capture uses the `capture` attribute of the [HTMLInputElement](https://www.w3.org/TR/html-media-capture/){:target="_blank"} interface to [activate features](#activating-the-media-capture), such as camera or microphone, to enable direct media capture when the user is uploading a file.
 
 This feature is supported in mobile applications only.
 
@@ -18,7 +18,7 @@ The following media formats can be used with the `capture` attribute:
 - `microphone`  
 Activates the device sound recorder.
 
-## Activating the Media Capture
+## Activate the media capture
 
 To provide users with the HTML media capture feature, you must learn to activate the media capture feature by selecting the file type during file upload:
 
@@ -40,19 +40,19 @@ To provide users with the HTML media capture feature, you must learn to activate
 
     If the `capture` attribute does not exist or the value has not been entered, the `filesystem` format is activated. If the `camera` or `camcorder` format is selected, the device camera is activated.
 
-    > **Note**  
+    > [!NOTE]
     > In the current version of Tizen Studio, the `microphone` format for the capture attribute is not available as the voice recorder application is not included.
 
-   The `accept` attribute (in [mobile](http://www.w3.org/TR/2014/REC-html5-20141028/forms.html#attr-input-accept) and [wearable](https://www.w3.org/TR/2014/CR-html5-20140429/forms.html#attr-input-accept) applications) indicates which file types are appropriate. If used with a device that has a camera, it activates the device camera. With a device without a camera, it activates the My photo folder.
+   The `accept` attribute (in [mobile](http://www.w3.org/TR/2014/REC-html5-20141028/forms.html#attr-input-accept){:target="_blank"} and [wearable](https://www.w3.org/TR/2014/CR-html5-20140429/forms.html#attr-input-accept){:target="_blank"} applications) indicates which file types are appropriate. If used with a device that has a camera, it activates the device camera. With a device without a camera, it activates the My photo folder.
 
    ![Activating media features](./media/media_capture_activating_features.png)
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [media_capture.html](http://download.tizen.org/misc/examples/w3c_html5/media/html_media_capture)
+- [media_capture.html](http://download.tizen.org/misc/examples/w3c_html5/media/html_media_capture){:target="_blank"}
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.4 and Higher for Mobile

--- a/docs/application/web/guides/w3c/multimedia/sound-policy.md
+++ b/docs/application/web/guides/w3c/multimedia/sound-policy.md
@@ -39,6 +39,6 @@ Sound is played on a tap event for:
 - HTML elements on which the mouseover event listener is registered
 - MediaController objects of the HTML media elements
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.4 and Higher for Mobile

--- a/docs/application/web/guides/w3c/multimedia/video-audio.md
+++ b/docs/application/web/guides/w3c/multimedia/video-audio.md
@@ -2,9 +2,9 @@
 
 You can use the HTML5 `audio` and `video` elements to play multimedia files streaming, without a separate plug-in.
 
-Using JavaScript, the playback can be controlled with [media events](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Events). The audio and video elements used as media elements inherit all the properties and methods of the `HTMLMediaElement` interface (in [mobile](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#media-element), [wearable](http://www.w3.org/TR/2014/CR-html5-20140429/embedded-content-0.html#media-element), and [TV](https://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#media-element) applications).
+Using JavaScript, the playback can be controlled with [media events](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Events){:target="_blank"}. The audio and video elements used as media elements inherit all the properties and methods of the `HTMLMediaElement` interface (in [mobile](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#media-element){:target="_blank"}, [wearable](http://www.w3.org/TR/2014/CR-html5-20140429/embedded-content-0.html#media-element){:target="_blank"}, and [TV](https://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#media-element){:target="_blank"} applications).
 
-The main features of the audio and video elements with JavaScript include:
+The main features of the audio and video elements with JavaScript include the following:
 
 - Creating a player
 
@@ -12,7 +12,7 @@ The main features of the audio and video elements with JavaScript include:
 
 - Controlling the playback
 
-  You can use the `Play()` and `Pause()` methods of the `Media` object (in [mobile](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#media-elements), [wearable](http://www.w3.org/TR/2014/CR-html5-20140429/embedded-content-0.html#media-elements), and [TV](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#media-elements) applications) to [control playing and pausing](#playing-media-files) media files. With media events, additional features can be used.
+  You can use the `Play()` and `Pause()` methods of the `Media` object (in [mobile](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#media-elements){:target="_blank"}, [wearable](http://www.w3.org/TR/2014/CR-html5-20140429/embedded-content-0.html#media-elements){:target="_blank"}, and [TV](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#media-elements) applications){:target="_blank"} to [control playing and pausing](#playing-media-files) media files. With media events, additional features can be used.
 
 - Retrieving duration and play time
 
@@ -20,7 +20,7 @@ The main features of the audio and video elements with JavaScript include:
 
 - Playing from a random position
 
-  You can indicate the playback time by [playing the media file from a random position](#moving-the-timeline-position). To do this, you must change the `currentTime` value of the `Media` object to trigger the `timeupdate` event (in [mobile](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#event-media-timeupdate), [wearable](http://www.w3.org/TR/2014/CR-html5-20140429/embedded-content-0.html#event-media-timeupdate), and [TV](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#event-media-timeupdate) applications).
+  You can indicate the playback time by [playing the media file from a random position](#moving-the-timeline-position). To do this, you must change the `currentTime` value of the `Media` object to trigger the `timeupdate` event (in [mobile](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#event-media-timeupdate){:target="_blank"}, [wearable](http://www.w3.org/TR/2014/CR-html5-20140429/embedded-content-0.html#event-media-timeupdate){:target="_blank"}, and [TV](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#event-media-timeupdate){:target="_blank"} applications).
 
 - Retrieving progress state
 
@@ -34,7 +34,7 @@ The main features of the audio and video elements with JavaScript include:
 
   You can [check whether the media data can be played](#checking-supported-media-formats) using the `canPlayType()` method. Basically, the MIME type must be set in the Web server in a format that is supported in Tizen. If a non-supported MIME type is used, you can [handle exceptions](#handling-errors) in advance.
 
-## Creating an Audio and Video Player
+## Create an audio and video player
 
 To provide users with HTML5 audio and video features, you must learn to create a simple player for streaming playback:
 
@@ -48,7 +48,7 @@ To provide users with HTML5 audio and video features, you must learn to create a
 
    ![Audio player](./media/video_audio3.png)
 
-2. To create a video player, create a `video` element including the necessary attributes. In addition to the attributes available for the `audio` element, you can also use the `width`, `height`, and `poster` attributes.
+2. To create a video player, create a `video` element including the necessary attributes. In addition to the attributes available for the `audio` element, you can also use the `width`, `height`, and `poster` attributes:
 
    ```
    <video id="video" src="media/video_sample.mp4"
@@ -61,23 +61,23 @@ To provide users with HTML5 audio and video features, you must learn to create a
 
    ![Video player before playback](./media/video_audio1.png) ![Video player during playback](./media/video_audio2.png)
 
-> **Note**  
+> [!NOTE]
 > The `preload` attribute is set to `auto` by default, meaning that the media metadata is automatically loaded. If you do not want to load the metadata, set the attribute value as `metadata` or `none`.
 
-> **Note**  
-> Carefully consider before using the `autoplay` feature (in [mobile](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#attr-media-autoplay), [wearable](http://www.w3.org/TR/2014/CR-html5-20140429/embedded-content-0.html#attr-media-autoplay), and [TV](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#attr-media-autoplay) applications), which plays content automatically in the mobile environment without user interaction. The user can face unintended Internet packet fees or interfering factors, such as playback being stopped unintentionally.
+> [!NOTE]
+> Carefully consider before using the `autoplay` feature (in [mobile](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#attr-media-autoplay){:target="_blank"}, [wearable](http://www.w3.org/TR/2014/CR-html5-20140429/embedded-content-0.html#attr-media-autoplay){:target="_blank"}, and [TV](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#attr-media-autoplay){:target="_blank"} applications), which plays content automatically in the mobile environment without user interaction. The user can face unintended Internet packet fees or interfering factors, such as playback being stopped unintentionally.
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following files:
 
-- [mini_code_audio.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element)
-- [mini_code_video.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element)
-- [audio_sample.mp3](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media)
-- [poster_sample.png](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media)
-- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media)
+- [mini_code_audio.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element){:target="_blank"}
+- [mini_code_video.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element){:target="_blank"}
+- [audio_sample.mp3](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media){:target="_blank"}
+- [poster_sample.png](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media){:target="_blank"}
+- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media){:target="_blank"}
 
-## Playing Media Files
+## Play media files
 
 To provide users with HTML5 audio and video features, you must learn to play and pause media files using custom controls:
 
@@ -95,7 +95,7 @@ To provide users with HTML5 audio and video features, you must learn to play and
 
    The **Pause** button is disabled until the play event occurs.
 
-2. Define the button functions. Play and pause the media file using the `play()` and `pause()` methods of the `HTMLMediaElement` interface (in [mobile](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#media-element), [wearable](http://www.w3.org/TR/2014/CR-html5-20140429/embedded-content-0.html#media-element), and [TV](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#media-element) applications).
+2. Define the button functions. Play and pause the media file using the `play()` and `pause()` methods of the `HTMLMediaElement` interface (in [mobile](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#media-element){:target="_blank"}, [wearable](http://www.w3.org/TR/2014/CR-html5-20140429/embedded-content-0.html#media-element){:target="_blank"}, and [TV](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#media-element){:target="_blank"} applications):
 
    ```
    <script>
@@ -137,19 +137,19 @@ To provide users with HTML5 audio and video features, you must learn to play and
 
    ![Playing files (in mobile applications only)](./media/video_audio4.png)
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following files:
 
-- [play_pause.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element)
-- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media)
+- [play_pause.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element){:target="_blank"}
+- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media){:target="_blank"}
 
 <a name="retrieve"></a>
-## Retrieving Media Information
+## Retrieve media information
 
 To provide users with HTML5 audio and video features, you must learn to retrieve the total duration and playing time of a media file:
 
-> **Note**  
+> [!NOTE]
 > The media file metadata can only be retrieved, if it is loaded in the application. The `preload` attribute is must be set to `auto`, or the `autoplay` attribute be set as `true`.
 
 1. Create the `video` element and the elements to display the total duration and playing time of the file:
@@ -236,14 +236,14 @@ To provide users with HTML5 audio and video features, you must learn to retrieve
 
    ![Displaying the duration and play time (in mobile applications only)](./media/video_audio5.png)
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following files:
 
-- [play_time_view.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element)
-- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media)
+- [play_time_view.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element){:target="_blank"}
+- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media){:target="_blank"}
 
-## Moving the Timeline Position
+## Move the timeline position
 
 To provide users with HTML5 audio and video features, you must learn to move the play position on the timeline:
 
@@ -292,14 +292,14 @@ To provide users with HTML5 audio and video features, you must learn to move the
 
    ![Moving the timeline position (in mobile applications only)](./media/video_audio6.png)
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following files:
 
-- [time_jumping.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element)
-- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media)
+- [time_jumping.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element){:target="_blank"}
+- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media){:target="_blank"}
 
-## Displaying the Progress State
+## Display the progress state
 
 To provide users with HTML5 audio and video features, you must learn to check the download progress status of media content:
 
@@ -314,7 +314,7 @@ To provide users with HTML5 audio and video features, you must learn to check th
 
    While the download is in progress, the `poster1.png` image is shown.
 
-2. The `buffered` attribute of the `video` object returns a [TimeRanges](http://www.w3.org/TR/html5/embedded-content-0.html#timeranges) object that represents the downloaded buffering range. Use the `end` property of the `TimeRanges` object to find out the end time (in seconds) of the buffered range:
+2. The `buffered` attribute of the `video` object returns a [TimeRanges](http://www.w3.org/TR/html5/embedded-content-0.html#timeranges){:target="_blank"} object that represents the downloaded buffering range. Use the `end` property of the `TimeRanges` object to find out the end time (in seconds) of the buffered range:
 
    ```
    <script>
@@ -329,7 +329,7 @@ To provide users with HTML5 audio and video features, you must learn to check th
            var buffered_end = buffered.end();
    ```
 
-3. Use the `progress` [media event](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Events) to convert the end time to percent form, and display the progress state:
+3. Use the `progress` [media event](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Events){:target="_blank"} to convert the end time to percent form, and display the progress state:
 
    ```
            /* Change to progress rate percent */
@@ -345,19 +345,19 @@ To provide users with HTML5 audio and video features, you must learn to check th
 
    ![Displaying progress state (in mobile applications only)](./media/video_audio7.png)
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following files:
 
-- [progress.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element)
-- [poster_sample.png](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media)
-- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media)
+- [progress.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element){:target="_blank"}
+- [poster_sample.png](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media){:target="_blank"}
+- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media){:target="_blank"}
 
-## Resizing the Video Screen
+## Resize the video screen
 
 To provide users with HTML5 audio and video features, you must learn to resize the video screen:
 
-> **Note**  
+> [!NOTE]
 > If the screen size is reduced, the basic `play` control can be wrongly positioned. Therefore, do not use the `controls` attribute when providing the resizing custom control.
 
 1. Create the `video` element and buttons used to control the screen size:
@@ -401,14 +401,14 @@ To provide users with HTML5 audio and video features, you must learn to resize t
 
    ![Resizing the video screen (in mobile applications only)](./media/video_audio8.png)
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following files:
 
-- [resize.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element)
-- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media)
+- [resize.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element){:target="_blank"}
+- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media){:target="_blank"}
 
-## Checking Supported Media Formats
+## Check supported media formats
 
 Tizen supports the following media formats:
 
@@ -431,7 +431,7 @@ To provide users with HTML5 audio and video features, you must learn to check wh
    </div>
    ```
 
-2. Use the `canPlayType()` method (in [mobile](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#dom-navigator-canplaytype), [wearable](http://www.w3.org/TR/2014/CR-html5-20140429/embedded-content-0.html#dom-navigator-canplaytype), and [TV](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#dom-navigator-canplaytype) applications) to check, whether the selected media files have an acceptable MIME type, and can be played:
+2. Use the `canPlayType()` method (in [mobile](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#dom-navigator-canplaytype){:target="_blank"}, [wearable](http://www.w3.org/TR/2014/CR-html5-20140429/embedded-content-0.html#dom-navigator-canplaytype){:target="_blank"}, and [TV](http://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#dom-navigator-canplaytype){:target="_blank"} applications) to check, whether the selected media files have an acceptable MIME type, and can be played:
 
    ```
    <script>
@@ -451,11 +451,11 @@ To provide users with HTML5 audio and video features, you must learn to check wh
 
 For the complete source code related to this use case, see the following files:
 
-- [can_play_type.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element)
-- [video_sample_001.ogv](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media)
-- [video_sample_002.webm](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media)
+- [can_play_type.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element){:target="_blank"}
+- [video_sample_001.ogv](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media){:target="_blank"}
+- [video_sample_002.webm](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media){:target="_blank"}
 
-## Handling Errors
+## Handle errors
 
 To provide users with HTML5 audio and video features, you must learn to handle errors that can occur during playback:
 
@@ -501,14 +501,14 @@ To provide users with HTML5 audio and video features, you must learn to handle e
    </script>
    ```
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following files:
 
-- [error.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element)
-- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media)
+- [error.html](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element){:target="_blank"}
+- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/media/html5_the_video_element_and_html5_the_audio_element/media){:target="_blank"}
 
-## Supported Codecs
+## Supported codecs
 
 The following tables list the codecs supported in Tizen.
 
@@ -533,7 +533,7 @@ The following tables list the codecs supported in Tizen.
 | Audio | AMR-WB                                   | No      | Yes     |
 | Audio | VORBIS                                   | Yes     | Yes     |
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/w3c/multimedia/webaudio.md
+++ b/docs/application/web/guides/w3c/multimedia/webaudio.md
@@ -4,29 +4,29 @@ You can include high-quality sound in your application by setting space and dire
 
 This feature is supported in mobile and TV applications only.
 
-The main features of the Web Audio API include:
+The main features of the Web Audio API include the following:
 
 - Loading source data
 
   You must [load source data](#loading-data-and-creating-audio-context) before using the Web Audio API. You can do this using [XMLHttprequest](../communication/xmlhttprequest.md).
 
-  The [AudioContext](https://www.w3.org/TR/2015/WD-webaudio-20151208/#AudioContext) interface is used to manage and play the sound. It creates a high quality sound and connects to the destination of the sound.
+  The [AudioContext](https://www.w3.org/TR/webaudio/#AudioContext){:target="_blank"} interface is used to manage and play the sound. It creates a high quality sound and connects to the destination of the sound.
 
 - Modular routing
 
-  [Modular routing](https://www.w3.org/TR/2015/WD-webaudio-20151208/#ModularRouting) means [routing audio data](#using-modular-routing) either in a direct manner, such as speaker output, or through a connection to [AudioNodes](https://www.w3.org/TR/2015/WD-webaudio-20151208/#the-audionode-interface), which handle, for example, volume adjustment and filters.
+  [Modular routing](https://www.w3.org/TR/webaudio/#ModularRouting){:target="_blank"} means [routing audio data](#using-modular-routing) either in a direct manner, such as speaker output, or through a connection to [AudioNodes](https://www.w3.org/TR/webaudio/#AudioNode){:target="_blank"}, which handle, for example, volume adjustment and filters.
 
 - Playing sound
 
   Use the `noteOn(time)` or `start(time)` method to [play sound](#playing-sound) with the time parameter for specifying the time interval in seconds after which the audio is played. For example, the `0` time value implies playing the audio immediately and the `currentTime + 0.75` time value implies that the audio is played after 0.75 seconds.
 
-  You can use the `noteOff(time)` or `stop(time)` methods similarly to stop the sound. After stopping sound, recreate the [AudioBufferSourceNode](https://www.w3.org/TR/2015/WD-webaudio-20151208/#AudioBufferSourceNode) interface instance to play sound again.
+  You can use the `noteOff(time)` or `stop(time)` methods similarly to stop the sound. After stopping sound, recreate the [AudioBufferSourceNode](https://www.w3.org/TR/webaudio/#AudioBufferSourceNode){:target="_blank"} interface instance to play sound again.
 
-## Loading Data and Creating Audio Context
+## Load data and create audio context
 
-To provide users with sophisticated audio features, you must learn to modulate source data into decoded audio data using [XMLHttpRequest](../communication/xmlhttprequest.md), and create an instance of the [AudioContext](https://www.w3.org/TR/2015/WD-webaudio-20151208/#AudioContext) interface:
+To provide users with sophisticated audio features, you must learn to modulate source data into decoded audio data using [XMLHttpRequest](../communication/xmlhttprequest.md), and create an instance of the [AudioContext](https://www.w3.org/TR/webaudio/#AudioContext){:target="_blank"} interface:
 
-1. To load source audio data:
+1. To load source audio data, follow these steps:
 
    1. Load a source audio file using XMLHttpRequest. Set the `responseType` to `arraybuffer` to receive binary response:
 
@@ -53,7 +53,7 @@ To provide users with sophisticated audio features, you must learn to modulate s
       </script>
       ```
 
-      This data is used in the [AudioBuffer](https://www.w3.org/TR/2015/WD-webaudio-20151208/#AudioBuffer).
+      This data is used in the [AudioBuffer](https://www.w3.org/TR/webaudio/#AudioBuffer){:target="_blank"}.
 
 2. To create an audio context:
 
@@ -68,11 +68,11 @@ To provide users with sophisticated audio features, you must learn to modulate s
 
    AudioContext instance supports various sound inputs, and it is possible to create an audio graph. You can create 1 or more sound sources to manage sound and connect to the sound destination.
 
-   The majority of the Web Audio API features, such as creating audio file data, decoding it, and creating [AudioNodes](https://www.w3.org/TR/2015/WD-webaudio-20151208/#the-audionode-interface) are managed using the methods of the `AudioContext` interface.
+   The majority of the Web Audio API features, such as creating audio file data, decoding it, and creating [AudioNodes](https://www.w3.org/TR/webaudio/#AudioNode){:target="_blank"} are managed using the methods of the `AudioContext` interface.
 
 3. To create an audio buffer:
 
-   Create an [AudioBuffer](https://www.w3.org/TR/2015/WD-webaudio-20151208/#AudioBuffer) interface using the array buffer of audio data response attributes of the `XMLHttpRequest()` method. Select from the following options:
+   Create an [AudioBuffer](https://www.w3.org/TR/webaudio/#AudioBuffer){:target="_blank"} interface using the array buffer of audio data response attributes of the `XMLHttpRequest()` method. Select from the following options:
 
    - Create the audio buffer using the `createBuffer()` method:
 
@@ -133,19 +133,19 @@ To provide users with sophisticated audio features, you must learn to modulate s
 
    To use an audio buffer created with the `createBuffer()` or `decodeAudioData()` method, the buffer must be allocated to the `audioBufferSourceNode` buffer.
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [web_audio_basic_playback.html](http://download.tizen.org/misc/examples/w3c_html5/media/web_audio_api)
+- [web_audio_basic_playback.html](http://download.tizen.org/misc/examples/w3c_html5/media/web_audio_api){:target="_blank"}
 
-## Using Modular Routing
+## Use modular routing
 
-To provide users with sophisticated audio features, you must learn to enable routing audio source data using [AudioNode](https://www.w3.org/TR/2015/WD-webaudio-20151208/#the-audionode-interface) objects:
+To provide users with sophisticated audio features, you must learn to enable routing audio source data using [AudioNode](https://www.w3.org/TR/webaudio/#AudioNode){:target="_blank"} objects:
 
 1. To route to speaker output in a direct sound destination:
 
-   1. Create a WebKit-based [AudioContext](https://www.w3.org/TR/2015/WD-webaudio-20151208/#AudioContext) instance:
+   1. Create a WebKit-based [AudioContext](https://www.w3.org/TR/webaudio/#AudioContext){:target="_blank"} instance:
 
       ```
       <script>
@@ -169,7 +169,7 @@ To provide users with sophisticated audio features, you must learn to enable rou
       </script>
       ```
 
-      All routing occurs within an `AudioContext` containing a single [AudioDestinationNode](https://www.w3.org/TR/2015/WD-webaudio-20151208/#AudioDestinationNode).
+      All routing occurs within an `AudioContext` containing a single [AudioDestinationNode](https://www.w3.org/TR/webaudio/#AudioDestinationNode){:target="_blank"}.
 
       ![Direct routing](./media/web_audio1.png)
 
@@ -212,19 +212,19 @@ To provide users with sophisticated audio features, you must learn to enable rou
 
       ![Routing from multiple sources](./media/web_audio2.png)
 
-`AudioNodes` can be used to activate sound effects, and create tweaks, audio parameters, and audio graphs using the [GainNode](https://www.w3.org/TR/2015/WD-webaudio-20151208/#GainNode) interface, or filter sounds using the [BiquadFilterNode](https://www.w3.org/TR/2015/WD-webaudio-20151208/#the-biquadfilternode-interface) interface.
+`AudioNodes` can be used to activate sound effects, and create tweaks, audio parameters, and audio graphs using the [GainNode](https://www.w3.org/TR/webaudio/#GainNode){:target="_blank"} interface, or filter sounds using the [BiquadFilterNode](https://www.w3.org/TR/webaudio/#BiquadFilterNode){:target="_blank"} interface.
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [web_audio_basic_playback.html](http://download.tizen.org/misc/examples/w3c_html5/media/web_audio_api)
+- [web_audio_basic_playback.html](http://download.tizen.org/misc/examples/w3c_html5/media/web_audio_api){:target="_blank"}
 
-## Playing Sound
+## Play sound
 
 To provide users with sophisticated audio features, you must learn to play sound:
 
-1. Create a WebKit-based [AudioContext](https://www.w3.org/TR/2015/WD-webaudio-20151208/#AudioContext) instance:
+1. Create a WebKit-based [AudioContext](https://www.w3.org/TR/webaudio/#AudioContext){:target="_blank"} instance:
 
    ```
    <script>
@@ -248,15 +248,15 @@ To provide users with sophisticated audio features, you must learn to play sound
 
    You can also use time as parameter of the `noteOff()` method. If you set the value as '0', the playback stops immediately.
 
-The `AudioContext` instance digitally modulates the audio source file into audio data. After creating the sound source, playback is implemented by processing audio data using [AudioNodes](https://www.w3.org/TR/2015/WD-webaudio-20151208/#the-audionode-interface) either directly to the speaker, or in the middle.
+The `AudioContext` instance digitally modulates the audio source file into audio data. After creating the sound source, playback is implemented by processing audio data using [AudioNodes](https://www.w3.org/TR/webaudio/#AudioNode){:target="_blank"} either directly to the speaker, or in the middle.
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [web_audio_basic_playback.html](http://download.tizen.org/misc/examples/w3c_html5/media/web_audio_api)
+- [web_audio_basic_playback.html](http://download.tizen.org/misc/examples/w3c_html5/media/web_audio_api){:target="_blank"}
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 3.0 and Higher for TV


### PR DESCRIPTION
This PR includes the fix of the following files which are part of the web application guides section of the Tizen Docs site:

File count: 6

/application/web/guides/w3c/multimedia/getusermedia.md
/application/web/guides/w3c/multimedia/video-audio.md
/application/web/guides/w3c/multimedia/media-capture.md
/application/web/guides/w3c/multimedia/webaudio.md
/application/web/guides/w3c/multimedia/sound-policy.md
/application/web/guides/w3c/communication/comm-guide.md