### PR TITLE
Retarget three links away from a page the site does not publish

### DIFF
--- a/docs/application/web/guides/applications/service-app.md
+++ b/docs/application/web/guides/applications/service-app.md
@@ -89,7 +89,7 @@ To manage Web service callbacks, follow these steps:
 
 A Web application package can contain one Web application and several Web services. Each application in the Web application package shares the same package ID and has a unique application ID. In the following example, you can use the `<tizen:application>` element to define information for the Web application. The `<tizen:service>` element is used to define information about the Web service. The Web application and the Web service have the same package ID and different application IDs.
 
-The Web application package file is installed, updated, and uninstalled as a single [package](../../index.md#package).
+The Web application package file is installed, updated, and uninstalled as a single [package](../development/index.md#package).
 
 To package the Web service with a Web application, define the service in the `config.xml` file. The `<tizen:service>` element allows you to define the characteristics of the Web service. For example, you can specify the name, type and starting JavaScipt file of the Web service:
 

--- a/docs/sdk-tools/baseline-sdk/web-tools/project-wizard.md
+++ b/docs/sdk-tools/baseline-sdk/web-tools/project-wizard.md
@@ -46,7 +46,7 @@ To move to the next step, select the profile and version, and click **Next**.
 <a name="app_type"></a>
 ## Application Type
 
-You can select the Web or native application type for your project. For more information, see [Web Application](../../../application/web/index.md) and [Native Application](../../../application/native/index.md).
+You can select the Web or native application type for your project. For more information, see [Web Application](../../../application/web/overview/overview.md) and [Native Application](../../../application/native/overview/overview.md).
 
 Based on the selected application type, a list of templates is shown in the template selection step.
 


### PR DESCRIPTION
## Summary

`docs/application/web/index.md` and `docs/application/native/index.md` resolve inside this repository, so the validator is satisfied, but neither is published:

```
/docs/application/web/index                     404
/docs/application/native/index                  404
/docs/application/web/guides/development/index  200
/docs/application/web/overview/overview         301 -> .../overview  200
```

The reason is that their only TOC entry is in `docs/application/toc_all.md` (line 293), and the publishing pipeline does not read that file — it is a structure document and the input for the orphan check, exactly as `CONTRIBUTING.md` warns under "Process for contributing". **A link whose target exists in the checkout but not on the site is invisible to `check_docs.py`**; it has to be found by asking the site.

Three links repointed at published pages:

**`web/guides/applications/service-app.md`** — "installed, updated, and uninstalled as a single [package]" pointed at `../../index.md#package`, the "Application package manager" section of the unpublished Web landing page. It now points at `../development/index.md#package`, whose heading is "Package the application" — the packaging step this sentence is describing, on a page that is published. `web/index.md` already links to that same anchor for the same purpose.

**`sdk-tools/baseline-sdk/web-tools/project-wizard.md`** — "see [Web Application] and [Native Application]" pointed at both unpublished landing pages. They now point at `application/{web,native}/overview/overview.md`.

## Not fixed here

That `docs/application/{web,native}/index.md` are substantial pages reachable from no published TOC is a separate problem. Either they should be registered in a TOC the pipeline reads, or reduced to stubs — worth its own issue rather than being folded into a link fix.

## Validation

- `python3 tools/check_docs.py --changed-only --base origin/master` — 0 errors, 0 warnings
- `python3 tools/check_docs.py --all` — 0 errors, the same 3 baselined route warnings as `master`
- Target URLs checked against a local instance of the published site
