### PR TITLE
Recognize tizen-docs-internal's frontmatter keys in D-FM

### DIFF
--- a/tools/tizendocs/checks/document.py
+++ b/tools/tizendocs/checks/document.py
@@ -28,8 +28,11 @@ def check_h1(index, path, source):
 
 FRONT_MATTER = "D-FM"
 
-#: The only key the corpus uses. SKILL.md tells authors not to invent others.
-KNOWN_KEYS = frozenset({"keyword"})
+#: keyword is this repo's own convention. title/sidebar_label/category are
+#: tizen-docs-internal's -- the same validator is used there (ported in
+#: tizen-docs-internal#81) against a corpus that uses both sets, so both are
+#: recognized here to keep the two in sync.
+KNOWN_KEYS = frozenset({"keyword", "title", "sidebar_label", "category"})
 
 
 def check_front_matter(index, path, source):


### PR DESCRIPTION
### Change Description ###

\`D-FM\`'s \`KNOWN_KEYS\` allowed only this repo's own \`keyword\` frontmatter
key. The same validator (\`tools/tizendocs\`, from #2387) was just ported to
tizen-docs-internal (developer-interface/tizen-docs-internal#81), whose
corpus also consistently uses \`title\`, \`sidebar_label\` and \`category\` --
28 files under \`docs/application/native/guides/11.0/user-interface/guide/\`,
every one with the same three keys and meaningful values (e.g.
\`title: Animation\`, \`category: animation-motion\`), confirmed intentional
rather than a typo.

Recognizing both repos' keys in the shared engine keeps the two
validators in sync rather than one silently drifting from the other.

### Bugs Fixed ###

 - None filed.

### API Changes ###

 - None.