### PR TITLE
fix(vstools): point the hot reload demo videos at the files that exist

### DIFF
--- a/docs/sdk-tools/vstools/getting-started/configuring-hotreload.md
+++ b/docs/sdk-tools/vstools/getting-started/configuring-hotreload.md
@@ -34,7 +34,7 @@ This example demonstrates using Hot Reload in a **Tizen ElmSharp-based UI** appl
     - A callback method is assigned to a button click event.
     - The app is launched in debug mode on a target device.
     - The callback method is modified and saved (Ctrl+S), applying Hot Reload without restarting.
-[![Demo Video: Hot reload without breakpoint](../tools/media/hotreload_without_bp.png)](/docs/application/vstools/media/Hotreload_Without_Breakpoint.mp4 "Reload example video without breakpoint")
+[![Demo Video: Hot reload without breakpoint](../tools/media/hotreload_without_bp.png)](../tools/media/Hotreload_Without_Breakpoint.mp4 "Reload example video without breakpoint")
 <br>
 
 2. **Tizen .NET Hot Reload With Breakpoint**<br>
@@ -42,4 +42,4 @@ This example demonstrates Hot Reload usage with a breakpoint in a **Tizen ElmSha
     - A breakpoint is set in the main method on a static method call.
     - The app is launched in debug mode on a target device.
     - The method is modified and saved (Ctrl+S), applying Hot Reload while debugging.
-[![Demo Video: Hot reload with breakpoint](../tools/media/hotreload_with_bp.png)](/docs/application/vstools/media/Hotreload_With_Breakpoint.mp4 "Reload example video with breakpoint")
+[![Demo Video: Hot reload with breakpoint](../tools/media/hotreload_with_bp.png)](../tools/media/Hotreload_With_Breakpoint.mp4 "Reload example video with breakpoint")


### PR DESCRIPTION
## Problem

Both demo video links on **Configuring hot reload** point at `/docs/application/vstools/media/` — a site-absolute path whose directory does not exist in this repository. Both 404 on the published site.

`docs/sdk-tools/vstools/getting-started/configuring-hotreload.md:37,45`

```
](/docs/application/vstools/media/Hotreload_Without_Breakpoint.mp4 "…")
](/docs/application/vstools/media/Hotreload_With_Breakpoint.mp4 "…")
```

## The videos are not missing — the path is wrong

They are in `docs/sdk-tools/vstools/tools/media/`:

```
docs/sdk-tools/vstools/tools/media/Hotreload_With_Breakpoint.mp4
docs/sdk-tools/vstools/tools/media/Hotreload_Without_Breakpoint.mp4
```

That is exactly where the **thumbnail images on the very same two lines** already point (`../tools/media/hotreload_with_bp.png`, `../tools/media/hotreload_without_bp.png`), and it is how the sibling page links them:

`docs/sdk-tools/vstools/tools/dotnet-hotreload.md:56`
```markdown
[![Hotreload Example Video](media/hotreload_with_bp.png)](media/Hotreload_With_Breakpoint.mp4 "…")
```

## Change

Make the link target match the image source beside it:

```diff
-](/docs/application/vstools/media/Hotreload_Without_Breakpoint.mp4 "…")
+](../tools/media/Hotreload_Without_Breakpoint.mp4 "…")
```

Two lines, one file.

## Scope

These were the **last two occurrences** of that dead prefix in the repository:

```console
$ grep -rn '/docs/application/vstools/media/' docs --include=*.md
docs/sdk-tools/vstools/getting-started/configuring-hotreload.md:37: …
docs/sdk-tools/vstools/getting-started/configuring-hotreload.md:45: …
$ ls docs/application/vstools
ls: cannot access 'docs/application/vstools': No such file or directory
```

The image references that used to share the same dead prefix were already repaired; only these link hrefs were left behind. They are easy to miss because a broken *link* does not surface in browser checks the way a broken *image* does — nothing fetches it until a reader clicks.