### PR TITLE
docs(platform): close the grid container instead of opening a second one

### DIFF
--- a/docs/platform/get-started/git-repo-structure.md
+++ b/docs/platform/get-started/git-repo-structure.md
@@ -85,7 +85,7 @@ Tizen source codes run a on PC emulator and an ARM-based reference device. This 
 <a href="http://download.tizen.org/releases/milestone/tizen/unified/">Snapshots ></a>
 </div>
 
-<div>
+</div>
 </section>
 
 The following table describes the Git repository structure for Tizen 3.0 and higher.


### PR DESCRIPTION
## What

`docs/platform/get-started/git-repo-structure.md` opens `<div class="docs-grid-container">`, lays out three `grid-item` cards, and then writes `<div>` where `</div>` was meant:

```diff
 <a href="http://download.tizen.org/releases/milestone/tizen/unified/">Snapshots ></a>
 </div>
 
-<div>
+</div>
 </section>
```

So the container is never closed, and an extra empty `<div>` is opened immediately before `</section>`.

## Why it matters

An unbalanced `<div>` in a document body is not cosmetic on a rendering site. The body is injected into the page template, so a stray open or close tag re-parents everything that follows it. On tizen.org.v2 the documentation body is the slot of an Alpine component — a `<div>` that leaks out of the body can end the component's `x-data` root early, which puts later siblings out of scope and stops that page's JavaScript.

This is the **only** document under `docs/` whose `<div>` tags do not balance once fenced and inline code are excluded (scanned all `.md` at `433c726bf`).

## Verification

- `<div>` open/close counts: **7 / 7** after the change (8 / 6 before).
- A full tag-stack walk over the file leaves nothing open and reports no mismatch.
- `python3 tools/check_docs.py --changed-only --base origin/master` → `0 ERROR, 0 WARN`.