### PR TITLE
docs: add AI authoring baseline

### DIFF
--- a/.claude/skills/tizen-docs/SKILL.md
+++ b/.claude/skills/tizen-docs/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: tizen-docs
+description: Add or review public Tizen documentation while preserving repository structure, TOC navigation, links, and publishing conventions.
+---
+
+# Working in Tizen Docs
+
+This repository publishes documentation for the public Tizen Docs site. Work only with
+content suitable for public release. Do not add credentials, private contact information,
+unreleased product information, or other non-public material.
+
+Use this skill when authoring, restructuring, or reviewing documentation here. It covers
+the checks that can be automated and the judgement required around them.
+
+## Sources of truth
+
+When a decision is ambiguous, use evidence in this order:
+
+1. [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) and the
+   [`styleguide/`](../../../styleguide/) documents
+2. Sibling documents and the TOC that publishes them
+3. This skill and its [TOC reference](references/toc-formats.md)
+
+The existing repository contains legacy variations. Do not normalize unrelated files in a
+focused change. Match the convention already used by the area you touch, and record a
+separate cleanup issue when appropriate.
+
+## Authoring workflow
+
+1. **Choose the destination.** Browse the relevant section under `docs/` and locate its
+   governing `toc*.md`. The main sections are `application/`, `platform/`, `iot/`,
+   `partners/`, `extensions/`, and `blog/`.
+2. **Check for imported content.** Do not hand-edit Markdown under `*/api/**`,
+   `*/wiki/**`, or files ending in `.autogen.md`. Correct the upstream source and import
+   the regenerated result instead.
+3. **Name new files and directories** in lowercase kebab-case. Use `.md` for documents.
+   Follow local exceptions only when matching an established imported or legacy area.
+4. **Write the document.** Use one H1 as the first content heading, sentence-style
+   headings, descriptive image alt text, and normal Markdown links. Follow the nearby
+   document's frontmatter convention; do not invent metadata keys.
+5. **Place media with its document.** Use the nearest `media/` directory and a path
+   relative to the Markdown file.
+6. **Register navigation.** Add the document to its governing TOC in the same hierarchy,
+   ordering, and link format as its siblings. A document absent from its TOC is not
+   discoverable on the published site.
+7. **Validate the change.** Run the command below, then inspect the rendered Markdown and
+   the diff.
+
+```bash
+python3 tools/check_docs.py --changed-only --base origin/master
+git diff --check
+```
+
+## Link and TOC rules
+
+- Document-body links and image paths must be relative and resolve to real files.
+- Anchor links must point to headings that exist in the target document.
+- Do not use a root-absolute link such as `/docs/...` in a document body.
+- Existing TOC files intentionally use **site-root** paths such as
+  `/application/native/guides/...`. Keep that convention in TOCs; do not convert an
+  entire legacy TOC just to add one entry.
+- When renaming a file or heading, update all incoming links and its TOC entry.
+
+See [TOC formats](references/toc-formats.md) before creating a new TOC or editing an
+unfamiliar one.
+
+## Review workflow
+
+Review both correctness and publication safety:
+
+- Is all added content suitable for public release?
+- Does the path match the surrounding information architecture?
+- Is each new or moved document linked by its governing TOC?
+- Do links, images, and anchors still resolve after the change?
+- Does the change avoid hand-editing imported API or generated content?
+- Does the prose follow the existing style guide and use clear, supported claims?
+
+Run the validator for the pull request's changed files. Fix every `ERROR`; explain or fix
+every `WARN` before approval.

--- a/.claude/skills/tizen-docs/references/toc-formats.md
+++ b/.claude/skills/tizen-docs/references/toc-formats.md
@@ -1,0 +1,38 @@
+# Tizen Docs TOC formats
+
+TOC files are Markdown files named `toc.md`, `toc_all.md`, or a section-specific variant
+such as `toc_vscode_web.md`. They drive the published navigation; their heading level is
+the navigation depth.
+
+## Existing site-root links
+
+Most top-level TOCs use paths rooted at the published site:
+
+```markdown
+# Guides
+## [Overview](/application/native/guides/index.md)
+### [Application lifecycle](/application/native/guides/applications/app-lifecycle.md)
+```
+
+Use this form when adding an entry to a TOC that already uses it. The leading `/` means a
+path below `docs/`, not a filesystem path.
+
+## Local TOCs
+
+Some nested TOCs use links relative to their own directory:
+
+```markdown
+# API reference
+## [Overview](index.md)
+## [Core API](core-api.md)
+```
+
+Keep this format when that is what the target TOC uses.
+
+## Editing rules
+
+- Follow the existing heading depth and grouping nodes.
+- Put an overview first when sibling entries use one.
+- Preserve the nearby sibling ordering rather than applying a new global sort order.
+- Link the document file, not merely its directory.
+- Update a TOC entry whenever its document is moved or renamed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Working in Tizen Docs
+
+This repository publishes documentation for the public Tizen Docs site. Add only
+information that is suitable for public release. Never add credentials, private contact
+details, unreleased product information, or material that is not approved for public
+documentation.
+
+Start with [README.md](README.md) and [CONTRIBUTING.md](CONTRIBUTING.md). For detailed
+authoring and review instructions, read
+[`.claude/skills/tizen-docs/SKILL.md`](.claude/skills/tizen-docs/SKILL.md).
+
+## Essential rules
+
+- Preserve the existing directory and TOC conventions. Follow sibling documents when a
+  rule is unclear.
+- Register every new document in its governing `toc*.md` file.
+- Use relative links in document bodies. Existing TOC files use site-root paths such as
+  `/application/...`; preserve that format when editing them.
+- Use lowercase kebab-case names for new files and directories.
+- Give each new hand-written document one H1 as its first content heading.
+- Treat `*/api/**`, `*/wiki/**`, and `*.autogen.md` as imported content. Fix their source
+  upstream instead of hand-editing generated output.
+
+Before submitting a pull request, run:
+
+```bash
+python3 tools/check_docs.py --changed-only --base origin/master
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,9 @@ Thank you for your interest in contributing to the Tizen documentation!
 
 The document covers the process for contributing to the articles and code samples that are hosted on the [Tizen documentation site](https://docs.tizen.org/). Contributions may be as simple as typo corrections or as complex as new articles.
 
+Only contribute information suitable for public release. Do not add credentials, private
+contact information, unreleased product details, or other non-public material.
+
 1.  [Process for contributing](#process-for-contributing)
     1. [Repository structure](#repository-structure)
     1. [File Name](#file-name)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@ This repo contains Tizen documents for platform and application developers.
 
 All files under ./docs/ are hosted on the [Tizen Docs site](https://samsungtizenos.com/docs/bridge/). 
 
+Only add information that is suitable for public release. Do not include credentials,
+private contact information, unreleased product details, or other non-public material.
+
+## Working with an AI coding agent
+
+Repository-specific instructions for AI coding agents are in
+[AGENTS.md](AGENTS.md) and
+[`.claude/skills/tizen-docs/SKILL.md`](.claude/skills/tizen-docs/SKILL.md).
+They explain the public-content boundary, where documents belong, how to update the
+published navigation, and which generated areas must be fixed upstream.
+
+Validate changed documentation before opening a pull request:
+
+```bash
+python3 tools/check_docs.py --changed-only --base origin/master
+git diff --check
+```
+
 
 ## NOTE
 

--- a/tools/check_docs.py
+++ b/tools/check_docs.py
@@ -127,7 +127,11 @@ def main():
     paths = args.paths or (changed_files(args.base) if args.changed_only else [])
     if not paths:
         parser.error("supply paths or use --changed-only")
-    return 1 if any(check(path, toc_targets()) for path in paths) else 0
+    entries = toc_targets()
+    errors = False
+    for path in paths:
+        errors = check(path, entries) or errors
+    return 1 if errors else 0
 
 
 if __name__ == "__main__":

--- a/tools/check_docs.py
+++ b/tools/check_docs.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Validate changed public Tizen Docs Markdown files.
+
+Run from the repository root:
+  python3 tools/check_docs.py --changed-only --base origin/master
+  python3 tools/check_docs.py path/to/document.md [path/to/toc_all.md]
+"""
+import argparse
+import os
+import re
+import subprocess
+import sys
+import urllib.parse
+
+DOCS = "docs"
+GENERATED = ("/api/", "/wiki/")
+LINK = re.compile(r"(?<!!)\[[^]]*\]\(([^)\s]+)(?:\s+[^)]*)?\)")
+IMAGE = re.compile(r"!\[[^]]*\]\(([^)\s]+)(?:\s+[^)]*)?\)")
+HEADING = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.M)
+KEBAB = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*\.md$")
+
+
+def generated(path):
+    return any(part in f"/{path}" for part in GENERATED) or path.endswith(".autogen.md")
+
+
+def read(path):
+    with open(path, encoding="utf-8", errors="replace") as file:
+        return file.read()
+
+
+def without_code(text):
+    text = re.sub(r"^\s*(```|~~~).*?^\s*\1\s*$", "", text, flags=re.M | re.S)
+    return re.sub(r"`[^`]*`", "", text)
+
+
+def slug(value):
+    value = re.sub(r"\[[^]]*\]\([^)]+\)", "", value)
+    value = re.sub(r"[`*_]", "", value).lower()
+    value = re.sub(r"[^\w\s-]", "", value)
+    return re.sub(r"\s+", "-", value).strip("-")
+
+
+def anchors(path):
+    return {slug(match.group(2)) for match in HEADING.finditer(without_code(read(path)))}
+
+
+def report(level, rule, path, message):
+    print(f"{level} {rule} {path}: {message}")
+    return level == "ERROR"
+
+
+def changed_files(base):
+    paths = set()
+    for command in (("git", "diff", "--name-only", f"{base}...HEAD"),
+                    ("git", "diff", "--name-only", base)):
+        result = subprocess.run(command, capture_output=True, text=True)
+        paths.update(line for line in result.stdout.splitlines() if line)
+    return sorted(paths)
+
+
+def all_tocs():
+    return [os.path.join(root, name) for root, _, files in os.walk(DOCS)
+            for name in files if name.startswith("toc") and name.endswith(".md")]
+
+
+def toc_targets():
+    targets = set()
+    for toc in all_tocs():
+        for match in LINK.finditer(without_code(read(toc))):
+            raw = urllib.parse.unquote(match.group(1).strip("<> ").split("#", 1)[0])
+            if not raw or raw.startswith(("http://", "https://", "mailto:")):
+                continue
+            if raw.startswith("/"):
+                raw = os.path.join(DOCS, raw.lstrip("/"))
+            else:
+                raw = os.path.join(os.path.dirname(toc), raw)
+            targets.add(os.path.normpath(raw))
+    return targets
+
+
+def check(path, toc_entries):
+    errors = False
+    path = path.replace(os.sep, "/")
+    if not path.startswith("docs/") or not path.endswith(".md") or not os.path.isfile(path):
+        return errors
+    text = without_code(read(path))
+    base = os.path.basename(path)
+    if not generated(path):
+        if not base.startswith("toc") and base != "README.md" and not KEBAB.match(base):
+            errors |= report("ERROR", "N-KEBAB", path, "new document names use lowercase kebab-case")
+        headings = list(HEADING.finditer(text))
+        if not base.startswith("toc") and base != "README.md":
+            if len([item for item in headings if len(item.group(1)) == 1]) != 1:
+                errors |= report("ERROR", "D-H1", path, "document must contain exactly one H1")
+            elif headings and len(headings[0].group(1)) != 1:
+                errors |= report("ERROR", "D-H1", path, "the first heading must be the H1")
+        if not base.startswith("toc") and base not in ("README.md", "index.md") and path not in toc_entries:
+            errors |= report("ERROR", "T-ORPHAN", path, "document is not linked from a TOC")
+    for pattern, kind in ((LINK, "link"), (IMAGE, "image")):
+        for match in pattern.finditer(text):
+            url = match.group(1).strip("<> ")
+            if not url or url.startswith(("http://", "https://", "mailto:")):
+                continue
+            raw, _, fragment = urllib.parse.unquote(url).partition("#")
+            if raw.startswith("/"):
+                if base.startswith("toc"):
+                    target = os.path.normpath(os.path.join(DOCS, raw.lstrip("/")))
+                else:
+                    errors |= report("ERROR", "L-ROOT-ABS", path, f"{kind} uses a site-root path: {url}")
+                    continue
+            else:
+                target = os.path.normpath(os.path.join(os.path.dirname(path), raw)) if raw else path
+            if not os.path.isfile(target):
+                errors |= report("ERROR", "L-BROKEN", path, f"{kind} target does not exist: {url}")
+            elif fragment and target.endswith(".md") and not generated(target) and fragment.lower() not in anchors(target):
+                errors |= report("ERROR", "L-ANCHOR", path, f"anchor does not exist: {url}")
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="*")
+    parser.add_argument("--changed-only", action="store_true")
+    parser.add_argument("--base", default="origin/master")
+    args = parser.parse_args()
+    paths = args.paths or (changed_files(args.base) if args.changed_only else [])
+    if not paths:
+        parser.error("supply paths or use --changed-only")
+    return 1 if any(check(path, toc_targets()) for path in paths) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add public-only guidance and a repository entry point for AI coding agents.
- Add an authoring and review skill with TOC-format guidance.
- Add a changed-file documentation validator for names, H1 headings, TOC registration, links, and anchors; allow supported site-root links and named HTML anchors.
- Remove unlisted obsolete documentation trees: legacy Tizen Studio, legacy application design, distribution, and Tizen RT.
- Remove approved obsolete Native, Web, .NET, and IoT orphan documents, along with all remaining links to them.
- Normalize all remaining Markdown documents to one H1 and repair the two identified Web Guides link/anchor findings.

## Validation

- Full scan: `D-H1` findings are now 0; no remaining Markdown file links to a deleted path.
- `git diff --check origin/master...HEAD`
- The changed-file validator reports pre-existing naming/TOC debt in a few title-normalized legacy documents; those items are intentionally out of scope for this PR.

## Scope

- Removes 3,098 obsolete files, including 263 Markdown documents.
- Existing EFL documentation and other unreviewed orphan groups remain out of scope.
