### PR TITLE
docs: fix five unbalanced HTML tags

### DIFF
--- a/docs/application/flutter/guides/flutter-tizen/macos-install.md
+++ b/docs/application/flutter/guides/flutter-tizen/macos-install.md
@@ -3,7 +3,7 @@
 ## System requirements
 
 - Operating system: macOS
-   - The [Rosetta translation environment](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment) must be available if you're installing on an [Apple Silicon](https://support.apple.com/en-us/HT211814) Mac.<p>
+   - The [Rosetta translation environment](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment) must be available if you're installing on an [Apple Silicon](https://support.apple.com/en-us/HT211814) Mac.
      ```sh
      sudo softwareupdate --install-rosetta --agree-to-license
      ```

--- a/docs/application/native/api/overview.md
+++ b/docs/application/native/api/overview.md
@@ -52,7 +52,6 @@ For example, see the "Privilege:" section in the following picture:
 <ul>
 <li><a href="common/9.0/index.html" target="_blank">9.0</a></li>
 <li><a href="common/8.0/index.html" target="_blank">8.0</a></li>
-</li>
 <li>Iot-Headed
   <ul>
     <li><a href="iot-headed/7.0/index.html" target="_blank">7.0</a></li>

--- a/docs/sdk-tools/baseline-sdk/common-tools/command-line-interface.md
+++ b/docs/sdk-tools/baseline-sdk/common-tools/command-line-interface.md
@@ -747,7 +747,7 @@ tizen build-app [options] [args specified with JSON-like format]
 			<th>Type</th>
 			<th>JSON-like expression</th>
 		</tr>
-	</tead>
+	</thead>
 	<tbody>
 		<tr>
 			<td><code>build</code></td>

--- a/docs/sdk-tools/baseline-sdk/tizen-core/tizen-core-cli.md
+++ b/docs/sdk-tools/baseline-sdk/tizen-core/tizen-core-cli.md
@@ -914,7 +914,7 @@ tz trust-anchor <sub-command> [options]
 			Options are:
 			<ul>
 				<li><code>-p</code>, <code>--project="."</code>          :Project path</li>
-        <li><code>-c</code>, <code--cert-paths=STRING</code>     :Path of the certificates inside the .trust-anchor/. Quote enclosed and comma separated</li>
+        <li><code>-c</code>, <code>--cert-paths=STRING</code>     :Path of the certificates inside the .trust-anchor/. Quote enclosed and comma separated</li>
 			</ul>
 			</td>
 		</tr>

--- a/docs/sdk-tools/baseline-sdk/web-tools/code-productivity.md
+++ b/docs/sdk-tools/baseline-sdk/web-tools/code-productivity.md
@@ -32,7 +32,7 @@ If you use the Code Beautifier in the **Source Editor** view, no new file is gen
 
 ![Code Beautifier with CSS file - after beautifying](./media/code_productivity_after_beautifying.png)
 
-## Using the Code Minifier</a>
+## Using the Code Minifier
 
 Minification is the process of compressing the code from its original size to the smallest size, without affecting its operation. The Code Minifier is a smart compression tool which removes or modifies unnecessary characters from the code.
 


### PR DESCRIPTION
## What

Five one-character HTML typos in `docs/` that leave an element open, or close one
that was never opened.

| File | Defect |
|---|---|
| `sdk-tools/baseline-sdk/common-tools/command-line-interface.md:750` | `</tead>` → `</thead>` |
| `sdk-tools/baseline-sdk/tizen-core/tizen-core-cli.md:917` | `<code--cert-paths=STRING</code>` — the opening tag is missing its `>`, so the tag name absorbs `</code` and the element never closes |
| `sdk-tools/baseline-sdk/web-tools/code-productivity.md:35` | stray `</a>` at the end of a heading |
| `application/native/api/overview.md:55` | stray `</li>` — a copy-paste leftover from 4d255b19 ("Add 8.0 Native API Reference"); there is no `<li>` group opening for the common versions |
| `application/flutter/guides/flutter-tizen/macos-install.md:6` | unclosed `<p>` before a fenced code block; the fence renders fine without it |

## Why it matters

A browser's error recovery is not the renderer's. On the developer site an
unclosed element swallows the elements that follow it, and a stray close tag
ends a wrapper early — which is how a page's JavaScript can stop running
altogether when the wrapper happens to be a component root.

## How it was verified

A tag-stack scan over **all 1,764 markdown files** under `docs/` (fenced code
blocks, inline code, HTML comments and backslash-escaped angle brackets
excluded):

```
before: scanned 1764 / imbalanced 5
after:  scanned 1764 / imbalanced 0
```

No other file in the tree is affected, and reverting any one of the five
edits brings that file back in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
