### PR TITLE
Update CODEOWNERS reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-* @theojin @safir-srbd @imrulanwar-srbd
+* @theojin @ey928-lee @jeesunhub


### PR DESCRIPTION
Swap the auto-requested reviewers in `.github/CODEOWNERS` from `@safir-srbd` (Safir Zawad) and `@imrulanwar-srbd` (Imrul Anwar) to `@ey928-lee` (Eunyoung Lee / 이은영) and `@jeesunhub` (김지선). `@theojin` stays.