### PR TITLE
Add Dotnet API reference link

### DIFF
--- a/docs/application/dotnet/guides/connectivity/bluetooth.md
+++ b/docs/application/dotnet/guides/connectivity/bluetooth.md
@@ -1303,5 +1303,7 @@ avrcpProfile.RepeatModeChanged -= EventHandlerRepeatModeChanged;
 
 
 ## Related information
-  * Dependencies
+- Dependencies
     -   Tizen 4.0 and Higher
+- API References
+    - [Tizen.Network.Bluetooth](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.Bluetooth.html) class

--- a/docs/application/dotnet/guides/connectivity/connection.md
+++ b/docs/application/dotnet/guides/connectivity/connection.md
@@ -156,5 +156,7 @@ To change the active connection profile and access connection details, follow th
 
 
 ## Related information
-* Dependencies
-  -   Tizen 4.0 and Higher
+- Dependencies
+    - Tizen 4.0 and Higher
+- API References
+    - [Tizen.Network.Connection](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.Connection.html) class

--- a/docs/application/dotnet/guides/connectivity/iotcon.md
+++ b/docs/application/dotnet/guides/connectivity/iotcon.md
@@ -359,5 +359,8 @@ To monitor the changes in a resource, follow the steps below:
 
 
 ## Related information
-* Dependencies
-  -   Tizen 4.0 and Higher
+- Dependencies
+    - Tizen 4.0 and Higher
+- API References
+    - [Tizen.Network.IoTConnectivity](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.IoTConnectivity.html) class
+

--- a/docs/application/dotnet/guides/connectivity/nfc.md
+++ b/docs/application/dotnet/guides/connectivity/nfc.md
@@ -777,5 +777,7 @@ To send HCE responses to the NFC reader, follow the steps below:
 
 
 ## Related information
-* Dependencies
-  -   Tizen 4.0 and Higher
+- Dependencies
+    - Tizen 4.0 and Higher
+- API References
+    - [Tizen.Network.Nfc](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.Nfc.html) class

--- a/docs/application/dotnet/guides/connectivity/nsd.md
+++ b/docs/application/dotnet/guides/connectivity/nsd.md
@@ -90,5 +90,7 @@ To discover remote DNS-SD services, follow these steps:
 
 
 ## Related information
-* Dependencies
-    -   Tizen 4.0 and Higher
+- Dependencies
+    -  Tizen 4.0 and Higher
+- API References
+    - [Tizen.Network.Nsd](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.Nsd.html) class

--- a/docs/application/dotnet/guides/connectivity/overview.md
+++ b/docs/application/dotnet/guides/connectivity/overview.md
@@ -41,5 +41,15 @@ You can use the following connectivity and wireless features in your .NET applic
     You can use IoTivity features in Tizen. You can use the seamless device-to-device connectivity to address the needs of the Internet of Things (IoT) through the open source reference implementation of the OIC (Open Interconnect Consortium) standard specifications.
 
 ## Related information
-* Dependencies
+- Dependencies
     -   Tizen 4.0 and Higher
+- API References
+	- [Tizen.Network.Connection](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.Connection.html) class
+    - [Tizen.Network.Nsd](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.Nsd.html) class
+	- [Tizen.Network.WiFi](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.WiFi.html) class
+	- [Tizen.Network.WiFiDirect](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.WiFiDirect.html) class
+	- [Tizen.Network.Bluetooth](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.Bluetooth.html) class
+	- [Tizen.Network.Nfc](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.Nfc.html) class
+	- [Tizen.Network.Smartcard](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.Smartcard.html) class
+	- [Tizen.Network.Stc](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.Stc.html) class
+    - [Tizen.Network.IoTConnectivity](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.IoTConnectivity.html) class

--- a/docs/application/dotnet/guides/connectivity/smartcard.md
+++ b/docs/application/dotnet/guides/connectivity/smartcard.md
@@ -251,5 +251,7 @@ To manage channels, follow the steps below:
     ```
 
 ## Related information
-* Dependencies
-    -   Tizen 4.0 and Higher
+- Dependencies
+    - Tizen 4.0 and Higher
+- API References
+    - [Tizen.Network.Smartcard](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.Smartcard.html) class

--- a/docs/application/dotnet/guides/connectivity/stc.md
+++ b/docs/application/dotnet/guides/connectivity/stc.md
@@ -161,6 +161,9 @@ To retrieve the statistics about total network data consumed by the applications
     
    ```
  
- ## Related information
+## Related information
 - Dependencies
-  -   Tizen 5.5 and Higher
+    - Tizen 5.5 and Higher
+- API References
+    - [Tizen.Network.Stc](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.Stc.html) class
+

--- a/docs/application/dotnet/guides/connectivity/wifi-direct.md
+++ b/docs/application/dotnet/guides/connectivity/wifi-direct.md
@@ -343,5 +343,9 @@ To deactivate Wi-Fi Direct when it is no longer needed (or the application is ex
 
 
 ## Related information
-* Dependencies
-  -   Tizen 4.0 and Higher
+- Dependencies
+    - Tizen 4.0 and Higher
+- API References
+    - [Tizen.Network.WiFiDirect](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.WiFiDirect.html) class
+
+

--- a/docs/application/dotnet/guides/connectivity/wifi.md
+++ b/docs/application/dotnet/guides/connectivity/wifi.md
@@ -239,5 +239,7 @@ catch (Exception e)
 
 
 ## Related information
-* Dependencies
-  -   Tizen 4.0 and Higher
+- Dependencies
+    -  Tizen 4.0 and Higher
+- API References
+    - [Tizen.Network.WiFi](/application/dotnet/api/TizenFX/latest/api/Tizen.Network.WiFi.html) class


### PR DESCRIPTION
### Change Description ###

Some API guide documents on docs.tizen.org do not have links to API References.
At least one link to an API Reference needs to be added.

- ./docs/application/dotnet/guides/connectivity/overview.md
- ./docs/application/dotnet/guides/connectivity/wifi-direct.md
- ./docs/application/dotnet/guides/connectivity/bluetooth.md
- ./docs/application/dotnet/guides/connectivity/connection.md
- ./docs/application/dotnet/guides/connectivity/wifi.md
- ./docs/application/dotnet/guides/connectivity/iotcon.md
- ./docs/application/dotnet/guides/connectivity/stc.md
- ./docs/application/dotnet/guides/connectivity/nsd.md
- ./docs/application/dotnet/guides/connectivity/nfc.md
- ./docs/application/dotnet/guides/connectivity/smartcard.md

