### PR TITLE
docs: fix outdated Tizen Studio setup docs

### DIFF
--- a/docs/application/tizen-studio/setup/hardware-accelerated-execution-manager.md
+++ b/docs/application/tizen-studio/setup/hardware-accelerated-execution-manager.md
@@ -15,7 +15,7 @@ Hardware requirements:
 <a name="on_Windows"></a>
 ## Installing Intel&reg; HAXM on Windows
 
-Supported Windows versions: 10/8.1/8/7 (32/64-bit)
+Supported Windows versions: 10 (64-bit)
 
 **HAXM is automatically installed as part of Tizen Studio**. If you want to install the HAXM separately, visit [http://download.tizen.org/sdk/haxm/7.0.0/win/](http://download.tizen.org/sdk/haxm/7.0.0/win/IntelHAXM_7.0.0.exe) and download the Windows installer package.
 
@@ -86,7 +86,7 @@ If you meet an installation failure because of hardware requirements, check the 
 <a name="on_MacOS"></a>
 ## Installing Intel&reg; HAXM on macOS
 
-Supported macOS versions: 10.12 Sierra (64-bit), 10.11 OS X El Capitan(64-bit), 10.10 Yosemite (64-bit), 10.9 Mavericks (64-bit), 10.8 Mountain Lion (64-bit)
+Supported macOS versions: 11.4 (Big Sur), 12.3 (Monterey)
 
 **HAXM is automatically installed as part of the Tizen Studio.** If you want to install the HAXM separately, visit [http://download.tizen.org/sdk/haxm/7.0.0/mac/](http://download.tizen.org/sdk/haxm/7.0.0/mac/IntelHAXM_7.0.0.dmg) and download the macOS installer package.In case the version 7.0.0 installation fails then the latest version of HAXM can be tried which is available at https://github.com/intel/haxm/releases/tag/v7.7.0
 

--- a/docs/application/tizen-studio/setup/openjdk.md
+++ b/docs/application/tizen-studio/setup/openjdk.md
@@ -37,17 +37,19 @@ This section explains how to install the OpenJDK version 12 for Windows:
     > [!NOTE]
     > If your `JAVA_HOME` variable is already created, select it and click **Edit...**.
 
-5. Enter `JAVA_HOME` in the variable name field and the JDK directory path, for example, `C:\Users\user\Desktop\jdk-12.0.2\bin` in the Variable value field.
+5. Enter `JAVA_HOME` in the variable name field and the JDK directory path, for example, `C:\Users\user\Desktop\jdk-12.0.2` in the Variable value field. Do **not** include the `bin` subdirectory in `JAVA_HOME`.
 
-6. Click **OK**. The Environment Variables window appears.
+6. Add `%JAVA_HOME%\bin` to the **Path** variable so that the `java` and `javac` executables are available from the command line.
 
-7. If you cannot find `JAVA_HOME` in **System variables** section, add the variable by repeating the 4, 5, and 6 steps.
+7. Click **OK**. The Environment Variables window appears.
 
-8. Save and close the **Environment Variables** window.
+8. If you cannot find `JAVA_HOME` in **System variables** section, add the variable by repeating the steps 4 through 7.
 
-9. Launch **Command Prompt**.
+9. Save and close the **Environment Variables** window.
 
-10. Run the following command to verify whether the OpenJDK version 12 is installed:
+10. Launch **Command Prompt**.
+
+11. Run the following command to verify whether the OpenJDK version 12 is installed:
     ```
     java -version
     ```
@@ -109,7 +111,7 @@ This section explains how to install the OpenJDK version 12 for macOS:
     ```
 
     > [!NOTE]
-    > If the OpenJDK version 12 is not installed, add the `export JAVA_HOME = /Library/Java/JavaVirtualMachines/jdk-12.jdk/Contents/Home` command in the `.profile` or `.bash_profile` file.
+    > If the OpenJDK version 12 is not installed, add the `export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-12.jdk/Contents/Home` command in the `.profile` or `.bash_profile` file.
 
 
 ## Install OpenJFX


### PR DESCRIPTION
## Summary

Fixes two outdated Tizen Studio setup documents reported in #1327 and #1393.

### #1327 — HAXM supported version lists

`hardware-accelerated-execution-manager.md` listed `Windows 10/8.1/8/7 (32/64-bit)` and macOS 10.8–10.12, both of which are long EOL. Updated to match the current `prerequisites.md`:

- Windows: **10 (64-bit)**
- macOS: **11.4 (Big Sur), 12.3 (Monterey)**

### #1393 — JAVA_HOME path includes \\bin

`openjdk.md` instructed users to set `JAVA_HOME` to `C:\\Users\\user\\Desktop\\jdk-12.0.2\\bin`. `JAVA_HOME` must point to the JDK root directory, **not** the `bin` subdirectory. Changes:

- Removed `\\bin` from the `JAVA_HOME` example and added a note not to include it.
- Added a new step to add `%JAVA_HOME%\\bin` to the **Path** variable so `java`/`javac` are available from the command line (the core of the original report).
- Fixed the macOS `export JAVA_HOME = /Library/...` command — spaces around `=` are invalid in shell assignment.

## Checklist

- [x] Text-only changes; no links added or removed
- [x] Version numbers cross-checked against `prerequisites.md`

Fixes #1327
Fixes #1393