### PR TITLE
Restore the neutral example URL in code samples, and record which areas are retired

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,35 @@ refresh that URL.
 feedback is applied. On a cadence, `master` is promoted to the `live` branch and your
 contribution appears at <https://samsungtizenos.com/docs>.
 
+## Retired areas
+
+Some areas of this repository are being retired on purpose. They are listed here so that a
+future reader can tell a deliberate removal from an accident, and so that removed pages are
+not reintroduced by a later contribution.
+
+**Tizen Studio.** The Eclipse-based Tizen Studio is no longer the documented development
+environment. Application development is documented for Visual Studio Code and Visual
+Studio instead, and the entry points are
+[`application/web/get-started/index.md`](docs/application/web/get-started/index.md) and
+[`application/native/get-started/index.md`](docs/application/native/get-started/index.md),
+which ask the reader to choose an IDE. Removed under this decision:
+
+- Tool guides under `docs/sdk-tools/baseline-sdk/` (`baseline-sdk` is Tizen Studio).
+- The Tizen Studio based Get Started walkthroughs under
+  `docs/application/{web,native}/get-started/` and their screenshots.
+- `docs/platform/reference/tizen-studio/`, the guides for building, extending and
+  contributing to Tizen Studio itself. Pull request #2391 had said this directory was left
+  untouched deliberately; #2397 removed it, because contributor documentation for a retired
+  product is retired with it. This note records that reversal, which the commit message of
+  #2397 did not.
+
+Do not add new pages to these areas. If a removed page still has inbound links from
+elsewhere, prefer a short stub pointing at the successor over leaving the link broken.
+
+**When you retire something yourself**, put the reason in the commit message body, not only
+in the pull request description. Pull request descriptions live on GitHub; the repository
+has to be able to explain itself on its own.
+
 ## File names
 
 - Only lowercase letters, numbers, and hyphens. No spaces or punctuation; use hyphens to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,6 @@ Studio instead, and the entry points are
 [`application/native/get-started/index.md`](docs/application/native/get-started/index.md),
 which ask the reader to choose an IDE. Removed under this decision:
 
-- Tool guides under `docs/sdk-tools/baseline-sdk/` (`baseline-sdk` is Tizen Studio).
 - The Tizen Studio based Get Started walkthroughs under
   `docs/application/{web,native}/get-started/` and their screenshots.
 - `docs/platform/reference/tizen-studio/`, the guides for building, extending and
@@ -100,8 +99,15 @@ which ask the reader to choose an IDE. Removed under this decision:
   product is retired with it. This note records that reversal, which the commit message of
   #2397 did not.
 
-Do not add new pages to these areas. If a removed page still has inbound links from
-elsewhere, prefer a short stub pointing at the successor over leaving the link broken.
+`docs/sdk-tools/baseline-sdk/` (Tizen Studio's own tool guides) is not on this list: #2397
+removed a handful of its pages, but most of it — 114 Markdown files, still linked 116 times
+from `docs/sdk-tools/toc_all.md` as of this writing — remains published. Retiring the rest
+is a separate, larger change; do not add new pages to it in the meantime, and do not read
+its continued presence here as a sign that the decision above does not apply to it.
+
+Do not add new pages to the areas already removed above. If a removed page still has
+inbound links from elsewhere, prefer a short stub pointing at the successor over leaving
+the link broken.
 
 **When you retire something yourself**, put the reason in the commit message body, not only
 in the pull request description. Pull request descriptions live on GitHub; the repository

--- a/docs/application/dotnet/guides/user-interface/nui/webview.md
+++ b/docs/application/dotnet/guides/user-interface/nui/webview.md
@@ -14,7 +14,7 @@ You can load the Web content as follows:
     var webview = new WebView()
     {
         Size = new Size(1280, 960),
-        Url = "https://samsungtizenos.com/docs"
+        Url = "https://docs.tizen.org"
     };
 
     NUIApplication.GetDefaultWindow().Add(webview);
@@ -41,7 +41,7 @@ You can load the Web content as follows:
         Size = new Size(1280, 960),
     };
 
-    webview.LoadUrl("https://samsungtizenos.com/docs");
+    webview.LoadUrl("https://docs.tizen.org");
     NUIApplication.GetDefaultWindow().Add(webview);
     ```
 
@@ -108,7 +108,7 @@ NUI `WebView` provides several APIs to control JavaScript in a currently loaded 
         webview.EvaluateJavaScript("document.body.style.backgroundColor = 'yellow';");
     };
 
-    webview.LoadUrl("https://samsungtizenos.com/docs");
+    webview.LoadUrl("https://docs.tizen.org");
 
     NUIApplication.GetDefaultWindow().Add(webview);
     ```
@@ -131,7 +131,7 @@ NUI `WebView` provides several APIs to control JavaScript in a currently loaded 
 
     mWebView.AddJavaScriptMessageHandler("InjectedObject", InjectedMethod);
 
-    webview.LoadUrl("https://samsungtizenos.com/docs");
+    webview.LoadUrl("https://docs.tizen.org");
 
     webview.PageLoadFinished += (s, e) =>
     {

--- a/docs/application/native/guides/app-management/tizen-action-2-0.md
+++ b/docs/application/native/guides/app-management/tizen-action-2-0.md
@@ -208,7 +208,7 @@ sdb shell action-tool execute '{
     "appid": "org.example.tidlcustomactionsample",
     "arguments": {
       "Id": "bookmark-1",
-      "Url": "https://samsungtizenos.com/docs",
+      "Url": "https://docs.tizen.org",
       "Title": "Tizen Documentation"
     }
   }


### PR DESCRIPTION
## Summary

Two unrelated hygiene fixes that both came out of auditing the recent documentation removals.

**Restore the neutral example URL in five code samples.** #2388 replaced the publishing host across the repository, and the replacement also landed inside strings that are not documentation links:

```csharp
webview.LoadUrl("https://samsungtizenos.com/docs");   // ×3, nui/webview.md
Url = "https://samsungtizenos.com/docs"               //     nui/webview.md
"Url": "https://samsungtizenos.com/docs",             //     tizen-action-2-0.md
```

These exist to give the WebView and the Tizen Action sample *some* page to load. The link checker never resolves them, and a reader who copies the sample ends up with one deployment's hostname compiled into their application. Restored to `https://docs.tizen.org`, the value recovered from `a608f0305^`. Documentation links to `samsungtizenos.com` are untouched — this is limited to strings inside code blocks.

**Write down which areas are retired.** #2397 deleted 49 Markdown files with a two-line commit message; the reasoning lives only in its pull request description. Reviewing those deletions file by file, all of them follow one product decision — the Eclipse-based Tizen Studio is no longer the documented development environment, and `get-started/index.md` now asks the reader to choose between Visual Studio Code and Visual Studio. That is worth stating once, in the file contributors are told to read first, so a later contribution does not reintroduce a page that was removed on purpose.

The new `CONTRIBUTING.md` section also records a reversal that is otherwise invisible: #2391 said `docs/platform/reference/tizen-studio/` was left untouched deliberately, and #2397 removed it the next day without saying so. It belongs to the same decision — contributor documentation for a retired product is retired with it — but the change of mind should be legible.

Finally it asks that future retirements put the reason in the commit message body. Pull request descriptions live on GitHub; the repository has to be able to explain itself on its own.

## Validation

- `python3 tools/check_docs.py --changed-only --base origin/master` — 0 errors, 0 warnings
- `python3 tools/check_docs.py --all` — 0 errors, the same 3 baselined route warnings as `master`
- `python3 -m pytest -q tools/tests` — 129 passed, 2 deselected
- `git diff --check`
