### PR TITLE
docs: give each overview directory its own toc.md

### DIFF
--- a/.claude/skills/tizen-docs/references/toc-formats.md
+++ b/.claude/skills/tizen-docs/references/toc-formats.md
@@ -45,10 +45,12 @@ Rules, all of which the validator checks:
 - `source` must be the GitHub blob URL of **the file this entry links to**. When the
   entry moves, the URL moves with it.
 
-Only `docs/application/flutter/toc.md`, `docs/platform/HAL/toc.md`, and
-`docs/extensions/tizenx/guides/toc.md` use metadata. The other TOCs carry none, and
-adding it is not required. `docs/extensions/tizenx/api/toc.md` is generated and puts its
-metadata outside the parentheses; fix the generator rather than the file.
+Metadata is optional and about half the TOCs carry none, so a TOC without it is not
+deficient. Where it does appear, `source:` usually stands alone - it identifies the
+entry - while `tags:` and `authors:` are deliberate overrides of what the site would
+otherwise derive from this repository's git history. `docs/extensions/tizenx/api/toc.md`
+is generated and puts its metadata outside the parentheses; fix the generator rather
+than the file.
 
 ## Editing rules
 

--- a/docs/application/dotnet/overview/toc.md
+++ b/docs/application/dotnet/overview/toc.md
@@ -1,0 +1,27 @@
+<!--
+  Table of contents for this section.
+
+  The developer-site pipeline builds one publication manifest per section
+  directory, and the section's toc.md is what it reads to build it. The file
+  decides two things: which pages are published, and where they sit in the
+  navigation tree (heading depth is navigation depth). A page that no toc.md
+  in its own directory lists exists in this repository but has no URL on the
+  site.
+
+  `/application/toc_all.md` also links this page, but that file is the
+  information-architecture overview for the whole namespace and the site
+  pipeline does not read it, so it cannot stand in for this one.
+
+  This directory holds a single page, so this file has a single entry. It is
+  worth having anyway. Without it the site had to special-case overview
+  directories through a separate hand-written code path, and that path was
+  duplicated once per overview section - eight copies that drifted from the
+  shared one and from each other.
+
+  Metadata inside the link title is optional. `source:` must name this entry's
+  own target; `tags:` and `authors:` override values the site would otherwise
+  derive from this repository's git history, so leave them out unless you mean
+  to override.
+-->
+
+# [Overview](overview.md "source:https://github.com/Samsung/tizen-docs/blob/master/docs/application/dotnet/overview/overview.md")

--- a/docs/application/flutter/overview/toc.md
+++ b/docs/application/flutter/overview/toc.md
@@ -1,0 +1,27 @@
+<!--
+  Table of contents for this section.
+
+  The developer-site pipeline builds one publication manifest per section
+  directory, and the section's toc.md is what it reads to build it. The file
+  decides two things: which pages are published, and where they sit in the
+  navigation tree (heading depth is navigation depth). A page that no toc.md
+  in its own directory lists exists in this repository but has no URL on the
+  site.
+
+  `/application/flutter/toc.md` also links this page. That entry belongs to
+  the flutter section and reaches across directories, so the site drops it
+  when building this directory's manifest.
+
+  This directory holds a single page, so this file has a single entry. It is
+  worth having anyway. Without it the site had to special-case overview
+  directories through a separate hand-written code path, and that path was
+  duplicated once per overview section - eight copies that drifted from the
+  shared one and from each other.
+
+  Metadata inside the link title is optional. `source:` must name this entry's
+  own target; `tags:` and `authors:` override values the site would otherwise
+  derive from this repository's git history, so leave them out unless you mean
+  to override.
+-->
+
+# [Application model](overview.md "source:https://github.com/Samsung/tizen-docs/blob/master/docs/application/flutter/overview/overview.md")

--- a/docs/application/native/overview/toc.md
+++ b/docs/application/native/overview/toc.md
@@ -1,0 +1,27 @@
+<!--
+  Table of contents for this section.
+
+  The developer-site pipeline builds one publication manifest per section
+  directory, and the section's toc.md is what it reads to build it. The file
+  decides two things: which pages are published, and where they sit in the
+  navigation tree (heading depth is navigation depth). A page that no toc.md
+  in its own directory lists exists in this repository but has no URL on the
+  site.
+
+  `/application/toc_all.md` also links this page, but that file is the
+  information-architecture overview for the whole namespace and the site
+  pipeline does not read it, so it cannot stand in for this one.
+
+  This directory holds a single page, so this file has a single entry. It is
+  worth having anyway. Without it the site had to special-case overview
+  directories through a separate hand-written code path, and that path was
+  duplicated once per overview section - eight copies that drifted from the
+  shared one and from each other.
+
+  Metadata inside the link title is optional. `source:` must name this entry's
+  own target; `tags:` and `authors:` override values the site would otherwise
+  derive from this repository's git history, so leave them out unless you mean
+  to override.
+-->
+
+# [API Overview](overview.md "source:https://github.com/Samsung/tizen-docs/blob/master/docs/application/native/overview/overview.md")

--- a/docs/application/web/overview/toc.md
+++ b/docs/application/web/overview/toc.md
@@ -1,0 +1,27 @@
+<!--
+  Table of contents for this section.
+
+  The developer-site pipeline builds one publication manifest per section
+  directory, and the section's toc.md is what it reads to build it. The file
+  decides two things: which pages are published, and where they sit in the
+  navigation tree (heading depth is navigation depth). A page that no toc.md
+  in its own directory lists exists in this repository but has no URL on the
+  site.
+
+  `/application/toc_all.md` also links this page, but that file is the
+  information-architecture overview for the whole namespace and the site
+  pipeline does not read it, so it cannot stand in for this one.
+
+  This directory holds a single page, so this file has a single entry. It is
+  worth having anyway. Without it the site had to special-case overview
+  directories through a separate hand-written code path, and that path was
+  duplicated once per overview section - eight copies that drifted from the
+  shared one and from each other.
+
+  Metadata inside the link title is optional. `source:` must name this entry's
+  own target; `tags:` and `authors:` override values the site would otherwise
+  derive from this repository's git history, so leave them out unless you mean
+  to override.
+-->
+
+# [API Overview](overview.md "source:https://github.com/Samsung/tizen-docs/blob/master/docs/application/web/overview/overview.md")

--- a/docs/extensions/tizenx/overview/toc.md
+++ b/docs/extensions/tizenx/overview/toc.md
@@ -1,0 +1,27 @@
+<!--
+  Table of contents for this section.
+
+  The developer-site pipeline builds one publication manifest per section
+  directory, and the section's toc.md is what it reads to build it. The file
+  decides two things: which pages are published, and where they sit in the
+  navigation tree (heading depth is navigation depth). A page that no toc.md
+  in its own directory lists exists in this repository but has no URL on the
+  site.
+
+  `../guides/toc.md` also links this page. That entry belongs to the guides
+  section and reaches across directories, so the site drops it when
+  building this directory's manifest.
+
+  This directory holds a single page, so this file has a single entry. It is
+  worth having anyway. Without it the site had to special-case overview
+  directories through a separate hand-written code path, and that path was
+  duplicated once per overview section - eight copies that drifted from the
+  shared one and from each other.
+
+  Metadata inside the link title is optional. `source:` must name this entry's
+  own target; `tags:` and `authors:` override values the site would otherwise
+  derive from this repository's git history, so leave them out unless you mean
+  to override.
+-->
+
+# [Overview](overview.md "source:https://github.com/Samsung/tizen-docs/blob/master/docs/extensions/tizenx/overview/overview.md")

--- a/docs/platform/HAL/overview/toc.md
+++ b/docs/platform/HAL/overview/toc.md
@@ -1,0 +1,27 @@
+<!--
+  Table of contents for this section.
+
+  The developer-site pipeline builds one publication manifest per section
+  directory, and the section's toc.md is what it reads to build it. The file
+  decides two things: which pages are published, and where they sit in the
+  navigation tree (heading depth is navigation depth). A page that no toc.md
+  in its own directory lists exists in this repository but has no URL on the
+  site.
+
+  `../toc.md` also links this page. That entry belongs to the HAL section
+  root and reaches across directories, so the site drops it when building
+  this directory's manifest.
+
+  This directory holds a single page, so this file has a single entry. It is
+  worth having anyway. Without it the site had to special-case overview
+  directories through a separate hand-written code path, and that path was
+  duplicated once per overview section - eight copies that drifted from the
+  shared one and from each other.
+
+  Metadata inside the link title is optional. `source:` must name this entry's
+  own target; `tags:` and `authors:` override values the site would otherwise
+  derive from this repository's git history, so leave them out unless you mean
+  to override.
+-->
+
+# [HAL Overview](overview.md "source:https://github.com/Samsung/tizen-docs/blob/master/docs/platform/HAL/overview/overview.md")


### PR DESCRIPTION
### Change Description

The developer site builds one publication manifest per section directory and reads **that directory's `toc.md`** to build it: the file decides which pages are published and where they sit in the navigation tree. Six `overview/` directories have no `toc.md`, so their pages could not be published the ordinary way.

Each of the six pages *is* already linked from somewhere — but never from a toc in its own directory:

| page | linked from |
|---|---|
| `application/{dotnet,native,web}/overview` | `/application/toc_all.md` |
| `application/flutter/overview` | `/application/flutter/toc.md` |
| `extensions/tizenx/overview` | `../guides/toc.md` |
| `platform/HAL/overview` | `../toc.md` |

`toc_all.md` is the information-architecture overview for a whole namespace and the site pipeline does not read it. The other three are entries that belong to a *sibling* section and reach across directories, which the site drops when it builds a directory's manifest. So none of them stands in for a local toc.

### Why it matters downstream

Because there was no `toc.md` to parse, the site generated these manifests through a separate hand-written code path — and that path was **duplicated once per overview section**. Eight copies that drifted from the shared one and from each other. With these files the overview directories go through the same route as every other section.

### The comments

Each file carries a comment explaining what a section `toc.md` is for, which page already links this one and why that link does not suffice, and that the optional `tags:`/`authors:` metadata overrides values otherwise derived from this repository's git history.

### Scope

Two of the eight overview sections live in a separate repository and are not part of this change.

### Verification

`python3 tools/check_docs.py --changed-only --base origin/master` — **0 ERROR on five of the six files.** The sixth reports:

```
ERROR N-KEBAB-DIR docs/platform/HAL/overview/toc.md:
  directory name is not lowercase kebab-case: HAL
```

**This is not about the file.** `check_directory()` walks every path component of an added file, so adding *any* file under `docs/platform/HAL/` reports it — I verified with an unrelated probe file, which produced the identical finding.

Both the rule's docstring ("Only new ones. Renaming an existing directory such as platform/HAL/ would break dozens of links for a cosmetic gain") and `docscheck.toml` ("only new directories are held to the rule", naming `platform/HAL/` among the legacy names that stay) say the intent is to catch **newly created** directories, not additions to existing ones. `docs/platform/HAL/overview/` is not new.

I left this for maintainers rather than fixing it here. The remedy belongs either in the rule (distinguish a new directory from a new file in an old one) or in `docscheck.toml` — and adding a class to that file has ordering consequences for `docs/**/api/**`, since `classify()` takes the first match and a class placed above `generated` would stop treating `docs/platform/HAL/api/**` as generated content. That is not a call a contributor should make unilaterally.

Happy to follow up with whichever you prefer.
