### PR TITLE
Fix code typo

### DIFF
--- a/docs/application/native/guides/ui/efl/mobile/component-list.md
+++ b/docs/application/native/guides/ui/efl/mobile/component-list.md
@@ -214,7 +214,7 @@ To register and define a callback for the `clicked,double` signal:
 void
 double_clicked_cb(void *data, Evas_Object *obj, void *event_info)
 {
-    elm_Object_Item *it = event_info;
+    Elm_Object_Item *it = event_info;
     elm_list_selected_item_set(it, EINA_FALSE);
 }
 ```


### PR DESCRIPTION
Changed to correct object name

### Change Description ###

Updated incorrect object type to correct object type. It should help people who copy-paste the example code. 


### Bugs Fixed ###

Example code would not compile with an incorrect data type.

### API Changes ###

N/A
