### PR TITLE
fix: swapped web app link and .net link under develop app for tizen t…

### DIFF
--- a/docs/platform/what-is-tizen/profiles/tv.md
+++ b/docs/platform/what-is-tizen/profiles/tv.md
@@ -31,7 +31,7 @@ To develop applications for Tizen TV, refer to the following:
 
 - [Smart TV Quick-start Guide](http://developer.samsung.com/tv/develop/getting-started/quick-start-guide){:target="_blank"}
 - [Create Tizen TV .NET Applications](https://developer.samsung.com/smarttv/develop/tizen-net-tv/getting-started/creating-net-tv-applications.html){:target="_blank"}
-- [Create Tizen TV TV Web applications](https://developer.samsung.com/smarttv/develop/getting-started/creating-tv-applications.html){:target="_blank"}
+- [Create Tizen TV Web applications](https://developer.samsung.com/smarttv/develop/getting-started/creating-tv-applications.html){:target="_blank"}
 
 
 ## Tizen TV devices

--- a/docs/platform/what-is-tizen/profiles/tv.md
+++ b/docs/platform/what-is-tizen/profiles/tv.md
@@ -30,8 +30,8 @@ The Samsung Smart TV SDK combines TV features with web-based technologies. The S
 To develop applications for Tizen TV, refer to the following:
 
 - [Smart TV Quick-start Guide](http://developer.samsung.com/tv/develop/getting-started/quick-start-guide){:target="_blank"}
-- [Create Tizen TV .NET Applications](https://developer.samsung.com/smarttv/develop/getting-started/creating-tv-applications.html){:target="_blank"}
-- [Create Tizen TV TV Web applications](https://developer.samsung.com/smarttv/develop/tizen-net-tv/getting-started/creating-net-tv-applications.html){:target="_blank"}
+- [Create Tizen TV .NET Applications](https://developer.samsung.com/smarttv/develop/tizen-net-tv/getting-started/creating-net-tv-applications.html){:target="_blank"}
+- [Create Tizen TV TV Web applications](https://developer.samsung.com/smarttv/develop/getting-started/creating-tv-applications.html){:target="_blank"}
 
 
 ## Tizen TV devices


### PR DESCRIPTION
…v section

### Change Description ###

Swapped  **Create Tizen TV .NET Applications** and **Create Tizen TV TV Web applications** links under [Develop applications for Tizen TV](https://github.com/Samsung/tizen-docs/blob/master/docs/platform/what-is-tizen/profiles/tv.md#develop-applications-for-tizen-tv) section because the links are directing the user to wrong page.


### Bugs Fixed ###
 - Issue #2105

