### PR TITLE
[Webapi] [10.0] Fixed invalid deprecation version in index.xml file

### DIFF
--- a/docs/application/web/api/10.0/device_api/mobile/index.xml
+++ b/docs/application/web/api/10.0/device_api/mobile/index.xml
@@ -90,9 +90,9 @@
 						<topic href="10.0/device_api/mobile/tizen/cordova/networkInformation.html" label="Network Information"/>
 					</topic>
 					<topic href="10.0/device_api/mobile/index.html#Deprecated API" label="Deprecated API">
-						<topic href="10.0/device_api/mobile/tizen/messaging.html" label="Messaging" deprecatedSince="9.0"/>
+						<topic href="10.0/device_api/mobile/tizen/messaging.html" label="Messaging" deprecatedSince="8.0"/>
 						<topic href="10.0/device_api/mobile/tizen/libteec.html" label="LibTeec" deprecatedSince="6.5"/>
-						<topic href="10.0/device_api/mobile/tizen/ppm.html" label="PrivacyPrivilege" deprecatedSince="9.0"/>
+						<topic href="10.0/device_api/mobile/tizen/ppm.html" label="PrivacyPrivilege" deprecatedSince="8.0"/>
 					</topic>
 				</topic>
 			</topic>

--- a/docs/application/web/api/10.0/device_api/wearable/index.xml
+++ b/docs/application/web/api/10.0/device_api/wearable/index.xml
@@ -86,7 +86,7 @@
 					</topic>
 					<topic href="10.0/device_api/wearable/index.html#Deprecated API" label="Deprecated API">
 						<topic href="10.0/device_api/wearable/tizen/libteec.html" label="LibTeec" deprecatedSince="6.5"/>
-						<topic href="10.0/device_api/wearable/tizen/ppm.html" label="PrivacyPrivilege" deprecatedSince="9.0"/>
+						<topic href="10.0/device_api/wearable/tizen/ppm.html" label="PrivacyPrivilege" deprecatedSince="8.0"/>
 					</topic>
 				</topic>
 			</topic>


### PR DESCRIPTION
While preparing index files update for 9.0 version, deprecate version was corrupted - probably with replace-all function.

This change restores original deprecate version == 8.0 for messaging and ppm.

This is the same change as
https://github.com/Samsung/tizen-docs/pull/2142 but for 10.0 API docs structure.


