### PR TITLE
List LibTeec in the TV Web API navigation for every version that has the page

### DIFF
--- a/docs/application/web/api/5.5/device_api/tv/index.xml
+++ b/docs/application/web/api/5.5/device_api/tv/index.xml
@@ -36,6 +36,7 @@
 					</topic>
 					<topic href="5.5/device_api/tv/index.html#Security" label="Security">
 						<topic href="5.5/device_api/tv/tizen/keymanager.html" label="Keymanager"/>
+						<topic href="5.5/device_api/tv/tizen/libteec.html" label="LibTeec"/>
 					</topic>
 					<topic href="5.5/device_api/tv/index.html#System" label="System">
 						<topic href="5.5/device_api/tv/tizen/systeminfo.html" label="System Information"/>

--- a/docs/application/web/api/6.0/device_api/tv/index.xml
+++ b/docs/application/web/api/6.0/device_api/tv/index.xml
@@ -38,6 +38,7 @@
 					</topic>
 					<topic href="6.0/device_api/tv/index.html#Security" label="Security">
 						<topic href="6.0/device_api/tv/tizen/keymanager.html" label="Keymanager"/>
+						<topic href="6.0/device_api/tv/tizen/libteec.html" label="LibTeec"/>
 					</topic>
 					<topic href="6.0/device_api/tv/index.html#System" label="System">
 						<topic href="6.0/device_api/tv/tizen/systeminfo.html" label="System Information"/>

--- a/docs/application/web/api/6.5/device_api/tv/index.xml
+++ b/docs/application/web/api/6.5/device_api/tv/index.xml
@@ -72,6 +72,9 @@
 						<topic href="6.5/device_api/tv/tizen/cordova/media.html" label="Media"/>
 						<topic href="6.5/device_api/tv/tizen/cordova/networkInformation.html" label="Network Information"/>
 					</topic>
+					<topic href="6.5/device_api/tv/index.html#Deprecated API" label="Deprecated API">
+						<topic href="6.5/device_api/tv/tizen/libteec.html" label="LibTeec" deprecatedSince="6.5"/>
+					</topic>
 				</topic>
 			</topic>
 			<topic href="6.5/w3c_api/w3c_api_tv.html" label="W3C/HTML5 and Supplementaries API Reference">

--- a/docs/application/web/api/toc.xml
+++ b/docs/application/web/api/toc.xml
@@ -79,6 +79,9 @@
 							<topic href="html/device_api/tv/tizen/cordova/media.html" label="Media" ></topic>
 							<topic href="html/device_api/tv/tizen/cordova/networkInformation.html" label="Network Information" ></topic>
 						</topic>
+						<topic href="html/device_api/tv/index.html#Deprecated API" label="Deprecated API">
+							<topic href="html/device_api/tv/tizen/libteec.html" label="LibTeec"/>
+						</topic>
 					</topic>
 				</topic>
 
@@ -248,6 +251,9 @@
 							<topic href="html/device_api/tv/tizen/cordova/globalization.html" label="Globalization" ></topic>
 							<topic href="html/device_api/tv/tizen/cordova/media.html" label="Media" ></topic>
 							<topic href="html/device_api/tv/tizen/cordova/networkInformation.html" label="Network Information" ></topic>
+						</topic>
+						<topic href="html/device_api/tv/index.html#Deprecated API" label="Deprecated API">
+							<topic href="html/device_api/tv/tizen/libteec.html" label="LibTeec"/>
 						</topic>
 					</topic>
 				</topic>
@@ -419,6 +425,9 @@
 							<topic href="html/device_api/tv/tizen/cordova/media.html" label="Media" ></topic>
 							<topic href="html/device_api/tv/tizen/cordova/networkInformation.html" label="Network Information" ></topic>
 						</topic>
+						<topic href="html/device_api/tv/index.html#Deprecated API" label="Deprecated API">
+							<topic href="html/device_api/tv/tizen/libteec.html" label="LibTeec"/>
+						</topic>
 					</topic>
 				</topic>
 
@@ -589,6 +598,9 @@
 							<topic href="html/device_api/tv/tizen/cordova/media.html" label="Media" ></topic>
 							<topic href="html/device_api/tv/tizen/cordova/networkInformation.html" label="Network Information" ></topic>
 						</topic>
+						<topic href="html/device_api/tv/index.html#Deprecated API" label="Deprecated API">
+							<topic href="html/device_api/tv/tizen/libteec.html" label="LibTeec"/>
+						</topic>
 					</topic>
 				</topic>
 
@@ -758,6 +770,9 @@
 							<topic href="html/device_api/tv/tizen/cordova/globalization.html" label="Globalization" ></topic>
 							<topic href="html/device_api/tv/tizen/cordova/media.html" label="Media" ></topic>
 							<topic href="html/device_api/tv/tizen/cordova/networkInformation.html" label="Network Information" ></topic>
+						</topic>
+						<topic href="html/device_api/tv/index.html#Deprecated API" label="Deprecated API">
+							<topic href="html/device_api/tv/tizen/libteec.html" label="LibTeec"/>
 						</topic>
 					</topic>
 				</topic>


### PR DESCRIPTION
## Summary

`docs/application/web/api/*/device_api/tv/tizen/libteec.html` exists for TV from 4.0 through 10.0, and `index.html` lists it in all of them, but the two navigation files disagreed about which versions have it:

| | 4.0 | 5.0 | 5.5 | 6.0 | 6.5 | 7.0 | 8.0 | 9.0 | 10.0 |
|---|---|---|---|---|---|---|---|---|---|
| `index.xml` | — | — | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ |
| `toc.xml` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |

(4.0 and 5.0 have no `device_api/tv/index.xml`.)

No version had the page in both files, and 6.5 had it in neither. `reviewguide/review_points_web_api.md` requires `index.html`, `index.xml` and `toc.xml` to be updated together; this closes the gap in the two that were behind.

## Which section it goes in depends on the version

LibTeec was deprecated in 6.5, and `index.html` already reflects that correctly:

| version | section in `index.html` |
|---|---|
| 5.5, 6.0 | `<h4 id="Security">`, listed after Keymanager |
| 6.5 – 10.0 | `<h4 id="Deprecated API">` |

The navigation now follows the page it describes:

- **5.5, 6.0** — added under the existing `Security` topic, after `Keymanager`, matching the row order in `index.html`, with no `deprecatedSince` attribute. The API was not deprecated in those releases.
- **6.5 – 10.0** — added under a `Deprecated API` topic with `deprecatedSince="6.5"`, identical in shape to the one 7.0 already had in `index.xml`.

Putting a `Deprecated API` node into 5.5 or 6.0 would have been the smaller edit, but it would claim the API was deprecated in a release that shipped before the deprecation, and its `href` would point at `index.html#Deprecated API` — an anchor that does not exist in those two files.

## Validation

- All six touched XML files parse as well-formed
- `python3 tools/check_docs.py --changed-only --base origin/master` — 0 errors, 0 warnings
- `python3 tools/check_docs.py --all` — 0 errors, the same 3 baselined route warnings as `master`
- `git diff --check`
