### PR TITLE
Remove non-printing characters M-oM-;M-?

### DIFF
--- a/docs/platform/developing/flashing-rpi.md
+++ b/docs/platform/developing/flashing-rpi.md
@@ -1,4 +1,4 @@
-﻿# Flash an Image to RPI
+# Flash an Image to RPI
 
 This topic describes how to flash Tizen on an SD card and setting up Raspberry Pi 4.
 > [!NOTE]

--- a/docs/platform/porting/kernel.md
+++ b/docs/platform/porting/kernel.md
@@ -1,4 +1,4 @@
-﻿# Kernel
+# Kernel
 
 For information on how to set up the Tizen OS development environment, see [Setting up the Development Environment](../developing/setting-up.md).
 


### PR DESCRIPTION
The `# Title` was broken because of the non-printing characters.
This commit is removing the characters.