### PR TITLE
Point the DataControl cross-reference at a native API page that exists

### DIFF
--- a/docs/application/web/api/10.0/device_api/tv/tizen/datacontrol.html
+++ b/docs/application/web/api/10.0/device_api/tv/tizen/datacontrol.html
@@ -1614,7 +1614,7 @@ catch (err)
                 </li>
           <li class="param">
 <span class="name">data</span>:
- Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/mobile/3.0/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
+ Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/common/latest/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
                 </li>
         </ul>
 </div>

--- a/docs/application/web/api/4.0/device_api/tv/tizen/datacontrol.html
+++ b/docs/application/web/api/4.0/device_api/tv/tizen/datacontrol.html
@@ -1614,7 +1614,7 @@ catch (err)
                 </li>
           <li class="param">
 <span class="name">data</span>:
- Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/mobile/3.0/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
+ Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/common/latest/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
                 </li>
         </ul>
 </div>

--- a/docs/application/web/api/5.0/device_api/tv/tizen/datacontrol.html
+++ b/docs/application/web/api/5.0/device_api/tv/tizen/datacontrol.html
@@ -1614,7 +1614,7 @@ catch (err)
                 </li>
           <li class="param">
 <span class="name">data</span>:
- Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/mobile/3.0/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
+ Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/common/latest/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
                 </li>
         </ul>
 </div>

--- a/docs/application/web/api/5.5/device_api/tv/tizen/datacontrol.html
+++ b/docs/application/web/api/5.5/device_api/tv/tizen/datacontrol.html
@@ -1614,7 +1614,7 @@ catch (err)
                 </li>
           <li class="param">
 <span class="name">data</span>:
- Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/mobile/3.0/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
+ Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/common/latest/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
                 </li>
         </ul>
 </div>

--- a/docs/application/web/api/6.0/device_api/tv/tizen/datacontrol.html
+++ b/docs/application/web/api/6.0/device_api/tv/tizen/datacontrol.html
@@ -1614,7 +1614,7 @@ catch (err)
                 </li>
           <li class="param">
 <span class="name">data</span>:
- Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/mobile/3.0/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
+ Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/common/latest/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
                 </li>
         </ul>
 </div>

--- a/docs/application/web/api/6.5/device_api/tv/tizen/datacontrol.html
+++ b/docs/application/web/api/6.5/device_api/tv/tizen/datacontrol.html
@@ -1614,7 +1614,7 @@ catch (err)
                 </li>
           <li class="param">
 <span class="name">data</span>:
- Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/mobile/3.0/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
+ Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/common/latest/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
                 </li>
         </ul>
 </div>

--- a/docs/application/web/api/7.0/device_api/tv/tizen/datacontrol.html
+++ b/docs/application/web/api/7.0/device_api/tv/tizen/datacontrol.html
@@ -1614,7 +1614,7 @@ catch (err)
                 </li>
           <li class="param">
 <span class="name">data</span>:
- Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/mobile/3.0/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
+ Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/common/latest/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
                 </li>
         </ul>
 </div>

--- a/docs/application/web/api/8.0/device_api/tv/tizen/datacontrol.html
+++ b/docs/application/web/api/8.0/device_api/tv/tizen/datacontrol.html
@@ -1614,7 +1614,7 @@ catch (err)
                 </li>
           <li class="param">
 <span class="name">data</span>:
- Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/mobile/3.0/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
+ Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/common/latest/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
                 </li>
         </ul>
 </div>

--- a/docs/application/web/api/9.0/device_api/tv/tizen/datacontrol.html
+++ b/docs/application/web/api/9.0/device_api/tv/tizen/datacontrol.html
@@ -1614,7 +1614,7 @@ catch (err)
                 </li>
           <li class="param">
 <span class="name">data</span>:
- Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/mobile/3.0/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
+ Object with information of columns and values of changed data. Actual data to be returned depends on data returned by data control provider application. Please refer to <a href="/application/native/api/common/latest/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a> documentation.
                 </li>
         </ul>
 </div>


### PR DESCRIPTION
## Summary

Nine copies of the TV `datacontrol.html` reference page — one per Web API version from 4.0 to 10.0 — link into the native API reference like this:

```html
<a href="/application/native/api/mobile/3.0/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html#ga319b58f16c7a2b007c64f218129e9042">native</a>
```

`docs/application/native/api/mobile/` no longer exists. The retired mobile and wearable profiles were removed in #2394, and 3.0 predates even that: the native API in this repository now ships `common/`, `iot-headed/` and `iot-headless/`, with `common/` covering 8.0, 9.0 and 10.0 plus the committed `latest` symlink. So all nine links have been dead, in every published version of the page.

Repointed at `common/latest/`. The link is a "for more detail, see the native side" cross-reference rather than a version-matched citation, and no `common/` directory goes back far enough to match a 4.0 or 5.0 page anyway, so the current reference is the useful target.

Confirmed that `common/latest/group__CAPI__DATA__CONTROL__PROVIDER__MODULE.html` exists and still carries the `ga319b58f16c7a2b007c64f218129e9042` anchor, so the deep link lands on the same function it always meant to.

## Validation

- `grep -r 'native/api/mobile/3.0' docs/` now returns nothing
- `python3 tools/check_docs.py --changed-only --base origin/master` — 0 errors, 0 warnings
- `python3 tools/check_docs.py --all` — 0 errors, the same 3 baselined route warnings as `master`
- `git diff --check`
