### PR TITLE
Fix a wrong link address in VS code's web content index

### DIFF
--- a/docs/application/toc_vscode_web.md
+++ b/docs/application/toc_vscode_web.md
@@ -19,7 +19,7 @@
 #### [Overview](/application/vscode-ext/getting-started/web-development-activity-tools.md)
 
 #### Managing Project
-##### [Create App](/application/vscode-ext/getting-started/creating-dotnet-application-projects.md)
+##### [Create App](/application/vscode-ext/getting-started/creating-web-application-projects.md)
 ##### [Web Assembly](/application/vscode-ext/tools/wasm.md)
 ##### [Tizen Project Configure](/application/vscode-ext/getting-started/configuring-tizen-project.md)
 ##### Tizen Certificate Management


### PR DESCRIPTION
### Change Description ###

Fix a wrong link address in VS code's web content index. 
(Here, dotnet is a typo. We need a page for creating a Web project.)

