### PR TITLE
Fixed index.html file by removing duplicated deprecated API table

### DIFF
--- a/docs/application/web/api/8.0/device_api/mobile/index.html
+++ b/docs/application/web/api/8.0/device_api/mobile/index.html
@@ -439,9 +439,6 @@ table.deprecated-api-list span.mandatory::after { content: "*"; font-weight: nor
 <td>Optional</td>
 <td>Yes<div class="partial-support">Only e-mail</div></td>
 </tr>
-</tbody></table>
-<h4 id="Deprecated API">Deprecated API</h4>
-<table class="deprecated-api-list"><thead><tr><th>API</th><th>Description</th><th>Version (Since)</th><th>Deprecated (Since)</th><th>Mobile</th><th>Supported on <br>Mobile Emulator</th></tr></thead><tbody>
 <tr><td><a href="tizen/libteec.html">LibTeec</a></td>
 <td>This API provides interfaces and methods for a TrustZone.</td>
 <td>4.0</td>

--- a/docs/application/web/api/9.0/device_api/mobile/index.html
+++ b/docs/application/web/api/9.0/device_api/mobile/index.html
@@ -439,9 +439,6 @@ table.deprecated-api-list span.mandatory::after { content: "*"; font-weight: nor
 <td>Optional</td>
 <td>Yes<div class="partial-support">Only e-mail</div></td>
 </tr>
-</tbody></table>
-<h4 id="Deprecated API">Deprecated API</h4>
-<table class="deprecated-api-list"><thead><tr><th>API</th><th>Description</th><th>Version (Since)</th><th>Deprecated (Since)</th><th>Mobile</th><th>Supported on <br>Mobile Emulator</th></tr></thead><tbody>
 <tr><td><a href="tizen/libteec.html">LibTeec</a></td>
 <td>This API provides interfaces and methods for a TrustZone.</td>
 <td>4.0</td>


### PR DESCRIPTION
"Deprecated API" table was duplicated in index.html file. This PR fixes this issue and integrates content of both "Deprecated API" tables.