### PR TITLE
docs(toc): put entries in the block that can actually publish them

### DIFF
--- a/docs/application/dotnet/guides/performance/tracer.md
+++ b/docs/application/dotnet/guides/performance/tracer.md
@@ -14,7 +14,7 @@ The main features of the `Tizen.Tracer` class include followings:
 
 ## Prerequisites
 
-To use the methods of [Tizen.Tracer](/application/dotnet/api/TizenFX/master/api/Tizen.Tracer.html), you should include the [Tizen](/application/dotnet/api/TizenFX/master/api/Tizen.html) namespace in your application:
+To use the methods of [Tizen.Tracer](/application/dotnet/api/15.0.0/common/Tizen.Tracer.md), you should include the [Tizen](/application/dotnet/api/15.0.0/common/Tizen.md) namespace in your application:
 
 ```csharp
 using Tizen;
@@ -24,7 +24,7 @@ using Tizen;
 <a name="tracer"></a>
 ## Put traces in the common trace buffer
 
-A trace is defined by two API calls: [Begin](/application/dotnet/api/TizenFX/master/api/Tizen.Tracer.html#Tizen_Tracer_Begin_System_String_) and [End](/application/dotnet/api/TizenFX/master/api/Tizen.Tracer.html#Tizen_Tracer_End), or [AsyncBegin](/application/dotnet/api/TizenFX/master/api/Tizen.Tracer.html#Tizen_Tracer_AsyncBegin_System_Int32_System_String_) and [AsyncEnd](/application/dotnet/api/TizenFX/master/api/Tizen.Tracer.html#Tizen_Tracer_AsyncEnd_System_Int32_System_String_).
+A trace is defined by two API calls: [Begin](/application/dotnet/api/15.0.0/common/Tizen.Tracer.md#Tizen_Tracer_Begin_System_String_) and [End](/application/dotnet/api/15.0.0/common/Tizen.Tracer.md#Tizen_Tracer_End), or [AsyncBegin](/application/dotnet/api/15.0.0/common/Tizen.Tracer.md#Tizen_Tracer_AsyncBegin_System_Int32_System_String_) and [AsyncEnd](/application/dotnet/api/15.0.0/common/Tizen.Tracer.md#Tizen_Tracer_AsyncEnd_System_Int32_System_String_).
 
 Here are examples:
   * Use synchronous tracing.
@@ -63,7 +63,7 @@ Here are examples:
 
   * Track changes of an integer counter.
 
-   If you want to track changes of an integer counter of your program in the trace, use [TraceValue](/application/dotnet/api/TizenFX/master/api/Tizen.Tracer.html#Tizen_Tracer_TraceValue_System_Int32_System_String_).
+   If you want to track changes of an integer counter of your program in the trace, use [TraceValue](/application/dotnet/api/15.0.0/common/Tizen.Tracer.md#Tizen_Tracer_TraceValue_System_Int32_System_String_).
 
    ```csharp
    void

--- a/docs/application/dotnet/guides/security/dpm.md
+++ b/docs/application/dotnet/guides/security/dpm.md
@@ -11,15 +11,15 @@ The DPM framework consists of the following tools:
 - **Device policy client library**: This contains all the device administration functions that a client application can call. The device policy client library communicates with the device policy manager using a built-in remote method invocation (RMI) engine.
 - **Device policy manager**: This manages all the device policies. It also provides interfaces for the device policy client library.
 
-The main features of the [Tizen.Security.DevicePolicyManager](/application/dotnet/api/TizenFX/master/api/Tizen.Security.DevicePolicyManager.html) namespace are as follows:
+The main features of the [Tizen.Security.DevicePolicyManager](/application/dotnet/api/14.0.0/common/Tizen.Security.DevicePolicyManager.md) namespace are as follows:
 
 - Managing policies
 
-  You can [track the state between the device admin client and the device policy manager](#client_application) using the `DevicePolicyManager` class provided by [Tizen.Security.DevicePolicyManager](/application/dotnet/api/TizenFX/master/api/Tizen.Security.DevicePolicyManager.html).
+  You can [track the state between the device admin client and the device policy manager](#client_application) using the `DevicePolicyManager` class provided by [Tizen.Security.DevicePolicyManager](/application/dotnet/api/14.0.0/common/Tizen.Security.DevicePolicyManager.md).
 
 - Checking restrictions
 
-  You can [check the restriction states of the device](#client_application), such as camera, microphone, Wi-Fi, Bluetooth, and USB, using the properties of the policy classes. [Tizen.Security.DevicePolicyManager](/application/dotnet/api/TizenFX/master/api/Tizen.Security.DevicePolicyManager.html) provides these policy classes.
+  You can [check the restriction states of the device](#client_application), such as camera, microphone, Wi-Fi, Bluetooth, and USB, using the properties of the policy classes. [Tizen.Security.DevicePolicyManager](/application/dotnet/api/14.0.0/common/Tizen.Security.DevicePolicyManager.md) provides these policy classes.
 
 The following figure illustrates the DPM framework process:
 
@@ -29,7 +29,7 @@ The following figure illustrates the DPM framework process:
 
 ## Prerequisites
 
-To use the methods and properties of the [Tizen.Security.DevicePolicyManager](/application/dotnet/api/TizenFX/master/api/Tizen.Security.DevicePolicyManager.html) namespace, include it in your application:
+To use the methods and properties of the [Tizen.Security.DevicePolicyManager](/application/dotnet/api/14.0.0/common/Tizen.Security.DevicePolicyManager.md) namespace, include it in your application:
 
 ```csharp
 using Tizen.Security.DevicePolicyManager;

--- a/docs/application/dotnet/guides/system/usb-host.md
+++ b/docs/application/dotnet/guides/system/usb-host.md
@@ -138,4 +138,4 @@ Programs which are dedicated for one specific device often hardcode the interfac
 - Dependencies
   - Since Tizen 3.0
 - API References
-  - [USB](/application/dotnet/api/TizenFX/llatest/api/Tizen.System.Usb.html)
+  - [USB](/application/dotnet/api/15.0.0/common/Tizen.System.Usb.md)

--- a/docs/application/dotnet/guides/user-interface/nui/nui-components/camera-view.md
+++ b/docs/application/dotnet/guides/user-interface/nui/nui-components/camera-view.md
@@ -4,7 +4,7 @@ keyword: camera, CameraView, NUI, CameraView.DisplayType
 
 # CameraView
 
-The [CameraView](/application/dotnet/api/TizenFX/API9/api/Tizen.NUI.BaseComponents.CameraView.html) class is the NUI view that displays [camera](/application/dotnet/guides/multimedia/camera.md).
+The [CameraView](/application/dotnet/api/15.0.0/common/Tizen.NUI.BaseComponents.CameraView.md) class is the NUI view that displays [camera](/application/dotnet/guides/multimedia/camera.md).
 
 
 ## Create a CameraView

--- a/docs/application/toc_all.md
+++ b/docs/application/toc_all.md
@@ -48,7 +48,6 @@
 #### [Overview](/application/dotnet/guides/applications/overview.md)
 #### [Service Application](/application/dotnet/guides/applications/service-application.md)
 #### UI Application
-##### [Widget Application](/application/web/guides/applications/web-widget.md)
 ##### [Overview](/application/dotnet/guides/applications/uiapplication/overview.md)
 ##### [Basic UI Application](/application/dotnet/guides/applications/uiapplication/ui-app.md)
 ##### [Component Based Application](/application/dotnet/guides/applications/uiapplication/component-based-app.md)
@@ -337,6 +336,7 @@
 
 #### [Service Application](/application/web/guides/applications/service-app.md)
 #### [Web Application Addon](/application/web/guides/applications/addon.md)
+#### [Widget Application](/application/web/guides/applications/web-widget.md)
 
 ### Application Management
 #### [Overview](/application/web/guides/app-management/overview.md)

--- a/docs/application/toc_all.md
+++ b/docs/application/toc_all.md
@@ -19,16 +19,16 @@
 ### [API Privileges](/application/dotnet/reference/api-privileges.md)
 ### [Hybrid Application](/application/dotnet/get-started/hybrid-application.md)
 ### [Install Samsung Smart TV Extension](/application/dotnet/get-started/install-samsung-tv-extension.md)
+
+### [Application Filtering](/application/dotnet/reference/app-filtering.md)
+
+## Guides
 ### Certificates
 #### [Overview](/application/dotnet/guides/concepts/signing-certificates/index.md)
 #### [Installing the Extension](/application/dotnet/guides/concepts/signing-certificates/installing-the-extension.md)
 #### [Creating Certificates](/application/dotnet/guides/concepts/signing-certificates/creating-certificates.md)
 #### [Signing Application with Certificate](/application/dotnet/guides/concepts/signing-certificates/signing-application-with-certificate.md)
 #### [Managing Certificate Profile](/application/dotnet/guides/concepts/signing-certificates/managing-certificate-profile.md)
-
-### [Application Filtering](/application/dotnet/reference/app-filtering.md)
-
-## Guides
 ### [Overview](/application/dotnet/guides/index.md)
 ### Account
 #### [Overview](/application/dotnet/guides/account/overview.md)

--- a/docs/application/toc_all.md
+++ b/docs/application/toc_all.md
@@ -314,12 +314,6 @@
 
 ## Tutorials
 ### [Overview](/application/web/tutorials/overview.md)
-### Application Development Process
-#### [Overview](/application/web/guides/development/index.md)
-#### [Creating the Application Project](/application/web/guides/development/creating-app-project.md)
-#### [Setting Project Properties](/application/web/guides/development/setting-properties.md)
-#### [Coding Applications](/application/web/guides/development/coding-app.md)
-#### [Running and Debugging Applications](/application/web/guides/development/run-debug-app.md)
 
 ### [Application Filtering](/application/web/reference/app-filtering.md)
 ### [Security and API Privileges](/application/web/reference/security-privileges.md)
@@ -331,6 +325,12 @@
 
 ## Guides
 ### [Overview](/application/web/guides/index.md)
+### Application Development Process
+#### [Overview](/application/web/guides/development/index.md)
+#### [Creating the Application Project](/application/web/guides/development/creating-app-project.md)
+#### [Setting Project Properties](/application/web/guides/development/setting-properties.md)
+#### [Coding Applications](/application/web/guides/development/coding-app.md)
+#### [Running and Debugging Applications](/application/web/guides/development/run-debug-app.md)
 ### Applications
 #### [Overview](/application/web/guides/applications/overview.md)
 

--- a/docs/application/toc_all.md
+++ b/docs/application/toc_all.md
@@ -551,14 +551,6 @@
 
 ## Tutorials
 ### [Overview](/application/native/tutorials/overview.md)
-### Application Development Process
-#### [Overview](/application/native/guides/development/index.md)
-#### [Creating the Application Project](/application/native/guides/development/creating-app-project.md)
-#### [Setting Project Properties](/application/native/guides/development/setting-properties.md)
-#### [Building Applications](/application/native/guides/development/building-app.md)
-#### [Running Applications](/application/native/guides/development/running-app.md)
-#### [Debugging Applications](/application/native/guides/development/debugging-app.md)
-#### [Optimizing Application Performance](/application/native/guides/development/performance.md)
 
 ### Understanding Tizen Programming
 #### [Application Filtering](/application/native/reference/app-filtering.md)
@@ -603,6 +595,14 @@
 ### [Best Practices for Location](/application/native/tutorials/feature/best-practice-battery.md)
 
 ## Guides
+### Application Development Process
+#### [Overview](/application/native/guides/development/index.md)
+#### [Creating the Application Project](/application/native/guides/development/creating-app-project.md)
+#### [Setting Project Properties](/application/native/guides/development/setting-properties.md)
+#### [Building Applications](/application/native/guides/development/building-app.md)
+#### [Running Applications](/application/native/guides/development/running-app.md)
+#### [Debugging Applications](/application/native/guides/development/debugging-app.md)
+#### [Optimizing Application Performance](/application/native/guides/development/performance.md)
 ### [Overview](/application/native/guides/index.md)
 ### Applications
 #### [Overview](/application/native/guides/applications/overview.md)


### PR DESCRIPTION
Follow-up to #2365, found while auditing the docs site build for pages that exist in this repo but never reach the site.

The site derives each section's table of contents from the surrounding `## ` block in `toc_all.md`. An entry whose path points **outside** that block's section is therefore published by nobody: the owning section never sees it, and the block's own section resolves it against the wrong base and finds nothing. No error, no warning — the page simply never gets built.

Four groups are in this state, all of them fallout from IA refactors that moved files without moving their toc entries:

| Entries | Where they are | Where the files live |
|---:|---|---|
| 1 | .NET "UI Application" block | `web/guides/applications/web-widget.md` |
| 5 | Web `## Tutorials` block | `web/guides/development/` |
| 5 | .NET `## Get Started` block | `dotnet/guides/concepts/signing-certificates/` |
| 7 | Native `## Tutorials` block | `native/guides/development/` |

Each group is moved into the `## Guides` block of its own section, matching where the files now live.

A fifth commit repoints four .NET guides at API URLs the site actually serves. They linked to `/application/dotnet/api/TizenFX/<ref>/api/<Type>.html` — a URL shape this site has never served, with the ref varying (`master`, `API9`, and one typo, `llatest`). Each now points at the newest published version containing that type, verified against the built tree.

## Verified

Built each affected section with these changes applied:

- all 18 pages are emitted (previously 0)
- the site-wide count of toc nodes with no corresponding file goes **13 → 0**
- the four repointed links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDih4oW3h83WtrbaA4ErBb
