### PR TITLE
Add a basic Tizen C# logging guide

### DIFF
--- a/docs/application/dotnet/guides/index.md
+++ b/docs/application/dotnet/guides/index.md
@@ -350,6 +350,7 @@ Tizen.Wearable.CircularUI supports Tizen wearable-specific user interfaces, and 
                         <li><a href="system/feedback.md">Feedback</a></li>
                         <li><a href="system/settings.md">System Settings</a></li>
                         <li><a href="system/system.md">System Information</a></li>
+                        <li><a href="system/system-logging.md">System Logging</a></li>
                     </ul>
                 </div>
             </div>

--- a/docs/application/dotnet/guides/system/overview.md
+++ b/docs/application/dotnet/guides/system/overview.md
@@ -21,6 +21,10 @@ You can use the following device settings and systems features in your .NET appl
 
     You can access information about the system settings. You can retrieve the system configuration related to user preferences.
 
+-   [System Logging](system-logging.md)
+
+    You can send messages to the system logger, to retrieve it later for debugging or diagnostics.
+
 ## Related information
 - Dependencies
   -   Tizen 4.0 and Higher

--- a/docs/application/dotnet/guides/system/system-logging.md
+++ b/docs/application/dotnet/guides/system/system-logging.md
@@ -1,0 +1,31 @@
+# Tizen System Logger
+
+Tizen has a basic system logger called `dlog`. For instructions on how to read them later via CLI tools please check out [the `dlogutil` section of the general dlog guide](../../../native/guides/error/system-logs.md#dlogutil). Other C# guides for other specific functionality will also usually contain logging examples if you'd like to know more.
+
+### Basic concepts
+
+Other than the message contents, a dlog log has two main traits: a priority level, and a string "tag":
+ * priority is one of a few named, ordered levels such as "error" or "verbose". See [the list in the native guide](../../../native/guides/error/system-logs.md#message). It is used for categorizing and filtering unimportant logs out.
+ * tag is an arbitrary string intended to help identify who sent the log, such as "MY_EXAMPLE_APP". Also used for filtering.
+
+### Example
+
+Nothing clever here, the priority level is just the function name within `Tizen.Log`, and the tag is the first arg. Apply priority level as appropriate, generally keep the tag consistent but unique to your app such that when reading you'd see all of your logs and no others.
+
+```csharp
+float ExampleReciprocal (float x) {
+	if (flag_verbose)
+		Tizen.Log.Verbose("MY_RECIPROCAL_CALCULATOR", "Calculating 1 / {}...", x);
+
+	if (x == 0.0f) {
+		Tizen.Log.Error("MY_RECIPROCAL_CALCULATOR", "Cannot divide by 0");
+		throw new Exception(...);
+	}
+
+	var result = 1.0f / x;
+
+	Tizen.Log.Debug("MY_RECIPROCAL_CALCULATOR", "Result was {}", result);
+	return result;
+}
+```
+

--- a/docs/application/toc_all.md
+++ b/docs/application/toc_all.md
@@ -192,6 +192,7 @@
 #### [Attached Devices](/application/dotnet/guides/system/attached-devices.md)
 #### [System Information](/application/dotnet/guides/system/system.md)
 #### [System Settings](/application/dotnet/guides/system/settings.md)
+#### [System Logging](/application/dotnet/guides/system/system-logging.md)
 #### [Sound and Vibration Feedback](/application/dotnet/guides/system/feedback.md)
 
 ###  Telephony

--- a/docs/application/toc_all_new.md
+++ b/docs/application/toc_all_new.md
@@ -198,6 +198,7 @@
 #### [Attached Devices](/application/dotnet/guides/system/attached-devices.md)
 #### [System Information](/application/dotnet/guides/system/system.md)
 #### [System Settings](/application/dotnet/guides/system/settings.md)
+#### [System Logging](/application/dotnet/guides/system/system-logging.md)
 #### [Sound and Vibration Feedback](/application/dotnet/guides/system/feedback.md)
 
 ###  Telephony


### PR DESCRIPTION
### Change Description ###

Adds a basic guide to C# Tizen logging. Logging has existed since the beginning of Tizen, is extensively used across docs, and is fairly self-explanatory so this is mostly for fulfilling somebody's formal requirements.