### PR TITLE
docs: require English for issues and pull requests

### DIFF
--- a/.claude/skills/tizen-docs/SKILL.md
+++ b/.claude/skills/tizen-docs/SKILL.md
@@ -9,6 +9,9 @@ This repository publishes documentation for the public Tizen Docs site. Work onl
 content suitable for public release. Do not add credentials, private contact information,
 unreleased product information, or other non-public material.
 
+Write issue and pull request titles, descriptions, and comments in English, regardless of
+the language used in the conversation that produced them.
+
 Use this skill when authoring, restructuring, or reviewing documentation here. It covers
 the checks that can be automated and the judgement required around them.
 
@@ -75,6 +78,7 @@ unfamiliar one.
 Review both correctness and publication safety:
 
 - Is all added content suitable for public release?
+- Are the issue/PR title, description, and comments written in English?
 - Does the path match the surrounding information architecture?
 - Is each new or moved document linked by its governing TOC?
 - Do links, images, and anchors still resolve after the change?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ authoring and review instructions, read
 - Give each new hand-written document one H1 as its first content heading.
 - Treat `*/api/**`, `*/wiki/**`, and `*.autogen.md` as imported content. Fix their source
   upstream instead of hand-editing generated output.
+- Write issue and pull request titles, descriptions, and comments in English, even if the
+  conversation that produced them was in another language.
 
 Before submitting a pull request, run:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,9 @@ The document covers the process for contributing to the articles and code sample
 Only contribute information suitable for public release. Do not add credentials, private
 contact information, unreleased product details, or other non-public material.
 
+Write all issues and pull requests (titles, descriptions, and comments) in English so that
+the whole community can read and participate in the discussion.
+
 1.  [Process for contributing](#process-for-contributing)
     1. [Repository structure](#repository-structure)
     1. [File Name](#file-name)
@@ -130,6 +133,7 @@ On a certain cadence, we push all commits from master branch into the live branc
 The following list shows some guiding rules that you should keep in mind when you're contributing to the Tizen documentation:
 
 - **DON'T** surprise us with large pull requests. Instead, file an issue and start a discussion so we can agree on a direction before you invest a large amount of time.
+- **DO** write issues and pull requests in English.
 - **DO** read the [style guide](styleguide/style.md) guideline.
 - **DO** use the [template](styleguide/template-guide.md) file as the starting point of your work.
 - **DO** create a separate branch on your fork before working on the articles.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ To contribute, see the [Contributing Guide](CONTRIBUTING.md) and the [issues lis
 
 Please take a look at the following instructions before starting.
 
+Write issues and pull requests in English.
+
 ### Workflow
 
 We are going to review <span class="labels lh-default d-block d-md-inline">


### PR DESCRIPTION
## Summary
- Add an explicit rule that issues and pull requests (titles, descriptions, comments) must be written in English, so the whole community can participate in the discussion.
- Reflected in README.md, CONTRIBUTING.md, AGENTS.md, and `.claude/skills/tizen-docs/SKILL.md` so both human contributors and AI coding agents follow it.

## Test plan
- [x] Reviewed rendered Markdown for README.md and CONTRIBUTING.md
- N/A `tools/check_docs.py` — no docs/ content changed