### PR TITLE
fix(tools): stop N-KEBAB-DIR from reporting additions to legacy directories

### DIFF
--- a/tools/docscheck.toml
+++ b/tools/docscheck.toml
@@ -70,6 +70,36 @@ reason = """Imported from another pipeline. Correct the upstream source and
 re-import; editing the output here is lost on the next import."""
 
 # ---------------------------------------------------------------------------
+# Directory names that predate N-KEBAB-DIR and stay.
+#
+# The rule holds *new* directories to lowercase kebab-case. Its check walks
+# every path component of an added file, though, so without this list adding
+# any file to one of these directories reports the directory - which is not
+# something the change can fix and not what the rule is for.
+#
+# Renaming them is off the table: HAL and NUI are the names people use, and a
+# rename would break every inbound link for a cosmetic gain. `doctor` reports
+# an entry here that no longer names a real directory, so the list cannot rot
+# into misleading text.
+#
+# New directories are still held to the rule: a name absent from this list is
+# reported as before.
+# ---------------------------------------------------------------------------
+
+[naming]
+legacy_directories = [
+  # Acronyms and product names, deliberately kept as written.
+  "HAL",
+  "NUIsetup",
+  "Tizen",
+  "codeExamples",
+  # Snake_case predating the rule, under the generated web API trees.
+  "device_api",
+  "ui_fw_api",
+  "w3c_api",
+]
+
+# ---------------------------------------------------------------------------
 # Rule severities. ERROR fails the run; WARN must be fixed or explained in
 # review; NOTE is advisory only. Globs are allowed, most specific first.
 # ---------------------------------------------------------------------------

--- a/tools/tests/fixtures/n-kebab-dir-legacy/added.txt
+++ b/tools/tests/fixtures/n-kebab-dir-legacy/added.txt
@@ -1,0 +1,1 @@
+docs/HAL/overview/overview.md

--- a/tools/tests/fixtures/n-kebab-dir-legacy/docs/HAL/overview/overview.md
+++ b/tools/tests/fixtures/n-kebab-dir-legacy/docs/HAL/overview/overview.md
@@ -1,0 +1,3 @@
+# Overview
+
+Body.

--- a/tools/tests/fixtures/n-kebab-dir-legacy/docs/toc_all.md
+++ b/tools/tests/fixtures/n-kebab-dir-legacy/docs/toc_all.md
@@ -1,0 +1,1 @@
+# [Overview](HAL/overview/overview.md)

--- a/tools/tests/test_config.py
+++ b/tools/tests/test_config.py
@@ -90,3 +90,18 @@ def test_missing_file_yields_an_empty_config():
     from tizendocs import config as module
     cfg = module.load(path="/nonexistent/docscheck.toml")
     assert cfg.source == "" and cfg.classes == []
+
+
+def test_legacy_directories_default_to_empty():
+    """A file without [naming] must not exempt anything."""
+    assert Config({}).legacy_directories == ()
+    assert not Config({}).legacy_directory("HAL")
+
+
+def test_legacy_directory_matches_exact_names_only():
+    """Substring matching here would exempt far more than intended."""
+    config = Config({"naming": {"legacy_directories": ["HAL"]}})
+    assert config.legacy_directory("HAL")
+    assert not config.legacy_directory("hal")
+    assert not config.legacy_directory("HALO")
+    assert not config.legacy_directory("my-HAL")

--- a/tools/tests/test_doctor.py
+++ b/tools/tests/test_doctor.py
@@ -76,3 +76,23 @@ def test_reports_a_class_fully_shadowed_by_an_earlier_one(tmp_path):
 
 def test_real_repository_configuration_is_healthy():
     assert list(doctor.problems(DocsIndex())) == []
+
+
+def test_legacy_directory_that_still_exists_is_not_reported(tmp_path):
+    """The list is only misleading once the directory it names is gone."""
+    (tmp_path / "docs" / "HAL").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "docs" / "HAL" / "page.md").write_text("# P\n", encoding="utf-8")
+    index = index_for(tmp_path, naming={"legacy_directories": ["HAL"]})
+    assert not [p for p in doctor.problems(index) if "legacy_directories" in p]
+
+
+def test_legacy_directory_that_is_gone_is_reported(tmp_path):
+    """A renamed or deleted directory leaves an entry that exempts nothing.
+
+    Left alone it keeps widening what N-KEBAB-DIR accepts while reading like
+    documentation of a decision that no longer applies.
+    """
+    index = index_for(tmp_path, naming={"legacy_directories": ["GoneForGood"]})
+    reported = [p for p in doctor.problems(index) if "legacy_directories" in p]
+    assert len(reported) == 1
+    assert "GoneForGood" in reported[0]

--- a/tools/tizendocs/checks/naming.py
+++ b/tools/tizendocs/checks/naming.py
@@ -25,9 +25,17 @@ def check_directory(index, path, source):
     """New directory names must be lowercase kebab-case.
 
     Only new ones. Renaming an existing directory such as platform/HAL/ would
-    break dozens of links for a cosmetic gain, so the legacy names stay.
+    break dozens of links for a cosmetic gain, so the legacy names stay and are
+    listed under [naming] in docscheck.toml.
+
+    That list is load-bearing rather than cosmetic. The rule is scoped to added
+    files, but this check walks every component of the path, so without it
+    adding *any* file inside a legacy directory reports the directory - a
+    finding the change cannot act on and the rule never meant to raise.
     """
     for part in os.path.dirname(path).split("/")[1:]:
+        if index.legacy_directory(part):
+            continue
         if not KEBAB_DIR.match(part):
             yield Finding(ERROR, DIR_RULE, path,
                           f"directory name is not lowercase kebab-case: {part}")

--- a/tools/tizendocs/config.py
+++ b/tools/tizendocs/config.py
@@ -99,6 +99,9 @@ class Config:
         self.rules = dict(data.get("rules", {}))
         #: rule id -> scope name. See Config.scope().
         self.scopes = dict(data.get("scope", {}))
+        #: directory names that predate N-KEBAB-DIR. See legacy_directory().
+        self.legacy_directories = tuple(
+            data.get("naming", {}).get("legacy_directories", ()))
 
     # ---- path classification (first match wins) --------------------------
 
@@ -135,6 +138,14 @@ class Config:
         """
         return any(entry.matches(path)
                    for entry in self.classes if entry.id == class_id)
+
+    def legacy_directory(self, name):
+        """Whether *name* is a directory that predates the kebab-case rule.
+
+        Listed in [naming]. Renaming these would break inbound links for a
+        cosmetic gain, so they stay and additions inside them are not reported.
+        """
+        return name in self.legacy_directories
 
     def exempt_existence(self, target):
         """Whether a link to *target* may point at a file that is not here."""

--- a/tools/tizendocs/doctor.py
+++ b/tools/tizendocs/doctor.py
@@ -48,6 +48,19 @@ def problems(index):
             yield (f"class {entry.id}: pattern matches nothing: {pattern}"
                    " - the path it exempted is gone, so delete it")
 
+    # [naming] rots the same way a class pattern does: a directory gets
+    # renamed or deleted and its entry becomes text that exempts nothing,
+    # while still quietly widening what the rule accepts.
+    if config.legacy_directories:
+        present = {part
+                   for path in paths
+                   for part in os.path.dirname(path).split("/")[1:]}
+        for name in config.legacy_directories:
+            if name not in present:
+                yield (f"[naming] legacy_directories: no directory named"
+                       f" {name!r} exists - the name it exempted is gone,"
+                       " so delete it")
+
     known = set(checks.RULE_IDS)
     for rule in config.rules:
         if "*" not in rule and rule not in known:

--- a/tools/tizendocs/index.py
+++ b/tools/tizendocs/index.py
@@ -94,6 +94,10 @@ class DocsIndex:
     def skips(self, path, rule):
         return self.config.skips(path, rule)
 
+    def legacy_directory(self, name):
+        """Whether *name* predates the kebab-case rule. See [naming]."""
+        return self.config.legacy_directory(name)
+
     def handwritten(self, path):
         """Whether *path* is a document a person is expected to edit.
 


### PR DESCRIPTION
### Change Description

`N-KEBAB-DIR`'s docstring says:

> Only new ones. Renaming an existing directory such as `platform/HAL/` would break dozens of links for a cosmetic gain, so the legacy names stay.

`docscheck.toml` says the same and scopes the rule `"added-only"`. **The code has no concept of a new directory.** `check_directory()` walks every path component of an added *file* and flags the first non-kebab segment — so adding any file under `docs/platform/HAL/` reports `HAL`, a finding the change cannot act on and one the rule never meant to raise. The `added-only` scope cannot express "except in these legacy directories" because it is applied to files.

Surfaced by #2395, which adds `docs/platform/HAL/overview/toc.md` and cannot pass the validator through no fault of its content. Reproduced independently with an unrelated probe file in the same directory.

### The fix

Adds `[naming] legacy_directories` to `docscheck.toml` and has `check_directory()` skip those components. Seven names, all of which exist today:

| names | why |
|---|---|
| `HAL`, `NUIsetup`, `Tizen`, `codeExamples` | acronyms and product names, deliberately kept as written |
| `device_api`, `ui_fw_api`, `w3c_api` | snake_case predating the rule, under the generated web API trees |

**Why a new top-level key rather than a `[[classes]]` entry with `skip_rules`:** a class placed above `generated` would stop treating `docs/**/api/**` as generated content, because `classify()` takes the first match. The exemption needed here is about a directory *name*, not a path class, and expressing it as one avoids that ordering hazard entirely.

`doctor` reports an entry that no longer names a real directory, so the list cannot rot into misleading text the way three `api-handwritten` patterns already did. **That check earned its keep immediately** — `wearable_widget` was in the first draft of this list and #2394 had already removed it:

```
docscheck.toml: [naming] legacy_directories: no directory named 'wearable_widget'
  exists - the name it exempted is gone, so delete it
```

### Verification

New directories are still held to the rule. Verified end to end with the `added-only` scope active, both directions:

```
docs/application/Bad_New_Dir/page.md   ERROR N-KEBAB-DIR   (still reported)
docs/platform/HAL/guides/probe.md      no N-KEBAB-DIR      (now allowed)
```

Tests: a fixture that **fails if the allowlist entry is removed** (so the exemption cannot silently stop being exercised), exact-match cases for the config accessor (`HAL` yes; `hal`, `HALO`, `my-HAL` no), and both `doctor` directions.

- `pytest tools/tests` → **120 passed**, 2 deselected (was 118)
- `check_docs.py --all` → 0 ERROR, 0 WARN, unchanged
- `check_docs.py doctor` → 0 problems

### Relationship to #2395

#2395 is the content PR that surfaced this and does not depend on it — the reviewer there confirmed its ERROR is this tool bug, not the file. Either order works; merging this one first makes #2395 report `0 ERROR`.
