### PR TITLE
[Fix] Update a link using renamed address

### DIFF
--- a/docs/application/dotnet/index.md
+++ b/docs/application/dotnet/index.md
@@ -36,7 +36,7 @@ The guides library introduce various features of .NET applications. The features
 
 <div class="row cards-container-infra">
     <div class="col col-6 col-xl-3">
-        <a href="guides/libraries/wcircularui/index.md" class="card card-infra h-100">
+        <a href="guides/user-interface/wcircularui/index.md" class="card card-infra h-100">
             <div class="card-body">
                 <p class="h3 card-title">Tizen Wearable CircularUI</p>
                 <p class="card-text">Learn how to create Tizen Wearable Xamarin Forms application more easily and efficiently.</p>


### PR DESCRIPTION
It seems that the following commit changed the place of index.md file, and missed a link refering the file.

    commit 90b92f054f8cd8a646298975e1fb8627e6559724
    Author: Michal Szczecinski <mihashco89@gmail.com>
    Date:   Fri Oct 1 10:55:52 2021 +0200

        [6.5][NET] Move NUI and WCircularUI to User interface section. (#1511)

        * [6.5][NET] Move NUI and WCircularUI to User interface section.

        This commit moves NUI and WCircularUI to one user interface section.
        User interface is common and important topic. This change makes it
        easier to search for it in the documentation tree.

        * [6.5][NET] User interface: Fixed menu order.

        * Update docs/application/toc_all.md

        Co-authored-by: sagarkedari <85727367+sagarkedari@users.noreply.github.com>

        * Update docs/application/dotnet/guides/index.md

        Co-authored-by: sagarkedari <85727367+sagarkedari@users.noreply.github.com>

        Co-authored-by: Michal Szczecinski <mihascho89@gmail.com>
        Co-authored-by: sagarkedari <85727367+sagarkedari@users.noreply.github.com>