### PR TITLE
Update kernel.md and flashing.md

### DIFF
--- a/docs/platform/developing/flashing.md
+++ b/docs/platform/developing/flashing.md
@@ -2,6 +2,8 @@
 
 The instructions for flashing depend on the type of device you are using. Instructions are available for the following devices:
 - TM1 reference device
+> [!NOTE]
+> TM1 was deprecated since Tizen 8.0
 
 To flash the Tizen image to the TM1 reference device:
 


### PR DESCRIPTION
### Change Description ###

TM1 was deprecated since Tizen8.0.
Its guidance is not valid. To provide a correct guidance, Update the flashing.md and kernel.md.
- Add U-boot build guidance
- Update a kernel build guidance from TM1 to RPi4
- Remove unlinked URL (wiki.tizen.orkg was shut-down.)
