### PR TITLE
Web application site fix (Part - 26)

### DIFF
--- a/docs/application/web/guides/w3c/communication/server-sent.md
+++ b/docs/application/web/guides/w3c/communication/server-sent.md
@@ -4,25 +4,25 @@ The Server-Sent Events feature is used to implement server push functionality in
 
 This feature is supported in mobile and TV applications only.
 
-The Server-Sent Events API defines a simple data structure and interface, and a communication mechanism to realize the server push. In addition, it can handle the received data in the general DOM event format. However, the API repeatedly requests the data from the client to the server, so it is not a complete server push. The repeat period of the server request is determined by the `retry` field value of the [event stream data](http://www.w3.org/TR/2015/REC-eventsource-20150203/#event-stream-interpretation). If the value is not defined, the repeat period is the default value of the browser.
+The Server-Sent Events API defines a simple data structure and interface, and a communication mechanism to realize the server push. In addition, it can handle the received data in the general DOM event format. However, the API repeatedly requests the data from the client to the server, so it is not a complete server push. The repeat period of the server request is determined by the `retry` field value of the [event stream data](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation){:target="_blank"}. If the value is not defined, the repeat period is the default value of the browser.
 
-The main features of the Server-Sent Events API include:
+The main features of the Server-Sent Events API include the following:
 
-- Creating an [EventSource](http://www.w3.org/TR/2015/REC-eventsource-20150203/#the-eventsource-interface) instance
+- Creating an [EventSource](https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface){:target="_blank"} instance
 
   The `EventSource` interface is the core object of server-sent event implementation. [Creating a new EventSource instance](#triggering-server-push-requests) triggers repeated server request automatically, and allows you to use the receiving data event. When creating the `EventSource` instance, you must use the URL of the server page sending the event stream as a parameter.
 
 - Receiving server push data
 
-  After triggering the server requests, you can [receive push data from the server](#receiving-server-push-data) by implementing the [message](http://www.w3.org/TR/2015/REC-eventsource-20150203/#handler-eventsource-onmessage) event.
+  After triggering the server requests, you can [receive push data from the server](#receiving-server-push-data) by implementing the [message](https://html.spec.whatwg.org/multipage/images.html#images-processing-model){:target="_blank"} event.
 
-  The received event stream data is parsed as a [MessageEvent](http://www.w3.org/TR/2015/REC-webmessaging-20150519/#the-messageevent-interfaces) object, to make the target data easily accessible.
+  The received event stream data is parsed as a [MessageEvent](https://html.spec.whatwg.org/multipage/comms.html#the-messageevent-interface){:target="_blank"} object, to make the target data easily accessible.
 
-## Triggering Server Push Requests
+## Trigger server push requests
 
 To take advantage of the server push feature, you must learn to connect to the server to request push data:
 
-1. Create an [EventSource](http://www.w3.org/TR/2015/REC-eventsource-20150203/#the-eventsource-interface) interface instance:
+1. Create an [EventSource](https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface){:target="_blank"} interface instance:
 
    ```
    <script>
@@ -30,10 +30,10 @@ To take advantage of the server push feature, you must learn to connect to the s
        var eventSource = new EventSource(serverPage);
    ```
 
-   > **Note**  
+   > [!NOTE]
    > For the server push to work, the `serverPage` parameter must contain the actual push server URL.
 
-2. Implement the event handler for the [open](http://www.w3.org/TR/2015/REC-eventsource-20150203/#handler-eventsource-onopen) event:
+2. Implement the event handler for the [open](https://html.spec.whatwg.org/multipage/images.html#images-processing-model){:target="_blank"} event:
 
    ```
        var log = document.getElementById('log')
@@ -45,7 +45,7 @@ To take advantage of the server push feature, you must learn to connect to the s
    </script>
    ```
 
-   The `open` event is triggered repeatedly based on the `retry` value of the [event stream data format](http://www.w3.org/TR/2015/REC-eventsource-20150203/#event-stream-interpretation), to request push messages from the server.
+   The `open` event is triggered repeatedly based on the `retry` value of the [event stream data format](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation){:target="_blank"}, to request push messages from the server.
 
 In the following figure, the `open` event is fired every 2 seconds.
 
@@ -53,20 +53,20 @@ In the following figure, the `open` event is fired every 2 seconds.
 
 ![Push request event](./media/server-sent_request.png)
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following files:
 
-- [server_sent_events_client1.html](http://download.tizen.org/misc/examples/w3c_html5/communication/server_sent_events)
-- [server_sent_events_server.php](http://download.tizen.org/misc/examples/w3c_html5/communication/server_sent_events)
+- [server_sent_events_client1.html](http://download.tizen.org/misc/examples/w3c_html5/communication/server_sent_events){:target="_blank"}
+- [server_sent_events_server.php](http://download.tizen.org/misc/examples/w3c_html5/communication/server_sent_events){:target="_blank"}
 
-## Receiving Server Push Data
+## Receive server push data
 
 To take advantage of the server push feature, you must learn to handle the push data events:
 
-1. Define the data server that the client connects to, according to the [event stream interpretation rules](http://www.w3.org/TR/2015/REC-eventsource-20150203/#event-stream-interpretation).
+1. Define the data server that the client connects to, according to the [event stream interpretation rules](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation){:target="_blank"}.
 
-   Set the [MIME type](http://www.w3.org/TR/2015/REC-eventsource-20150203/#text-event-stream) to `text/event-stream` so that the event stream can be sent, and set the header not to be cached.
+   Set the [MIME type](https://html.spec.whatwg.org/multipage/iana.html#iana){:target="_blank"} to `text/event-stream` so that the event stream can be sent, and set the header not to be cached:
 
    ```
    <?php
@@ -80,7 +80,7 @@ To take advantage of the server push feature, you must learn to handle the push 
    ?>
    ```
 
-2. Create an [EventSource](http://www.w3.org/TR/2015/REC-eventsource-20150203/#the-eventsource-interface) interface instance and implement the event handler for the [message](http://www.w3.org/TR/2015/REC-eventsource-20150203/#handler-eventsource-onmessage) event:
+2. Create an [EventSource](https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface){:target="_blank"} interface instance and implement the event handler for the [message](https://html.spec.whatwg.org/multipage/images.html#images-processing-model){:target="_blank"} event:
 
    ```
    <script>
@@ -107,14 +107,14 @@ In the following figure, the `open` event is fired every 2 seconds and the `mess
 
 ![Push message event](./media/server-sent_message.png)
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following files:
 
-- [server_sent_events_client2.html](http://download.tizen.org/misc/examples/w3c_html5/communication/server_sent_events)
-- [server_sent_events_server.php](http://download.tizen.org/misc/examples/w3c_html5/communication/server_sent_events)
+- [server_sent_events_client2.html](http://download.tizen.org/misc/examples/w3c_html5/communication/server_sent_events){:target="_blank"}
+- [server_sent_events_server.php](http://download.tizen.org/misc/examples/w3c_html5/communication/server_sent_events){:target="_blank"}
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 3.0 and Higher for TV

--- a/docs/application/web/guides/w3c/communication/web-messaging.md
+++ b/docs/application/web/guides/w3c/communication/web-messaging.md
@@ -2,21 +2,21 @@
 
 Web messaging is used to deliver messages between documents. Web messaging allows [cross-origin resource sharing (CORS)](../security/cors.md).
 
-The main features of the HTML5 Web Messaging API include:
+The main features of the HTML5 Web Messaging API include the following:
 
 - Cross-document messaging
 
-  You can [send and receive data between more than 2 Web pages](#using-cross-document-messaging). Because the [Same Origin Policy](http://www.w3.org/2001/tag/dj9/scriptorigin.html) is not applied for cross-document messaging, communication between other domains is also possible.
+  You can [send and receive data between more than 2 Web pages](#using-cross-document-messaging). Because the [Same Origin Policy](http://www.w3.org/2001/tag/dj9/scriptorigin.html){:target="_blank"} is not applied for cross-document messaging, communication between other domains is also possible.
 
 - Channel messaging
 
-   You can [send and receive messages through the port](#using-channel-messaging) of the `MessageChannel` interface (in [mobile](http://www.w3.org/TR/2015/REC-webmessaging-20150519/#message-channels), [wearable](http://www.w3.org/TR/2012/CR-webmessaging-20120501/#message-channels), and [TV](http://www.w3.org/TR/2015/REC-webmessaging-20150519/#message-channels) applications).
+   You can [send and receive messages through the port](#using-channel-messaging) of the `MessageChannel` interface (in [mobile](https://html.spec.whatwg.org/multipage/web-messaging.html#message-channels){:target="_blank"}, [wearable](https://html.spec.whatwg.org/multipage/web-messaging.html#message-channels){:target="_blank"}, and [TV](https://html.spec.whatwg.org/multipage/web-messaging.html#message-channels){:target="_blank"} applications).
 
-With the Web Messaging API, messages are sent and received asynchronously using the `MessageEvent` object (in [mobile](http://www.w3.org/TR/2015/REC-webmessaging-20150519/#the-messageevent-interfaces), [wearable](http://www.w3.org/TR/2012/CR-webmessaging-20120501/#event-definitions), and [TV](http://www.w3.org/TR/2015/REC-webmessaging-20150519/#the-messageevent-interfaces) applications), within 1 domain or between different domains.
+With the Web Messaging API, messages are sent and received asynchronously using the `MessageEvent` object (in [mobile](https://html.spec.whatwg.org/multipage/comms.html#the-messageevent-interface){:target="_blank"}, [wearable](https://html.spec.whatwg.org/multipage/comms.html#the-messageevent-interface){:target="_blank"}, and [TV](https://html.spec.whatwg.org/multipage/comms.html#the-messageevent-interface){:target="_blank"} applications), within 1 domain or between different domains.
 
-## Using Cross-document Messaging
+## Use cross-document messaging
 
-Send the message from the sending page using the `postMessage()` method of the receiving page window object (in [mobile](http://www.w3.org/TR/2015/REC-webmessaging-20150519/#posting-messages), [wearable](http://www.w3.org/TR/2012/CR-webmessaging-20120501/#posting-messages), and [TV](http://www.w3.org/TR/2015/REC-webmessaging-20150519/#posting-messages) applications). To receive the page, the receiving page window object must be registered to receive messages.
+Send the message from the sending page using the `postMessage()` method of the receiving page window object (in [mobile](https://html.spec.whatwg.org/multipage/web-messaging.html#posting-messages){:target="_blank"}, [wearable](https://html.spec.whatwg.org/multipage/web-messaging.html#posting-messages){:target="_blank"}, and [TV](https://html.spec.whatwg.org/multipage/web-messaging.html#posting-messages){:target="_blank"} applications). To receive the page, the receiving page window object must be registered to receive messages.
 
 The `postMessage()` method supports the following parameters:
 
@@ -36,7 +36,7 @@ Learning how to use cross-document messaging enhances the communication capabili
 
 3. In document A, use the `sendMessage()` method to send a message to document B.
 
-   Use the `postMessage()` method of the `iframe` window, which sends the message from the method content, to deliver the message to the `iframe`.
+   Use the `postMessage()` method of the `iframe` window, which sends the message from the method content, to deliver the message to the `iframe`:
 
    ```
    <script>
@@ -60,19 +60,19 @@ Learning how to use cross-document messaging enhances the communication capabili
    </script>
    ```
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [web_messaging_cross_document_messaging.htm](http://download.tizen.org/misc/examples/w3c_html5/communication/html5_web_messaging)
+- [web_messaging_cross_document_messaging.htm](http://download.tizen.org/misc/examples/w3c_html5/communication/html5_web_messaging){:target="_blank"}
 
-## Using Channel Messaging
+## Use channel messaging
 
 The `MessageChannel` instance broadcasts message sending and receiving, and has 2 properties: `port1` and `port2`. Each port is used to send and receive messages, and a message that is sent from one port with the `postMessage()` method is received by the other through the `message` event.
 
 Learning how to use channel messaging enhances the communication capabilities of your application:
 
-1. To send a message from document A to document B, create in document A a `MessageChannel` interface instance (in [mobile](http://www.w3.org/TR/2015/REC-webmessaging-20150519/#message-channels), [wearable](http://www.w3.org/TR/2012/CR-webmessaging-20120501/#message-channels), and [TV](http://www.w3.org/TR/2015/REC-webmessaging-20150519/#message-channels) applications), which has 2 `message port` attributes (in [mobile](http://www.w3.org/TR/2015/REC-webmessaging-20150519/#message-ports), [wearable](http://www.w3.org/TR/2012/CR-webmessaging-20120501/#message-ports), [TV](http://www.w3.org/TR/2015/REC-webmessaging-20150519/#message-ports) applications): `port1` and `port2`.
+1. To send a message from document A to document B, create in document A a `MessageChannel` interface instance (in [mobile](https://html.spec.whatwg.org/multipage/web-messaging.html#message-channels){:target="_blank"}, [wearable](https://html.spec.whatwg.org/multipage/web-messaging.html#message-channels){:target="_blank"}, and [TV](https://html.spec.whatwg.org/multipage/web-messaging.html#message-channels){:target="_blank"} applications), which has 2 `message port` attributes (in [mobile](https://html.spec.whatwg.org/multipage/web-messaging.html#message-ports){:target="_blank"}, [wearable](https://html.spec.whatwg.org/multipage/web-messaging.html#message-ports){:target="_blank"}, [TV](https://html.spec.whatwg.org/multipage/web-messaging.html#message-ports){:target="_blank"} applications): `port1` and `port2`.
 
    The `port2` attribute of the `MessageChannel` instance is delivered to document B through the `postMessage()` method of the document B window object:
 
@@ -97,11 +97,11 @@ Learning how to use channel messaging enhances the communication capabilities of
    </script>
    ```
 
-   > **Note**  
-   > The `postMessage()` method can have 3 parameters: `message`, `origin` (in [mobile](http://www.w3.org/TR/2015/REC-webmessaging-20150519/#security-postmsg), [wearable](http://www.w3.org/TR/2012/CR-webmessaging-20120501/#security-postmsg), and [TV](http://www.w3.org/TR/2015/REC-webmessaging-20150519/#security-postmsg) applications), and `ports`.  
+   > [!NOTE]
+   > The `postMessage()` method can have 3 parameters: `message`, `origin` (in [mobile](https://html.spec.whatwg.org/multipage/web-messaging.html#posting-messages){:target="_blank"}, [wearable](https://html.spec.whatwg.org/multipage/web-messaging.html#posting-messages){:target="_blank"}, and [TV](https://html.spec.whatwg.org/multipage/web-messaging.html#posting-messages){:target="_blank"} applications), and `ports`.  
    > According to the W3C specifications, the arguments are ordered as `message`, `origin`, and `ports`. However, in Tizen, the order used is actually `message`, `ports`, and `origin`. This approach is used in all browsers that currently support the `MessageChannel` interface.
 
-2. Define a `message` event in the `window` object of document B, and register the event handler in the `port` sent from document A.
+2. Define a `message` event in the `window` object of document B, and register the event handler in the `port` sent from document A:
 
    ```
    <script>
@@ -121,14 +121,14 @@ Learning how to use channel messaging enhances the communication capabilities of
 
    A message sent through the `postMessage()` method of `port1` from document A is received through the `message` event of `port2` in document B, and the message sent through the `postMessage()` method of `port2` from document B is received through the `message` event of `port1` in document A.
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following files:
 
-- [web_messaging_channel_messaging.htm](http://download.tizen.org/misc/examples/w3c_html5/communication/html5_web_messaging)
-- [web_messaging_channel_messaging_iframe.htm](http://download.tizen.org/misc/examples/w3c_html5/communication/html5_web_messaging)
+- [web_messaging_channel_messaging.htm](http://download.tizen.org/misc/examples/w3c_html5/communication/html5_web_messaging){:target="_blank"}
+- [web_messaging_channel_messaging_iframe.htm](http://download.tizen.org/misc/examples/w3c_html5/communication/html5_web_messaging){:target="_blank"}
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/w3c/communication/websocket.md
+++ b/docs/application/web/guides/w3c/communication/websocket.md
@@ -4,13 +4,13 @@ WebSocket in a Web environment enables connection-oriented full duplex communica
 
 The difference between the previously used communication method in the Web environment and the new  Web socket lies in the protocol. The Web socket protocol uses HTTP in establishing a connection, however, all communication after the connection is established happens using the Web socket's independent protocol.
 
-With a Web socket, the used header is extremely small, causing very little overhead. A long-term connection is used as a basis, meaning that if there is connection, sending data from client or server is possible. The long-term connection means that data can be sent and received through 1 connection, and you do not need to establish a separate connection for each sending and receiving instance. [Ping and pong frames](http://www.w3.org/TR/2012/CR-websockets-20120920/#ping-and-pong-frames) can also be used.
+With a Web socket, the used header is extremely small, causing very little overhead. A long-term connection is used as a basis, meaning that if there is connection, sending data from client or server is possible. The long-term connection means that data can be sent and received through 1 connection, and you do not need to establish a separate connection for each sending and receiving instance. [Ping and pong frames](https://websockets.spec.whatwg.org//#ping-and-pong-frames){:target="_blank"} can also be used.
 
-The main features of the WebSocket API include:
+The main features of the WebSocket API include the following:
 
 - Connecting to a server
 
-  To [connect to a server](#connecting-to-the-socket-server), you must create a [WebSocket](http://www.w3.org/TR/2012/CR-websockets-20120920/#the-websocket-interface) interface with the socket server URL as a mandatory parameter. The [URL format has some restrictions](http://www.w3.org/TR/2012/CR-websockets-20120920/#parsing-websocket-urls), for example, it must use the `ws` or `wss` protocol. If the URL is not valid or uses a wrong protocol, a syntax error occurs.
+  To [connect to a server](#connecting-to-the-socket-server), you must create a [WebSocket](https://websockets.spec.whatwg.org//#the-websocket-interface){:target="_blank"} interface with the socket server URL as a mandatory parameter. The [URL format has some restrictions](https://websockets.spec.whatwg.org//#the-websocket-interface){:target="_blank"}, for example, it must use the `ws` or `wss` protocol. If the URL is not valid or uses a wrong protocol, a syntax error occurs.
 
 - Sending data
 
@@ -24,11 +24,11 @@ The main features of the WebSocket API include:
 
   When the connection is no longer needed, you can [close the connection](#closing-the-socket-connection) with the `close()` method.
 
-## Connecting to the Socket Server
+## Connect to the socket server
 
 To use the Web socket features in your application, you must learn to connect to a socket server:
 
-1. Create a [WebSocket](http://www.w3.org/TR/2012/CR-websockets-20120920/#the-websocket-interface) interface instance using a valid socket server URL as a parameter:
+1. Create a [WebSocket](https://websockets.spec.whatwg.org//#the-websocket-interface){:target="_blank"} interface instance using a valid socket server URL as a parameter:
 
    ```
    var webSocketUrl = 'wss://html5labs-interop.cloudapp.net:443/echo';
@@ -54,17 +54,17 @@ To use the Web socket features in your application, you must learn to connect to
 
    If the connection is established, the `readyState` attribute is changed to `1` and the `open` event is triggered. If the connection fails, the attribute value is set to `3`, and the HTTP 503 error is returned.
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [web_socket.htm](http://download.tizen.org/misc/examples/w3c_html5/communication/the_websocket_api)
+- [web_socket.htm](http://download.tizen.org/misc/examples/w3c_html5/communication/the_websocket_api){:target="_blank"}
 
-## Sending Data to the Server
+## Send data to the server
 
 To use the Web socket features in your application, you must learn to connect to send data to the server:
 
-1. Create a [WebSocket](http://www.w3.org/TR/2012/CR-websockets-20120920/#the-websocket-interface) interface instance using a valid socket server URL as a parameter:
+1. Create a [WebSocket](https://websockets.spec.whatwg.org//#the-websocket-interface){:target="_blank"} interface instance using a valid socket server URL as a parameter:
 
    ```
    var webSocketUrl = 'wss://html5labs-interop.cloudapp.net:443/echo';
@@ -74,7 +74,7 @@ To use the Web socket features in your application, you must learn to connect to
 
 2. Check the `readyState` attribute value, which is `1` (OPEN), if the socket is connected.
 
-   If the socket is connected, use the `send()` method to send the data.
+   If the socket is connected, use the `send()` method to send the data:
 
    ```
    function sendMessage(msg) {
@@ -84,17 +84,17 @@ To use the Web socket features in your application, you must learn to connect to
    }
    ```
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [web_socket.htm](http://download.tizen.org/misc/examples/w3c_html5/communication/the_websocket_api)
+- [web_socket.htm](http://download.tizen.org/misc/examples/w3c_html5/communication/the_websocket_api){:target="_blank"}
 
-## Receiving Data from the Server
+## Receive data from the server
 
 To use the Web socket features in your application, you must learn to receive data from the server:
 
-1. Create a [WebSocket](http://www.w3.org/TR/2012/CR-websockets-20120920/#the-websocket-interface) interface instance using a valid socket server URL as a parameter:
+1. Create a [WebSocket](https://websockets.spec.whatwg.org//#the-websocket-interface){:target="_blank"} interface instance using a valid socket server URL as a parameter:
 
    ```
    var webSocketUrl = 'wss://html5labs-interop.cloudapp.net:443/echo';
@@ -102,7 +102,7 @@ To use the Web socket features in your application, you must learn to receive da
    var webSocket = new WebSocket(webSocketURL);
    ```
 
-2. Register the `message` event in the `WebSocket` instance. The event is triggered when data is received from the server.
+2. Register the `message` event in the `WebSocket` instance. The event is triggered when data is received from the server:
 
    ```
    webSocket.onmessage = function(e) {
@@ -110,17 +110,17 @@ To use the Web socket features in your application, you must learn to receive da
    };
    ```
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [web_socket.htm](http://download.tizen.org/misc/examples/w3c_html5/communication/the_websocket_api)
+- [web_socket.htm](http://download.tizen.org/misc/examples/w3c_html5/communication/the_websocket_api){:target="_blank"}
 
-## Closing the Socket Connection
+## Close the socket connection
 
 To use the Web socket features in your application, you must learn to close the socket connection:
 
-1. Create a [WebSocket](http://www.w3.org/TR/2012/CR-websockets-20120920/#the-websocket-interface) interface instance using a valid socket server URL as a parameter:
+1. Create a [WebSocket](https://websockets.spec.whatwg.org//#the-websocket-interface){:target="_blank"} interface instance using a valid socket server URL as a parameter:
 
    ```
    var webSocketUrl = 'wss://html5labs-interop.cloudapp.net:443/echo';
@@ -138,7 +138,7 @@ To use the Web socket features in your application, you must learn to close the 
 
 3. Check the `readyState` attribute value, which is `1` (OPEN), if the socket is connected.
 
-   If the socket is connected, use the `close()` method to close the connection between the client and the server.
+   If the socket is connected, use the `close()` method to close the connection between the client and the server:
 
    ```
    function closeConnection() {
@@ -148,13 +148,13 @@ To use the Web socket features in your application, you must learn to close the 
    }
    ```
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [web_socket.htm](http://download.tizen.org/misc/examples/w3c_html5/communication/the_websocket_api)
+- [web_socket.htm](http://download.tizen.org/misc/examples/w3c_html5/communication/the_websocket_api){:target="_blank"}
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/w3c/communication/xmlhttprequest.md
+++ b/docs/application/web/guides/w3c/communication/xmlhttprequest.md
@@ -1,17 +1,17 @@
 # XMLHttpRequest
 
-You can send HTTP (or HTTPS) [requests](http://www.w3.org/TR/2014/WD-XMLHttpRequest-20140130/#request) to and receive [responses](http://www.w3.org/TR/2014/WD-XMLHttpRequest-20140130/#response) from a Web server using JavaScript. The API is based on the [HTML5](http://www.w3.org/TR/2014/CR-html5-20140429/) specification and the Ajax mechanism widely used in the Web environment, and it has been enhanced from the older [XMLHttpRequest](http://www.w3.org/TR/2012/WD-XMLHttpRequest-20121206/) API.
+You can send HTTP (or HTTPS) [requests](https://www.w3.org/TR/XMLHttpRequest/){:target="_blank"} to and receive [responses](https://www.w3.org/TR/XMLHttpRequest/){:target="_blank"} from a Web server using JavaScript. The API is based on the [HTML5](https://www.w3.org/TR/2014/CR-html5-20140429/){:target="_blank"} specification and the Ajax mechanism widely used in the Web environment, and it has been enhanced from the older [XMLHttpRequest](https://www.w3.org/TR/XMLHttpRequest/){:target="_blank"} API.
 
-The main features of the XMLHttpRequest API include:
+The main features of the XMLHttpRequest API include the following:
 
 - Supporting cross-origin request sharing (CORS)
 
   In the older XMLHttpRequest API, only same-origin resource sharing was possible. However, the latest XMLHttpRequest API supports [CORS](../security/cors.md).
 
-  To [send a cross-origin request](#sending-a-cross-origin-request), you must create an [XMLHttpRequest](http://www.w3.org/TR/2014/WD-XMLHttpRequest-20140130/#dom-xmlhttprequest) interface instance and use its `open()` method. Set the request URL method parameter as the cross-origin URL.
+  To [send a cross-origin request](#sending-a-cross-origin-request), you must create an [XMLHttpRequest](https://www.w3.org/TR/XMLHttpRequest/){:target="_blank"} interface instance and use its `open()` method. Set the request URL method parameter as the cross-origin URL.
 
-> **Note**  
-> For the cross-origin request to work, [the authority for the external domain access must be set](../security/cors.md#using-simple-requests) in the server belonging to the cross-origin URL.
+ > [!NOTE]
+ > For the cross-origin request to work, [the authority for the external domain access must be set](../security/cors.md#using-simple-requests) in the server belonging to the cross-origin URL.
 
 - Supporting various response types
 
@@ -19,24 +19,24 @@ The main features of the XMLHttpRequest API include:
 
 - Supporting form data
 
-  The newly supported [FormData](http://www.w3.org/TR/2014/WD-XMLHttpRequest-20140130/#interface-formdata) interface makes it possible to upload data from an entire form. For more information, see [Uploading Files with Ajax](#uploading-files-with-ajax).
+  The newly supported [FormData](https://www.w3.org/TR/XMLHttpRequest/){:target="_blank"} interface makes it possible to upload data from an entire form. For more information, see [Uploading Files with Ajax](#uploading-files-with-ajax).
 
 - Receiving a more fragmented response state on the request progress status
 
-  The XMLHttpRequst API provides more [event handlers](http://www.w3.org/TR/2014/WD-XMLHttpRequest-20140130/#event-handlers) for [tracking the request status and response](#handling-request-events). In addition, the `onprogress` event handler allows you to [check the send status of a large capacity file download](#tracking-download-progress-state).
+  The XMLHttpRequst API provides more [event handlers](https://www.w3.org/TR/XMLHttpRequest/){:target="_blank"} for [tracking the request status and response](#handling-request-events). In addition, the `onprogress` event handler allows you to [check the send status of a large capacity file download](#tracking-download-progress-state).
 
-## Sending a Cross-origin Request
+## Send a cross-origin request
 
 To use the XML HTTP request features in your application, you must learn to send a cross-origin request:
 
-1. Create an [XMLHttpRequest](http://www.w3.org/TR/2014/WD-XMLHttpRequest-20140130/#dom-xmlhttprequest) interface instance:
+1. Create an [XMLHttpRequest](https://www.w3.org/TR/XMLHttpRequest/){:target="_blank"} interface instance:
 
    ```
    <script>
        var client = new XMLHttpRequest();
    ```
 
-2. Open the connection with the `open()` method using the cross-domain URL as a parameter. Send the request with the `send()` method.
+2. Open the connection with the `open()` method using the cross-domain URL as a parameter. Send the request with the `send()` method:
 
    ```
        client.open('GET', 'video_sample.mp4');
@@ -44,28 +44,28 @@ To use the XML HTTP request features in your application, you must learn to send
    </script>
    ```
 
-	> **Note**  
+	> [!NOTE]
 	> Cross-domain access only works if [the server allows the domain access of the client](../security/cors.md#using-simple-requests).
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following files:
 
-- [xhr3.html](http://download.tizen.org/misc/examples/w3c_html5/communication/xmlhttprequest_level_2)
-- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/communication/xmlhttprequest_level_2)
+- [xhr3.html](http://download.tizen.org/misc/examples/w3c_html5/communication/xmlhttprequest_level_2){:target="_blank"}
+- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/communication/xmlhttprequest_level_2){:target="_blank"}
 
-## Uploading Files with Ajax
+## Upload files with Ajax
 
 To use the XML HTTP request features in your application, you must learn to upload files in the background with Ajax:
 
-1. Define the input elements for the file upload. Use the `upload()` method for the button click event to upload the file when the button is clicked.
+1. Define the input elements for the file upload. Use the `upload()` method for the button click event to upload the file when the button is clicked:
 
    ```
    <input type="file" id="uploadfile" name="uploadfile"/>
    <input type="button" value="upload" onclick="upload()"/>
    ```
 
-2. In the `upload()` method, create a [FormData](http://www.w3.org/TR/2014/WD-XMLHttpRequest-20140130/#interface-formdata) interface instance, and add the [file](http://www.w3.org/wiki/HTML/Elements/input/file) element with the attached file into it. Use the `send()` method to send the `FormData` to the server.
+2. In the `upload()` method, create a [FormData](https://www.w3.org/TR/XMLHttpRequest/){:target="_blank"} interface instance, and add the [file](http://www.w3.org/wiki/HTML/Elements/input/file){:target="_blank"} element with the attached file into it. Use the `send()` method to send the `FormData` to the server:
 
    ```
    <script>
@@ -93,13 +93,13 @@ To use the XML HTTP request features in your application, you must learn to uplo
    </script>
    ```
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [xhr1.html](http://download.tizen.org/misc/examples/w3c_html5/communication/xmlhttprequest_level_2)
+- [xhr1.html](http://download.tizen.org/misc/examples/w3c_html5/communication/xmlhttprequest_level_2){:target="_blank"}
 
-## Handling Request Events
+## Handle request events
 
 To use the XML HTTP request features in your application, you must learn to track requests through events:
 
@@ -109,7 +109,7 @@ To use the XML HTTP request features in your application, you must learn to trac
    <div id="divText"></div>
    ```
 
-2. Create an [XMLHttpRequest](http://www.w3.org/TR/2014/WD-XMLHttpRequest-20140130/#dom-xmlhttprequest) interface instance and define event handlers for it:
+2. Create an [XMLHttpRequest](https://www.w3.org/TR/XMLHttpRequest/){:target="_blank"} interface instance and define event handlers for it:
 
    ```
    <script>
@@ -132,7 +132,7 @@ To use the XML HTTP request features in your application, you must learn to trac
        client.send();
    ```
 
-3. Define the actions of each [event handler](http://www.w3.org/TR/2014/WD-XMLHttpRequest-20140130/#event-handlers):
+3. Define the actions of each [event handler](https://www.w3.org/TR/XMLHttpRequest/){:target="_blank"}:
 
    ```
        /* When the request begins */
@@ -185,18 +185,18 @@ To use the XML HTTP request features in your application, you must learn to trac
    </script>
    ```
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following files:
 
-- [xhr2.html](http://download.tizen.org/misc/examples/w3c_html5/communication/xmlhttprequest_level_2)
-- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/communication/xmlhttprequest_level_2)
+- [xhr2.html](http://download.tizen.org/misc/examples/w3c_html5/communication/xmlhttprequest_level_2){:target="_blank"}
+- [video_sample.mp4](http://download.tizen.org/misc/examples/w3c_html5/communication/xmlhttprequest_level_2){:target="_blank"}
 
-## Tracking Download Progress State
+## Track download progress state
 
 To use the XML HTTP request features in your application, you must learn to track download progress:
 
-1. Define the input elements for managing a download. Use the `sendRequest()` and `abortRequest()` methods for the button click events to start and cancel a download.
+1. Define the input elements for managing a download. Use the `sendRequest()` and `abortRequest()` methods for the button click events to start and cancel a download:
 
    ```
    <input type="button" value="Send XMLHttpRequest" onclick="sendRequest()"/>
@@ -204,7 +204,7 @@ To use the XML HTTP request features in your application, you must learn to trac
    <div id="divText"></div>
    ```
 
-2. Create an [XMLHttpRequest](http://www.w3.org/TR/2014/WD-XMLHttpRequest-20140130/#dom-xmlhttprequest) interface instance and define the handlers for the `onprogress` and `onabort` events to track the download progress and cancellation events:
+2. Create an [XMLHttpRequest](https://www.w3.org/TR/XMLHttpRequest/){:target="_blank"} interface instance and define the handlers for the `onprogress` and `onabort` events to track the download progress and cancellation events:
 
    ```
    <script>
@@ -215,7 +215,7 @@ To use the XML HTTP request features in your application, you must learn to trac
    </script>
    ```
 
-3. Use the `send()` method to request for a file to be read when the **Start download** button is clicked. When the **Cancel download** button is clicked, use the `abort()` method to cancel the download.
+3. Use the `send()` method to request for a file to be read when the **Start download** button is clicked. When the **Cancel download** button is clicked, use the `abort()` method to cancel the download:
 
    ```
    <script>
@@ -230,7 +230,7 @@ To use the XML HTTP request features in your application, you must learn to trac
        }
    ```
 
-4. During the download, use the `onprogresshandler` event handler to track the current and total download size, and calculate the download status. With the `onaborthandler` event handler, you can display the cancellation notification on the screen.
+4. During the download, use the `onprogresshandler` event handler to track the current and total download size, and calculate the download status. With the `onaborthandler` event handler, you can display the cancellation notification on the screen:
 
    ```
        function onprogresshandler(e) {
@@ -243,13 +243,13 @@ To use the XML HTTP request features in your application, you must learn to trac
    </script>
    ```
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [xhr3.html](http://download.tizen.org/misc/examples/w3c_html5/communication/xmlhttprequest_level_2)
+- [xhr3.html](http://download.tizen.org/misc/examples/w3c_html5/communication/xmlhttprequest_level_2){:target="_blank"}
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/w3c/storage/file.md
+++ b/docs/application/web/guides/w3c/storage/file.md
@@ -2,43 +2,43 @@
 
 You can access a local storage to read file information. In mobile applications, you can also manipulate files by accessing sandboxed file systems.
 
-The main features of the File API include:
+The main features of the File API include the following:
 
 - Local file management
 
   - Reading local file information
 
-    You can select a local file to upload using the `FileList` interface (in [mobile](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#dfn-filelist), [wearable](http://www.w3.org/TR/2011/WD-FileAPI-20111020/#dfn-filelist), and [TV](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#dfn-filelist) applications), which creates and returns a `File` object (in [mobile](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#file), [wearable](http://www.w3.org/TR/2011/WD-FileAPI-20111020/#file), and [TV](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#file) applications).
+    You can select a local file to upload using the `FileList` interface (in [mobile](https://www.w3.org/TR/FileAPI/#filelist-section){:target="_blank"}, [wearable](https://www.w3.org/TR/FileAPI/#filelist-section){:target="_blank"}, and [TV](https://www.w3.org/TR/FileAPI/#filelist-section){:target="_blank"} applications), which creates and returns a `File` object (in [mobile](https://www.w3.org/TR/FileAPI/#file-section){:target="_blank"}, [wearable](https://www.w3.org/TR/FileAPI/#file-section){:target="_blank"}, and [TV](https://www.w3.org/TR/FileAPI/#file-section){:target="_blank"} applications).
 
     The `File` object is used to [read basic file information](#reading-local-file-information).
 
   - Reading local file content
 
-    You can use the reading methods of the `FileReader` interface (in [mobile](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#dfn-filereader), [wearable](http://www.w3.org/TR/2011/WD-FileAPI-20111020/#FileReader-interface), and [TV](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#dfn-filereader) applications) to [read file content](#reading-local-file-content) in text, binary, or `dataURL` format. If the data is loaded, the `onload` event occurs. This event uses the data reading methods according to file format.
+    You can use the reading methods of the `FileReader` interface (in [mobile](https://www.w3.org/TR/FileAPI/#APIASynch){:target="_blank"}, [wearable](https://www.w3.org/TR/FileAPI/#dfn-filereader){:target="_blank"}, and [TV](https://www.w3.org/TR/FileAPI/#APIASynch){:target="_blank"} applications) to [read file content](#reading-local-file-content) in text, binary, or `dataURL` format. If the data is loaded, the `onload` event occurs. This event uses the data reading methods according to file format.
 
   - Slicing local files
 
-    You can use the `slice()` method with a local file or the `Blob` interface (in [mobile](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#blob), [wearable](http://www.w3.org/TR/2011/WD-FileAPI-20111020/#blob), and [TV](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#blob) applications) to [slice data objects](#slicing-blob). You can use the created blob to read data as a binary string using the `FileReader` interface.
+    You can use the `slice()` method with a local file or the `Blob` interface (in [mobile](https://www.w3.org/TR/FileAPI/#blob-section){:target="_blank"}, [wearable](https://www.w3.org/TR/FileAPI/#blob-section){:target="_blank"}, and [TV](https://www.w3.org/TR/FileAPI/#blob-section){:target="_blank"} applications) to [slice data objects](#slicing-blob). You can use the created blob to read data as a binary string using the `FileReader` interface.
 
 - Sandboxed file system management **in mobile applications only**
 
   - Accessing sandboxed file systems
 
-    You can [request access to a sandboxed file system](#accessing-a-sandboxed-file-system-in-mobile-applications) using the [LocalFileSystem](http://www.w3.org/TR/2011/WD-file-system-api-20110419/#using-localfilesystem) interface.
+    You can [request access to a sandboxed file system](#accessing-a-sandboxed-file-system-in-mobile-applications) using the [LocalFileSystem](https://www.w3.org/TR/file-system-api/){:target="_blank"} interface.
 
   - Displaying files in a sandboxed file system
 
-    You can use `readEntries()` method of the [DirectoryReader](http://www.w3.org/TR/2011/WD-file-system-api-20110419/#the-directoryreader-interface) interface to [display directories or files](#displaying-files-in-a-sandboxed-file-system-in-mobile-applications).
+    You can use `readEntries()` method of the [DirectoryReader](https://www.w3.org/TR/file-system-api/){:target="_blank"} interface to [display directories or files](#displaying-files-in-a-sandboxed-file-system-in-mobile-applications).
 
   - Creating a directory or file within a sandboxed file system
 
-    You can use the `getDirectory()` and `getFile()` methods of the [DirectoryEntry](http://www.w3.org/TR/2011/WD-file-system-api-20110419/#the-directoryentry-interface) interface) to [create a directory or file](#creating-a-directory-or-file-in-mobile-applications).
+    You can use the `getDirectory()` and `getFile()` methods of the [DirectoryEntry](https://www.w3.org/TR/file-system-api/){:target="_blank"} interface to [create a directory or file](#creating-a-directory-or-file-in-mobile-applications).
 
   - Deleting a directory or file within a sandboxed file system
 
-    You can use the `removeRecursively()` method of the `DirectoryEntry` interface and the `remove()` method of the [Entry](http://www.w3.org/TR/2011/WD-file-system-api-20110419/#the-entry-interface) interface to [delete a directory or file](#removing-a-directory-or-file-in-mobile-applications).
+    You can use the `removeRecursively()` method of the `DirectoryEntry` interface and the `remove()` method of the [Entry](https://www.w3.org/TR/file-system-api/){:target="_blank"} interface to [delete a directory or file](#removing-a-directory-or-file-in-mobile-applications).
 
-## Reading Local File Information
+## Read local file information
 
 Reading basic information, such as file name, size, MIME type, modification date, and path, of a local file is a useful file management skill:
 
@@ -49,10 +49,10 @@ Reading basic information, such as file name, size, MIME type, modification date
    <div id="selectedFileInfoList"></div>
    ```
 
-	> **Note**  
+	> [!NOTE]
 	> To enable multiple upload, use the `multiple` attribute.
 
-2. Create a `FileList` instance (in [mobile](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#dfn-filelist), [wearable](http://www.w3.org/TR/2011/WD-FileAPI-20111020/#dfn-filelist), and [TV](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#dfn-filelist) applications):
+2. Create a `FileList` instance (in [mobile](https://www.w3.org/TR/FileAPI/#filelist-section){:target="_blank"}, [wearable](https://www.w3.org/TR/FileAPI/#filelist-section){:target="_blank"}, and [TV](https://www.w3.org/TR/FileAPI/#filelist-section){:target="_blank"} applications):
 
    ```
    <script>
@@ -87,13 +87,13 @@ Reading basic information, such as file name, size, MIME type, modification date
    **Figure: Displaying file information (in mobile applications only)**  
    ![Displaying file information (in mobile applications only)](./media/file1.png)
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [file_api_reading_local_files_info.html](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api)
+- [file_api_reading_local_files_info.html](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api){:target="_blank"}
 
-## Reading Local File Content
+## Read local file content
 
 Reading a local image file in a Web application is a useful file management skill:
 
@@ -104,7 +104,7 @@ Reading a local image file in a Web application is a useful file management skil
    <div id="selectedFileInfoList"></div>
    ```
 
-2. Create a `FileReader` instance (in [mobile](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#dfn-filereader), [wearable](http://www.w3.org/TR/2011/WD-FileAPI-20111020/#FileReader-interface), and [TV](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#dfn-filereader) applications) to read the content of the local image file. Use the `readAsDataURL()` method to read data in the `dataURL` format.
+2. Create a `FileReader` instance (in [mobile](https://www.w3.org/TR/FileAPI/#APIASynch){:target="_blank"}, [wearable](https://www.w3.org/TR/FileAPI/#APIASynch){:target="_blank"}, and [TV](https://www.w3.org/TR/FileAPI/#APIASynch){:target="_blank"} applications) to read the content of the local image file. Use the `readAsDataURL()` method to read data in the `dataURL` format.
 
    If the data is loaded, an `onload` event is fired. Create an `img` element to allocate the event result property value for rendering:
 
@@ -146,15 +146,15 @@ Reading a local image file in a Web application is a useful file management skil
    **Figure: Displaying an image file (in mobile applications only)**  
    ![Displaying an image file (in mobile applications only)](./media/file2.png)
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [file_api_reading_local_files.html](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api)
+- [file_api_reading_local_files.html](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api){:target="_blank"}
 
-## Slicing Blob
+## Slice blob
 
-Slicing a local file using the `Blob` interface (in [mobile](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#blob), [wearable](http://www.w3.org/TR/2011/WD-FileAPI-20111020/#blob), and [TV](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#blob) applications) is a useful file management skill:
+Slicing a local file using the `Blob` interface (in [mobile](https://www.w3.org/TR/FileAPI/#blob-section){:target="_blank"}, [wearable](https://www.w3.org/TR/FileAPI/#blob-section){:target="_blank"}, and [TV](https://www.w3.org/TR/FileAPI/#blob-section){:target="_blank"} applications) is a useful file management skill:
 
 1. Create the `<input type="file">` element, the element for inputting the start byte and the end byte for slice, and the element for displaying the slicing result:
 
@@ -167,7 +167,7 @@ Slicing a local file using the `Blob` interface (in [mobile](http://www.w3.org/T
    <div id="result" style="padding: 25px 10px 0 20px;"></div>
    ```
 
-2. To read the local file, create a `FileReader` instance (in [mobile](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#dfn-filereader), [wearable](http://www.w3.org/TR/2011/WD-FileAPI-20111020/#FileReader-interface), and [TV](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#dfn-filereader) applications):
+2. To read the local file, create a `FileReader` instance (in [mobile](https://www.w3.org/TR/FileAPI/#APIASynch){:target="_blank"}, [wearable](https://www.w3.org/TR/FileAPI/#APIASynch){:target="_blank"}, and [TV](https://www.w3.org/TR/FileAPI/#APIASynch){:target="_blank"} applications):
 
    ```
    <script>
@@ -175,7 +175,7 @@ Slicing a local file using the `Blob` interface (in [mobile](http://www.w3.org/T
    </script>
    ```
 
-3. Slice the defined byte range (from `startByte` to `endByte`) using the `slice()` method of the `File` interface (in [mobile](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#file), [wearable](http://www.w3.org/TR/2011/WD-FileAPI-20111020/#file), and [TV](http://www.w3.org/TR/2015/WD-FileAPI-20150421/#file) applications):
+3. Slice the defined byte range (from `startByte` to `endByte`) using the `slice()` method of the `File` interface (in [mobile](https://www.w3.org/TR/FileAPI/#file-section){:target="_blank"}, [wearable](https://www.w3.org/TR/FileAPI/#file-section){:target="_blank"}, and [TV](https://www.w3.org/TR/FileAPI/#file-section){:target="_blank"} applications):
 
    ```
    <script>
@@ -218,17 +218,17 @@ Slicing a local file using the `Blob` interface (in [mobile](http://www.w3.org/T
    **Figure: Slicing a file (in mobile applications only)**  
    ![Slicing a file (in mobile applications only)](./media/file3.png)
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [file_api_slicing_blob.htm](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api)
+- [file_api_slicing_blob.htm](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api){:target="_blank"}
 
-## Accessing a Sandboxed File System in Mobile Applications
+## Access a sandboxed file system in Mobile Applications
 
 Requesting access to sandboxed sections of a local file system is a useful file management skill:
 
-1. Use the `requestFileSystem()` method of the [LocalFileSystem](http://www.w3.org/TR/2011/WD-file-system-api-20110419/#using-localfilesystem) interface to request access to sandboxed sections of a local file system:
+1. Use the `requestFileSystem()` method of the [LocalFileSystem](https://www.w3.org/TR/file-system-api/){:target="_blank"} interface to request access to sandboxed sections of a local file system:
 
    ```
    <script>
@@ -253,18 +253,18 @@ Requesting access to sandboxed sections of a local file system is a useful file 
    </script>
    ```
 
-   > **Note**  
+   > [!NOTE]
    > The `requestFileSystem()` method is created in the Web application program when it is initially called.
  
    The directory file in the file system root can be searched, created and deleted by accessing local file system.
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [file_api_file_system.htm](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api)
+- [file_api_file_system.htm](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api){:target="_blank"}
 
-## Displaying Files in a Sandboxed File System in Mobile Applications
+## Display files in a sandboxed file system in Mobile Applications
 
 Reading a file or directory in a sandboxed section of a local file system is a useful file management skill:
 
@@ -275,7 +275,7 @@ Reading a file or directory in a sandboxed section of a local file system is a u
    <ul id="resultSection"></ul>
    ```
 
-2. To read the entry within the file system, use the `createReader()` method of the [DirectoryEntry](http://www.w3.org/TR/2011/WD-file-system-api-20110419/#the-directoryentry-interface) interface:
+2. To read the entry within the file system, use the `createReader()` method of the [DirectoryEntry](https://www.w3.org/TR/file-system-api/){:target="_blank"} interface:
 
    ```
    <script>
@@ -288,13 +288,13 @@ Reading a file or directory in a sandboxed section of a local file system is a u
            var dirReader = root.createReader();
    ```
 
-3. Use the `readEntries()` method of the [DirectoryReader](http://www.w3.org/TR/2011/WD-file-system-api-20110419/#the-directoryreader-interface) interface to read all entries:
+3. Use the `readEntries()` method of the [DirectoryReader](https://www.w3.org/TR/file-system-api/){:target="_blank"} interface to read all entries:
 
    ```
            dirReader.readEntries(function(entries) {
    ```
 
-4. Display the list of the relevant entries using the [Entry](http://www.w3.org/TR/2011/WD-file-system-api-20110419/#the-entry-interface) interface:
+4. Display the list of the relevant entries using the [Entry](https://www.w3.org/TR/file-system-api/){:target="_blank"} interface:
 
    ```
                if (!entries.length) {
@@ -323,22 +323,22 @@ Reading a file or directory in a sandboxed section of a local file system is a u
    </script>
     ```
 
-> **Note**  
+> [!NOTE]
 > For error handling, see [Accessing a Sandboxed File System](#accessing-a-sandboxed-file-system-in-mobile-applications).
 
 **Figure: Displaying files**
 
 ![Displaying files](./media/file4.png)
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following files:
 
-- [file_api_file_system.htm](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api)
-- [icon_file.png](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api/img)
-- [icon_folder.png](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api/img)
+- [file_api_file_system.htm](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api){:target="_blank"}
+- [icon_file.png](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api/img){:target="_blank"}
+- [icon_folder.png](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api/img){:target="_blank"}
 
-## Creating a Directory or File in Mobile Applications
+## Create a directory or file in Mobile Applications
 
 Creating a directory or file in a sandboxed section of a local file system is a useful file management skill:
 
@@ -380,19 +380,19 @@ Creating a directory or file in a sandboxed section of a local file system is a 
     </script>
     ```
 
-    > **Note**  
+    > [!NOTE]
     > For error handling, see [Accessing a Sandboxed File System](#accessing-a-sandboxed-file-system-in-mobile-applications).
 
     **Figure: Adding a file**  
     ![Adding a file](./media/file5.png)
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [file_api_file_system.htm](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api)
+- [file_api_file_system.htm](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api){:target="_blank"}
 
-## Removing a Directory or File in Mobile Applications
+## Remove a directory or file in Mobile Applications
 
 Deleting a directory or file in a sandboxed section of a local file system is a useful file management skill:
 
@@ -427,19 +427,19 @@ Deleting a directory or file in a sandboxed section of a local file system is a 
    </script>
    ```
 
-   > **Note**  
+   > [!NOTE]
    > For error handling, see [Accessing a Sandboxed File System](#accessing-a-sandboxed-file-system-in-mobile-applications).
 
    **Figure: Deleting files**  
    ![Deleting files](./media/file6.png)
 
-### Source Code
+### Source code
 
 For the complete source code related to this use case, see the following file:
 
-- [file_api_file_system.htm](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api)
+- [file_api_file_system.htm](http://download.tizen.org/misc/examples/w3c_html5/storage/file_api){:target="_blank"}
 
-## Related Information
+## Related information
 * Dependencies
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable

--- a/docs/application/web/guides/w3c/storage/storage-guide.md
+++ b/docs/application/web/guides/w3c/storage/storage-guide.md
@@ -24,7 +24,7 @@ The main storage features are:
 
   Enables you to create databases and access them using SQL statements.
 
-## Related Information
+## Related information
 * Dependencies  
   - Tizen 2.4 and Higher for Mobile
   - Tizen 2.3.1 and Higher for Wearable


### PR DESCRIPTION
This PR includes the fix of the following files which are part of the web application guides section of the Tizen Docs site:

File count: 6

/application/web/guides/w3c/communication/web-messaging.md
/application/web/guides/w3c/communication/websocket.md
/application/web/guides/w3c/communication/xmlhttprequest.md
/application/web/guides/w3c/communication/server-sent.md
/application/web/guides/w3c/storage/storage-guide.md
/application/web/guides/w3c/storage/file.md