### PR TITLE
[WebAPI] Links conversion

### DIFF
--- a/docs/application/web/api/10.1/device_api/tv/tizen/account.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/account.html
@@ -35,10 +35,10 @@ instance bound to the account.          </li>
         </ul>
         <p>
 To use <em>add(), remove(), and update()</em> methods of AccountManager a web application needs to be an account provider application.
-A web application is an account provider when its <em>config.xml</em> contains <a href="/application/tizen-studio/web-tools/config-editor#mw_account">Account provider section</a>. For example:<br>&lt;tizen:account multiple-account-support="true"&gt;<br>      &lt;tizen:icon section="Account"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:icon section="AccountSmall"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:display-name xml:lang="en-gb"&gt;Test&lt;/tizen:display-name&gt;<br>      &lt;tizen:capability&gt;http://tizen.org/account/capability/contact&lt;/tizen:capability&gt;<br>&lt;/tizen:account&gt;
+A web application is an account provider when its <em>config.xml</em> contains <a href="https://samsungtizenos.com/docs/sdk-tools/web/visual-studio/vstools/tools/manifest-editor#content-account-provider-element">Account provider section</a>. For example:<br>&lt;tizen:account multiple-account-support="true"&gt;<br>      &lt;tizen:icon section="Account"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:icon section="AccountSmall"&gt;icon.png&lt;/tizen:icon&gt;<br>      &lt;tizen:display-name xml:lang="en-gb"&gt;Test&lt;/tizen:display-name&gt;<br>      &lt;tizen:capability&gt;http://tizen.org/account/capability/contact&lt;/tizen:capability&gt;<br>&lt;/tizen:account&gt;
         </p>
         <p>
-For more information about how to use Account API, see <a href="/application/web/guides/personal/account">Account Guide</a>.
+For more information about how to use Account API, see <a href="https://samsungtizenos.com/docs/application/web/guides/personal/account">Account Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>
@@ -654,7 +654,7 @@ If the account is added successfully, an accountId and provider are newly assign
             <p>
 This method can be used only by an account provider application.<br>If the application is registered as provider, it will be launched to authenticate the account.
 You should implement the appcontrol for the account provider.<br>For more details, see
-<a href="/application/web/guides/personal/account#retrieving-providers">Account Provider</a>            </p>
+<a href="https://samsungtizenos.com/docs/application/web/guides/personal/account#content-retrieve-providers">Account Provider</a>            </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
@@ -955,7 +955,7 @@ If you want to get all accounts, omit the applicationId argument.
 <div class="description">
             <p>
 You can register your application as an account provider by writing account related information in <var>config.xml</var>.<br>For more details, see
-<a href="/application/web/guides/personal/account#retrieving-providers">Account Provider</a>            </p>
+<a href="https://samsungtizenos.com/docs/application/web/guides/personal/account#content-retrieve-providers">Account Provider</a>            </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>
  public
@@ -1446,7 +1446,7 @@ To guarantee the running of the application on a device with Account feature, de
 <li class="feature">http://tizen.org/feature/account</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Account {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/alarm.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/alarm.html
@@ -35,7 +35,7 @@ for accessing only external storage using this API, a privilege <a href="http://
 for accessing internal and external storage using this API, privileges (<a href="http://tizen.org/privilege/mediastorage">http://tizen.org/privilege/mediastorage</a> and <a href="http://tizen.org/privilege/externalstorage">http://tizen.org/privilege/externalstorage</a>) must be provided.          </li>
         </ul>
         <p>
-For more information on the Alarm features, see <a href="/application/web/guides/alarm/alarms">Alarm Guide</a>.
+For more information on the Alarm features, see <a href="https://samsungtizenos.com/docs/application/web/guides/alarm/alarms">Alarm Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>
@@ -256,8 +256,8 @@ It defines the number of seconds in a week.
 <div class="description">
             <p>
 Sets an alarm with the application ID to be run. You should definitely provide the application ID to run
-and the <a href="/application/web/guides/app-management/app-controls#application-control-request">application control</a> information if it is necessary.
-For more information about the application control, see <a href="application.html">The Application API</a>.
+and the <a href="https://samsungtizenos.com/docs/application/web/guides/app-management/app-controls#application-control-request">application control</a> information if it is necessary.
+For more information about the application control, see <a href="application">The Application API</a>.
             </p>
            </div>
 <p><span class="privilegelevel">Privilege level: </span>

--- a/docs/application/web/api/10.1/device_api/tv/tizen/application.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/application.html
@@ -33,7 +33,7 @@ the basic operations for the current application such as exit or hide.
 The <em>Application</em> interface provides application event broadcasting and listening features. An application can broadcast user events to other listening applications and listen to broadcasted user events from other applications and from system.
         </p>
         <p>
-For more information on the Application features, see <a href="/application/web/guides/applications/overview">Application Guide</a>, <a href="/application/web/guides/app-management/app-group">Application Group Guide</a> or <a href="/application/web/guides/app-management/app-controls">Application Control Guide</a>.
+For more information on the Application features, see <a href="https://samsungtizenos.com/docs/application/web/guides/applications/overview">Application Guide</a>, <a href="https://samsungtizenos.com/docs/application/web/guides/app-management/app-group">Application Group Guide</a> or <a href="https://samsungtizenos.com/docs/application/web/guides/app-management/app-controls">Application Control Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>
@@ -1117,7 +1117,7 @@ for (var i = 0; i &lt; appCerts.length; i++)
 <div class="description">
             <p>
 The shared directory is used to export data to other applications. Its structure is described in
-<a href="/application/native/tutorials/details/io-overview">File System Directory Hierarchy</a>.
+<a href="https://samsungtizenos.com/docs/application/web/guides/data/file-system">File System Directory Hierarchy</a>.
             </p>
            </div>
 <div class="description">
@@ -1127,7 +1127,7 @@ If the ID is set to <var>null</var> or not set at all, it returns the shared dir
            </div>
 <p><span class="remark">Remark: </span>
  Since Tizen 3.0, <var>shared/data</var> directory is not created for web applications. For other applications it will be not created by default and should be considered as optional
-(refer to <a href="/application/native/tutorials/details/io-overview">table about shared/data</a> for more details).
+(refer to <a href="https://samsungtizenos.com/docs/application/web/guides/data/file-system">table about shared/data</a> for more details).
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -2852,7 +2852,7 @@ tizen.application.getAppsInfo(onListInstalledApps);
             </p>
 <div class="description">
             <p>
-Example of using can be find at <a href="application.html#ApplicationManager::addAppStatusChangeListener">addAppStatusChangeListener</a> code example.
+Example of using can be find at <a href="application#ApplicationManager::addAppStatusChangeListener">addAppStatusChangeListener</a> code example.
             </p>
            </div>
 <div class="parameters">
@@ -2887,7 +2887,7 @@ Example of using can be find at <a href="application.html#ApplicationManager::ad
 <div class="description">
           <p>
 System events do not require an application identifier to be specified. If one is specified, the event will be interpreted as an user event.
-List of supported system event is available in <a href="https://docs.tizen.org/application/native/guides/app-management/event/#platform-event-types">Native API guides</a>.
+List of supported system event is available in <a href="https://samsungtizenos.com/docs/application/native/guides/app-management/event#content-platform-event-types">Native API guides</a>.
           </p>
          </div>
 <div class="attributes">
@@ -2943,7 +2943,7 @@ To guarantee the running of the application on a device which has battery, decla
 <li class="feature">http://tizen.org/feature/battery</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Application {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/archive.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/archive.html
@@ -27,7 +27,7 @@ for accessing only external storage using this API, a privilege <a href="http://
 for accessing internal and external storage using this API, privileges (<a href="http://tizen.org/privilege/mediastorage">http://tizen.org/privilege/mediastorage</a> and <a href="http://tizen.org/privilege/externalstorage">http://tizen.org/privilege/externalstorage</a>) must be provided.          </li>
         </ul>
         <p>
-For more information about how to use Archive API, see <a href="/application/web/guides/data/file-archiving">File Archiving Guide</a>.
+For more information about how to use Archive API, see <a href="https://samsungtizenos.com/docs/application/web/guides/data/file-archiving">File Archiving Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/10.1/device_api/tv/tizen/bluetooth.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/bluetooth.html
@@ -36,7 +36,7 @@ Act as a GATT client (Generic Attribute Profile client)          </li>
 Configure the local GATT server (Generic Attribute Profile)          </li>
         </ul>
         <p>
-For more information on the Bluetooth features, see <a href="/application/web/guides/connectivity/bluetooth">Bluetooth Guide</a>.
+For more information on the Bluetooth features, see <a href="https://samsungtizenos.com/docs/application/web/guides/connectivity/bluetooth">Bluetooth Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>
@@ -506,8 +506,8 @@ OPEN - corresponds to opened bluetooth socket.            </li>
  6.0
           </p>
 <p><span class="remark">Remark: </span>
- <em>BluetoothLESolicitationUUID</em> is an alias for <a href="bluetooth.html#BluetoothUUID">BluetoothUUID</a>. Values of both types can take the same 16-bit, 32-bit or 128-bit forms.
-Functions taking <em>BluetoothLESolicitationUUID</em> parameters will accept the same UUID formats as those accepting <a href="bluetooth.html#BluetoothUUID">BluetoothUUID</a> values.
+ <em>BluetoothLESolicitationUUID</em> is an alias for <a href="bluetooth#BluetoothUUID">BluetoothUUID</a>. Values of both types can take the same 16-bit, 32-bit or 128-bit forms.
+Functions taking <em>BluetoothLESolicitationUUID</em> parameters will accept the same UUID formats as those accepting <a href="bluetooth#BluetoothUUID">BluetoothUUID</a> values.
           </p>
 </div>
 <div class="enum" id="BluetoothAdvertisePacketType">
@@ -932,7 +932,7 @@ advertise.solicitationuuids = ["180f", "7cae86d2-a021-11ea-bb37-0242ac130002"];
             </div>
 <div class="description">
             <p>
-See the <a href="https://www.bluetooth.com/wp-content/uploads/Sitecore-Media-Library/Gatt/Xml/Characteristics/org.bluetooth.characteristic.gap.appearance.xml">list of appearance codes</a> for sample values.
+See the <a href="https://www.bluetooth.com/specifications/assigned-numbers/">list of appearance codes</a> for sample values.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1143,7 +1143,7 @@ catch (err)
  http://tizen.org/privilege/bluetooth
             </p>
 <p><span class="remark">Remark: </span>
- To check if this method is supported or not, use <a href="systeminfo.html#SystemInfo::getCapability">tizen.systeminfo.getCapability</a>("http://tizen.org/feature/network.bluetooth.le").
+ To check if this method is supported or not, use <a href="systeminfo#SystemInfo::getCapability">tizen.systeminfo.getCapability</a>("http://tizen.org/feature/network.bluetooth.le").
             </p>
 <div class="returntype">
 <p><span class="return">Return value:</span></p>
@@ -2973,10 +2973,10 @@ UnknownError - If any other error occurs              </li>
  http://tizen.org/privilege/bluetooth
             </p>
 <p><span class="remark">Remark: </span>
- Values of <a href="bluetooth.html#BluetoothLEAdvertiseData::uuids">service UUIDs</a> and <a href="bluetooth.html#BluetoothLEAdvertiseData::solicitationuuids">solicitation UUIDs</a> may be converted to one of equivalent formats defined in <a href="bluetooth.html#BluetoothUUID">BluetoothUUID</a> before advertising. Consult the documentation of these fields for more information.
+ Values of <a href="bluetooth#BluetoothLEAdvertiseData::uuids">service UUIDs</a> and <a href="bluetooth#BluetoothLEAdvertiseData::solicitationuuids">solicitation UUIDs</a> may be converted to one of equivalent formats defined in <a href="bluetooth#BluetoothUUID">BluetoothUUID</a> before advertising. Consult the documentation of these fields for more information.
             </p>
 <p><span class="remark">Remark: </span>
- Consult the documentation of <a href="bluetooth.html#BluetoothLEAdvertiseData::serviceData">BluetoothLEAdvertiseData::serviceData</a> for the information about the UUID format of service data that can be advertised.
+ Consult the documentation of <a href="bluetooth#BluetoothLEAdvertiseData::serviceData">BluetoothLEAdvertiseData::serviceData</a> for the information about the UUID format of service data that can be advertised.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -3651,7 +3651,7 @@ UnknownError - If any other error occurs              </li>
  http://tizen.org/privilege/bluetooth
             </p>
 <p><span class="remark">Remark: </span>
- <a href="bluetooth.html#BluetoothGATTServerCharacteristic">BluetothGATTServerCharacteristic</a> objects do not support this function. An attempt to call it for such an object will result in an exception.
+ <a href="bluetooth#BluetoothGATTServerCharacteristic">BluetothGATTServerCharacteristic</a> objects do not support this function. An attempt to call it for such an object will result in an exception.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -3747,7 +3747,7 @@ UnknownError - If any other error occurs              </li>
  http://tizen.org/privilege/bluetooth
             </p>
 <p><span class="remark">Remark: </span>
- <a href="bluetooth.html#BluetoothGATTServerCharacteristic">BluetothGATTServerCharacteristic</a> objects do not support this function. An attempt to call it for such an object will result in an exception.
+ <a href="bluetooth#BluetoothGATTServerCharacteristic">BluetothGATTServerCharacteristic</a> objects do not support this function. An attempt to call it for such an object will result in an exception.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -3844,7 +3844,7 @@ adapter.startScan(function onsuccess(device)
  http://tizen.org/privilege/bluetooth
             </p>
 <p><span class="remark">Remark: </span>
- <a href="bluetooth.html#BluetoothGATTServerCharacteristic">BluetothGATTServerCharacteristic</a> objects do not support this function. An attempt to call it for such an object will result in an exception.
+ <a href="bluetooth#BluetoothGATTServerCharacteristic">BluetothGATTServerCharacteristic</a> objects do not support this function. An attempt to call it for such an object will result in an exception.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -3926,10 +3926,10 @@ Calling this function has no effect if there is no listener with given id.
             </p>
            </div>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="bluetooth.html#BluetoothGATTCharacteristic::addValueChangeListener">addValueChangeListener</a> code example.
+ Example of using can be find at <a href="bluetooth#BluetoothGATTCharacteristic::addValueChangeListener">addValueChangeListener</a> code example.
             </p>
 <p><span class="remark">Remark: </span>
- Value change listeners cannot be registered and thus unregistered for <a href="bluetooth.html#BluetoothGATTServerCharacteristic">BluetothGATTServerCharacteristic</a> objects. An attempt to remove value change listener for such an object will result in no operation.
+ Value change listeners cannot be registered and thus unregistered for <a href="bluetooth#BluetoothGATTServerCharacteristic">BluetothGATTServerCharacteristic</a> objects. An attempt to remove value change listener for such an object will result in no operation.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -4469,7 +4469,7 @@ The ErrorCallback is launched with these error types:
  http://tizen.org/privilege/bluetooth
             </p>
 <p><span class="remark">Remark: </span>
- <a href="bluetooth.html#BluetoothGATTServerDescriptor">BluetothGATTServerDescriptor</a> objects do not support this function. An attempt to call it for such an object will result in an exception.
+ <a href="bluetooth#BluetoothGATTServerDescriptor">BluetothGATTServerDescriptor</a> objects do not support this function. An attempt to call it for such an object will result in an exception.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -4566,7 +4566,7 @@ UnknownError - If any other error occurs              </li>
  http://tizen.org/privilege/bluetooth
             </p>
 <p><span class="remark">Remark: </span>
- <a href="bluetooth.html#BluetoothGATTServerDescriptor">BluetothGATTServerDescriptor</a> objects do not support this function. An attempt to call it for such an object will result in an exception.
+ <a href="bluetooth#BluetoothGATTServerDescriptor">BluetothGATTServerDescriptor</a> objects do not support this function. An attempt to call it for such an object will result in an exception.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -5471,7 +5471,7 @@ server.getConnectionMtu("12:34:56:78:90:ab", successCB, errorCB);
  6.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="bluetooth.html#BluetoothLEAdapter::startScan">startScan</a> code example.
+ Example of using can be find at <a href="bluetooth#BluetoothLEAdapter::startScan">startScan</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -5511,7 +5511,7 @@ server.getConnectionMtu("12:34:56:78:90:ab", successCB, errorCB);
  6.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="bluetooth.html#BluetoothLEAdapter::startAdvertise">startAdvertise</a> code example.
+ Example of using can be find at <a href="bluetooth#BluetoothLEAdapter::startAdvertise">startAdvertise</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -5553,7 +5553,7 @@ server.getConnectionMtu("12:34:56:78:90:ab", successCB, errorCB);
  6.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="bluetooth.html#BluetoothLEDevice::addConnectStateChangeListener">addConnectStateChangeListener</a> code example.
+ Example of using can be find at <a href="bluetooth#BluetoothLEDevice::addConnectStateChangeListener">addConnectStateChangeListener</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -8382,7 +8382,7 @@ function unRegisterChatService()
  6.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="bluetooth.html#BluetoothAdapter::setChangeListener">setChangeListener</a> code example.
+ Example of using can be find at <a href="bluetooth#BluetoothAdapter::setChangeListener">setChangeListener</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -8465,7 +8465,7 @@ function unRegisterChatService()
  6.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="bluetooth.html#BluetoothAdapter::getDevice">getDevice</a> and <a href="bluetooth.html#BluetoothAdapter::createBonding">createBonding</a> code examples.
+ Example of using can be find at <a href="bluetooth#BluetoothAdapter::getDevice">getDevice</a> and <a href="bluetooth#BluetoothAdapter::createBonding">createBonding</a> code examples.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -8506,7 +8506,7 @@ function unRegisterChatService()
  6.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="bluetooth.html#BluetoothAdapter::getKnownDevices">getKnownDevices</a> code example.
+ Example of using can be find at <a href="bluetooth#BluetoothAdapter::getKnownDevices">getKnownDevices</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -8551,7 +8551,7 @@ Each element is a BluetoothDevice.
  6.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="bluetooth.html#BluetoothAdapter::discoverDevices">discoverDevices</a> code example.
+ Example of using can be find at <a href="bluetooth#BluetoothAdapter::discoverDevices">discoverDevices</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -8647,7 +8647,7 @@ After that, this device is no longer visible.
  6.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="bluetooth.html#BluetoothDevice::connectToServiceByUUID">connectToServiceByUUID</a> code example.
+ Example of using can be find at <a href="bluetooth#BluetoothDevice::connectToServiceByUUID">connectToServiceByUUID</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -8688,7 +8688,7 @@ After that, this device is no longer visible.
  6.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="bluetooth.html#BluetoothAdapter::registerRFCOMMServiceByUUID">registerRFCOMMServiceByUUID</a> code example.
+ Example of using can be find at <a href="bluetooth#BluetoothAdapter::registerRFCOMMServiceByUUID">registerRFCOMMServiceByUUID</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -8756,7 +8756,7 @@ To guarantee that the Bluetooth Low Energy application runs on a device with Blu
 <li class="feature">http://tizen.org/feature/network.bluetooth.le.gatt.server</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Bluetooth {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/content.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/content.html
@@ -30,7 +30,7 @@ for accessing only external storage using this API, a privilege <a href="http://
 for accessing internal and external storage using this API, privileges (<a href="http://tizen.org/privilege/mediastorage">http://tizen.org/privilege/mediastorage</a> and <a href="http://tizen.org/privilege/externalstorage">http://tizen.org/privilege/externalstorage</a>) must be provided.          </li>
         </ul>
         <p>
-For more information on the Content features, see <a href="/application/web/guides/data/stored-content">Stored Content Management</a>.
+For more information on the Content features, see <a href="https://samsungtizenos.com/docs/application/web/guides/data/stored-content">Stored Content Management</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>
@@ -406,7 +406,7 @@ tizen.content.getDirectories(getDirectoriesCB, errorCB);
 <div class="description">
             <p>
 This method allows searching based on a supplied filter. For more details on AbstractFilter, see the
-<a href="tizen.html#::Tizen::AbstractFilter">Tizen</a> module. The filter allows precise searching such
+<a href="tizen#::Tizen::AbstractFilter">Tizen</a> module. The filter allows precise searching such
 as "return all songs by artist U2, ordered by name".
             </p>
             <p>
@@ -427,7 +427,7 @@ UnknownError: In any other error case.              </li>
             </p>
 <p><span class="remark">Remark: </span>
  Attributes available for <em>Content</em> objects filtering are listed in
-<a href="/application/web/guides/data/data-filter#content-filter-attributes">Data Filtering and Sorting guide</a>.
+<a href="https://samsungtizenos.com/docs/application/web/guides/data/data-filter#content-filter-attributes">Data Filtering and Sorting guide</a>.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -844,7 +844,7 @@ Calling this function has no effect if there is no listener with given id.
           <li class="param">
 <span class="name">listenerId</span>:
  Identifier of the listener to be removed. It is returned by.
-<a href="./content.html#ContentManager::addChangeListener">addChangeListener()</a> when a listener is successfully added.
+<a href="content#ContentManager::addChangeListener">addChangeListener()</a> when a listener is successfully added.
                 </li>
         </ul>
 </div>
@@ -1077,14 +1077,14 @@ tizen.content.find(findCB);
  2.1
             </p>
 <p><span class="remark">Remark: </span>
- This callback is also invoked upon success of the <a href="content.html#ContentManager::scanDirectory">scanDirectory()</a> method since Tizen 2.4. Therefore, the <em>uri</em> parameter may now also be the URI of a <em>ContentDirectory</em> object.
+ This callback is also invoked upon success of the <a href="content#ContentManager::scanDirectory">scanDirectory()</a> method since Tizen 2.4. Therefore, the <em>uri</em> parameter may now also be the URI of a <em>ContentDirectory</em> object.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
           <li class="param">
 <span class="name">uri</span>:
- The URI of the <a href="content.html#Content">Content</a> or the <a href="content.html#ContentDirectory">ContentDirectory</a> object.
+ The URI of the <a href="content#Content">Content</a> or the <a href="content#ContentDirectory">ContentDirectory</a> object.
                 </li>
         </ul>
 </div>

--- a/docs/application/web/api/10.1/device_api/tv/tizen/cordova/device-motion.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/cordova/device-motion.html
@@ -228,7 +228,7 @@ Timestamp: 1456480118000
 <p><span class="return">Return value:</span></p>
 <ul>
 <span class="return">DOMString:</span>
- DOMString The watch id that must be passed to <a href="device-motion.html#Accelerometer::clearWatch">clearWatch</a> to stop watching.
+ DOMString The watch id that must be passed to <a href="device-motion#Accelerometer::clearWatch">clearWatch</a> to stop watching.
               </ul>
 </div>
 <div class="exceptionlist">
@@ -295,7 +295,7 @@ Please wait 3 seconds for the next measurement...
 <ul>
           <li class="param">
 <span class="name">watchID</span>:
- The id of the watch returned from <a href="device-motion.html#Accelerometer::watchAcceleration">watchAcceleration</a>.
+ The id of the watch returned from <a href="device-motion#Accelerometer::watchAcceleration">watchAcceleration</a>.
                 </li>
         </ul>
 </div>
@@ -551,7 +551,7 @@ To guarantee that the DeviceMotion application runs on a device with the DeviceM
 <li class="feature">http://tizen.org/feature/sensor.accelerometer</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module DeviceMotion {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/cordova/events.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/cordova/events.html
@@ -97,13 +97,13 @@ Network Information events            </th>
             <td>
 online            </td>
             <td>
-<a href="networkInformation.html#OnlineEventCallback">OnlineEventCallback</a>            </td>
+<a href="networkInformation#OnlineEventCallback">OnlineEventCallback</a>            </td>
           </tr>
           <tr>
             <td>
 offline            </td>
             <td>
-<a href="networkInformation.html#OfflineEventCallback">OfflineEventCallback</a>            </td>
+<a href="networkInformation#OfflineEventCallback">OfflineEventCallback</a>            </td>
           </tr>
         </table>
        </div>

--- a/docs/application/web/api/10.1/device_api/tv/tizen/cordova/file.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/cordova/file.html
@@ -3164,7 +3164,7 @@ entry.createWriter(successCallback, errorCallback);
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="file.html#FileSystem">FileSystem</a> code example.
+ Example of using can be find at <a href="file#FileSystem">FileSystem</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -3205,7 +3205,7 @@ entry.createWriter(successCallback, errorCallback);
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="file.html#DirectoryEntry::getDirectory">DirectoryEntry::getDirectory</a> code example.
+ Example of using can be find at <a href="file#DirectoryEntry::getDirectory">DirectoryEntry::getDirectory</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -3246,7 +3246,7 @@ entry.createWriter(successCallback, errorCallback);
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="file.html#DirectoryReader::readEntries">DirectoryReader::readEntries</a> code example.
+ Example of using can be find at <a href="file#DirectoryReader::readEntries">DirectoryReader::readEntries</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -3287,7 +3287,7 @@ entry.createWriter(successCallback, errorCallback);
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="file.html#Entry::getMetadata">Entry::getMetadata</a> code example.
+ Example of using can be find at <a href="file#Entry::getMetadata">Entry::getMetadata</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -3328,7 +3328,7 @@ entry.createWriter(successCallback, errorCallback);
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="file.html#FileEntry::createWriter">FileEntry::createWriter</a> code example.
+ Example of using can be find at <a href="file#FileEntry::createWriter">FileEntry::createWriter</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -3369,7 +3369,7 @@ entry.createWriter(successCallback, errorCallback);
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="file.html#FileEntry::file">FileEntry::file</a> code example.
+ Example of using can be find at <a href="file#FileEntry::file">FileEntry::file</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -3410,7 +3410,7 @@ entry.createWriter(successCallback, errorCallback);
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="file.html#Entry::remove">Entry::remove</a> code example.
+ Example of using can be find at <a href="file#Entry::remove">Entry::remove</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -3442,7 +3442,7 @@ entry.createWriter(successCallback, errorCallback);
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="file.html#Entry::getMetadata">Entry::getMetadata</a> code example.
+ Example of using can be find at <a href="file#Entry::getMetadata">Entry::getMetadata</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>

--- a/docs/application/web/api/10.1/device_api/tv/tizen/cordova/media.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/cordova/media.html
@@ -762,7 +762,7 @@ setTimeout(function()
 <div class="interface" id="MediaError">
 <a class="backward-compatibility-anchor" name="::Media::MediaError"></a><h3>1.2. MediaError</h3>
 <div class="brief">
- A <em>MediaError</em> object is returned to the <a href="media.html#MediaErrorCallback">MediaErrorCallback</a> function when an error occurs.
+ A <em>MediaError</em> object is returned to the <a href="media#MediaErrorCallback">MediaErrorCallback</a> function when an error occurs.
           </div>
 <pre class="webidl prettyprint">  interface MediaError {
     const short MEDIA_ERR_ABORTED = 1;
@@ -855,7 +855,7 @@ setTimeout(function()
 <ul>
           <li class="param">
 <span class="name">status</span>:
- The status of the <a href="media.html#Media">Media</a> object. It is equal to one of the Media interface constant: MEDIA_NONE, MEDIA_STARTING, MEDIA_RUNNING, MEDIA_PAUSED or MEDIA_STOPPED.
+ The status of the <a href="media#Media">Media</a> object. It is equal to one of the Media interface constant: MEDIA_NONE, MEDIA_STARTING, MEDIA_RUNNING, MEDIA_PAUSED or MEDIA_STOPPED.
                 </li>
         </ul>
 </div>
@@ -924,7 +924,7 @@ If an application uses startRecord() or stopRecord(), declare the following feat
 <li class="feature">http://tizen.org/feature/media.audio_recording</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Media {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/cordova/networkInformation.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/cordova/networkInformation.html
@@ -386,7 +386,7 @@ checkConnection();
 The <var>online</var> event fires when an application goes online, and the device becomes connected to the Internet.
           </p>
           <p>
-Applications typically should use document.addEventListener() to attach an event listener once the <a href="events.html#DeviceReadyEventCallback">deviceready</a> event fires.
+Applications typically should use document.addEventListener() to attach an event listener once the <a href="events#DeviceReadyEventCallback">deviceready</a> event fires.
           </p>
           <p>
 Original documentation: <a href="https://www.npmjs.com/package/cordova-plugin-network-information#online">Cordova online event</a>          </p>
@@ -439,7 +439,7 @@ function onOnline()
 The <var>online</var> event fires when an application goes online, and the device becomes connected to the Internet.
           </p>
           <p>
-Applications typically should use document.addEventListener() to attach an event listener once the <a href="events.html#DeviceReadyEventCallback">deviceready</a> event fires.
+Applications typically should use document.addEventListener() to attach an event listener once the <a href="events#DeviceReadyEventCallback">deviceready</a> event fires.
           </p>
           <p>
 Original documentation: <a href="https://www.npmjs.com/package/cordova-plugin-network-information#offline">Cordova offline event</a>          </p>
@@ -491,7 +491,7 @@ To guarantee that the NetworkInformation application runs on a device with the N
 <li class="feature">http://tizen.org/feature/network.telephony</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module NetworkInformation {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/datacontrol.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/datacontrol.html
@@ -18,7 +18,7 @@
 The Data Control functionality provides a way to access specific data that is exported by other applications.
         </p>
         <p>
-Please read the <a href="/application/web/guides/app-management/data-control">Data Control guide</a> to know how to share own application data with other applications.
+Please read the <a href="https://samsungtizenos.com/docs/application/web/guides/app-management/data-control">Data Control guide</a> to know how to share own application data with other applications.
         </p>
        </div>
 <p><span class="version">Since: </span>
@@ -404,7 +404,7 @@ IOError - If a DB operation has failed.              </li>
             </p>
 <p><span class="remark">Remark: </span>
  To monitor DataControl provider data changes, it is not enough to implement a listener in the DataControl consumer. You also need to implement the data change sending functionality in the DataControl provider.
-The data sending implementation determines the actual change data returned to the DataControl consumer. For more information on the DataControl provider implementation, see <a href="/application/native/guides/app-management/data-control#monitoring-data-changes">Monitoring Data Changes</a>.
+The data sending implementation determines the actual change data returned to the DataControl consumer. For more information on the DataControl provider implementation, see <a href="https://samsungtizenos.com/docs/application/native/guides/app-management/data-control">Monitoring Data Changes</a>.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -1614,7 +1614,7 @@ catch (err)
                 </li>
           <li class="param">
 <span class="name">data</span>:
- Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/mobile/3.0/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
+ Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="https://samsungtizenos.com/docs/application/native/api/10.0.0/common/group__CAPI__DATA__CONTROL__PROVIDER__MODULE#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
                 </li>
         </ul>
 </div>

--- a/docs/application/web/api/10.1/device_api/tv/tizen/download.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/download.html
@@ -26,7 +26,7 @@ for accessing only external storage using this API, a privilege <a href="http://
 for accessing internal and external storage using this API, privileges (<a href="http://tizen.org/privilege/mediastorage">http://tizen.org/privilege/mediastorage</a> and <a href="http://tizen.org/privilege/externalstorage">http://tizen.org/privilege/externalstorage</a>) must be provided.          </li>
         </ul>
         <p>
-For more information on the Download features, see <a href="/application/web/guides/connectivity/download">Download Guide</a>.
+For more information on the Download features, see <a href="https://samsungtizenos.com/docs/application/web/guides/connectivity/download">Download Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>
@@ -252,7 +252,7 @@ The <em>tizen.download</em> object allows access to the functionality of the Dow
             </div>
 <div class="description">
             <p>
-If the destination is not specified or is an empty string, the file will be downloaded to the default storage: "Downloads". For more information, see <a href="filesystem.html">Filesystem API</a>.
+If the destination is not specified or is an empty string, the file will be downloaded to the default storage: "Downloads". For more information, see <a href="filesystem">Filesystem API</a>.
             </p>
             <p>
 The default value is an empty string.
@@ -1125,7 +1125,7 @@ DownloadNetworkType <em>ALL</em> can be available on a ethernet-enabled device. 
 <li class="feature">http://tizen.org/feature/network.ethernet</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Download {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/exif.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/exif.html
@@ -32,7 +32,7 @@ for accessing only external storage using this API, a privilege <a href="http://
 for accessing internal and external storage using this API, privileges (<a href="http://tizen.org/privilege/mediastorage">http://tizen.org/privilege/mediastorage</a> and <a href="http://tizen.org/privilege/externalstorage">http://tizen.org/privilege/externalstorage</a>) must be provided.          </li>
         </ul>
         <p>
-For more information about how to use Exif API, see <a href="/application/web/guides/multimedia/jpeg-exif">Exif Guide</a>.
+For more information about how to use Exif API, see <a href="https://samsungtizenos.com/docs/application/web/guides/multimedia/jpeg-exif">Exif Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/10.1/device_api/tv/tizen/filesystem.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/filesystem.html
@@ -104,7 +104,7 @@ for accessing internal and external storage using this API, privileges (<a href=
 <b>Remark:</b> Methods, which names end with <var>NonBlocking</var> are asynchronous and are executed in background in the order in which they were called. Corresponding methods without <var>NonBlocking</var> at the end are synchronous and will block further instructions execution, until they are finished.
         </p>
         <p>
-For more information on the Filesystem features, see <a href="/application/web/guides/data/file-system">File System Guide</a>.
+For more information on the Filesystem features, see <a href="https://samsungtizenos.com/docs/application/web/guides/data/file-system">File System Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/10.1/device_api/tv/tizen/iotcon.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/iotcon.html
@@ -32,7 +32,7 @@ for accessing only external storage using this API, a privilege <a href="http://
 for accessing internal and external storage using this API, privileges (<a href="http://tizen.org/privilege/mediastorage">http://tizen.org/privilege/mediastorage</a> and <a href="http://tizen.org/privilege/externalstorage">http://tizen.org/privilege/externalstorage</a>) must be provided.          </li>
         </ul>
         <p>
-For more information on the IoT features, see <a href="/application/web/guides/connectivity/iotcon">IoT Guide</a>.
+For more information on the IoT features, see <a href="https://samsungtizenos.com/docs/application/web/guides/connectivity/iotcon">IoT Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>
@@ -587,7 +587,7 @@ catch (err)
             </p>
 <div class="description">
             <p>
-This method returns the common timeout value for methods: <br><a href="iotcon.html#Client::findDeviceInfo">findDeviceInfo</a><br><a href="iotcon.html#Client::findPlatformInfo">findPlatformInfo</a><br><a href="iotcon.html#Client::findResource">findResource</a><br><a href="iotcon.html#RemoteResource::methodGet">methodGet</a><br><a href="iotcon.html#RemoteResource::methodPut">methodPut</a><br><a href="iotcon.html#RemoteResource::methodPost">methodPost</a><br><a href="iotcon.html#RemoteResource::methodDelete">methodDelete</a><br>All asynchronous APIs have the same timeout value, there is no way to have different timeout values at each method.
+This method returns the common timeout value for methods: <br><a href="iotcon#Client::findDeviceInfo">findDeviceInfo</a><br><a href="iotcon#Client::findPlatformInfo">findPlatformInfo</a><br><a href="iotcon#Client::findResource">findResource</a><br><a href="iotcon#RemoteResource::methodGet">methodGet</a><br><a href="iotcon#RemoteResource::methodPut">methodPut</a><br><a href="iotcon#RemoteResource::methodPost">methodPost</a><br><a href="iotcon#RemoteResource::methodDelete">methodDelete</a><br>All asynchronous APIs have the same timeout value, there is no way to have different timeout values at each method.
 Without a response after the specified time, the mentioned methods would trigger an error callback with <var>TimeoutError</var>.
             </p>
            </div>
@@ -622,7 +622,7 @@ console.log("Timeout value is " + timeout);
             </p>
 <div class="description">
             <p>
-The timeout value is common for methods: <br><a href="iotcon.html#Client::findDeviceInfo">findDeviceInfo</a><br><a href="iotcon.html#Client::findPlatformInfo">findPlatformInfo</a><br><a href="iotcon.html#Client::findResource">findResource</a><br><a href="iotcon.html#RemoteResource::methodGet">methodGet</a><br><a href="iotcon.html#RemoteResource::methodPut">methodPut</a><br><a href="iotcon.html#RemoteResource::methodPost">methodPost</a><br><a href="iotcon.html#RemoteResource::methodDelete">methodDelete</a><br>All asynchronous APIs have the same timeout value, there is no way to have different timeout values at each method.
+The timeout value is common for methods: <br><a href="iotcon#Client::findDeviceInfo">findDeviceInfo</a><br><a href="iotcon#Client::findPlatformInfo">findPlatformInfo</a><br><a href="iotcon#Client::findResource">findResource</a><br><a href="iotcon#RemoteResource::methodGet">methodGet</a><br><a href="iotcon#RemoteResource::methodPut">methodPut</a><br><a href="iotcon#RemoteResource::methodPost">methodPost</a><br><a href="iotcon#RemoteResource::methodDelete">methodDelete</a><br>All asynchronous APIs have the same timeout value, there is no way to have different timeout values at each method.
 Without a response after the specified time, the mentioned methods would trigger an error callback with <var>TimeoutError</var>.
             </p>
            </div>
@@ -726,7 +726,7 @@ watchId = tizen.iotcon.addGeneratedPinListener(RandomPinSuccess);
  3.0
             </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#Iotcon::addGeneratedPinListener">addGeneratedPinListener</a> code example.
+ Example of using can be find at <a href="iotcon#Iotcon::addGeneratedPinListener">addGeneratedPinListener</a> code example.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -1022,7 +1022,7 @@ Resource type: oic.wk.ad
  http://tizen.org/privilege/internet
             </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#Client::addPresenceEventListener">addPresenceEventListener</a> code example.
+ Example of using can be find at <a href="iotcon#Client::addPresenceEventListener">addPresenceEventListener</a> code example.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -1595,7 +1595,7 @@ server.stopPresence();
  http://tizen.org/privilege/internet
             </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#Server::startPresence">startPresence</a> code example.
+ Example of using can be find at <a href="iotcon#Server::startPresence">startPresence</a> code example.
             </p>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
@@ -2375,7 +2375,7 @@ catch (err)
  http://tizen.org/privilege/internet
             </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#RemoteResource::startObserving">startObserving</a> code example.
+ Example of using can be find at <a href="iotcon#RemoteResource::startObserving">startObserving</a> code example.
             </p>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
@@ -2496,7 +2496,7 @@ key: openstate, value: open
  http://tizen.org/privilege/internet
             </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#RemoteResource::startCaching">startCaching</a> code example.
+ Example of using can be find at <a href="iotcon#RemoteResource::startCaching">startCaching</a> code example.
             </p>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
@@ -2628,7 +2628,7 @@ Calling this function has no effect if listener is not set.
  http://tizen.org/privilege/internet
             </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#RemoteResource::setResourceStateChangeListener">setResourceStateChangeListener</a> code example.
+ Example of using can be find at <a href="iotcon#RemoteResource::setResourceStateChangeListener">setResourceStateChangeListener</a> code example.
             </p>
 <div class="exceptionlist">
 <p><span class="except">Exceptions:</span></p>
@@ -3459,7 +3459,7 @@ Calling this function has no effect if listener was not set.
             </p>
            </div>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#Resource::setRequestListener">setRequestListener</a> code example.
+ Example of using can be find at <a href="iotcon#Resource::setRequestListener">setRequestListener</a> code example.
             </p>
 </dd>
 </dl>
@@ -3800,7 +3800,7 @@ query["filter"] = filter;
 <div class="interface deprecated" id="Response">
 <a class="backward-compatibility-anchor" name="::Iotcon::Response"></a><h3>2.13. Response</h3>
 <div class="brief">
- The Response Interface holds response from server for specified request of client. It is server-side object, Response on client-side is hold as <a href="iotcon.html#RemoteResponse">RemoteResponse</a> object.
+ The Response Interface holds response from server for specified request of client. It is server-side object, Response on client-side is hold as <a href="iotcon#RemoteResponse">RemoteResponse</a> object.
           </div>
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 10.0.
@@ -4017,7 +4017,7 @@ response.send();
 <div class="interface deprecated" id="RemoteResponse">
 <a class="backward-compatibility-anchor" name="::Iotcon::RemoteResponse"></a><h3>2.14. RemoteResponse</h3>
 <div class="brief">
- The RemoteResponse Interface holds response from server for specified request of client, this is client-side version of <a href="iotcon.html#Response">Response</a> object.
+ The RemoteResponse Interface holds response from server for specified request of client, this is client-side version of <a href="iotcon#Response">Response</a> object.
           </div>
 <p class="deprecated"><b>Deprecated.</b>
  Deprecated Since 10.0.
@@ -4271,7 +4271,7 @@ response.send();
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#Resource::setRequestListener">setRequestListener</a> code example.
+ Example of using can be find at <a href="iotcon#Resource::setRequestListener">setRequestListener</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -4408,7 +4408,7 @@ for <em>Client.findResource()</em>.
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#Client::findResource">findResource</a> code example.
+ Example of using can be find at <a href="iotcon#Client::findResource">findResource</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -4452,7 +4452,7 @@ for <em>Client.findResource()</em>.
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#Client::addPresenceEventListener">addPresenceEventListener</a> code example.
+ Example of using can be find at <a href="iotcon#Client::addPresenceEventListener">addPresenceEventListener</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -4496,7 +4496,7 @@ for <em>Client.findResource()</em>.
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#Client::findDeviceInfo">findDeviceInfo</a> code example.
+ Example of using can be find at <a href="iotcon#Client::findDeviceInfo">findDeviceInfo</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -4540,7 +4540,7 @@ for <em>Client.findResource()</em>.
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#Client::findPlatformInfo">findPlatformInfo</a> code example.
+ Example of using can be find at <a href="iotcon#Client::findPlatformInfo">findPlatformInfo</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -4584,7 +4584,7 @@ for <em>Client.findResource()</em>.
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#RemoteResource::methodGet">methodGet</a> code example.
+ Example of using can be find at <a href="iotcon#RemoteResource::methodGet">methodGet</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -4628,7 +4628,7 @@ for <em>Client.findResource()</em>.
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#RemoteResource::setResourceStateChangeListener">setResourceStateChangeListener</a> code example.
+ Example of using can be find at <a href="iotcon#RemoteResource::setResourceStateChangeListener">setResourceStateChangeListener</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -4672,7 +4672,7 @@ for <em>Client.findResource()</em>.
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#RemoteResource::startCaching">startCaching</a> code example.
+ Example of using can be find at <a href="iotcon#RemoteResource::startCaching">startCaching</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -4716,7 +4716,7 @@ for <em>Client.findResource()</em>.
  3.0
           </p>
 <p><span class="remark">Remark: </span>
- Example of using can be find at <a href="iotcon.html#Iotcon::addGeneratedPinListener">addGeneratedPinListener</a> code example.
+ Example of using can be find at <a href="iotcon#Iotcon::addGeneratedPinListener">addGeneratedPinListener</a> code example.
           </p>
 <div class="methods">
 <h4>Methods</h4>
@@ -4760,7 +4760,7 @@ To guarantee this application will run on a device with a Iotcon, add the below 
 <li class="feature">http://tizen.org/feature/iot.ocf</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Iotcon {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/keymanager.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/keymanager.html
@@ -15,7 +15,7 @@
         </div>
 <div class="description">
         <p>
-For more information on the Key Manager features, see <a href="/application/web/guides/security/secure-key">Key Manager Guide</a>.
+For more information on the Key Manager features, see <a href="https://samsungtizenos.com/docs/application/web/guides/security/secure-key">Key Manager Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/10.1/device_api/tv/tizen/libteec.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/libteec.html
@@ -1349,7 +1349,7 @@ To guarantee that the CA is running on a device with TrustZone support, declare 
 <li class="feature">http://tizen.org/feature/security.tee</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/tutorials/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module LibTeec {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/mediacontroller.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/mediacontroller.html
@@ -21,7 +21,7 @@ and metadata from media controller server to client. Allows to control server st
 by sending commands from client.
         </p>
         <p>
-For more information on the Media Controller features, see <a href="/application/web/guides/multimedia/media-controller">Media Controller Guide</a>.
+For more information on the Media Controller features, see <a href="https://samsungtizenos.com/docs/application/web/guides/multimedia/media-controller">Media Controller Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>
@@ -7219,7 +7219,7 @@ Interface is used as a success method for:
 <ul>
           <li class="param">
 <span class="name">data</span><span class="optional"> [nullable]</span>:
- Response data object sent by the command handler. This object is compatible with <a href="tizen.html#Bundle">Bundle</a> object.
+ Response data object sent by the command handler. This object is compatible with <a href="tizen#Bundle">Bundle</a> object.
                 </li>
           <li class="param">
 <span class="name">code</span><span class="optional"> [optional]</span>:
@@ -7423,7 +7423,7 @@ Related functions:
                 </li>
           <li class="param">
 <span class="name">data</span>:
- Response object. This object is compatible with <a href="tizen.html#Bundle">Bundle</a>.
+ Response object. This object is compatible with <a href="tizen#Bundle">Bundle</a>.
                 </li>
         </ul>
 </div>

--- a/docs/application/web/api/10.1/device_api/tv/tizen/messageport.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/messageport.html
@@ -15,7 +15,7 @@
         </div>
 <div class="description">
         <p>
-For more information on the Message Port features, see <a href="/application/web/guides/app-management/message-port">Message Port Guide</a>.
+For more information on the Message Port features, see <a href="https://samsungtizenos.com/docs/application/web/guides/app-management/message-port">Message Port Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/10.1/device_api/tv/tizen/metadata.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/metadata.html
@@ -33,7 +33,7 @@ for accessing only external storage using this API, a privilege <a href="http://
 for accessing internal and external storage using this API, privileges (<a href="http://tizen.org/privilege/mediastorage">http://tizen.org/privilege/mediastorage</a> and <a href="http://tizen.org/privilege/externalstorage">http://tizen.org/privilege/externalstorage</a>) must be provided.          </li>
         </ul>
         <p>
-For more information about how to use Metadata API, see <a href="/application/web/guides/multimedia/metadata">Metadata Guide</a>.
+For more information about how to use Metadata API, see <a href="https://samsungtizenos.com/docs/application/web/guides/multimedia/metadata">Metadata Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/10.1/device_api/tv/tizen/ml.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/ml.html
@@ -16,11 +16,11 @@
 <div class="description">
         <ul>
           <li>
-Single API: useful for a simple usage scenario of neural network models. It allows invoking a neural network model with a single instance of input data for the model directly. For more information, see <a href="ml_single.html">ML Single API</a>.          </li>
+Single API: useful for a simple usage scenario of neural network models. It allows invoking a neural network model with a single instance of input data for the model directly. For more information, see <a href="ml_single">ML Single API</a>.          </li>
           <li>
-Pipeline API: useful for an advanced usage scenario of neural network models. It allows creating inference pipelines with multiple neural network models. For more information, see <a href="ml_pipeline.html">ML Pipeline API</a>.          </li>
+Pipeline API: useful for an advanced usage scenario of neural network models. It allows creating inference pipelines with multiple neural network models. For more information, see <a href="ml_pipeline">ML Pipeline API</a>.          </li>
           <li>
-Trainer API: useful for creating and training Machine Learning models locally on the device. For more information, see <a href="ml_trainer.html">ML Trainer API</a>.          </li>
+Trainer API: useful for creating and training Machine Learning models locally on the device. For more information, see <a href="ml_trainer">ML Trainer API</a>.          </li>
         </ul>
        </div>
 <p><span class="version">Since: </span>
@@ -305,7 +305,7 @@ The <em>tizen.ml</em> object allows access to the Machine Learning API.
 <li class="attribute" id="MachineLearningManager::single">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">MachineLearningSingle </span><span class="name">single</span></span><div class="brief">
- Provides methods for <a href="ml_single.html">Machine Learning Single Shot API</a>.
+ Provides methods for <a href="ml_single">Machine Learning Single Shot API</a>.
             </div>
 <p><span class="version">Since: </span>
  6.5
@@ -314,7 +314,7 @@ The <em>tizen.ml</em> object allows access to the Machine Learning API.
 <li class="attribute" id="MachineLearningManager::pipeline">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">MachineLearningPipeline </span><span class="name">pipeline</span></span><div class="brief">
- Provides methods for <a href="ml_pipeline.html">Machine Learning Pipeline API</a>.
+ Provides methods for <a href="ml_pipeline">Machine Learning Pipeline API</a>.
             </div>
 <p><span class="version">Since: </span>
  6.5
@@ -323,7 +323,7 @@ The <em>tizen.ml</em> object allows access to the Machine Learning API.
 <li class="attribute" id="MachineLearningManager::trainer">
 <span class="attrName"><span class="readonly">                readonly
 </span><span class="type">MachineLearningTrainer </span><span class="name">trainer</span></span><div class="brief">
- Provides methods for <a href="ml_trainer.html">Machine Learning Trainer API</a>.
+ Provides methods for <a href="ml_trainer">Machine Learning Trainer API</a>.
             </div>
 <p><span class="version">Since: </span>
  6.5
@@ -1614,7 +1614,7 @@ To guarantee the running of the application on a device which supports Machine L
 <li class="feature">http://tizen.org/feature/machine_learning.training</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module MachineLearning {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/ml_pipeline.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/ml_pipeline.html
@@ -62,7 +62,7 @@ for accessing only recorder using this API, a privilege <a href="http://tizen.or
 for accessing camera and recorder using this API, privileges (<a href="http://tizen.org/privilege/camera">http://tizen.org/privilege/camera</a> and <a href="http://tizen.org/privilege/recorder">http://tizen.org/privilege/recorder</a>) must be provided.          </li>
         </ul>
         <p>
-For more information on the Pipeline API features, see <a href="/application/web/guides/machine-learning/pipeline">Pipeline Guide</a>.
+For more information on the Pipeline API features, see <a href="https://samsungtizenos.com/docs/application/web/guides/machine-learning/pipeline">Pipeline Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>
@@ -1965,13 +1965,13 @@ result to <em>output</em>. <em>output</em> contents will be passed to the furthe
 To use their contents after callback return, copy them to objects valid outside the callback.
             </p>
 <p><span class="remark">Remark: </span>
- The <em>input</em> and <em>output</em> cannot be disposed. Calling the <a href="ml.html#TensorsData::dispose">TensorsData::dispose()</a>has no effect.
+ The <em>input</em> and <em>output</em> cannot be disposed. Calling the <a href="ml#TensorsData::dispose">TensorsData::dispose()</a>has no effect.
             </p>
 <p><span class="remark">Remark: </span>
- The <em>input</em> cannot be modified. Calling <a href="ml.html#TensorsData::setTensorRawData">TensorsData::setTensorRawData()</a> on <em>input</em> has no effect.
+ The <em>input</em> cannot be modified. Calling <a href="ml#TensorsData::setTensorRawData">TensorsData::setTensorRawData()</a> on <em>input</em> has no effect.
             </p>
 <p><span class="remark">Remark: </span>
- The <em>output</em> passed to the callback contains random values. Use <a href="ml.html#TensorsData::setTensorRawData">TensorsData::setTensorRawData()</a> to modify it.
+ The <em>output</em> passed to the callback contains random values. Use <a href="ml#TensorsData::setTensorRawData">TensorsData::setTensorRawData()</a> to modify it.
             </p>
 <p><span class="remark">Remark: </span>
  Returning a negative status value stops the pipeline and changes its state to <var>UNKNOWN</var>.
@@ -2034,7 +2034,7 @@ To guarantee the running of the application on a device with Machine Learning In
 <li class="feature">http://tizen.org/feature/machine_learning.inference</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Pipeline {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/ml_single.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/ml_single.html
@@ -130,7 +130,7 @@ Use <a href="#SingleShot::close">SingleShot::close()</a> method to close the ope
 <ul>
           <li class="param">
 <span class="name">modelPath</span>:
- Path to a model. Check <a href="filesystem.html">Filesystem API</a> for more information about valid path in Tizen.
+ Path to a model. Check <a href="filesystem">Filesystem API</a> for more information about valid path in Tizen.
                 </li>
           <li class="param">
 <span class="name">inTensorsInfo</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
@@ -242,7 +242,7 @@ AbortError - if any other error occurs.              </li>
 <ul>
           <li class="param">
 <span class="name">modelPath</span>:
- Path to a model. Check <a href="filesystem.html">Filesystem API</a> for more information about valid path in Tizen.
+ Path to a model. Check <a href="filesystem">Filesystem API</a> for more information about valid path in Tizen.
                 </li>
           <li class="param">
 <span class="name">successCallback</span>:
@@ -834,7 +834,7 @@ catch (e)
 <ul>
           <li class="param">
 <span class="name">tensorsData</span>:
- <a href="ml.html#TensorsData">TensorsData</a> object containing the inferred result. Object need to be manually disposed with <a href="ml.html#TensorsData::dispose">TensorsData::dispose()</a> method when no longer needed.
+ <a href="ml#TensorsData">TensorsData</a> object containing the inferred result. Object need to be manually disposed with <a href="ml#TensorsData::dispose">TensorsData::dispose()</a> method when no longer needed.
                 </li>
         </ul>
 </div>
@@ -865,7 +865,7 @@ To guarantee that the ML application runs on a device with the ML Inference feat
 <li class="feature">http://tizen.org/feature/machine_learning.inference</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">3. Full WebIDL</h2>
 <pre class="webidl prettyprint">module MLSingleShot {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/ml_trainer.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/ml_trainer.html
@@ -367,22 +367,22 @@ console.log("Type of layer: " + l1.type);
             </p>
 <div class="description">
             <p>
-Each file provided to the function should match format described in <a href="https://docs.tizen.org/application/native/guides/machine-learning/machine-learning-training/#set-a-dataset-from-file">machine learning guide</a>            </p>
+Each file provided to the function should match format described in <a href="https://samsungtizenos.com/docs/application/native/guides/machine-learning/machine-learning-training#content-set-a-dataset-from-file">machine learning guide</a>            </p>
            </div>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
 <ul>
           <li class="param">
 <span class="name">train</span>:
- Path for file with data for training. Check <a href="filesystem.html">Filesystem API</a> for more information about valid path in Tizen.
+ Path for file with data for training. Check <a href="filesystem">Filesystem API</a> for more information about valid path in Tizen.
                 </li>
           <li class="param">
 <span class="name">validate</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
- Path for file with data for validating. Check <a href="filesystem.html">Filesystem API</a> for more information about valid path in Tizen.
+ Path for file with data for validating. Check <a href="filesystem">Filesystem API</a> for more information about valid path in Tizen.
                 </li>
           <li class="param">
 <span class="name">test</span><span class="optional"> [optional]</span>:
- Path for file with data for testing. Check <a href="filesystem.html">Filesystem API</a> for more information about valid path in Tizen.
+ Path for file with data for testing. Check <a href="filesystem">Filesystem API</a> for more information about valid path in Tizen.
                 </li>
         </ul>
 </div>
@@ -471,7 +471,7 @@ console.log("Type of optimizer: " + opt.type);
             </p>
 <div class="description">
             <p>
-See the <a href="https://docs.tizen.org/application/native/guides/machine-learning/machine-learning-training/#create-a-model-from-ini-formatted-file">Trainer Guide</a> to learn about configuration file structure.
+See the <a href="https://samsungtizenos.com/docs/application/native/guides/machine-learning/machine-learning-training#content-create-a-model-from-ini-formatted-file">Trainer Guide</a> to learn about configuration file structure.
             </p>
             <p>
 Even if the model is created from a file, switching, modifying, or setting a component is possible until you compile model with <a href="#Model::compile">Model::compile</a>.
@@ -482,7 +482,7 @@ Even if the model is created from a file, switching, modifying, or setting a com
 <ul>
           <li class="param">
 <span class="name">configPath</span><span class="optional"> [optional]</span>:
- Path to config file. Only INI formatted files <var>*.ini</var> are supported to create a model from a file. Check <a href="filesystem.html">Filesystem API</a> for more information about valid path in Tizen.
+ Path to config file. Only INI formatted files <var>*.ini</var> are supported to create a model from a file. Check <a href="filesystem">Filesystem API</a> for more information about valid path in Tizen.
                 </li>
         </ul>
 </div>
@@ -1945,7 +1945,7 @@ To guarantee that the ML application runs on a device with the ML Trainer featur
 <li class="feature">http://tizen.org/feature/machine_learning.training</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Trainer {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/package.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/package.html
@@ -26,7 +26,7 @@ for accessing only external storage using this API, a privilege <a href="http://
 for accessing internal and external storage using this API, privileges (<a href="http://tizen.org/privilege/mediastorage">http://tizen.org/privilege/mediastorage</a> and <a href="http://tizen.org/privilege/externalstorage">http://tizen.org/privilege/externalstorage</a>) must be provided.          </li>
         </ul>
         <p>
-For more information on the Package features, see <a href="/application/web/guides/app-management/packages">Package Guide</a>.
+For more information on the Package features, see <a href="https://samsungtizenos.com/docs/application/web/guides/app-management/packages">Package Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>
@@ -649,12 +649,12 @@ Calling this function has no effect if listener is not set.
 <div class="description">
             <p>
 The icon path of the package is the same as the icon path of the relevant application
-(see the <a href="application.html#ApplicationInformation::iconPath">iconPath</a> attribute of
-the <a href="application.html#ApplicationInformation">ApplicationInformation</a> interface).
+(see the <a href="application#ApplicationInformation::iconPath">iconPath</a> attribute of
+the <a href="application#ApplicationInformation">ApplicationInformation</a> interface).
             </p>
             <p>
 The relevant application is the one with the same
-<a href="application.html#ApplicationInformation::packageId">packageId</a> as the
+<a href="application#ApplicationInformation::packageId">packageId</a> as the
 <a href="#PackageInformation::id">id</a> of this package.
             </p>
            </div>

--- a/docs/application/web/api/10.1/device_api/tv/tizen/ppm.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/ppm.html
@@ -16,7 +16,7 @@
 <div class="description">
         <p>
 A Tizen Web application has privileges defined in <em>config.xml</em> file, but for legal purposes, in case of privacy-related privileges, there could be a need of asking user directly with proper pop-up.
-List of privacy-related privileges is available on <a href="/application/web/tutorials/sec-privileges">Security and API Privileges</a> page.
+List of privacy-related privileges is available on <a href="https://samsungtizenos.com/docs/application/web/reference/security-privileges">Security and API Privileges</a> page.
 Privacy Privilege API allows:
         </p>
         <ul>

--- a/docs/application/web/api/10.1/device_api/tv/tizen/push.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/push.html
@@ -30,7 +30,7 @@ Registering your application, if the application has not been registered yet    
 Getting notification data          </li>
         </ul>
         <p>
-For more information on the Push features, see <a href="/application/web/guides/messaging/push">Push Guide</a>.
+For more information on the Push features, see <a href="https://samsungtizenos.com/docs/application/web/guides/messaging/push">Push Guide</a>.
         </p>
         <p>
 To use Push features the application needs the permission to access the Tizen Push servers.
@@ -238,7 +238,7 @@ The <em>connect()</em> method must be called before calling the <em>register()</
  http://tizen.org/privilege/push
             </p>
 <p><span class="remark">Remark: </span>
- In order to use the push messaging service, see <a href="/application/web/guides/messaging/push">Push Guide</a>.
+ In order to use the push messaging service, see <a href="https://samsungtizenos.com/docs/application/web/guides/messaging/push">Push Guide</a>.
             </p>
 <div class="parameters">
 <p><span class="param">Parameters:</span></p>
@@ -595,7 +595,7 @@ The registration ID: 04a150867a50f48cb79695ac732cbe550b4a6782fffd23cbc14ba8dd5c5
 </dt>
 <dd>
 <div class="brief">
- Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the <a href="push.html#PushManager::connect">connect()</a> method will be invoked to retrieve the notifications.
+ Requests to get unread push notifications. As a consequence, the PushNotificationCallback which was set using the <a href="push#PushManager::connect">connect()</a> method will be invoked to retrieve the notifications.
             </div>
 <div class="synopsis"><pre class="signature prettyprint">void getUnreadNotifications();</pre></div>
 <p><span class="version">Since: </span>
@@ -678,7 +678,7 @@ tizen.push.connect(stateChangeCallback, notificationCallback);
 <div class="description">
             <p>
 If the application is launched by the push service, the push service is connected when the application is launched.
-Therefore, you can get push messages without calling the <a href="push.html#PushManager::connect">connect()</a> function.
+Therefore, you can get push messages without calling the <a href="push#PushManager::connect">connect()</a> function.
             </p>
             <p>
 If the application was not launched by the push service, this method returns <var>null</var>.
@@ -999,7 +999,7 @@ To guarantee that the push application runs on a device with the push feature, d
 <li class="feature">http://tizen.org/feature/network.push</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module Push {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/systeminfo.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/systeminfo.html
@@ -82,7 +82,7 @@ SIM              - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/
 WIFI_NETWORK     - tizen.systeminfo.getCapability(<em>"http://tizen.org/feature/network.wifi"</em>)          </li>
         </ul>
         <p>
-For more information on the System Information features, see <a href="/application/web/guides/device/system-information">System Information Guide</a>.
+For more information on the System Information features, see <a href="https://samsungtizenos.com/docs/application/web/guides/device/system-information">System Information Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>
@@ -750,7 +750,7 @@ console.log("The available memory size is " + tizen.systeminfo.getAvailableMemor
             </p>
 <div class="description">
             <p>
-See the available <a href="./systeminfo_capability_keys.html">device capability keys</a>.
+See the available <a href="https://samsungtizenos.com/docs/misc/feature">device capability keys</a>.
 The additional keys for the custom device capability are specified by OEMs and vendors.
             </p>
            </div>
@@ -1107,7 +1107,7 @@ NotSupportedError - If the given <var>property</var> is not supported (since Tiz
                 </li>
           <li class="param">
 <span class="name">options</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
- An object containing the various options for fetching the properties requested. See <a href="./systeminfo.html#::SystemInfo::SystemInfoOptions">details</a>.
+ An object containing the various options for fetching the properties requested. See <a href="./systeminfo#::SystemInfo::SystemInfoOptions">details</a>.
                 </li>
           <li class="param">
 <span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
@@ -2860,7 +2860,7 @@ If the source is "HDMI 2", the <em>number</em> is 2.
             <p>
 The <em>signal</em> attribute can be <var>null</var>. The <var>null</var> value means that information about signal could not be retrieved at the time of returning this object.
 If the value is <var>true</var>, it means that there is signal provided. The value set to <var>false</var> means, that there is no signal.
-By default getPropertyValue functions does not support this member, and will return object with <em>signal</em> value set to <var>null</var>, it is supported only by TVWindow module. To get data about signal use <a href="./tvwindow.html#TVWindowManager::getSource">tizen.tvwindow.getSource()</a> or <a href="./tvwindow.html#TVWindowManager::setSource">tizen.tvwindow.setSource()</a>.
+By default getPropertyValue functions does not support this member, and will return object with <em>signal</em> value set to <var>null</var>, it is supported only by TVWindow module. To get data about signal use <a href="./tvwindow#TVWindowManager::getSource">tizen.tvwindow.getSource()</a> or <a href="./tvwindow#TVWindowManager::setSource">tizen.tvwindow.setSource()</a>.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -3203,7 +3203,7 @@ To guarantee the running of the application on a device which supports Wi-Fi, de
 <li class="feature">http://tizen.org/feature/network.wifi</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module SystemInfo {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/time.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/time.html
@@ -36,7 +36,7 @@ This API can be used to get TZDate objects with full time zone support, convert 
 between timezones, retrieve available timezones.
         </p>
         <p>
-For more information on the Time features, see <a href="/application/web/guides/device/time">Time Guide</a>.
+For more information on the Time features, see <a href="https://samsungtizenos.com/docs/application/web/guides/device/time">Time Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/10.1/device_api/tv/tizen/tizen.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/tizen.html
@@ -25,7 +25,7 @@ Additionally, this API specifies the location in the ECMAScript hierarchy in whi
 the Tizen Web Device API is instantiated (<em>window.tizen</em>).
         </p>
         <p>
-For more information on the Tizen features, see <a href="/application/web/guides/index">Tizen Guide</a>.
+For more information on the Tizen features, see <a href="https://samsungtizenos.com/docs/application/web/guides/index">Tizen Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>
@@ -1413,7 +1413,7 @@ The attempt to set an attribute value may or may not raise WebAPIException synch
             </div>
 <div class="description">
             <p>
-For the possible values of this attribute, see <a href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a>.
+For the possible values of this attribute, see <a href="https://webidl.spec.whatwg.org/#idl-DOMException">DOMException</a>.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1442,7 +1442,7 @@ ServiceNotAvailableError - The requested service is not available.              
 VerificationError - An error occurred in authentication and so the requested method cannot be completed.              </li>
             </ul>
             <p>
-For other possible values of this attribute, see the values defined in <a href="https://heycam.github.io/webidl/#idl-DOMException-error-names">DOM error names</a>            </p>
+For other possible values of this attribute, see the values defined in <a href="https://webidl.spec.whatwg.org/#idl-DOMException">DOM error names</a>            </p>
            </div>
 <p><span class="version">Since: </span>
  2.0
@@ -1493,7 +1493,7 @@ This interface will be used by the APIs in order to return them in the error cal
             </div>
 <div class="description">
             <p>
-Possible values are defined in <a href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a>.
+Possible values are defined in <a href="https://webidl.spec.whatwg.org/#idl-DOMException">DOMException</a>.
             </p>
            </div>
 <p><span class="version">Since: </span>
@@ -1522,7 +1522,7 @@ ServiceNotAvailableError - The requested service is not available.              
 VerificationError - An error occurred in authentication and so the requested method cannot be completed.              </li>
             </ul>
             <p>
-For other possible values of this attribute, see the values defined in <a href="https://heycam.github.io/webidl/#idl-DOMException-error-names">DOM error names</a>            </p>
+For other possible values of this attribute, see the values defined in <a href="https://webidl.spec.whatwg.org/#idl-DOMException-error-names">DOM error names</a>            </p>
            </div>
 <p><span class="version">Since: </span>
  2.0

--- a/docs/application/web/api/10.1/device_api/tv/tizen/tvaudiocontrol.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/tvaudiocontrol.html
@@ -751,7 +751,7 @@ To guarantee the running of this application on a device with a TV audio control
 <li class="feature">http://tizen.org/feature/tv.audio</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module TVAudioControl {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/tvdisplaycontrol.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/tvdisplaycontrol.html
@@ -445,7 +445,7 @@ To guarantee the running of this application on a device with a TV display contr
 <li class="feature">http://tizen.org/feature/tv.display</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module TVDisplayControl {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/tvinfo.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/tvinfo.html
@@ -593,7 +593,7 @@ To guarantee the running of this application on a device with a caption and so o
 <li class="feature">http://tizen.org/feature/tv.information</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module TVInfo {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/tvinputdevice.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/tvinputdevice.html
@@ -604,7 +604,7 @@ To guarantee the running of this application on a device with a TV input device 
 <li class="feature">http://tizen.org/feature/tv.inputdevice</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module TVInputDevice {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/tvwindow.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/tvwindow.html
@@ -403,7 +403,7 @@ catch (error)
           <li class="param">
 <span class="name">successCallback</span>:
  The method to invoke when the intput source has been changed successfully.
-The result SystemInfoVideoSourceInfo object will have the <em>signal</em> property filled only when the window was shown using <a href="./tvwindow.html#TVWindowManager::show">show()</a> function.
+The result SystemInfoVideoSourceInfo object will have the <em>signal</em> property filled only when the window was shown using <a href="./tvwindow#TVWindowManager::show">show()</a> function.
                 </li>
           <li class="param">
 <span class="name">errorCallback</span><span class="optional"> [optional]</span><span class="optional"> [nullable]</span>:
@@ -518,7 +518,7 @@ setSource() is successfully done, source type: HDMI, source port number: 4, sign
 <p><span class="return">Return value:</span></p>
 <ul>
 <span class="return">SystemInfoVideoSourceInfo:</span>
- The information about the current video source. Returned object will have the <em>signal</em> property, stating whether there is signal provided or not on the source, this property value will be filled only when the window was shown using <a href="./tvwindow.html#TVWindowManager::show">show()</a> function.
+ The information about the current video source. Returned object will have the <em>signal</em> property, stating whether there is signal provided or not on the source, this property value will be filled only when the window was shown using <a href="./tvwindow#TVWindowManager::show">show()</a> function.
               </ul>
 </div>
 <div class="exceptionlist">
@@ -1367,7 +1367,7 @@ To guarantee the running of this application on a device with a TV picture-in-pi
 <li class="feature">http://tizen.org/feature/tv.pip</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module TVWindow {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/voicecontrol.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/voicecontrol.html
@@ -899,7 +899,7 @@ To guarantee that the voice control application runs on a device with microphone
 <li class="feature">http://tizen.org/feature/microphone</li>
 </div>
 <p></p>
-                    For more information, see <a href="/application/web/tutorials/app-filtering">Application Filtering.</a>
+                    For more information, see <a href="https://samsungtizenos.com/docs/application/web/reference/app-filtering">Application Filtering.</a>
 </div>
 <h2 id="full-webidl">4. Full WebIDL</h2>
 <pre class="webidl prettyprint">module VoiceControl {

--- a/docs/application/web/api/10.1/device_api/tv/tizen/websetting.html
+++ b/docs/application/web/api/10.1/device_api/tv/tizen/websetting.html
@@ -27,7 +27,7 @@ Set a custom user agent string of the web view in the Web application.          
 Note that all the settings using the Web Setting API is bound to your application; thus, no other applications are affected via the Web Setting API calls within your application.
         </p>
         <p>
-For more information on the Web Setting features, see <a href="/application/web/guides/device/web-view">Web Setting Guide</a>.
+For more information on the Web Setting features, see <a href="https://samsungtizenos.com/docs/application/web/guides/device/web-view">Web Setting Guide</a>.
         </p>
        </div>
 <p><span class="version">Since: </span>

--- a/docs/application/web/api/10.1/w3c_api/w3c_api_tv.html
+++ b/docs/application/web/api/10.1/w3c_api/w3c_api_tv.html
@@ -23,7 +23,7 @@
             </div>
                 <p>The APIs listed in this category are all part of the W3C specifications. Some of the APIs are stable while others are draft specifications. The draft APIs are subject to change as the W3C specification evolves.</p>
                 <p>The W3C APIs are categorized based on the functionality to make it easier to locate specific APIs.
-                 To learn the Tizen features provided by the W3C/HTML5 and  some supplementary APIs, see <a href="/application/web/guides/w3c/w3c-overview">Guide to W3C/HTML5 and Some Supplementary Features</a>.</p>
+                 To learn the Tizen features provided by the W3C/HTML5 and  some supplementary APIs, see <a href="https://samsungtizenos.com/docs/application/web/guides/w3c/w3c-overview">Guide to W3C/HTML5 and Some Supplementary Features</a>.</p>
             <div><h4 id="dom">Default Web Privilege</h4>
                 <p> Tizen WebApp have default privileges listed in below table.</p>
                 <table width="90%">
@@ -252,7 +252,7 @@
                                         <li><code>compassneedscalibration</code> event</li>
                                     </ul>
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/app-filtering">Required feature</a>:
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/app-filtering">Required feature</a>:
                                             <ul>
                                                 <li><code>http://tizen.org/feature/sensor.accelerometer</code></li>
                                                 <li><code>http://tizen.org/feature/sensor.gyroscope</code></li>
@@ -291,7 +291,7 @@
                                     the screen orientation state, to be informed when this state changes
                                     and to be able to lock the screen orientation to a specific state</br>
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/app-filtering">Required feature</a>:
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/app-filtering">Required feature</a>:
                                             <ul>
                                                 <li><code>http://tizen.org/feature/sensor.accelerometer</code></li>
                                             </ul>
@@ -377,9 +377,9 @@
                                         <li>method <code>getUserMedia() -> webkitGetUserMedia()</code></li>
                                     </ul>
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/mediacapture</code></li>
-                                        <li><a href="/application/web/tutorials/app-filtering">Required feature</a>:
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/mediacapture</code></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/app-filtering">Required feature</a>:
                                             <ul>
                                                 <li><code>http://tizen.org/feature/microphone</code></li>
                                             </ul>
@@ -422,9 +422,9 @@
                                     <!--
                                     <div>SpeechRecognition</div>
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/internet</code></li>
-                                        <li><a href="/application/web/tutorials/app-filtering">Required feature</a>:
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/internet</code></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/app-filtering">Required feature</a>:
                                             <ul>
                                                 <li><code>http://tizen.org/feature/speech.recognition</code></li>
                                                 <li><code>http://tizen.org/feature/network.internet</code></li>
@@ -435,7 +435,7 @@
                                     -->
                                     <div>SpeechSynthesis</div>
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/app-filtering">Required feature</a>:
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/app-filtering">Required feature</a>:
                                             <ul>
                                                 <li><code>http://tizen.org/feature/speech.synthesis</code></li>
                                             </ul>
@@ -457,10 +457,10 @@
                                 <td id="websocket" name="websocket"><a href="http://www.w3.org/TR/2012/CR-websockets-20120920">The WebSocket API</a></td>
                                 <td>Offers bi-directional network connectivity.</br>
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/internet</code></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/internet</code></li>
                                         <!--
-                                        <li><a href="/application/web/tutorials/app-filtering">Required feature</a>:
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/app-filtering">Required feature</a>:
                                             <ul>
                                                 <li><code>http://tizen.org/feature/network.internet</code></li>
                                             </ul>
@@ -474,10 +474,10 @@
                                 <td id="httpreq" name="httpreq"><a href="http://www.w3.org/TR/2014/WD-XMLHttpRequest-20140130/">XMLHttpRequest Level 1</a></td>
                                 <td>Enhancements on XHR, including binary file uploading, formdata submission, transfer progress, etc.</br>
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/internet</code></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/internet</code></li>
                                         <!--
-                                        <li><a href="/application/web/tutorials/app-filtering">Required feature</a>:
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/app-filtering">Required feature</a>:
                                             <ul>
                                                 <li><code>http://tizen.org/feature/network.internet</code></li>
                                             </ul>
@@ -491,10 +491,10 @@
                                 <td id="serversent" name="serversent"><a href="http://www.w3.org/TR/2015/REC-eventsource-20150203/">Server-Sent Events</a></td>
                                 <td>The API allows triggering DOM events based on push notifications(via HTTP and other protocols).</br>
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/internet</code></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/internet</code></li>
                                         <!--
-                                        <li><a href="/application/web/tutorials/app-filtering">Required feature</a>:
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/app-filtering">Required feature</a>:
                                             <ul>
                                                 <li><code>http://tizen.org/feature/network.internet</code></li>
                                             </ul>
@@ -522,10 +522,10 @@
                                         <li><code>getKey</code> of <code>PushSubscription</code> interface</li>
                                     </ul>
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/push</code></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/push</code></li>
                                         <!--
-                                        <li><a href="/application/web/tutorials/app-filtering">Required feature</a>:
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/app-filtering">Required feature</a>:
                                             <ul>
                                                 <li><code>http://tizen.org/feature/network.internet</code></li>
                                             </ul>
@@ -556,8 +556,8 @@
                                 <td id="file" name="file"><a href="http://www.w3.org/TR/2015/WD-FileAPI-20150421/">File API</a></td>
                                 <td>Reads files from local device file system.<br>
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/unlimitedstorage</code></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/unlimitedstorage</code></li>
                                     </ul>
                                 </td>
                                 <td align="center">WD</td>
@@ -567,8 +567,8 @@
                                 <td id="directory" name="directory"><a href="http://www.w3.org/TR/2011/WD-file-system-api-20110419">File API: Directories and System</a></td>
                                 <td>API that allows accessing the device file system.</br>
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/unlimitedstorage</code></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/unlimitedstorage</code></li>
                                     </ul>
                                 </td>
                                 <td align="center"><strong>Deprecated Since 3.0</strong></td>
@@ -583,8 +583,8 @@
                                         <li><code>saveAs</code> of <code>Window</code> interface</li>
                                     </ul>
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/unlimitedstorage</code></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/unlimitedstorage</code></li>
                                     </ul>
                                 </td>
                                 <td align="center"><strong>Deprecated Since 3.0</strong></td>
@@ -594,10 +594,10 @@
                                 <td id="cache" name="cache"><a href="http://www.w3.org/TR/2014/REC-html5-20141028/browsers.html#appcache">HTML5 Application caches</a></td>
                                 <td>HTML5 application cache and custom handlers.</br>
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/internet</code></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/internet</code></li>
                                         <!--
-                                        <li><a href="/application/web/tutorials/app-filtering">Required feature</a>:
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/app-filtering">Required feature</a>:
                                             <ul>
                                                 <li><code>http://tizen.org/feature/network.internet</code></li>
                                             </ul>
@@ -611,8 +611,8 @@
                                 <td id="database" name="database"><a href="http://www.w3.org/TR/2015/REC-IndexedDB-20150108/">Indexed Database API</a></td>
                                 <td>A database of values and hierarchical objects that integrates naturally with JavaScript, and can be queried and updated very efficiently.<br>
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/unlimitedstorage</code></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/unlimitedstorage</code></li>
                                     </ul>
                                 </td>
                                 <td align="center">REC</td>
@@ -622,8 +622,8 @@
                                 <td id="sql" name="sql"><a href="http://www.w3.org/TR/2010/NOTE-webdatabase-20101118/">Web SQL Database</a></td>
                                 <td>API for storing data in databases that can be queried using a variant of SQL.</br>
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br>                              </li>
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/unlimitedstorage</code></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br>                              </li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/unlimitedstorage</code></li>
                                     </ul>
                                 </td>
                                 <td align="center"><strong>Deprecated Since 3.0</strong></td>
@@ -652,10 +652,10 @@
                                 <td id="cross" name="cross"><a href="http://www.w3.org/TR/2014/REC-cors-20140116/">Cross-Origin Resource Sharing</a></td>
                                 <td>Sharing of resources across different domains.</br>
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/internet</code></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/internet</code></li>
                                         <!--
-                                        <li><a href="/application/web/tutorials/app-filtering">Required feature</a>:
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/app-filtering">Required feature</a>:
                                             <ul>
                                                 <li><code>http://tizen.org/feature/network.internet</code></li>
                                             </ul>
@@ -726,8 +726,8 @@
                                 <td id="webnoti" name="webnoti"><a href="http://www.w3.org/TR/2015/REC-notifications-20151022/">Web Notifications</a></td>
                                 <td>To define an API for displaying simple notifications to the user.<br>
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/notification</code></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/notification</code></li>
                                     </ul>
                                 </td>
                                 <td align="center">REC</td>
@@ -790,9 +790,9 @@
                                 <td id="geo"><a href="http://www.w3.org/TR/2013/REC-geolocation-API-20131024/">Geolocation API Specification</a></td>
                                 <td>Provides scripted access to geographical location information associated with the hosting device.
                                     <ul class="xmlconfig">
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
-                                        <li><a href="/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/location</code></li>
-                                        <li><a href="/application/web/tutorials/app-filtering">Required feature</a>: <code>http://tizen.org/feature/location.gps</code></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege level</a>: Public</br></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/location</code></li>
+                                        <li><a href="https://samsungtizenos.com/docs/application/web/tutorials/app-filtering">Required feature</a>: <code>http://tizen.org/feature/location.gps</code></li>
                                     </ul>
                                 </td>
                                 <td align="center">REC</td>
@@ -858,8 +858,8 @@
                                 <td>Provides a way for an element to be displayed in full screen mode programmatically. The method and attribute currently not supported are:
                                     <li><code>requestFullScreenWithKeys</code> of element</li>
                                     <li><code>allowFullScreen</code> of <code>iframe</code> element</li>
-                                <p><a href="/application/web/tutorials/sec-privileges">Privilege Level</a>: Public</br>
-                                <a href="/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/fullscreen</code>  </p>
+                                <p><a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege Level</a>: Public</br>
+                                <a href="https://samsungtizenos.com/docs/application/web/tutorials/sec-privileges">Privilege</a>: <code>http://tizen.org/privilege/fullscreen</code>  </p>
                                 </td>
                                 </tr>
                             <tr>


### PR DESCRIPTION
* Convert internal relative links (/application/web/...) to absolute URLs (https://samsungtizenos.com/docs/...)
* remove .html extensions from same-file anchor links across all API documentation

Analogous change for 10.1 as #2398 was for other versions.