### PR TITLE
docs: repair obsolete API references

### DIFF
--- a/docs/application/dotnet/guides/alarm/alarms.md
+++ b/docs/application/dotnet/guides/alarm/alarms.md
@@ -62,7 +62,7 @@ You can set an alarm which, when it expires, either launches an application or s
 > Improperly designed alarms can cause battery drain and put a significant load on the server. For this reason, any repeating alarm that uses a (#PERIOD) is considered an inexact alarm.
 
 > [!NOTE]
-> Since Tizen 6.0, the time period value of an alarm can be one of the values of the [Tizen.Applications.AlarmManager.AlarmStandardPeriod](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.AlarmManager.AlarmStandardPeriod.html) enumeration. For the `CreateAlarm()` method of the `Tizen.Applications.AlarmManager` class, if you use `AlarmStandardPeriod`, the time period value of the alarm is guaranteed. If `AlarmStandardPeriod` is not used, the minimum period value is 600 seconds, and the actual repeat interval is not strictly guaranteed by the system.
+> Since Tizen 6.0, the time period value of an alarm can be one of the values of the `Tizen.Applications.AlarmManager.AlarmStandardPeriod` enumeration. For the `CreateAlarm()` method of the `Tizen.Applications.AlarmManager` class, if you use `AlarmStandardPeriod`, the time period value of the alarm is guaranteed. If `AlarmStandardPeriod` is not used, the minimum period value is 600 seconds, and the actual repeat interval is not strictly guaranteed by the system.
 
 -   To set an alarm to launch an application, follow these steps:
 
@@ -142,7 +142,7 @@ myAlarm = AlarmManager.CreateAlarm(dt.AddSeconds(20), appControl);
 
 You can set a recurring alarm that goes off at a specific moment, and thereafter at regular intervals.
 
-To schedule a recurring alarm to go off on specific days of the week, use the `CreateAlarm()` method of the [Tizen.Applications.AlarmManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.AlarmManager.html) class, with values of the [Tizen.Applications.AlarmManager.AlarmWeekFlag](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.AlarmManager.AlarmWeekFlag.html) enumeration as the second parameter. You can join multiple values together to set the alarm to trigger on multiple days of the week.
+To schedule a recurring alarm to go off on specific days of the week, use the `CreateAlarm()` method of the [Tizen.Applications.AlarmManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.AlarmManager.html) class, with values of the `Tizen.Applications.AlarmManager.AlarmWeekFlag` enumeration as the second parameter. You can join multiple values together to set the alarm to trigger on multiple days of the week.
 
 The following example schedules an application control to be invoked at a set time every Tuesday and Friday:
 
@@ -206,5 +206,5 @@ You can list all scheduled alarms, and cancel alarms either one by one or all at
 - API References
     - [Tizen.Applications.AlarmManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.AlarmManager) class
     - [Tizen.Applications.Alarm](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.Alarm) class
-    - [Tizen.Applications.AlarmManager.AlarmWeekFlag](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.AlarmManager.AlarmWeekFlag) enum
-    - [Tizen.Applications.AlarmManager.AlarmStandardPeriod](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.AlarmManager.AlarmStandardPeriod) enum
+    - `Tizen.Applications.AlarmManager.AlarmWeekFlag` enum
+    - `Tizen.Applications.AlarmManager.AlarmStandardPeriod` enum

--- a/docs/application/dotnet/guides/app-management/app-manager.md
+++ b/docs/application/dotnet/guides/app-management/app-manager.md
@@ -170,4 +170,4 @@ To get information on the current application, follow these steps:
   - Dependencies
     -   Tizen 4.0 and Higher
   - API References
-    - [Tizen.Applications.ApplicationManager](/application/dotnet/api/TizenFX/latest/api/Tizen.Applications.ApplicationManagerhtml) class
+    - [Tizen.Applications.ApplicationManager](/application/dotnet/api/15.0.0/common/Tizen.Applications.ApplicationManager.md) class

--- a/docs/application/dotnet/guides/machine-learning/pipeline.md
+++ b/docs/application/dotnet/guides/machine-learning/pipeline.md
@@ -300,4 +300,4 @@ Element Properties:
   - Tizen 6.0 and Higher
 
 - API References
-  - [Tizen.MachineLearning.Inference.Pipeline](/application/dotnet/api/TizenFX/latest/api/Tizen.MachineLearning.Inference.pipeline.html) class
+  - [Tizen.MachineLearning.Inference.Pipeline](/application/dotnet/api/15.0.0/common/Tizen.MachineLearning.Inference.Pipeline.md) class

--- a/docs/application/dotnet/guides/multimedia/pose-detection.md
+++ b/docs/application/dotnet/guides/multimedia/pose-detection.md
@@ -4,15 +4,9 @@ Pose detection is a new feature of Media Vision Inference API since Tizen 6.5 (C
 
 ## Background
 
-In Tizen, human body pose landmarks and body parts are defined as follows:
-
-**Figure: Definition of human body pose landmarks and body parts**
-
-![Body pose](/application/native/guides/multimedia/media/mediavision_pose_tizen_def.png)
+In Tizen, human body pose landmarks and body parts are defined as follows.
 
 The pose landmark detection models are available in Open Model Zoo such as [hosted model zoo](https://www.tensorflow.org/lite/guide/hosted_models#floating_point_models){:target="_blank"} or public GitHub site such as [public pose model](https://github.com/tyoungroy/PoseEstimationForMobile){:target="_blank"}. The public pose models provide landmark information, such as the number of landmarks and locations. To use them correctly, you must map the information to landmarks based on the definition. For example, you can use the [public pose model](https://github.com/tyoungroy/PoseEstimationForMobile){:target="_blank"}, which provides 14 landmarks as follows:
-
-![Body pose](/application/native/guides/multimedia/media/mediavision_pose_public_model_def.png),
 
 In this model, `-1` denotes that there are no landmarks. Using this landmark information, you can create a mapping file. Suppose you create a mapping file with the name `pose_mapping.txt`, then you can populate the `pose_mapping.txt` file as follows:
 
@@ -60,8 +54,6 @@ In this model, `-1` denotes that there are no landmarks. Using this landmark inf
 
 
 The MoCap file includes the movements of objects or a person. There are various MoCap formats, but a well known BioVision Hierarchy (BVH) file is supported in Media Vision. BVH file has a hierarchy structure to provide landmark information with landmarks' names, and the structure can be changed. It means that landmark information is different from the definition. To use the BVH file correctly, you have to map the information to the landmarks based on the definitions. For example, the [BVH file](/application/native/guides/multimedia/media/mediavision_pose_bvh_sample.bvh) describes a squat pose as follows:
-
-![Body pose](/application/native/guides/multimedia/media/mediavision_pose_bvh_sample.png)
 
 The example starts with hips and ends with the left foot with 15 landmarks. You can create a mapping file named `mocap_mapping.txt` as follows:
 

--- a/docs/application/dotnet/guides/performance/tracer.md
+++ b/docs/application/dotnet/guides/performance/tracer.md
@@ -14,7 +14,7 @@ The main features of the `Tizen.Tracer` class include followings:
 
 ## Prerequisites
 
-To use the methods of [Tizen.Tracer](/application/dotnet/api/TizenFX/master/api/Tizen.Tracer.html), you should include the [Tizen](/application/dotnet/api/TizenFX/master/api/Tizen.html) namespace in your application:
+To use the methods of [Tizen.Tracer](/application/dotnet/api/15.0.0/common/Tizen.Tracer.md), you should include the [Tizen](/application/dotnet/api/15.0.0/common/Tizen.md) namespace in your application:
 
 ```csharp
 using Tizen;
@@ -24,7 +24,7 @@ using Tizen;
 <a name="tracer"></a>
 ## Put traces in the common trace buffer
 
-A trace is defined by two API calls: [Begin](/application/dotnet/api/TizenFX/master/api/Tizen.Tracer.html#Tizen_Tracer_Begin_System_String_) and [End](/application/dotnet/api/TizenFX/master/api/Tizen.Tracer.html#Tizen_Tracer_End), or [AsyncBegin](/application/dotnet/api/TizenFX/master/api/Tizen.Tracer.html#Tizen_Tracer_AsyncBegin_System_Int32_System_String_) and [AsyncEnd](/application/dotnet/api/TizenFX/master/api/Tizen.Tracer.html#Tizen_Tracer_AsyncEnd_System_Int32_System_String_).
+A trace is defined by two API calls: [Begin](/application/dotnet/api/15.0.0/common/Tizen.Tracer.md#Tizen_Tracer_Begin_System_String_) and [End](/application/dotnet/api/15.0.0/common/Tizen.Tracer.md#Tizen_Tracer_End), or [AsyncBegin](/application/dotnet/api/15.0.0/common/Tizen.Tracer.md#Tizen_Tracer_AsyncBegin_System_Int32_System_String_) and [AsyncEnd](/application/dotnet/api/15.0.0/common/Tizen.Tracer.md#Tizen_Tracer_AsyncEnd_System_Int32_System_String_).
 
 Here are examples:
   * Use synchronous tracing.
@@ -63,7 +63,7 @@ Here are examples:
 
   * Track changes of an integer counter.
 
-   If you want to track changes of an integer counter of your program in the trace, use [TraceValue](/application/dotnet/api/TizenFX/master/api/Tizen.Tracer.html#Tizen_Tracer_TraceValue_System_Int32_System_String_).
+   If you want to track changes of an integer counter of your program in the trace, use [TraceValue](/application/dotnet/api/15.0.0/common/Tizen.Tracer.md#Tizen_Tracer_TraceValue_System_Int32_System_String_).
 
    ```csharp
    void

--- a/docs/application/dotnet/guides/security/dpm.md
+++ b/docs/application/dotnet/guides/security/dpm.md
@@ -11,15 +11,15 @@ The DPM framework consists of the following tools:
 - **Device policy client library**: This contains all the device administration functions that a client application can call. The device policy client library communicates with the device policy manager using a built-in remote method invocation (RMI) engine.
 - **Device policy manager**: This manages all the device policies. It also provides interfaces for the device policy client library.
 
-The main features of the [Tizen.Security.DevicePolicyManager](/application/dotnet/api/TizenFX/master/api/Tizen.Security.DevicePolicyManager.html) namespace are as follows:
+The main features of the [Tizen.Security.DevicePolicyManager](/application/dotnet/api/14.0.0/common/Tizen.Security.DevicePolicyManager.md) namespace are as follows:
 
 - Managing policies
 
-  You can [track the state between the device admin client and the device policy manager](#client_application) using the `DevicePolicyManager` class provided by [Tizen.Security.DevicePolicyManager](/application/dotnet/api/TizenFX/master/api/Tizen.Security.DevicePolicyManager.html).
+  You can [track the state between the device admin client and the device policy manager](#client_application) using the `DevicePolicyManager` class provided by [Tizen.Security.DevicePolicyManager](/application/dotnet/api/14.0.0/common/Tizen.Security.DevicePolicyManager.md).
 
 - Checking restrictions
 
-  You can [check the restriction states of the device](#client_application), such as camera, microphone, Wi-Fi, Bluetooth, and USB, using the properties of the policy classes. [Tizen.Security.DevicePolicyManager](/application/dotnet/api/TizenFX/master/api/Tizen.Security.DevicePolicyManager.html) provides these policy classes.
+  You can [check the restriction states of the device](#client_application), such as camera, microphone, Wi-Fi, Bluetooth, and USB, using the properties of the policy classes. [Tizen.Security.DevicePolicyManager](/application/dotnet/api/14.0.0/common/Tizen.Security.DevicePolicyManager.md) provides these policy classes.
 
 The following figure illustrates the DPM framework process:
 
@@ -29,7 +29,7 @@ The following figure illustrates the DPM framework process:
 
 ## Prerequisites
 
-To use the methods and properties of the [Tizen.Security.DevicePolicyManager](/application/dotnet/api/TizenFX/master/api/Tizen.Security.DevicePolicyManager.html) namespace, include it in your application:
+To use the methods and properties of the [Tizen.Security.DevicePolicyManager](/application/dotnet/api/14.0.0/common/Tizen.Security.DevicePolicyManager.md) namespace, include it in your application:
 
 ```csharp
 using Tizen.Security.DevicePolicyManager;

--- a/docs/application/dotnet/guides/system/usb-host.md
+++ b/docs/application/dotnet/guides/system/usb-host.md
@@ -138,4 +138,4 @@ Programs which are dedicated for one specific device often hardcode the interfac
 - Dependencies
   - Since Tizen 3.0
 - API References
-  - [USB](/application/dotnet/api/TizenFX/llatest/api/Tizen.System.Usb.html)
+  - [USB](/application/dotnet/api/15.0.0/common/Tizen.System.Usb.md)

--- a/docs/application/dotnet/guides/user-interface/nui/nui-components/camera-view.md
+++ b/docs/application/dotnet/guides/user-interface/nui/nui-components/camera-view.md
@@ -4,7 +4,7 @@ keyword: camera, CameraView, NUI, CameraView.DisplayType
 
 # CameraView
 
-The [CameraView](/application/dotnet/api/TizenFX/API9/api/Tizen.NUI.BaseComponents.CameraView.html) class is the NUI view that displays [camera](/application/dotnet/guides/multimedia/camera.md).
+The [CameraView](/application/dotnet/api/15.0.0/common/Tizen.NUI.BaseComponents.CameraView.md) class is the NUI view that displays [camera](/application/dotnet/guides/multimedia/camera.md).
 
 
 ## Create a CameraView

--- a/docs/application/dotnet/reference/app-filtering.md
+++ b/docs/application/dotnet/reference/app-filtering.md
@@ -70,7 +70,7 @@ To enable filtering for your .NET application, add the feature list for the appl
 
     The manifest file (`tizen-manifest.xml`) is updated automatically.
 
-The following table shows the available requirements for an application package. If you want to check which features are necessary for using a specific API, see the related feature in the TizenFX [API Reference](/application/dotnet/api/TizenFX/latest/):
+The following table shows the available requirements for an application package. If you want to check which features are necessary for using a specific API, see the related feature in the TizenFX API reference:
 
 **Table: Available requirements**
 

--- a/docs/application/native/guides/development/setting-properties.md
+++ b/docs/application/native/guides/development/setting-properties.md
@@ -100,7 +100,7 @@ To enable filtering for your native application:
 
 2. Select a feature from the [predefined list of features available for filtering](../../reference/app-filtering.md).
 
-   To check which features are necessary for using a specific API, see the related feature in the native API reference.
+   To check which features are necessary for using a specific API, see the related feature in the [Native API reference](https://samsungtizenos.com/docs/application/native/overview).
 
 3. Click **OK**.
 

--- a/docs/application/native/guides/development/setting-properties.md
+++ b/docs/application/native/guides/development/setting-properties.md
@@ -100,7 +100,7 @@ To enable filtering for your native application:
 
 2. Select a feature from the [predefined list of features available for filtering](../../reference/app-filtering.md).
 
-   To check which features are necessary for using a specific API, see the related feature in the native [API Reference](../../api/mobile/latest/index.html).
+   To check which features are necessary for using a specific API, see the related feature in the native API reference.
 
 3. Click **OK**.
 

--- a/docs/application/native/guides/security/security-tip.md
+++ b/docs/application/native/guides/security/security-tip.md
@@ -55,7 +55,7 @@ In a mandatory access control system, an application that accesses sensitive res
 
 - Tizen provides API-level access control for security-sensitive operations that can harm user privacy and system stability, if not used properly. If the application uses such sensitive APIs, it must declare the required privileges in the manifest file.
 
-  To determine whether an API requires privileges to be used, see the API reference.
+  To determine whether an API requires privileges to be used, see the [Native API reference](https://samsungtizenos.com/docs/application/native/overview).
 
 In Tizen 3.0, the platform uses core privileges for access control, but the concept of the application privilege declaration is not changed. As in Tizen 2.X, the application can declare required privileges in the manifest file according to their own application type.
 

--- a/docs/application/native/guides/security/security-tip.md
+++ b/docs/application/native/guides/security/security-tip.md
@@ -55,7 +55,7 @@ In a mandatory access control system, an application that accesses sensitive res
 
 - Tizen provides API-level access control for security-sensitive operations that can harm user privacy and system stability, if not used properly. If the application uses such sensitive APIs, it must declare the required privileges in the manifest file.
 
-  To determine whether an API requires privileges to be used, see the [API Reference](../../api/common/latest/index.html).
+  To determine whether an API requires privileges to be used, see the API reference.
 
 In Tizen 3.0, the platform uses core privileges for access control, but the concept of the application privilege declaration is not changed. As in Tizen 2.X, the application can declare required privileges in the manifest file according to their own application type.
 

--- a/docs/application/native/reference/removed-history.md
+++ b/docs/application/native/reference/removed-history.md
@@ -406,7 +406,3 @@ The following table provides detailed information regarding removed functions an
 | Application Framework - Widget - Widget Viewer | All functions of this module | Since 10.0 | 11.0 | No longer available | - |
 | UI - Minicontrol | All functions of this module | Since 10.0 | 11.0 | No longer available | - |
 | Multimedia - Mediaeditor | All functions of this module | Since 7.0 | 11.0 | No longer available | - |
-
-## Related information
-
-- Tizen Native API Reference

--- a/docs/application/native/reference/removed-history.md
+++ b/docs/application/native/reference/removed-history.md
@@ -409,4 +409,4 @@ The following table provides detailed information regarding removed functions an
 
 ## Related information
 
-- [Tizen Native API Reference](../api/overview.md)
+- Tizen Native API Reference

--- a/docs/application/tizen-studio/native-tools/resource-manager.md
+++ b/docs/application/tizen-studio/native-tools/resource-manager.md
@@ -93,7 +93,7 @@ To quickly manage resources in Tizen Studio:
 
 4. Check the `res.xml` file content.![Check the res.xml file](./media/resource_manager_check_res_xml.png)
 
-5. Add code for loading alternative resources by using the Resource Manager API (in [mobile](../../native/api/mobile/latest/group__CAPI__RESOURCE__MANAGER__MODULE.html) applications).![Load resources](./media/resource_manager_add_code.png)
+5. Add code for loading alternative resources by using the Resource Manager API.![Load resources](./media/resource_manager_add_code.png)
 
 6. Build and run the project.
 

--- a/docs/application/tizen-studio/native-tools/resource-manager.md
+++ b/docs/application/tizen-studio/native-tools/resource-manager.md
@@ -93,7 +93,7 @@ To quickly manage resources in Tizen Studio:
 
 4. Check the `res.xml` file content.![Check the res.xml file](./media/resource_manager_check_res_xml.png)
 
-5. Add code for loading alternative resources by using the Resource Manager API.![Load resources](./media/resource_manager_add_code.png)
+5. Add code for loading alternative resources by using the [Resource Manager API](/application/native/api/10.0.0/common/group__CAPI__RESOURCE__MANAGER__MODULE.md).![Load resources](./media/resource_manager_add_code.png)
 
 6. Build and run the project.
 

--- a/docs/application/tizen-studio/native-tools/ui-builder/convert-projects.md
+++ b/docs/application/tizen-studio/native-tools/ui-builder/convert-projects.md
@@ -75,10 +75,10 @@ To display visually-edited views (created in the UI Builder) and code-based user
 
 | Name       | Type                                     | Description                              |
 |------------|------------------------------------------|------------------------------------------|
-| window     | Elementary window | Forms the first window of the application. |
-| bg         | Background | Sets a background for a window or any container object. |
-| conformant | Conformant | Provides space for indicators, virtual keypads, and softkey windows. |
-| naviframe  | Naviframe | Manages UI Builder views.                |
+| window     | [Elementary window](/application/native/api/10.0.0/common/group__Elm__Win__Group.md) | Forms the first window of the application. |
+| bg         | [Background](/application/native/api/10.0.0/common/group__Elm__Bg.md) | Sets a background for a window or any container object. |
+| conformant | [Conformant](/application/native/api/10.0.0/common/group__Elm__Conformant.md) | Provides space for indicators, virtual keypads, and softkey windows. |
+| naviframe  | [Naviframe](/application/native/api/10.0.0/common/group__Elm__Naviframe__Group.md) | Manages UI Builder views.                |
 
 ## Converting to a UI Builder Project
 

--- a/docs/application/tizen-studio/native-tools/ui-builder/convert-projects.md
+++ b/docs/application/tizen-studio/native-tools/ui-builder/convert-projects.md
@@ -75,10 +75,10 @@ To display visually-edited views (created in the UI Builder) and code-based user
 
 | Name       | Type                                     | Description                              |
 |------------|------------------------------------------|------------------------------------------|
-| window     | Elementary window (in [mobile](../../../native/api/mobile/latest/group__Elm__Win__Group.html) and [wearable](../../../native/api/wearable/latest/group__Elm__Win__Group.html) applications) | Forms the first window of the application. |
-| bg         | Background (in [mobile](../../../native/api/mobile/latest/group__Elm__Bg.html) and [wearable](../../../native/api/wearable/latest/group__Elm__Bg.html) applications) | Sets a background for a window or any container object. |
-| conformant | Conformant (in [mobile](../../../native/api/mobile/latest/group__Elm__Conformant.html) and [wearable](../../../native/api/wearable/latest/group__Elm__Conformant.html) applications) | Provides space for indicators, virtual keypads, and softkey windows. |
-| naviframe  | Naviframe (in [mobile](../../../native/api/mobile/latest/group__Elm__Naviframe__Group.html) and [wearable](../../../native/api/wearable/latest/group__Elm__Naviframe__Group.html) applications) | Manages UI Builder views.                |
+| window     | Elementary window | Forms the first window of the application. |
+| bg         | Background | Sets a background for a window or any container object. |
+| conformant | Conformant | Provides space for indicators, virtual keypads, and softkey windows. |
+| naviframe  | Naviframe | Manages UI Builder views.                |
 
 ## Converting to a UI Builder Project
 

--- a/docs/application/tizen-studio/release-notes/4-6-release-notes.md
+++ b/docs/application/tizen-studio/release-notes/4-6-release-notes.md
@@ -10,7 +10,7 @@
   - Tizen IDE is now supported on macOS Monterey
   - Visual Studio Code Extension for Tizen is now supported on macOS Monterey
 - Multi App and Hybrid App support
-  - Added the following Multi app and Hybrid app support in [CLI (TZ)](../tizen-core/tizen-core-cli.md), [VS](../../vstools/Tizen/hybrid.md), and VSCode extension for Tizen
+  - Added the following Multi app and Hybrid app support in [CLI (TZ)](../tizen-core/tizen-core-cli.md), [VS](../../vstools/Tizen/hybrid.md), and [VSCode](../../vscode-ext/Tizen/hybrid.md) extension for Tizen
 
 **Multi App**
   

--- a/docs/application/tizen-studio/release-notes/4-6-release-notes.md
+++ b/docs/application/tizen-studio/release-notes/4-6-release-notes.md
@@ -10,7 +10,7 @@
   - Tizen IDE is now supported on macOS Monterey
   - Visual Studio Code Extension for Tizen is now supported on macOS Monterey
 - Multi App and Hybrid App support
-  - Added the following Multi app and Hybrid app support in [CLI (TZ)](../tizen-core/tizen-core-cli.md), [VS](../../vstools/Tizen/hybrid.md), and [VSCode](../../vscode-ext/Tizen/hybrid.md) extension for Tizen
+  - Added the following Multi app and Hybrid app support in [CLI (TZ)](../tizen-core/tizen-core-cli.md), [VS](../../vstools/Tizen/hybrid.md), and VSCode extension for Tizen
 
 **Multi App**
   

--- a/docs/application/tizen-studio/web-tools/web-simulator-features.md
+++ b/docs/application/tizen-studio/web-tools/web-simulator-features.md
@@ -118,7 +118,7 @@ You can use the **Packages and Applications** panel to verify created operations
 
 ![Packages and Applications panel](./media/simulator_panel_package.png)
 
-You can receive notifications of changes in the list of installed packages. The `setPackageInfoEventListener()` method of the `PackageManager` interface (in [TV](../../web/api/latest/device_api/tv/tizen/package.html#PackageManager) applications) registers an event listener for changes in the installed packages list. To unsubscribe the listener, use the `unsetPackageInfoEventListener()` method. You can use the `PackageInformationEventCallback` interface (in [TV](../../web/api/latest/device_api/tv/tizen/package.html#PackageInformationEventCallback) applications) to define listeners for receiving notifications.
+You can receive notifications of changes in the list of installed packages. The `setPackageInfoEventListener()` method of the `PackageManager` interface (in [TV](../../web/api/10.0.0/tv/device_api/tv/tizen/package.md#PackageManager) applications) registers an event listener for changes in the installed packages list. To unsubscribe the listener, use the `unsetPackageInfoEventListener()` method. You can use the `PackageInformationEventCallback` interface (in [TV](../../web/api/10.0.0/tv/device_api/tv/tizen/package.md#PackageInformationEventCallback) applications) to define listeners for receiving notifications.
 
 Learning to receive notifications when the list of installed packages changes allows you to manage device packages from your application:
 

--- a/docs/application/web/api/10.0/device_api/tv/tizen/application.html
+++ b/docs/application/web/api/10.0/device_api/tv/tizen/application.html
@@ -1117,7 +1117,7 @@ for (var i = 0; i &lt; appCerts.length; i++)
 <div class="description">
             <p>
 The shared directory is used to export data to other applications. Its structure is described in
-<a href="/application/native/guides/essentials/file-system">File System Directory Hierarchy</a>.
+<a href="/application/web/guides/data/file-system.md">File System Directory Hierarchy</a>.
             </p>
            </div>
 <div class="description">
@@ -1127,7 +1127,7 @@ If the ID is set to <var>null</var> or not set at all, it returns the shared dir
            </div>
 <p><span class="remark">Remark: </span>
  Since Tizen 3.0, <var>shared/data</var> directory is not created for web applications. For other applications it will be not created by default and should be considered as optional
-(refer to <a href="/application/native/guides/essentials/file-system">table about shared/data</a> for more details).
+(refer to <a href="/application/web/guides/data/file-system.md">table about shared/data</a> for more details).
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/4.0/device_api/tv/tizen/application.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/application.html
@@ -1117,7 +1117,7 @@ for (var i = 0; i &lt; appCerts.length; i++)
 <div class="description">
             <p>
 The shared directory is used to export data to other applications. Its structure is described in
-<a href="/application/native/guides/essentials/file-system">File System Directory Hierarchy</a>.
+<a href="/application/web/guides/data/file-system.md">File System Directory Hierarchy</a>.
             </p>
            </div>
 <div class="description">
@@ -1127,7 +1127,7 @@ If the ID is set to <var>null</var> or not set at all, it returns the shared dir
            </div>
 <p><span class="remark">Remark: </span>
  Since Tizen 3.0, <var>shared/data</var> directory is not created for web applications. For other applications it will be not created by default and should be considered as optional
-(refer to <a href="/application/native/guides/essentials/file-system">table about shared/data</a> for more details).
+(refer to <a href="/application/web/guides/data/file-system.md">table about shared/data</a> for more details).
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/5.0/device_api/tv/tizen/application.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/application.html
@@ -1117,7 +1117,7 @@ for (var i = 0; i &lt; appCerts.length; i++)
 <div class="description">
             <p>
 The shared directory is used to export data to other applications. Its structure is described in
-<a href="/application/native/guides/essentials/file-system">File System Directory Hierarchy</a>.
+<a href="/application/web/guides/data/file-system.md">File System Directory Hierarchy</a>.
             </p>
            </div>
 <div class="description">
@@ -1127,7 +1127,7 @@ If the ID is set to <var>null</var> or not set at all, it returns the shared dir
            </div>
 <p><span class="remark">Remark: </span>
  Since Tizen 3.0, <var>shared/data</var> directory is not created for web applications. For other applications it will be not created by default and should be considered as optional
-(refer to <a href="/application/native/guides/essentials/file-system">table about shared/data</a> for more details).
+(refer to <a href="/application/web/guides/data/file-system.md">table about shared/data</a> for more details).
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/application.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/application.html
@@ -1117,7 +1117,7 @@ for (var i = 0; i &lt; appCerts.length; i++)
 <div class="description">
             <p>
 The shared directory is used to export data to other applications. Its structure is described in
-<a href="/application/native/guides/essentials/file-system">File System Directory Hierarchy</a>.
+<a href="/application/web/guides/data/file-system.md">File System Directory Hierarchy</a>.
             </p>
            </div>
 <div class="description">
@@ -1127,7 +1127,7 @@ If the ID is set to <var>null</var> or not set at all, it returns the shared dir
            </div>
 <p><span class="remark">Remark: </span>
  Since Tizen 3.0, <var>shared/data</var> directory is not created for web applications. For other applications it will be not created by default and should be considered as optional
-(refer to <a href="/application/native/guides/essentials/file-system">table about shared/data</a> for more details).
+(refer to <a href="/application/web/guides/data/file-system.md">table about shared/data</a> for more details).
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/application.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/application.html
@@ -1117,7 +1117,7 @@ for (var i = 0; i &lt; appCerts.length; i++)
 <div class="description">
             <p>
 The shared directory is used to export data to other applications. Its structure is described in
-<a href="/application/native/guides/essentials/file-system">File System Directory Hierarchy</a>.
+<a href="/application/web/guides/data/file-system.md">File System Directory Hierarchy</a>.
             </p>
            </div>
 <div class="description">
@@ -1127,7 +1127,7 @@ If the ID is set to <var>null</var> or not set at all, it returns the shared dir
            </div>
 <p><span class="remark">Remark: </span>
  Since Tizen 3.0, <var>shared/data</var> directory is not created for web applications. For other applications it will be not created by default and should be considered as optional
-(refer to <a href="/application/native/guides/essentials/file-system">table about shared/data</a> for more details).
+(refer to <a href="/application/web/guides/data/file-system.md">table about shared/data</a> for more details).
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/6.5/device_api/tv/tizen/application.html
+++ b/docs/application/web/api/6.5/device_api/tv/tizen/application.html
@@ -1117,7 +1117,7 @@ for (var i = 0; i &lt; appCerts.length; i++)
 <div class="description">
             <p>
 The shared directory is used to export data to other applications. Its structure is described in
-<a href="/application/native/guides/essentials/file-system">File System Directory Hierarchy</a>.
+<a href="/application/web/guides/data/file-system.md">File System Directory Hierarchy</a>.
             </p>
            </div>
 <div class="description">
@@ -1127,7 +1127,7 @@ If the ID is set to <var>null</var> or not set at all, it returns the shared dir
            </div>
 <p><span class="remark">Remark: </span>
  Since Tizen 3.0, <var>shared/data</var> directory is not created for web applications. For other applications it will be not created by default and should be considered as optional
-(refer to <a href="/application/native/guides/essentials/file-system">table about shared/data</a> for more details).
+(refer to <a href="/application/web/guides/data/file-system.md">table about shared/data</a> for more details).
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/7.0/device_api/tv/tizen/application.html
+++ b/docs/application/web/api/7.0/device_api/tv/tizen/application.html
@@ -1117,7 +1117,7 @@ for (var i = 0; i &lt; appCerts.length; i++)
 <div class="description">
             <p>
 The shared directory is used to export data to other applications. Its structure is described in
-<a href="/application/native/guides/essentials/file-system">File System Directory Hierarchy</a>.
+<a href="/application/web/guides/data/file-system.md">File System Directory Hierarchy</a>.
             </p>
            </div>
 <div class="description">
@@ -1127,7 +1127,7 @@ If the ID is set to <var>null</var> or not set at all, it returns the shared dir
            </div>
 <p><span class="remark">Remark: </span>
  Since Tizen 3.0, <var>shared/data</var> directory is not created for web applications. For other applications it will be not created by default and should be considered as optional
-(refer to <a href="/application/native/guides/essentials/file-system">table about shared/data</a> for more details).
+(refer to <a href="/application/web/guides/data/file-system.md">table about shared/data</a> for more details).
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/8.0/device_api/tv/tizen/application.html
+++ b/docs/application/web/api/8.0/device_api/tv/tizen/application.html
@@ -1117,7 +1117,7 @@ for (var i = 0; i &lt; appCerts.length; i++)
 <div class="description">
             <p>
 The shared directory is used to export data to other applications. Its structure is described in
-<a href="/application/native/guides/essentials/file-system">File System Directory Hierarchy</a>.
+<a href="/application/web/guides/data/file-system.md">File System Directory Hierarchy</a>.
             </p>
            </div>
 <div class="description">
@@ -1127,7 +1127,7 @@ If the ID is set to <var>null</var> or not set at all, it returns the shared dir
            </div>
 <p><span class="remark">Remark: </span>
  Since Tizen 3.0, <var>shared/data</var> directory is not created for web applications. For other applications it will be not created by default and should be considered as optional
-(refer to <a href="/application/native/guides/essentials/file-system">table about shared/data</a> for more details).
+(refer to <a href="/application/web/guides/data/file-system.md">table about shared/data</a> for more details).
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>

--- a/docs/application/web/api/9.0/device_api/tv/tizen/application.html
+++ b/docs/application/web/api/9.0/device_api/tv/tizen/application.html
@@ -1117,7 +1117,7 @@ for (var i = 0; i &lt; appCerts.length; i++)
 <div class="description">
             <p>
 The shared directory is used to export data to other applications. Its structure is described in
-<a href="/application/native/guides/essentials/file-system">File System Directory Hierarchy</a>.
+<a href="/application/web/guides/data/file-system.md">File System Directory Hierarchy</a>.
             </p>
            </div>
 <div class="description">
@@ -1127,7 +1127,7 @@ If the ID is set to <var>null</var> or not set at all, it returns the shared dir
            </div>
 <p><span class="remark">Remark: </span>
  Since Tizen 3.0, <var>shared/data</var> directory is not created for web applications. For other applications it will be not created by default and should be considered as optional
-(refer to <a href="/application/native/guides/essentials/file-system">table about shared/data</a> for more details).
+(refer to <a href="/application/web/guides/data/file-system.md">table about shared/data</a> for more details).
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>


### PR DESCRIPTION
## Summary
- remove obsolete Mobile/Wearable API links without replacing removed profile-specific documentation
- repair malformed and retired .NET API URLs using generated versioned API paths
- replace references to API pages that are not generated with plain code references
- remove pose illustrations whose source assets no longer exist; retain the published BVH sample link
- update the Web Simulator TV API references to the published 10.0.0 API pages

## Validation
- `git diff --check`
- confirmed every replacement API target exists in the generated documentation tree
- confirmed TV API anchors `PackageManager` and `PackageInformationEventCallback` exist
- confirmed the three original source files contain no `native/api/mobile/latest` or `native/api/wearable/latest` links