### PR TITLE
Raise the depth of SDK tool index to a higher level

### DIFF
--- a/docs/application/toc_vs-ext_dotnet.md
+++ b/docs/application/toc_vs-ext_dotnet.md
@@ -68,4 +68,4 @@
 ##### [Hybrid Application Development](/application/vstools/Tizen/hybrid.md)
 ##### [TizenNUIGadget RPK Development](/application/vstools/Tizen/nuigadget-rpk.md)
 
-### [Tool Index](/application/sdktool_index.md)
+## [Tool Index](/application/sdktool_index.md)

--- a/docs/application/toc_vs-ext_native.md
+++ b/docs/application/toc_vs-ext_native.md
@@ -63,4 +63,4 @@
 ##### [Hybrid Application Development](/application/vstools/Tizen/hybrid.md)
 ##### [TizenNUIGadget RPK Development](/application/vstools/Tizen/nuigadget-rpk.md)
 
-### [Tool Index](/application/sdktool_index.md)
+## [Tool Index](/application/sdktool_index.md)

--- a/docs/application/toc_vs-ext_web.md
+++ b/docs/application/toc_vs-ext_web.md
@@ -59,4 +59,4 @@
 ##### [Hybrid Application Development](/application/vstools/Tizen/hybrid.md)
 ##### [TizenNUIGadget RPK Development](/application/vstools/Tizen/nuigadget-rpk.md)
 
-### [Tool Index](/application/sdktool_index.md)
+## [Tool Index](/application/sdktool_index.md)

--- a/docs/application/toc_vscode_dotnet.md
+++ b/docs/application/toc_vscode_dotnet.md
@@ -68,4 +68,4 @@
 ##### [RPK Application Development](/application/vscode-ext/Tizen/rpk.md)
 ##### [Tizen VSCode Command](/application/vscode-ext/Tizen/command.md)
 
-### [Tool Index](/application/sdktool_index.md)
+## [Tool Index](/application/sdktool_index.md)

--- a/docs/application/toc_vscode_native.md
+++ b/docs/application/toc_vscode_native.md
@@ -62,4 +62,4 @@
 ##### [RPK Application Development](/application/vscode-ext/Tizen/rpk.md)
 ##### [Tizen VSCode Command](/application/vscode-ext/Tizen/command.md)
 
-### [Tool Index](/application/sdktool_index.md)
+## [Tool Index](/application/sdktool_index.md)

--- a/docs/application/toc_vscode_web.md
+++ b/docs/application/toc_vscode_web.md
@@ -62,4 +62,4 @@
 ##### [RPK Application Development](/application/vscode-ext/Tizen/rpk.md)
 ##### [Tizen VSCode Command](/application/vscode-ext/Tizen/command.md)
 
-### [Tool Index](/application/sdktool_index.md)
+## [Tool Index](/application/sdktool_index.md)


### PR DESCRIPTION
### Change Description ###

Raise the depth of SDK tool index to a higher level.

Expose the SDK tool index menu at the same level as menus like Overview and Release Notes.

