### PR TITLE
[11.0][Tizen.Applications.ComponentBased.ComponentPort] Deprecate ComponentPort's APIs

### DIFF
--- a/docs/application/dotnet/guides/app-management/component-port.md
+++ b/docs/application/dotnet/guides/app-management/component-port.md
@@ -1,5 +1,8 @@
 # Component Port
 
+> [!NOTE]
+> All ComponentPort APIs have been deprecated since Tizen 11.0 and will be removed after two releases without any alternatives.
+
 Tizen components of the component-based applications can communicate with each other using component ports. Components can send and receive serializable objects through component port communication.
 
 The main feature of the `Tizen.Applications.ComponentBased.ComponentPort` class includes the following:


### PR DESCRIPTION
### Change Description ###

Add Deprecate note in componentPort's document

 - ACR : https://jira.sec.samsung.net/browse/TCSACR-643

