### PR TITLE
Fix stale cross-section links

### DIFF
--- a/docs/application/dotnet/overview/overview.md
+++ b/docs/application/dotnet/overview/overview.md
@@ -60,7 +60,7 @@ The TizenFX API exposes Tizen-specific platform features through C# interfaces, 
 - **Tizen.Uix**: Text-to-speech, speech-to-text, and input methods
 - **Tizen.Webview**: Embedded web browsing functionality
 
-For the complete API reference, see the [TizenFX API documentation](/application/dotnet/api/TizenFX/index.html).
+For the complete API reference, see the [TizenFX API documentation](/application/dotnet/api/TizenFX/latest/api/Tizen.html).
 
 ### Natural User Interface (NUI)
 
@@ -115,5 +115,5 @@ Visual Studio Tools for Tizen provides the project templates, build integration,
 
 ## Related Documentation
 
-- **[API Reference](/application/dotnet/api/TizenFX/index.html)**: Complete API documentation
+- **[API Reference](/application/dotnet/api/TizenFX/latest/api/Tizen.html)**: Complete API documentation
 - **[Guides](../guides/index.md)**: Detailed feature tutorials and examples

--- a/docs/application/flutter/guides/flutter-tizen/develop-plugin.md
+++ b/docs/application/flutter/guides/flutter-tizen/develop-plugin.md
@@ -163,7 +163,7 @@ Types such as `flutter::MethodCall` and `flutter::EncodableValue` in the templat
 
 - C++17 standards
 - [cpp_client_wrapper](https://github.com/flutter-tizen/engine/tree/HEAD/shell/platform/common/client_wrapper/include/flutter)
-- [Tizen native APIs](../../../native/api/common/latest/index.html)
+- [Tizen native APIs](../../../native/api/common/latest/group__CAPI__APPLICATION__FRAMEWORK.html)
 - External native libraries, if any (static/shared)
 
 Note: The API references for Tizen TV are not publicly available. However, most of the Tizen common APIs are also available for the TV profile, so you may refer to the common API references when developing plugins for TV devices.

--- a/docs/application/native/guides/development/index.md
+++ b/docs/application/native/guides/development/index.md
@@ -40,7 +40,7 @@ Implementing your application consists of:
 
 - **Coding applications**
 
-  Code your application in Tizen Studio using the namespaces defined in the Native API Reference ([API reference](../../api/common/latest/modules.html)).
+  Code your application in Tizen Studio using the APIs defined in the [Application Framework API reference](../../api/common/latest/group__CAPI__APPLICATION__FRAMEWORK.html).
 
 If needed, update the privileges of the application.
 

--- a/docs/platform/HAL/overview/overview.md
+++ b/docs/platform/HAL/overview/overview.md
@@ -68,4 +68,4 @@ For detailed information on each subsystem, refer to the following guides:
 - [Security](../guides/security.md) - Auth, Certs, Keys
 - [Machine Learning](../guides/ml.md) - Hardware-accelerated inference
 
-For API documentation, see the [HAL API Reference](../api/1.0/index.html).
+For API documentation, see the [HAL API Reference](../api/1.0/modules.html).

--- a/docs/platform/porting/overview.md
+++ b/docs/platform/porting/overview.md
@@ -14,7 +14,7 @@ The following figure illustrates the Tizen architecture for smart phone and tabl
 
 ![Tizen architecture](media/what-is-tizen-architecture.png)
 
-For more information on the Tizen framework layer, see the [Tizen Application Types](../../application/index.md#tizen-application-types).
+The Tizen framework layer supports .NET, web, and native applications.
 
 ## Core layer
 

--- a/docs/platform/what-is-tizen/profiles/tizen-custom.md
+++ b/docs/platform/what-is-tizen/profiles/tizen-custom.md
@@ -17,7 +17,7 @@ To develop applications for Tizen custom device, refer to the following:
 - [Native application development with VS Code](../../../sdk-tools/vscode-ext/Tizen/native.md)
 
 ## Create Tizen custom images
-Tizen provides a building block pool of components mainly based on the [Tizen Native API sets](../../../application/native/api/iot-headed/latest/index.html)
+Tizen provides a building block pool of components mainly based on the [Tizen Native API sets](../../../application/native/overview/overview.md)
 
 **Building block presets for Tizen core:**
 - The minimum set of bootable modules that make up the Tizen platform image for Tizen devices.


### PR DESCRIPTION
### Change Description ###

- Replace stale TizenFX landing links with the current API page.
- Point Flutter and native documentation at published API and overview pages.
- Remove or replace references to landing pages that are not published by the documentation site.
- Repair the HAL API version link.

### Bugs Fixed ###

- Fix six stale cross-section links detected by the downstream publication check.

### API Changes ###

None.

### Validation ###

- python3 tools/check_docs.py --changed-only --base origin/master (0 errors, 0 warnings)
- git diff --check