### PR TITLE
docs: place Widget Application guides in their platform TOCs

### DIFF
--- a/docs/application/toc_all.md
+++ b/docs/application/toc_all.md
@@ -339,6 +339,7 @@
 #### [Overview](/application/web/guides/applications/overview.md)
 
 #### [Service Application](/application/web/guides/applications/service-app.md)
+#### [Widget Application](/application/web/guides/applications/web-widget.md)
 #### [Web Application Addon](/application/web/guides/applications/addon.md)
 
 ### Application Management

--- a/docs/application/toc_all.md
+++ b/docs/application/toc_all.md
@@ -48,7 +48,6 @@
 #### [Overview](/application/dotnet/guides/applications/overview.md)
 #### [Service Application](/application/dotnet/guides/applications/service-application.md)
 #### UI Application
-##### [Widget Application](/application/web/guides/applications/web-widget.md)
 ##### [Overview](/application/dotnet/guides/applications/uiapplication/overview.md)
 ##### [Basic UI Application](/application/dotnet/guides/applications/uiapplication/ui-app.md)
 ##### [Component Based Application](/application/dotnet/guides/applications/uiapplication/component-based-app.md)


### PR DESCRIPTION
## Summary
- remove the misplaced Web Widget Application entry from the .NET UI Application section
- add that entry to the Web Guides Applications section
- retain the existing .NET Widget Application entry

## Validation
- `git diff --check`
- confirmed the .NET, Web, and Native Widget Application guides each have one TOC entry in their respective platform sections