### PR TITLE
Document repository structure and link reviewguide/ from the skill

### DIFF
--- a/.claude/skills/tizen-docs/SKILL.md
+++ b/.claude/skills/tizen-docs/SKILL.md
@@ -19,10 +19,12 @@ the checks that can be automated and the judgement required around them.
 
 When a decision is ambiguous, use evidence in this order:
 
-1. [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) and the
-   [`styleguide/`](../../../styleguide/) documents
+1. [`CONTRIBUTING.md`](../../../CONTRIBUTING.md), the
+   [`styleguide/`](../../../styleguide/) documents, and the
+   [`reviewguide/`](../../../reviewguide/) documents
 2. Sibling documents and the TOC that publishes them
-3. This skill and its [TOC reference](references/toc-formats.md)
+3. This skill and its [directory map](references/directory-map.md) and
+   [TOC reference](references/toc-formats.md)
 
 The existing repository contains legacy variations. Do not normalize unrelated files in a
 focused change. Match the convention already used by the area you touch, and record a
@@ -32,7 +34,9 @@ separate cleanup issue when appropriate.
 
 1. **Choose the destination.** Browse the relevant section under `docs/` and locate its
    governing `toc*.md`. The main sections are `application/`, `platform/`, `iot/`,
-   `partners/`, `extensions/`, and `blog/`.
+   `partners/`, `extensions/`, and `blog/`. See the [directory map](references/directory-map.md)
+   for what each section and subdirectory contains, including which sibling files are
+   generated content that should not be edited by hand.
 2. **Check for imported content.** Do not hand-edit Markdown under `*/api/**`,
    `*/wiki/**`, or files ending in `.autogen.md`. Correct the upstream source and import
    the regenerated result instead.
@@ -87,3 +91,21 @@ Review both correctness and publication safety:
 
 Run the validator for the pull request's changed files. Fix every `ERROR`; explain or fix
 every `WARN` before approval.
+
+For area-specific review points, consult the matching guide under
+[`reviewguide/`](../../../reviewguide/) before approving:
+
+- [`review_points_guide.md`](../../../reviewguide/review_points_guide.md) — general guide
+  pages: branches, headings, adding/renaming/moving/deleting a page, tags
+- [`review_points_web_api.md`](../../../reviewguide/review_points_web_api.md) — required
+  for any change under `application/web/api/`: those files are HTML, not Markdown, and
+  must use HTML markup (`<strong>`, `<li>`), not Markdown syntax
+- [`review_points_release_note.md`](../../../reviewguide/review_points_release_note.md) —
+  release-note conventions (release date, tone, TOC registration) for Tizen Studio and
+  Tizen Platform notes
+- [`stg_build.md`](../../../reviewguide/stg_build.md) — use the Jenkins-built staging URL
+  attached to the PR to check rendered output before approving
+- [`update_docs_tizen_org.md`](../../../reviewguide/update_docs_tizen_org.md) — how an
+  approved `master` change is promoted to the live site via a separate `master` → `live`
+  pull request; not needed for routine content review, but relevant when a reviewer is
+  also asked to publish

--- a/.claude/skills/tizen-docs/references/directory-map.md
+++ b/.claude/skills/tizen-docs/references/directory-map.md
@@ -1,0 +1,131 @@
+# Tizen Docs directory map
+
+A directory-by-directory breakdown of this repository, current as of the snapshot in
+which this file was written. File and subdirectory counts are hand-written Markdown
+under `docs/` unless noted otherwise; they will drift as the site grows, so treat them
+as orientation, not a contract. When exact placement matters, browse the directory
+itself.
+
+Use this alongside [TOC formats](toc-formats.md): this file tells you *where* a
+document belongs; that file tells you *how* to wire it into navigation once it is
+there.
+
+## Repository root
+
+| Path | Purpose |
+| --- | --- |
+| `README.md`, `AGENTS.md`, `CONTRIBUTING.md` | Entry points for humans and AI agents |
+| `LICENSE-CODE` | BSD-3-Clause license for code samples |
+| `content-license.md` | CC BY 3.0 license for documentation content |
+| `.github/CODEOWNERS` | Default reviewers for the whole repo |
+| `.github/pull_request_template.md` | Required PR sections: Change Description, Bugs Fixed, API Changes |
+| `styleguide/` | Writing rules — see below |
+| `reviewguide/` | Reviewer walkthroughs — see below |
+| `tools/check_docs.py` | Link/TOC validator; run before every PR |
+| `.claude/skills/tizen-docs/` | This skill |
+
+## `docs/` — published site source
+
+Everything under `docs/` is published to the Tizen Docs site. It contains roughly
+1,900 hand-authored Markdown pages and, separately, tens of thousands of generated,
+versioned API-reference files (mostly static HTML with supporting JS/CSS) under
+`*/api/**` directories. The generated files are imported from another pipeline; never
+hand-edit them (see AGENTS.md). The counts below are Markdown-file counts unless a row
+says otherwise.
+
+### `docs/application/` (~880 hand-written `.md`, plus ~53,000 generated API files)
+
+Application-developer guides, organized by SDK/language profile and by tool:
+
+| Subdirectory | Content |
+| --- | --- |
+| `native/` (228 md) | C API guides, tutorials, overview. `native/api/` holds versioned, generated HTML API reference (e.g. `5.0/`, `6.5/`) — do not hand-edit. |
+| `web/` (164 md) | Web/W3C API guides. `web/api/` holds the largest generated HTML block in the repo (device_api, ui_fw_api, w3c_api, versioned by release). See `reviewguide/review_points_web_api.md` before touching anything under here — Web is unusual in that the API reference itself lives in this repo as HTML, not Markdown, and must follow HTML markup conventions, not Markdown syntax. |
+| `dotnet/` (201 md) | .NET/Xamarin guides; small generated `api/` stub. |
+| `flutter/` (13 md) | Flutter guides — the newest, smallest profile. |
+| `tizen-studio/` (138 md) | Tizen Studio IDE guide. |
+| `vscode-ext/` (66 md) | VS Code extension guide. |
+| `vstools/` (51 md) | Visual Studio Tools for Tizen (Windows). |
+| `vstools-mac/` (1 md) | Visual Studio Tools for Tizen (Mac). |
+| `features/` (5 md), `profiles/` (3 md) | Small cross-cutting overview pages. |
+
+`application/` also carries several parallel top-level TOCs — `toc_all.md`,
+`toc_all_new.md`, `toc_vscode_native.md`, `toc_vscode_web.md`, `toc_vscode_dotnet.md`,
+`toc_vs-ext_native.md`, `toc_vs-ext_web.md`, `toc_vs-ext_dotnet.md` — one per IDE/profile
+combination. Confirm which TOC(s) govern a page before editing navigation; a page can be
+linked from more than one.
+
+### `docs/platform/` (121 md, no generated bulk)
+
+Platform/OS documentation:
+
+- `what-is-tizen/` — product overview, versions, device/profile summaries
+- `HAL/` — hardware abstraction layer guides and API
+- `compliance/` — compliance program, specification, test docs
+- `developing/` — building, cloning, flashing, contributing to the Tizen platform itself
+- `get-started/` — repo structure, conventions, workflow for platform contributors
+- `porting/` — porting guides by subsystem (kernel, graphics, multimedia, connectivity, location)
+- `reference/` — GBS, Gerrit, MIC, TIC FAQ, Docker setup, TP usage
+- `release-notes/` — one file per Tizen platform version, back to Tizen 1.0
+
+### `docs/extensions/tizenx/` (819 md, ~800 of which are generated API reference)
+
+TizenX extension SDK documentation:
+
+- `overview/` (1 md) — introduction
+- `guides/` (18 md) — one guide per component (tizenx-zlog, tizenx-rpcport, tizenx-aurum, tizenx-genui, tizen-ui)
+- `api/` (~800 md) — one directory per namespace (e.g. `Tizen.UI`, `Tizen.UI.Components`,
+  `Tizen.UI.Widget`, `TizenX.GenUI`, `TizenX.RPCPort`, `TizenX.ZLog`, `TizenX.Aurum`).
+  Generated from source; treat as imported content per AGENTS.md.
+
+### `docs/iot/` (16 hand-written md, plus ~8,100 generated API files)
+
+IoT profile guides and overview (`get-started/`, `guides/`, `index.md`). `iot/api/`
+holds generated, versioned HTML API reference at the same scale as
+`application/web/api/` — do not hand-edit.
+
+### `docs/partners/` (7 md)
+
+Partner program docs: `iot-partners/`, `specialist/`.
+
+### `docs/blog/` (3 md)
+
+Blog posts, including a `dotnet/` subfolder and `index.md`.
+
+### `docs/images/`, `docs/menu.yaml`, and root docs
+
+- `images/` — image assets shared across sections (not tied to one document's `media/`)
+- `menu.yaml` — top navigation config (top-level sections shown/hidden on the site)
+- `get-started.md`, `glossary.md`, `trademarks.md` — standalone pages with no owning section
+
+## `styleguide/`
+
+Writing rules referenced from `AGENTS.md` and this skill's "Sources of truth":
+`style.md` (headings, tone), `naming-rules.md` (Tizen term naming), `template-guide.md`,
+`custom-style.md`, `sample1.md` (worked example), plus a `media/` folder of screenshots.
+
+## `reviewguide/`
+
+Reviewer-facing walkthroughs, not yet referenced elsewhere in this skill — consult them
+when reviewing a PR in the matching area:
+
+- `review_points_guide.md` — general guide-page review points: branches, headings, adding
+  a page (`toc_all.md`, `overview.md`), renaming/moving/deleting a page, tags
+- `review_points_web_api.md` — Web API specifics: these files are HTML, not Markdown; use
+  HTML tags (`<strong>`, `<li>`), not Markdown syntax, when editing them
+- `review_points_release_note.md` — release-note conventions for both Tizen Studio and
+  Tizen Platform notes: release date, tone, TOC registration
+- `stg_build.md` — how to use the staging (stg) preview URL that Jenkins builds for each
+  PR to check rendered output before merge
+- `update_docs_tizen_org.md` — how a merged `master` change is promoted to the live
+  `docs.tizen.org` site via a `master` → `live` pull request
+
+## Cross-cutting: generated vs. hand-written content
+
+Every `*/api/**` directory in this repository (`application/native/api`,
+`application/web/api`, `application/dotnet/api`, `extensions/tizenx/api`, `iot/api`) is
+generated and/or versioned content imported from elsewhere. Together they account for
+the large majority of files tracked in this repository. `AGENTS.md` states the rule;
+this map exists so you know, before you open an editor, which of the roughly 80,000
+files under `docs/` are actually meant to be hand-edited (~1,900 Markdown pages) and
+which are not.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,38 @@ All files under ./docs/ are hosted on the [Tizen Docs site](https://samsungtizen
 Only add information that is suitable for public release. Do not include credentials,
 private contact information, unreleased product details, or other non-public material.
 
+## Repository structure
+
+```
+tizen-docs/
+├── docs/                       # Published site source (docs.tizen.org)
+│   ├── application/            # App developer guides — native, web, dotnet, flutter,
+│   │   │                       #   plus tizen-studio/vscode-ext/vstools tooling docs
+│   │   └── */api/               # Generated API reference (HTML). Do not hand-edit.
+│   ├── platform/                # Platform/OS docs — HAL, compliance, porting,
+│   │                            #   developing, reference, release-notes, what-is-tizen
+│   ├── extensions/tizenx/       # TizenX extension SDK guides + generated API reference
+│   ├── iot/                     # IoT profile guides + generated API reference
+│   ├── partners/                # Partner program docs
+│   ├── blog/                    # Blog posts
+│   ├── images/                  # Shared site images
+│   └── menu.yaml, get-started.md, glossary.md, trademarks.md
+├── styleguide/                  # Writing style and naming-rule references
+├── reviewguide/                 # PR reviewer walkthroughs (per content type, stg build)
+├── tools/check_docs.py          # Link/TOC validator, run before every PR
+├── .github/                     # CODEOWNERS, pull request template
+└── .claude/skills/tizen-docs/   # Claude Code skill for authoring and review
+```
+
+`docs/` mixes hand-written Markdown with generated, versioned API-reference dumps
+(HTML/JS/CSS under `*/api/**`). Of the roughly 80,000 tracked files under `docs/`, only
+about 1,900 are hand-authored `.md` pages; the rest is generated API reference that must
+be fixed upstream, never edited by hand — see
+[AGENTS.md](AGENTS.md) for the full rule.
+
+For a directory-by-directory breakdown with file counts, see the skill's
+[directory map](.claude/skills/tizen-docs/references/directory-map.md).
+
 ## Working with an AI coding agent
 
 Repository-specific instructions for AI coding agents are in


### PR DESCRIPTION
### Change Description ###

- Add a "Repository structure" section to README.md: a top-level tree of the repo plus
  docs/, and a note that most of the ~80k files tracked under docs/ are generated,
  versioned API reference (under */api/**) rather than hand-authored Markdown.
- Add .claude/skills/tizen-docs/references/directory-map.md: a directory-by-directory
  breakdown (application/{native,web,dotnet,flutter,tizen-studio,vscode-ext,vstools,...},
  platform/*, extensions/tizenx/*, iot/*, partners/*, blog/*) with file counts and notes
  on which subtrees are generated content, for use when choosing where a new document
  belongs or reviewing a PR's placement.
- Link the new directory map from SKILL.md's "Sources of truth" and "Choose the
  destination" steps.
- Link the five existing reviewguide/ documents from SKILL.md's "Review workflow"
  section. They were not referenced by the skill before this change, so guidance such as
  "application/web/api files must use HTML markup, not Markdown" (review_points_web_api.md)
  or how to use the stg preview build (stg_build.md) was easy for a reviewer to miss.

No content under docs/ changes; `tools/check_docs.py --changed-only --base master` and
`git diff --check` both pass clean.

### Bugs Fixed ###

- N/A

### API Changes ###

- N/A